### PR TITLE
Add OSS Review Toolkit configuration file

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,6 @@
+excludes:
+  scopes:
+  - name: "devDependencies"
+    reason: "BUILD_TOOL_OF"
+    comment: "These are dependencies only used for development. They are not distributed in the context of this product."
+


### PR DESCRIPTION
The OSS Review Toolkit scans projects in order to collect information
needed for evaluating license compliance. This involves determining all
transitive dependencies and its respective licenses. For details,
see: https://github.com/heremaps/oss-review-toolkit/tree/master/docs

This change configures the scanner to ignore dependencies which are not
distributed along with the release.