### PR TITLE
HARP-3510: Implement text display from an XYZ Project.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -957,6 +957,10 @@ export function isLineTechnique(technique: Technique): technique is LineTechniqu
     return technique.name === "line";
 }
 
+export function isSolidLineTechnique(technique: Technique): technique is LineTechnique {
+    return technique.name === "solid-line";
+}
+
 export function isSegmentsTechnique(technique: Technique): technique is SegmentsTechnique {
     return technique.name === "segments";
 }

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -785,6 +785,7 @@ export interface Style {
      * Human readable description.
      */
     description?: string;
+
     /**
      * Compile-time condition.
      */
@@ -859,6 +860,11 @@ export interface Style {
      * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
      */
     metricUnit?: string;
+
+    /**
+     * XYZ defines the property to display as text label of a feature in the styles.
+     */
+    labelProperty?: string;
 }
 
 export interface Vector3Like {
@@ -1256,6 +1262,10 @@ export class StyleSetEvaluator {
 
                         if (currStyle.renderOrderBiasProperty !== undefined) {
                             technique.renderOrderBiasProperty = currStyle.renderOrderBiasProperty;
+                        }
+
+                        if (currStyle.labelProperty !== undefined) {
+                            technique.label = currStyle.labelProperty;
                         }
 
                         if (currStyle.renderOrderBiasRange !== undefined) {

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -6,11 +6,17 @@
 
 import {
     DecodedTile,
-    Geometry,
     getBufferAttribute,
+    isPoiTechnique,
+    isTextTechnique,
     PoiTechnique,
-    Technique
+    TextTechnique
 } from "@here/harp-datasource-protocol";
+import {
+    GeoJsonPoiGeometry,
+    GeoJsonTextGeometry,
+    GeoJsonTextPathGeometry
+} from "@here/harp-geojson-datasource/lib/GeoJsonDecoder";
 import { DEFAULT_TEXT_DISTANCE_SCALE, TextElement, Tile, TileObject } from "@here/harp-mapview";
 import * as THREE from "three";
 
@@ -57,7 +63,6 @@ interface LabeledIconParams {
 /**
  * It contains default values for the labeled icons
  */
-
 const DEFAULT_LABELED_ICON: Readonly<LabeledIconParams> = {
     priority: 1000,
     scale: 0.5,
@@ -85,6 +90,7 @@ export class GeoJsonTile extends Tile {
     static readonly POINT_MARKER_SIZE = 128;
 
     private m_currentZoomLevel: number | undefined;
+    private m_preparedPaths?: GeoJsonTextPathGeometry[];
 
     /**
      * Tiles render at all zoom levels. This method stores the zoom level in order to know how to
@@ -109,61 +115,216 @@ export class GeoJsonTile extends Tile {
     }
 
     /**
-     * Given a decode tile, it adds labeled icons to it. This methods ovveride the
+     * Given a decode tile, it adds labeled icons to it. This method overrides the
      * `createTextElements` in the [[Tile]] class.
      *
-     * @param decodedTile The decoded tile received by the [[GeoJsonDecoder]]
+     * @param decodedTile The decoded tile received by the [[GeoJsonDecoder]].
      */
     createTextElements(decodedTile: DecodedTile) {
-        super.createTextElements(decodedTile);
-        if (decodedTile.geometries !== undefined) {
-            for (const geometry of decodedTile.geometries) {
-                const groups = geometry.groups;
-                const groupCount = groups.length;
-
-                for (let groupIndex = 0; groupIndex < groupCount; ) {
-                    const group = groups[groupIndex++];
-                    const techniqueIndex = group.technique;
-                    const technique = decodedTile.techniques[techniqueIndex];
-
-                    if (technique.name === "labeled-icon") {
-                        this.addLabeledIcons(geometry, technique);
-                    }
+        if (decodedTile.poiGeometries !== undefined) {
+            for (const geometry of decodedTile.poiGeometries) {
+                const techniqueIndex = geometry.technique!;
+                const technique = decodedTile.techniques[techniqueIndex];
+                if (isPoiTechnique(technique)) {
+                    this.addPois(geometry, technique);
+                }
+            }
+        }
+        if (decodedTile.textGeometries !== undefined) {
+            for (const geometry of decodedTile.textGeometries) {
+                const techniqueIndex = geometry.technique!;
+                const technique = decodedTile.techniques[techniqueIndex];
+                if (isTextTechnique(technique)) {
+                    this.addTexts(geometry, technique);
+                }
+            }
+        }
+        if (decodedTile.textPathGeometries !== undefined) {
+            this.m_preparedPaths = this.prepareTextPaths(decodedTile.textPathGeometries);
+            for (const textPath of this.m_preparedPaths) {
+                const techniqueIndex = textPath.technique!;
+                const technique = decodedTile.techniques[techniqueIndex];
+                if (isTextTechnique(technique)) {
+                    this.addTextPaths(textPath, technique);
                 }
             }
         }
     }
 
-    private addLabeledIcons(geometry: Geometry, technique: Technique) {
-        geometry.vertexAttributes.forEach(vertexAttribute => {
-            const attribute = getBufferAttribute(vertexAttribute);
-            for (let index = 0; index < attribute.count; index++) {
-                const position = new THREE.Vector3(
-                    attribute.getX(index),
-                    attribute.getY(index),
-                    attribute.getZ(index)
-                );
+    /**
+     * Calls `addTextPath` for each TextPath.
+     *
+     * @param geometry The TextPath geometry.
+     * @param technique Text technique.
+     */
+    private addTextPaths(geometry: GeoJsonTextPathGeometry, technique: TextTechnique) {
+        const path: THREE.Vector2[] = [];
+        for (let i = 0; i < geometry.path.length; i += 2) {
+            path.push(new THREE.Vector2(geometry.path[i], geometry.path[i + 1]));
+        }
 
-                let geojsonProperties;
-                if (geometry.objInfos !== undefined) {
-                    geojsonProperties = geometry.objInfos[index];
-                }
-
-                this.addLabeledIcon(position, technique, geojsonProperties);
-            }
-        });
+        const properties = geometry.objInfos !== undefined ? geometry.objInfos : undefined;
+        this.addTextPath(path, geometry.text, technique, properties);
     }
 
     /**
-     * Add a labeled icon available for mouse picking at the given position.
+     * Add a label available for mouse picking at the given path.
+     *
+     * @param path Path of the text path.
+     * @param tec Technique in use.
+     * @param geojsonProperties Properties defined by the user.
+     */
+    private addTextPath(
+        path: THREE.Vector2[],
+        text: string,
+        technique: TextTechnique,
+        geojsonProperties?: {}
+    ) {
+        const priority =
+            technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
+        const scale = technique.scale === undefined ? DEFAULT_LABELED_ICON.scale : technique.scale;
+        const xOffset =
+            technique.xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : technique.xOffset;
+        const yOffset =
+            technique.yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : technique.yOffset;
+
+        const featureId = DEFAULT_LABELED_ICON.featureId;
+
+        const textElement = new TextElement(
+            text,
+            path,
+            priority,
+            scale,
+            xOffset,
+            yOffset,
+            featureId
+        );
+
+        // Set the userData of the TextElement to the geojsonProperties, then it will be available
+        // for picking.
+        if (geojsonProperties !== undefined) {
+            textElement.userData = geojsonProperties;
+        }
+
+        const mayOverlap =
+            technique.mayOverlap === undefined
+                ? DEFAULT_LABELED_ICON.iconMayOverlap
+                : technique.mayOverlap;
+        const reserveSpace =
+            technique.reserveSpace === undefined
+                ? DEFAULT_LABELED_ICON.textReserveSpace
+                : technique.reserveSpace;
+        const distanceScale = DEFAULT_TEXT_DISTANCE_SCALE;
+
+        textElement.mayOverlap = mayOverlap;
+        textElement.reserveSpace = reserveSpace;
+        textElement.distanceScale = distanceScale;
+
+        this.addUserTextElement(textElement);
+    }
+
+    /**
+     * Calls `addText` on each vertex of the geometry.
+     *
+     * @param geometry The Text geometry.
+     * @param technique Text technique.
+     */
+    private addTexts(geometry: GeoJsonTextGeometry, technique: TextTechnique) {
+        const attribute = getBufferAttribute(geometry.positions);
+
+        const currentVertexCache = new THREE.Vector2();
+
+        for (let index = 0; index < attribute.count; index++) {
+            currentVertexCache.set(attribute.getX(index), attribute.getY(index));
+            const properties =
+                geometry.objInfos !== undefined ? geometry.objInfos[index] : undefined;
+            const text = geometry.stringCatalog![geometry.texts[0]] as string;
+            this.addText(currentVertexCache, text, technique, properties);
+        }
+    }
+
+    /**
+     * Add a label available for mouse picking at the given position.
      *
      * @param position position of the labeled Icon, in world coordinate.
      * @param tec Technique in use.
      * @param geojsonProperties Properties defined by the user.
      */
-    private addLabeledIcon(position: THREE.Vector3, tec: Technique, geojsonProperties?: {}) {
-        const technique = tec as PoiTechnique;
+    private addText(
+        position: THREE.Vector2,
+        text: string,
+        technique: TextTechnique,
+        geojsonProperties?: {}
+    ) {
+        const priority =
+            technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
+        const scale = technique.scale === undefined ? DEFAULT_LABELED_ICON.scale : technique.scale;
+        const xOffset =
+            technique.xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : technique.xOffset;
+        const yOffset =
+            technique.yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : technique.yOffset;
 
+        const featureId = DEFAULT_LABELED_ICON.featureId;
+        const textElement = new TextElement(
+            text,
+            position,
+            priority,
+            scale,
+            xOffset,
+            yOffset,
+            featureId
+        );
+
+        // Set the userData of the TextElement to the geojsonProperties, then it will be available
+        // for picking.
+        if (geojsonProperties !== undefined) {
+            textElement.userData = geojsonProperties;
+        }
+
+        const mayOverlap =
+            technique.mayOverlap === undefined
+                ? DEFAULT_LABELED_ICON.iconMayOverlap
+                : technique.mayOverlap;
+        const reserveSpace =
+            technique.reserveSpace === undefined
+                ? DEFAULT_LABELED_ICON.textReserveSpace
+                : technique.reserveSpace;
+        const distanceScale = DEFAULT_TEXT_DISTANCE_SCALE;
+
+        textElement.mayOverlap = mayOverlap;
+        textElement.reserveSpace = reserveSpace;
+        textElement.distanceScale = distanceScale;
+
+        this.addUserTextElement(textElement);
+    }
+
+    /**
+     * Calls `addPoi` on each vertex of the geometry.
+     *
+     * @param geometry The POI geometry.
+     * @param technique POI technique.
+     */
+    private addPois(geometry: GeoJsonPoiGeometry, technique: PoiTechnique) {
+        const attribute = getBufferAttribute(geometry.positions);
+
+        const currentVertexCache = new THREE.Vector2();
+
+        for (let index = 0; index < attribute.count; index++) {
+            currentVertexCache.set(attribute.getX(index), attribute.getY(index));
+            const properties =
+                geometry.objInfos !== undefined ? geometry.objInfos[index] : undefined;
+            this.addPoi(currentVertexCache, technique, properties);
+        }
+    }
+
+    /**
+     * Add a POI available for mouse picking at the given position.
+     *
+     * @param position position of the labeled Icon, in world coordinate.
+     * @param tec Technique in use.
+     * @param geojsonProperties Properties defined by the user.
+     */
+    private addPoi(position: THREE.Vector2, technique: PoiTechnique, geojsonProperties?: {}) {
         const label = DEFAULT_LABELED_ICON.label;
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
@@ -172,14 +333,38 @@ export class GeoJsonTile extends Tile {
             technique.xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : technique.xOffset;
         const yOffset =
             technique.yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : technique.yOffset;
+
+        const featureId = DEFAULT_LABELED_ICON.featureId;
+        const textElement = new TextElement(
+            label,
+            position,
+            priority,
+            scale,
+            xOffset,
+            yOffset,
+            featureId
+        );
+
+        // Set the userData of the TextElement to the geojsonProperties, then it will be available
+        // for picking.
+        if (geojsonProperties !== undefined) {
+            textElement.userData = geojsonProperties;
+        }
+
         const mayOverlap =
             technique.iconMayOverlap === undefined
                 ? DEFAULT_LABELED_ICON.iconMayOverlap
                 : technique.iconMayOverlap;
         const reserveSpace =
-            technique.textReserveSpace === undefined
+            technique.iconReserveSpace === undefined
                 ? DEFAULT_LABELED_ICON.textReserveSpace
-                : technique.textReserveSpace;
+                : technique.iconReserveSpace;
+        const distanceScale = DEFAULT_TEXT_DISTANCE_SCALE;
+
+        textElement.mayOverlap = mayOverlap;
+        textElement.reserveSpace = reserveSpace;
+        textElement.distanceScale = distanceScale;
+
         const alwaysOnTop =
             technique.alwaysOnTop === undefined
                 ? DEFAULT_LABELED_ICON.alwaysOnTop
@@ -201,29 +386,6 @@ export class GeoJsonTile extends Tile {
                 ? technique.imageTexture
                 : DEFAULT_LABELED_ICON.imageTextureName;
 
-        const featureId = DEFAULT_LABELED_ICON.featureId;
-        const textElement = new TextElement(
-            label,
-            position,
-            priority,
-            scale,
-            xOffset,
-            yOffset,
-            featureId
-        );
-
-        textElement.mayOverlap = mayOverlap;
-        textElement.reserveSpace = reserveSpace;
-        textElement.alwaysOnTop = alwaysOnTop;
-
-        // Set the userData of the TextElement to the geojsonProperties, then it will be available
-        // for picking.
-        if (geojsonProperties !== undefined) {
-            textElement.userData = geojsonProperties;
-        }
-
-        const distanceScale = DEFAULT_TEXT_DISTANCE_SCALE;
-
         textElement.poiInfo = {
             technique,
             imageTextureName,
@@ -236,7 +398,7 @@ export class GeoJsonTile extends Tile {
             featureId
         };
 
-        textElement.distanceScale = distanceScale;
+        textElement.alwaysOnTop = alwaysOnTop;
 
         this.addUserTextElement(textElement);
     }

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -27,7 +27,7 @@ import {
 } from "@here/harp-datasource-protocol";
 import { MapEnv } from "@here/harp-datasource-protocol/lib/Theme";
 import { LINE_VERTEX_ATTRIBUTE_DESCRIPTORS, Lines, triangulateLine } from "@here/harp-lines";
-import { LoggerManager } from "@here/harp-utils";
+import { LoggerManager, Math2D } from "@here/harp-utils";
 import earcut from "earcut";
 import * as THREE from "three";
 
@@ -86,18 +86,6 @@ export enum LineType {
 }
 
 export class OmvDecodedTileEmitter implements IOmvEmitter {
-    private static computeLineLengthSqr(line: number[]) {
-        let lineLengthSqr: number = 0;
-
-        const len = line.length - 3;
-        for (let i = 0; i < len; i += 2) {
-            const xDiff = line[i + 2] - line[i];
-            const yDiff = line[i + 3] - line[i + 1];
-            lineLengthSqr += xDiff * xDiff + yDiff * yDiff;
-        }
-        return lineLengthSqr;
-    }
-
     // mapping from style index to mesh buffers
     private readonly m_meshBuffers = new Map<number, MeshBuffers>();
 
@@ -410,7 +398,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                         continue;
                     }
                     for (const aLine of lines) {
-                        const pathLengthSqr = OmvDecodedTileEmitter.computeLineLengthSqr(aLine);
+                        const pathLengthSqr = Math2D.computeSquaredLineLength(aLine);
                         this.m_textPathGeometries.push({
                             technique: techniqueIndex,
                             path: aLine,

--- a/@here/harp-utils/lib/Math2D.ts
+++ b/@here/harp-utils/lib/Math2D.ts
@@ -85,6 +85,23 @@ export namespace Math2D {
     }
 
     /**
+     * Computes the squared length of a line.
+     *
+     * @param line An array of even length, which form a line via [x,y,x,y,...] pairs.
+     */
+    export function computeSquaredLineLength(line: number[]): number {
+        let squaredLineLength: number = 0;
+
+        const length = line.length - 3;
+        for (let i = 0; i < length; i += 2) {
+            const xDiff = line[i + 2] - line[i];
+            const yDiff = line[i + 3] - line[i + 1];
+            squaredLineLength += xDiff * xDiff + yDiff * yDiff;
+        }
+        return squaredLineLength;
+    }
+
+    /**
      * Compute squared distance between a 2D point and a 2D line segment.
      *
      * @param px Test point X


### PR DESCRIPTION
This PR implements the TextPaths on the lines when enabled in XYZ Studio. 

In addition, until this change the GeoJsonDataSource was defining every TextElement or POI via a single point, passed in Tile#geometries alongside the other geometries. No use of Tile#poiGeometries or Tile#textGeometries. However the TextPath cannot be inferred without using the Tile#textPathGeometries. So to be consistent, all the previous code was moved to avail of these various buffers. Hence the size of the PR.