### PR TITLE
HARP-2944: Set a custom tag template for npm

### DIFF
--- a/@here/datasource-protocol/.npmrc
+++ b/@here/datasource-protocol/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/datasource-protocol@"

--- a/@here/debug-datasource/.npmrc
+++ b/@here/debug-datasource/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/debug-datasource@"

--- a/@here/download-manager/.npmrc
+++ b/@here/download-manager/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/download-manager@"

--- a/@here/fetch/.npmrc
+++ b/@here/fetch/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/fetch@"

--- a/@here/geojson-datasource/.npmrc
+++ b/@here/geojson-datasource/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/geojson-datasource@"

--- a/@here/geoutils/.npmrc
+++ b/@here/geoutils/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/geoutils@"

--- a/@here/harp-examples/.npmrc
+++ b/@here/harp-examples/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/harp-examples@"

--- a/@here/lines/.npmrc
+++ b/@here/lines/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/lines@"

--- a/@here/lrucache/.npmrc
+++ b/@here/lrucache/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/lrucache@"

--- a/@here/map-controls/.npmrc
+++ b/@here/map-controls/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/map-controls@"

--- a/@here/map-theme/.npmrc
+++ b/@here/map-theme/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/map-theme@"

--- a/@here/mapview-decoder/.npmrc
+++ b/@here/mapview-decoder/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/mapview-decoder@"

--- a/@here/mapview/.npmrc
+++ b/@here/mapview/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/mapview@"

--- a/@here/materials/.npmrc
+++ b/@here/materials/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/materials@"

--- a/@here/omv-datasource/.npmrc
+++ b/@here/omv-datasource/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/omv-datasource@"

--- a/@here/test-utils/.npmrc
+++ b/@here/test-utils/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/test-utils@"

--- a/@here/text-renderer/.npmrc
+++ b/@here/text-renderer/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/text-renderer@"

--- a/@here/utils/.npmrc
+++ b/@here/utils/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/utils@"

--- a/@here/webtile-datasource/.npmrc
+++ b/@here/webtile-datasource/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix="@here/webtile-datasource@"


### PR DESCRIPTION
When releasing the submodules, use a custom tag template so that the
tags from the various subdirectories don't overwrite each other. Follow
the pattern that lerna uses for independent releases.