### PR TITLE
Use yarn instead of npm for version patch

### DIFF
--- a/@here/datasource-protocol/.npmrc
+++ b/@here/datasource-protocol/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/datasource-protocol@"

--- a/@here/datasource-protocol/.yarnrc
+++ b/@here/datasource-protocol/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/datasource-protocol %s"
+version-tag-prefix "@here/datasource-protocol@"

--- a/@here/debug-datasource/.npmrc
+++ b/@here/debug-datasource/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/debug-datasource@"

--- a/@here/debug-datasource/.yarnrc
+++ b/@here/debug-datasource/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/debug-datasource %s"
+version-tag-prefix "@here/debug-datasource@"

--- a/@here/download-manager/.npmrc
+++ b/@here/download-manager/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/download-manager@"

--- a/@here/download-manager/.yarnrc
+++ b/@here/download-manager/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/download-manager %s"
+version-tag-prefix "@here/download-manager@"

--- a/@here/fetch/.npmrc
+++ b/@here/fetch/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/fetch@"

--- a/@here/fetch/.yarnrc
+++ b/@here/fetch/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/fetch %s"
+version-tag-prefix "@here/fetch@"

--- a/@here/geojson-datasource/.npmrc
+++ b/@here/geojson-datasource/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/geojson-datasource@"

--- a/@here/geojson-datasource/.yarnrc
+++ b/@here/geojson-datasource/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/geojson-datasource %s"
+version-tag-prefix "@here/geojson-datasource@"

--- a/@here/geoutils/.npmrc
+++ b/@here/geoutils/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/geoutils@"

--- a/@here/geoutils/.yarnrc
+++ b/@here/geoutils/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/geoutils %s"
+version-tag-prefix "@here/geoutils@"

--- a/@here/harp-examples/.npmrc
+++ b/@here/harp-examples/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/harp-examples@"

--- a/@here/harp-examples/.yarnrc
+++ b/@here/harp-examples/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/harp-examples %s"
+version-tag-prefix "@here/harp-examples@"

--- a/@here/lines/.npmrc
+++ b/@here/lines/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/lines@"

--- a/@here/lines/.yarnrc
+++ b/@here/lines/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/lines %s"
+version-tag-prefix "@here/lines@"

--- a/@here/lrucache/.npmrc
+++ b/@here/lrucache/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/lrucache@"

--- a/@here/lrucache/.yarnrc
+++ b/@here/lrucache/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/lrucache %s"
+version-tag-prefix "@here/lrucache@"

--- a/@here/map-controls/.npmrc
+++ b/@here/map-controls/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/map-controls@"

--- a/@here/map-controls/.yarnrc
+++ b/@here/map-controls/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/map-controls %s"
+version-tag-prefix "@here/map-controls@"

--- a/@here/map-theme/.npmrc
+++ b/@here/map-theme/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/map-theme@"

--- a/@here/map-theme/.yarnrc
+++ b/@here/map-theme/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/map-theme %s"
+version-tag-prefix "@here/map-theme@"

--- a/@here/mapview-decoder/.npmrc
+++ b/@here/mapview-decoder/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/mapview-decoder@"

--- a/@here/mapview-decoder/.yarnrc
+++ b/@here/mapview-decoder/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/mapview-decoder %s"
+version-tag-prefix "@here/mapview-decoder@"

--- a/@here/mapview/.npmrc
+++ b/@here/mapview/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/mapview@"

--- a/@here/mapview/.yarnrc
+++ b/@here/mapview/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/mapview %s"
+version-tag-prefix "@here/mapview@"

--- a/@here/materials/.npmrc
+++ b/@here/materials/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/materials@"

--- a/@here/materials/.yarnrc
+++ b/@here/materials/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/materials %s"
+version-tag-prefix "@here/materials@"

--- a/@here/omv-datasource/.npmrc
+++ b/@here/omv-datasource/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/omv-datasource@"

--- a/@here/omv-datasource/.yarnrc
+++ b/@here/omv-datasource/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/omv-datasource %s"
+version-tag-prefix "@here/omv-datasource@"

--- a/@here/test-utils/.npmrc
+++ b/@here/test-utils/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/test-utils@"

--- a/@here/test-utils/.yarnrc
+++ b/@here/test-utils/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/test-utils %s"
+version-tag-prefix "@here/test-utils@"

--- a/@here/text-renderer/.npmrc
+++ b/@here/text-renderer/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/text-renderer@"

--- a/@here/text-renderer/.yarnrc
+++ b/@here/text-renderer/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/text-renderer %s"
+version-tag-prefix "@here/text-renderer@"

--- a/@here/utils/.npmrc
+++ b/@here/utils/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/utils@"

--- a/@here/utils/.yarnrc
+++ b/@here/utils/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/utils %s"
+version-tag-prefix "@here/utils@"

--- a/@here/webtile-datasource/.npmrc
+++ b/@here/webtile-datasource/.npmrc
@@ -1,1 +1,0 @@
-tag-version-prefix="@here/webtile-datasource@"

--- a/@here/webtile-datasource/.yarnrc
+++ b/@here/webtile-datasource/.yarnrc
@@ -1,0 +1,2 @@
+version-git-message "@here/webtile-datasource %s"
+version-tag-prefix "@here/webtile-datasource@"


### PR DESCRIPTION
"npm version patch" doesn't create a tag or a commit if it's not in the
root of the git repository. This is quite inconsistent and not
overrideable. Use yarn instead.