### PR TITLE
Version bump for package release

### DIFF
--- a/@here/datasource-protocol/package.json
+++ b/@here/datasource-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/datasource-protocol",
-  "version": "0.2.59",
+  "version": "0.2.60",
   "description": "Datasource protocol",
   "main": "index.js",
   "typings": "index",

--- a/@here/debug-datasource/package.json
+++ b/@here/debug-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/debug-datasource",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Overlay useful for debugging map data",
   "main": "index.js",
   "typings": "index",

--- a/@here/download-manager/package.json
+++ b/@here/download-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/download-manager",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "Typescript version of a download manager",
   "main": "index.js",
   "typings": "index",

--- a/@here/fetch/package.json
+++ b/@here/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/fetch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Typescript version of a fetch function",
   "main": "index.js",
   "browser": "index.web.js",

--- a/@here/geojson-datasource/package.json
+++ b/@here/geojson-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/geojson-datasource",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Typescript version of geojson-datasource",
   "main": "index.js",
   "typings": "index",

--- a/@here/geoutils/package.json
+++ b/@here/geoutils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/geoutils",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "Typescript version of geoutils",
   "main": "index.js",
   "typings": "index",

--- a/@here/harp-examples/package.json
+++ b/@here/harp-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/harp-examples",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Visualisation Library Examples",
   "bin": "harp-examples",
   "scripts": {

--- a/@here/lines/package.json
+++ b/@here/lines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/lines",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "Create three.js geometries for wide lines",
   "main": "index.js",
   "typings": "index",

--- a/@here/lrucache/package.json
+++ b/@here/lrucache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/lrucache",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "LRU cache",
   "main": "index.js",
   "typings": "index",

--- a/@here/map-controls/package.json
+++ b/@here/map-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/map-controls",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Camera controller which implements a common default set of camera functionality in a map context.",
   "main": "index.js",
   "typings": "index",

--- a/@here/map-theme/package.json
+++ b/@here/map-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/map-theme",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Map themes",
   "main": "index.js",
   "typings": "index",

--- a/@here/mapview-decoder/package.json
+++ b/@here/mapview-decoder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/mapview-decoder",
-  "version": "0.2.46",
+  "version": "0.2.47",
   "description": "Decoder worker for mapview",
   "main": "index.js",
   "typings": "index",

--- a/@here/mapview/package.json
+++ b/@here/mapview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/mapview",
-  "version": "0.7.76",
+  "version": "0.7.77",
   "description": "MapView renderer",
   "main": "index.js",
   "typings": "index",

--- a/@here/materials/package.json
+++ b/@here/materials/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/materials",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Harp4Web Materials",
   "main": "index.js",
   "typings": "index",

--- a/@here/omv-datasource/package.json
+++ b/@here/omv-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/omv-datasource",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "description": "OMV Data source",
   "main": "index.js",
   "typings": "index",

--- a/@here/test-utils/package.json
+++ b/@here/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/test-utils",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Provides utilities for tests",
   "main": "index.js",
   "browser": "index.web.js",

--- a/@here/text-renderer/package.json
+++ b/@here/text-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/text-renderer",
-  "version": "0.2.56",
+  "version": "0.2.57",
   "description": "SDF based text rendering for TypeScript",
   "main": "index.js",
   "typings": "index",

--- a/@here/utils/package.json
+++ b/@here/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/utils",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Provides utilities: logging, debugging and etc.",
   "main": "index.js",
   "scripts": {

--- a/@here/webtile-datasource/package.json
+++ b/@here/webtile-datasource/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@here/webtile-datasource",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "WebTile Data source",
   "main": "index.js",
   "typings": "index",


### PR DESCRIPTION
@here/geoutils@0.2.53
@here/utils@0.1.16
@here/materials@0.1.12
@here/lines@0.1.37
@here/datasource-protocol@0.2.60
@here/fetch@0.2.1
@here/download-manager@0.1.50
@here/lrucache@0.1.43
@here/text-renderer@0.2.57
@here/test-utils@0.1.8
@here/mapview@0.7.77
@here/mapview-decoder@0.2.47
@here/map-controls@0.1.48
@here/omv-datasource@0.2.56
@here/debug-datasource@0.1.39
@here/geojson-datasource@0.2.5
@here/map-theme@0.1.69
@here/webtile-datasource@0.2.37
@here/harp-examples@0.1.1