### PR TITLE
HARP-3888: Fixes to MapView in order to postpone datasources

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1144,6 +1144,21 @@ export class MapView extends THREE.EventDispatcher {
         return dataSource
             .connect()
             .then(() => {
+                return new Promise((resolve) => {
+                    if (this.theme !== undefined) {
+                        resolve();
+                        return;
+                    }
+
+                    const resolveOnce = () => {
+                        this.removeEventListener(MapViewEventNames.ThemeLoaded, resolveOnce);
+                        resolve();
+                    };
+
+                    this.addEventListener(MapViewEventNames.ThemeLoaded, resolveOnce);
+                });
+            })
+            .then(() => {
                 const alreadyRemoved = this.m_tileDataSources.indexOf(dataSource) === -1;
                 if (alreadyRemoved) {
                     return;


### PR DESCRIPTION
In this PR I've added a code that solves the problem in `hello_one-thread` example:

```
TileDataSource.ts?2bf3:206 Uncaught (in promise) TypeError: Cannot read property 'then' of undefined
--
at OmvDataSource.updateTile (TileDataSource.ts?2bf3:206)
at OmvTile.reload (Tile.ts?b79b:628)
at renderListEntry.visibleTiles.forEach.tile (VisibleTileSet.ts?53da:619)
at Array.forEach (<anonymous>)
at VisibleTileSet.markDataSourceTilesDirty (VisibleTileSet.ts?53da:617)
at VisibleTileSet.markTilesDirty (VisibleTileSet.ts?53da:447)
at MapView.markTilesDirty (MapView.ts?9893:1487)
at OmvDataSource.setStyleSet (OmvDataSource.ts?2411:202)
at getDataSourcesByStyleSetName.forEach.ds (MapView.ts?9893:801)
at Array.forEach (<anonymous>)
```

**Explanation**
The error was happening because dataSource was loaded before the theme was loaded in `MapView`. The code checks if there is a Theme object in `this.theme`, if there is - we continue, else - continue when `MapViewEventNames.ThemeLoaded` was fired