### PR TITLE
HARP-3174: removing usage of arrow functions in test

### DIFF
--- a/@here/harp-datasource-protocol/test/DataSourceProtocolTest.ts
+++ b/@here/harp-datasource-protocol/test/DataSourceProtocolTest.ts
@@ -4,18 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { createMaterial } from "../lib/DecodedTile";
 import { getObjectConstructor, ShaderTechnique } from "../lib/Techniques";
 
 import { assert } from "chai";
 import * as THREE from "three";
 
-describe("DataSourceProtocol", () => {
-    it("ok", () => {
+describe("DataSourceProtocol", function() {
+    it("ok", function() {
         assert.isTrue(true);
     });
 
-    it("ShaderTechnique", () => {
+    it("ShaderTechnique", function() {
         const technique: ShaderTechnique = {
             name: "shader",
             primitive: "line",
@@ -54,7 +57,7 @@ describe("DataSourceProtocol", () => {
         }
     });
 
-    it("ObjectConstructor", () => {
+    it("ObjectConstructor", function() {
         const ExtrudedLineCtor = getObjectConstructor({
             name: "extruded-line",
             color: "#f00",

--- a/@here/harp-datasource-protocol/test/OutlineIndicesDetectorTest.ts
+++ b/@here/harp-datasource-protocol/test/OutlineIndicesDetectorTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import {
     pointInsideTileExtents,
@@ -13,56 +16,56 @@ import {
     pointsOnYAxisAlignedTileBorder
 } from "../lib/OutlineIndicesDetector";
 
-describe("The OutlineIndicesDetector check if an index is needed", () => {
+describe("The OutlineIndicesDetector check if an index is needed", function() {
     const tileExtent = 1.0;
-        describe("#pointInsideTileExtents", () => {
-        it("returns true if the point is inside the tile extents", () => {
+    describe("#pointInsideTileExtents", function() {
+        it("returns true if the point is inside the tile extents", function() {
             assert.equal(pointInsideTileExtents(0.9, 0.9, tileExtent), true);
         });
-        it("returns false if it is bigger than the tile extents", () => {
+        it("returns false if it is bigger than the tile extents", function() {
             assert.equal(pointInsideTileExtents(1.2, -1.0, tileExtent), false);
         });
     });
 
-    describe("#pointsOnYAxisAlignedTileBorder", () => {
-        it("returns true if the points are on the opposite horizontal borders", () => {
+    describe("#pointsOnYAxisAlignedTileBorder", function() {
+        it("returns true if the points are on the opposite horizontal borders", function() {
             assert.equal(pointsOnYAxisAlignedTileBorder(2.0, 0.99, 1.0, 0.9, tileExtent), true);
         });
-        it("returns false if the points are in the same horizontal borders", () => {
+        it("returns false if the points are in the same horizontal borders", function() {
             assert.equal(pointsOnYAxisAlignedTileBorder(1.0, 1.01, 1.0, 0.0, tileExtent), false);
         });
     });
 
-    describe("#pointsOnXAxisAlignedTileBorder", () => {
-        it("returns true if the points are on the opposite vertical borders", () => {
+    describe("#pointsOnXAxisAlignedTileBorder", function() {
+        it("returns true if the points are on the opposite vertical borders", function() {
             assert.equal(pointsOnXAxisAlignedTileBorder(0.7, 2.0, -0.5, 1.0, tileExtent), true);
         });
-        it("returns false if the points are on the same vertical border", () => {
+        it("returns false if the points are on the same vertical border", function() {
             assert.equal(pointsOnXAxisAlignedTileBorder(0.7, 1.0, -0.5, 1.0, tileExtent), false);
         });
     });
-    describe("#pointsAreToDiagonalTileBorder", () => {
+    describe("#pointsAreToDiagonalTileBorder", function() {
         const msg =
             "returns true if a line goes diagonally from an upper tile on the y axis to the" +
             " vertical border of the tile";
-        it(msg, () => {
+        it(msg, function() {
             assert.equal(pointsAreToDiagonalTileBorder(0.7, 1.1, 1.0, 0.9, tileExtent), true);
         });
-        it("returns false if the last point is not on the tile", () => {
+        it("returns false if the last point is not on the tile", function() {
             assert.equal(pointsAreToDiagonalTileBorder(0.7, 1.1, 0.5, 0.9, tileExtent), false);
         });
     });
-    describe("#pointsAreFromDiagonalTileBorder", () => {
+    describe("#pointsAreFromDiagonalTileBorder", function() {
         const msg =
             "returns true if a line goes diagonally from the vertical border of the tile to" +
             " next tile on the y axis";
-        it(msg, () => {
+        it(msg, function() {
             assert.equal(pointsAreFromDiagonalTileBorder(1, 0.8, 0.8, 1.2, tileExtent), true);
         });
-        it("returns false if a line moves diagonally inside the same tile", () => {
+        it("returns false if a line moves diagonally inside the same tile", function() {
             assert.equal(pointsAreFromDiagonalTileBorder(1, 0.8, 0.8, 0.9, tileExtent), false);
         });
-        it("returns false if it does not start on the tile", () => {
+        it("returns false if it does not start on the tile", function() {
             assert.equal(pointsAreFromDiagonalTileBorder(0.7, 0.8, 0.8, 1.2, tileExtent), false);
         });
     });

--- a/@here/harp-datasource-protocol/test/TileInfoTest.ts
+++ b/@here/harp-datasource-protocol/test/TileInfoTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { TileKey } from "@here/harp-geoutils";
 import { FillTechnique, LineTechnique, SquaresTechnique, Technique } from "../lib/Techniques";
 import { MapEnv } from "../lib/Theme";
@@ -18,7 +21,7 @@ import {
 
 import { assert } from "chai";
 
-describe("ExtendedTileInfo", () => {
+describe("ExtendedTileInfo", function() {
     const tileKey = new TileKey(0, 0, 0);
 
     interface RingData {
@@ -319,7 +322,7 @@ describe("ExtendedTileInfo", () => {
         checkPolygonFeatureGroup(tileInfo.polygonGroup);
     }
 
-    it("create ExtendedTileInfoWriter", () => {
+    it("create ExtendedTileInfoWriter", function() {
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
 
@@ -332,7 +335,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter#addPointInfo", () => {
+    it("ExtendedTileInfoWriter#addPointInfo", function() {
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
 
@@ -360,7 +363,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter access pointInfo", () => {
+    it("ExtendedTileInfoWriter access pointInfo", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -421,7 +424,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter access multiple pointInfo", () => {
+    it("ExtendedTileInfoWriter access multiple pointInfo", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -519,7 +522,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter store and access lineInfo", () => {
+    it("ExtendedTileInfoWriter store and access lineInfo", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -574,7 +577,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter store and access multiple lineInfos", () => {
+    it("ExtendedTileInfoWriter store and access multiple lineInfos", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -664,7 +667,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter store and access polygonInfo", () => {
+    it("ExtendedTileInfoWriter store and access polygonInfo", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -727,7 +730,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter store and access multiple polygonInfos-1", () => {
+    it("ExtendedTileInfoWriter store and access multiple polygonInfos-1", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -824,7 +827,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter store and access multiple polygonInfos-2", () => {
+    it("ExtendedTileInfoWriter store and access multiple polygonInfos-2", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -924,7 +927,7 @@ describe("ExtendedTileInfo", () => {
         checkFeatureGroups(tileInfo);
     });
 
-    it("ExtendedTileInfoWriter store and access multiple polygonInfos-3", () => {
+    it("ExtendedTileInfoWriter store and access multiple polygonInfos-3", function() {
         // Arrange
         const tileInfo = new ExtendedTileInfo(tileKey, true);
         const writer = new ExtendedTileInfoWriter(tileInfo, /*storeExtendedTags*/ true);
@@ -1114,14 +1117,14 @@ describe("ExtendedTileInfo", () => {
     //     );
     // }
 
-    // it("ExtendedTileInfoWriter measure store polygonInfos - NullTileVisitor", () => {
+    // it("ExtendedTileInfoWriter measure store polygonInfos - NullTileVisitor", function() {
     //     const tileVisitor = new NullTileHandler();
     //     createAndVisitManyPolygonInfos(tileVisitor, 1000, 10, 25);
     //     createAndVisitManyPolygonInfos(tileVisitor, 5000, 2, 200);
     //     createAndVisitManyPolygonInfos(tileVisitor, 5000, 5, 25);
     // }).timeout(0);
 
-    // it("ExtendedTileInfoWriter measure store polygonInfos - Copying TileVisitor", () => {
+    // it("ExtendedTileInfoWriter measure store polygonInfos - Copying TileVisitor", function() {
     //     const tileVisitor = new TileHandler();
     //     createAndVisitManyPolygonInfos(tileVisitor, 1000, 10, 25);
     //     createAndVisitManyPolygonInfos(tileVisitor, 5000, 2, 200);

--- a/@here/harp-debug-datasource/test/Test.ts
+++ b/@here/harp-debug-datasource/test/Test.ts
@@ -6,8 +6,11 @@
 
 import { assert } from "chai";
 
-describe("debug-datasource", () => {
-    it("ok", () => {
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+describe("debug-datasource", function() {
+    it("ok", function() {
         assert.isTrue(true);
     });
 });

--- a/@here/harp-download-manager/test/DownloadManagerTest.ts
+++ b/@here/harp-download-manager/test/DownloadManagerTest.ts
@@ -6,13 +6,14 @@
 
 // tslint:disable:completed-docs
 // tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import "@here/harp-fetch";
 import { assert } from "chai";
 import * as sinon from "sinon";
 import { DownloadManager } from "../index";
 
-describe("DownloadManager", () => {
+describe("DownloadManager", function() {
     const fakeDataUrl = `https://download.example.url`;
 
     function createMockDownloadResponse() {
@@ -29,7 +30,7 @@ describe("DownloadManager", () => {
         return mock;
     }
 
-    it("#downloadJson handles successful download response", async () => {
+    it("#downloadJson handles successful download response", async function() {
         // Arrange
         const mock = createMockDownloadResponse();
         mock.json.resolves({ version: "4" });
@@ -45,7 +46,7 @@ describe("DownloadManager", () => {
         assert.deepEqual(response, { version: "4" });
     });
 
-    it("#downloadJson handles HTTP 404 status response", async () => {
+    it("#downloadJson handles HTTP 404 status response", async function() {
         // Arrange
         const mock = createMockDownloadResponse();
         mock.status = 404;
@@ -72,7 +73,7 @@ describe("DownloadManager", () => {
         assert.deepEqual(data, { version: "4" });
     });
 
-    it("#instance handles returning same single static instance correctly", async () => {
+    it("#instance handles returning same single static instance correctly", async function() {
         const downloadMgr1 = DownloadManager.instance();
         const downloadMgr2 = DownloadManager.instance();
 
@@ -83,7 +84,7 @@ describe("DownloadManager", () => {
      * Note, DownloadManager limits the number of html headers sent to MAX_PARALLEL_DOWNLOADS, but
      * will allow more then MAX_PARALLEL_DOWNLOADS of parallel download under the hood.
      */
-    it("#downloadJson performs download with maxParallelDownloads exceeded", async () => {
+    it("#downloadJson performs download with maxParallelDownloads exceeded", async function() {
         // Arrange
         const MAX_PARALLEL_DOWNLOADS = 16;
         const CALLS_NUMBER = 32;

--- a/@here/harp-geojson-datasource/test/GeoJsonTest.ts
+++ b/@here/harp-geojson-datasource/test/GeoJsonTest.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { Flattener } from "./../lib/utils/Flattener";
 
-describe("FlatCopier", () => {
-    it("flattens JSON-like objects", () => {
+describe("FlatCopier", function() {
+    it("flattens JSON-like objects", function() {
         const jsonLike = {
             number: 0,
             boolean: false,

--- a/@here/harp-geoutils/test/GeoCoordinatesTest.ts
+++ b/@here/harp-geoutils/test/GeoCoordinatesTest.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 
-describe("GeoCoordinates", () => {
+describe("GeoCoordinates", function() {
     const tests = [
         { args: [90, 180], expected: [90, 180] },
         { args: [-90, -180], expected: [-90, -180] },
@@ -26,7 +29,7 @@ describe("GeoCoordinates", () => {
         { args: [361, 123, 50], expected: [1, 123, 50] }
     ];
 
-    tests.forEach(test => {
+    tests.forEach(function(test) {
         it(
             "normalized GeoCoordinates { " +
                 test.args[0] +
@@ -35,7 +38,7 @@ describe("GeoCoordinates", () => {
                 ", " +
                 test.args[2] +
                 " }",
-            () => {
+            function() {
                 const normalized = new GeoCoordinates(
                     test.args[0],
                     test.args[1],

--- a/@here/harp-geoutils/test/MathUtilsTest.ts
+++ b/@here/harp-geoutils/test/MathUtilsTest.ts
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
 import { MathUtils } from "../lib/math/MathUtils";
 
 const epsilon = 0.000001;
 
-describe("MathUtils", () => {
-    it("angleDistanceDeg", () => {
+describe("MathUtils", function() {
+    it("angleDistanceDeg", function() {
         assert.approximately(MathUtils.angleDistanceDeg(90, 0), 90, epsilon);
         assert.approximately(MathUtils.angleDistanceDeg(0, -90), 90, epsilon);
         assert.approximately(MathUtils.angleDistanceDeg(0, 180), 180, epsilon);
@@ -21,7 +24,7 @@ describe("MathUtils", () => {
         assert.approximately(MathUtils.angleDistanceDeg(359, 1), -2, epsilon);
     });
 
-    it("interpolateAnglesRad basics", () => {
+    it("interpolateAnglesRad basics", function() {
         assert.approximately(MathUtils.interpolateAnglesDeg(0, 90, 0), 0, epsilon);
         assert.approximately(MathUtils.interpolateAnglesDeg(0, 180, 0), 0, epsilon);
         assert.approximately(MathUtils.interpolateAnglesDeg(0, 360, 0), 0, epsilon);
@@ -40,7 +43,7 @@ describe("MathUtils", () => {
         assert.approximately(MathUtils.interpolateAnglesDeg(0, -90, 0.5), -45, epsilon);
     });
 
-    it("interpolateAnglesRad corner cases", () => {
+    it("interpolateAnglesRad corner cases", function() {
         assert.approximately(MathUtils.interpolateAnglesDeg(-1, 1, 0.5), 0, epsilon);
         assert.approximately(MathUtils.interpolateAnglesDeg(-90, 90, 0.5), 0, epsilon);
         assert.approximately(MathUtils.interpolateAnglesDeg(-91, 91, 0.5), -180, epsilon);

--- a/@here/harp-geoutils/test/TileKeyTest.ts
+++ b/@here/harp-geoutils/test/TileKeyTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { GeoBox } from "../lib/coordinates/GeoBox";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
@@ -12,15 +15,15 @@ import { TileKey } from "../lib/tiling/TileKey";
 import { TileKeyUtils } from "../lib/tiling/TileKeyUtils";
 import { webMercatorTilingScheme } from "../lib/tiling/WebMercatorTilingScheme";
 
-describe("TileKey", () => {
-    it("toHereTile", () => {
+describe("TileKey", function() {
+    it("toHereTile", function() {
         assert.strictEqual(TileKey.fromRowColumnLevel(0, 0, 0).toHereTile(), "1");
         assert.strictEqual(TileKey.fromRowColumnLevel(1, 1, 1).toHereTile(), "7");
         assert.strictEqual(TileKey.fromRowColumnLevel(3, 5, 3).toHereTile(), "91");
         assert.strictEqual(TileKey.fromRowColumnLevel(25920, 35136, 16).toHereTile(), "6046298112");
     });
 
-    it("fromHereTile", () => {
+    it("fromHereTile", function() {
         assert.isTrue(TileKey.fromHereTile("1").equals(TileKey.fromRowColumnLevel(0, 0, 0)));
         assert.isTrue(TileKey.fromHereTile("7").equals(TileKey.fromRowColumnLevel(1, 1, 1)));
         assert.isTrue(TileKey.fromHereTile("91").equals(TileKey.fromRowColumnLevel(3, 5, 3)));
@@ -29,13 +32,13 @@ describe("TileKey", () => {
         );
     });
 
-    it("fromHereTileCached", () => {
+    it("fromHereTileCached", function() {
         const tileKey = TileKey.fromHereTile("377894432");
         assert.strictEqual(tileKey.toHereTile(), "377894432");
         assert.strictEqual(tileKey.mortonCode(), 377894432);
     });
 
-    it("largeNumberDivision", () => {
+    it("largeNumberDivision", function() {
         // make sure that dividing by a large number by 2 actually produces correct results
         let x = Math.pow(2, 52);
         for (let i = 51; i > 0; --i) {
@@ -44,14 +47,14 @@ describe("TileKey", () => {
         }
     });
 
-    it("getSubHereTile", () => {
+    it("getSubHereTile", function() {
         assert.strictEqual("4", TileKey.fromRowColumnLevel(2, 2, 2).getSubHereTile(1));
         assert.strictEqual("5", TileKey.fromRowColumnLevel(2, 3, 2).getSubHereTile(1));
         assert.strictEqual("6", TileKey.fromRowColumnLevel(3, 2, 2).getSubHereTile(1));
         assert.strictEqual("7", TileKey.fromRowColumnLevel(3, 3, 2).getSubHereTile(1));
     });
 
-    it("addedSubHereTile", () => {
+    it("addedSubHereTile", function() {
         assert.isTrue(
             TileKey.fromRowColumnLevel(1, 1, 1)
                 .addedSubHereTile("1")
@@ -81,8 +84,8 @@ describe("TileKey", () => {
     });
 });
 
-describe("WebMercator", () => {
-    it("getTileKey", () => {
+describe("WebMercator", function() {
+    it("getTileKey", function() {
         const coords = new GeoCoordinates(52.504951, 13.371806);
 
         const tileKey = webMercatorTilingScheme.getTileKey(coords, 14) as TileKey;
@@ -91,7 +94,7 @@ describe("WebMercator", () => {
         assert.strictEqual(tileKey.column, 8800);
     });
 
-    it("project", () => {
+    it("project", function() {
         const coords = new GeoCoordinates(52.504951, 13.371806);
         const projected = webMercatorProjection.projectPoint(coords);
         const unprojected = webMercatorProjection.unprojectPoint(projected);
@@ -100,7 +103,7 @@ describe("WebMercator", () => {
         assert.approximately(coords.longitudeInRadians, unprojected.longitudeInRadians, 0.0001);
     });
 
-    it("projectBox", () => {
+    it("projectBox", function() {
         const tileKey = TileKey.fromRowColumnLevel(0, 0, 0);
         const box = webMercatorTilingScheme.getGeoBox(tileKey);
         const projectedBox = webMercatorProjection.projectBox(box);
@@ -128,7 +131,7 @@ describe("WebMercator", () => {
         );
     });
 
-    it("geoRect", () => {
+    it("geoRect", function() {
         const northParis = new GeoCoordinates(49.097766, 2.333063);
         const prague = new GeoCoordinates(50.092733, 14.41723);
 
@@ -143,7 +146,7 @@ describe("WebMercator", () => {
         ]);
     });
 
-    it("geoBox", () => {
+    it("geoBox", function() {
         const tileKey = TileKey.fromRowColumnLevel(0, 0, 0);
         const rect = webMercatorTilingScheme.getGeoBox(tileKey);
         assert.isTrue(rect.southWest.latitudeInRadians < rect.northEast.latitudeInRadians);
@@ -151,8 +154,8 @@ describe("WebMercator", () => {
     });
 });
 
-describe("TileKeyUtils", () => {
-    it("geoRectangleToTileKeys", () => {
+describe("TileKeyUtils", function() {
+    it("geoRectangleToTileKeys", function() {
         const geoBox = new GeoBox(
             new GeoCoordinates(52.5163, 13.3777), // Brandenburg gate
             new GeoCoordinates(52.5309, 13.385) // HERE office

--- a/@here/harp-lines/test/Test.ts
+++ b/@here/harp-lines/test/Test.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
-describe("lines", () => {
-    it("ok", () => {
+describe("lines", function() {
+    it("ok", function() {
         assert.isTrue(true);
     });
 });

--- a/@here/harp-lrucache/test/LRUCacheTest.ts
+++ b/@here/harp-lrucache/test/LRUCacheTest.ts
@@ -9,6 +9,7 @@ import { Entry, LRUCache } from "../lib/LRUCache";
 
 // tslint:disable:no-string-literal
 // tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 // helper class to access protected members of LRUCache
 class TestLRUCache<Key, Value> extends LRUCache<Key, Value> {

--- a/@here/harp-map-controls/test/MapControlsTest.ts
+++ b/@here/harp-map-controls/test/MapControlsTest.ts
@@ -4,23 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { MapView } from "@here/harp-mapview";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { MapControls } from "../lib/MapControls";
 
-describe("MapControls", () => {
+describe("MapControls", function() {
     let sandbox: sinon.SinonSandbox;
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox();
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    describe("on object creation", () => {
+    describe("on object creation", function() {
         let addEventListener: () => {};
         let mapView: MapView;
         let mapControls: MapControls;
@@ -30,7 +33,7 @@ describe("MapControls", () => {
         let minZoom: number;
         let minCameraHeight: number;
 
-        beforeEach(() => {
+        beforeEach(function() {
             addEventListener = sandbox.stub();
             camera = {} as any;
             domElement = { addEventListener } as any;
@@ -48,28 +51,28 @@ describe("MapControls", () => {
             mapControls = new MapControls(mapView);
         });
 
-        it("initializes camera property using value from constructor param", () => {
+        it("initializes camera property using value from constructor param", function() {
             expect(mapControls.camera).to.be.equals(camera);
         });
 
-        it("initializes domElement property using value from constructor param", () => {
+        it("initializes domElement property using value from constructor param", function() {
             expect(mapControls.domElement).to.be.equals(domElement);
         });
 
-        it("initializes minZoomLevel property using value from constructor param", () => {
+        it("initializes minZoomLevel property using value from constructor param", function() {
             expect(mapControls.minZoomLevel).to.be.equals(minZoom);
         });
 
-        it("initializes maxZoomLevel property using value from constructor param", () => {
+        it("initializes maxZoomLevel property using value from constructor param", function() {
             expect(mapControls.maxZoomLevel).to.be.equals(maxZoom);
         });
 
-        it("initializes minCameraHeight property using value from constructor param", () => {
+        it("initializes minCameraHeight property using value from constructor param", function() {
             expect(mapControls.minCameraHeight).to.be.equals(minCameraHeight);
         });
     });
 
-    it("correctly updates mapView on mouse move", () => {
+    it("correctly updates mapView on mouse move", function() {
         const updateStub = sandbox.stub();
         //@ts-ignore
         const mapControls = new MapControls({
@@ -83,7 +86,7 @@ describe("MapControls", () => {
         expect(updateStub.callCount).to.be.equal(1);
     });
 
-    it("correctly updates mapView on touch move", () => {
+    it("correctly updates mapView on touch move", function() {
         const updateStub = sandbox.stub();
         //@ts-ignore
         const mapControls = new MapControls({

--- a/@here/harp-map-controls/test/UtilsTest.ts
+++ b/@here/harp-map-controls/test/UtilsTest.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { safeParseDecimalInt } from "../lib/Utils";
 
-describe("MapControls", () => {
-    describe("Utils", () => {
-        it("safeParseDecimalInt", () => {
+describe("MapControls", function() {
+    describe("Utils", function() {
+        it("safeParseDecimalInt", function() {
             assert.equal(safeParseDecimalInt("0", 1), 0);
             assert.equal(safeParseDecimalInt("123456789", 666), 123456789);
 

--- a/@here/harp-map-theme/test/DefaultThemeTest.ts
+++ b/@here/harp-map-theme/test/DefaultThemeTest.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
-describe("DefaultTheme", () => {
-    it("ok", () => {
+describe("DefaultTheme", function() {
+    it("ok", function() {
         assert.isTrue(true);
     });
 });

--- a/@here/harp-mapview-decoder/test/MapViewDecoderTest.ts
+++ b/@here/harp-mapview-decoder/test/MapViewDecoderTest.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-describe("MapViewDecoder", () => {
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+describe("MapViewDecoder", function() {
     // tslint:disable-next-line:no-empty
-    it("isOk", () => {});
+    it("isOk", function() {});
 });

--- a/@here/harp-mapview-decoder/test/TileDataSourceTest.ts
+++ b/@here/harp-mapview-decoder/test/TileDataSourceTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { DecodedTile, Geometry, ITileDecoder, TileInfo } from "@here/harp-datasource-protocol";
 import "@here/harp-fetch";
 import {
@@ -80,8 +83,8 @@ function createMockMapView() {
     } as any) as MapView;
 }
 
-describe("TileDataSource", () => {
-    it("#dispose cascades to decoder", () => {
+describe("TileDataSource", function() {
+    it("#dispose cascades to decoder", function() {
         const decoder = createMockTileDecoder();
         const testedDataSource = new TileDataSource(new TileFactory(Tile), {
             styleSetName: "",
@@ -94,7 +97,7 @@ describe("TileDataSource", () => {
         testedDataSource.dispose();
         assert.equal(decoder.dispose.callCount, 1);
     });
-    it("uses tileFactory to construct tiles with custom type", () => {
+    it("uses tileFactory to construct tiles with custom type", function() {
         class CustomTile extends Tile {
             constructor(dataSource: DataSource, tileKey: TileKey) {
                 super(dataSource, tileKey);
@@ -114,7 +117,7 @@ describe("TileDataSource", () => {
         assert(mockTile instanceof CustomTile);
     });
 
-    it("#updateTile: tile disposing cancels load, skips decode and tile update", async () => {
+    it("#updateTile: tile disposing cancels load, skips decode and tile update", async function() {
         const mockDataProvider = createMockDataProvider();
 
         const abortController = new AbortController();
@@ -165,7 +168,7 @@ describe("TileDataSource", () => {
         assert.equal(spyTileSetDecodedTile.callCount, 0);
     });
 
-    it("subsequent, overlapping #updateTile calls load & decode tile once", async () => {
+    it("subsequent, overlapping #updateTile calls load & decode tile once", async function() {
         const mockDataProvider = createMockDataProvider();
         const mockDecoder = createMockTileDecoder();
 
@@ -198,7 +201,7 @@ describe("TileDataSource", () => {
         assert(spyTileSetDecodedTile.calledWith(fakeEmptyGeometry));
     });
 
-    it("Empty decoded tiles are ignored", async () => {
+    it("Empty decoded tiles are ignored", async function() {
         const mockDataProvider = createMockDataProvider();
         const mockDecoder = createMockTileDecoder();
 

--- a/@here/harp-mapview/test/ColorCacheTest.ts
+++ b/@here/harp-mapview/test/ColorCacheTest.ts
@@ -4,16 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
 import { ColorCache } from "../lib/ColorCache";
 
-describe("ColorCache", () => {
-    it("empty", () => {
+describe("ColorCache", function() {
+    it("empty", function() {
         assert.equal(ColorCache.instance.size, 0);
     });
 
-    it("get", () => {
+    it("get", function() {
         const white = ColorCache.instance.getColor("#ffffff");
         const black = ColorCache.instance.getColor("#000000");
 
@@ -31,7 +34,7 @@ describe("ColorCache", () => {
         assert.equal(black.b, 0.0);
     });
 
-    it("clear", () => {
+    it("clear", function() {
         const white = ColorCache.instance.getColor("#ffffff");
         const black = ColorCache.instance.getColor("#000000");
 

--- a/@here/harp-mapview/test/ConcurrentWorkerSetTest.ts
+++ b/@here/harp-mapview/test/ConcurrentWorkerSetTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import * as sinon from "sinon";
 
@@ -39,9 +42,9 @@ const sampleRequest: DecodeTileRequest = {
     projection: "bar"
 };
 
-describe("ConcurrentWorkerSet", () => {
+describe("ConcurrentWorkerSet", function() {
     let sandbox: sinon.SinonSandbox;
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox();
         if (typeof window === "undefined") {
             // fake Worker constructor for node environment
@@ -49,14 +52,14 @@ describe("ConcurrentWorkerSet", () => {
         }
     });
 
-    afterEach(() => {
+    afterEach(function() {
         if (typeof window === "undefined") {
             delete global.Worker;
         }
         sandbox.restore();
     });
 
-    it("The constructor creates a defined set of workers.", async () => {
+    it("The constructor creates a defined set of workers.", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
 
@@ -78,7 +81,7 @@ describe("ConcurrentWorkerSet", () => {
         assert(workerConstructorStub.alwaysCalledWith("./foo.js"));
     });
 
-    it("#add/removeReference: terminates workers when reference counts reaches 0", async () => {
+    it("#add/removeReference: terminates workers when reference counts == 0", async function() {
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
 
         willExecuteWorkerScript(workerConstructorStub, self => {
@@ -104,7 +107,7 @@ describe("ConcurrentWorkerSet", () => {
         });
     });
 
-    it("#stop terminates all workers", async () => {
+    it("#stop terminates all workers", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
         willExecuteWorkerScript(workerConstructorStub, self => {
@@ -143,7 +146,7 @@ describe("ConcurrentWorkerSet", () => {
         assert.equal(workerConstructorStub.prototype.postMessage.callCount, 0);
     });
 
-    it("#destroy immediately terminates all workers", async () => {
+    it("#destroy immediately terminates all workers", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
         willExecuteWorkerScript(workerConstructorStub, self => {
@@ -181,7 +184,7 @@ describe("ConcurrentWorkerSet", () => {
         assert.equal(workerConstructorStub.prototype.postMessage.callCount, 0);
     });
 
-    it("#postMessage sends message to one random worker", async () => {
+    it("#postMessage sends message to one random worker", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
         willExecuteWorkerScript(workerConstructorStub, self => {
@@ -204,7 +207,7 @@ describe("ConcurrentWorkerSet", () => {
         });
     });
 
-    it("#broadcastMessage sends message to all workers", async () => {
+    it("#broadcastMessage sends message to all workers", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
         willExecuteWorkerScript(workerConstructorStub, self => {
@@ -227,7 +230,7 @@ describe("ConcurrentWorkerSet", () => {
         });
     });
 
-    it("#invokeRequest basic scenario", async () => {
+    it("#invokeRequest basic scenario", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
 
@@ -291,7 +294,7 @@ describe("ConcurrentWorkerSet", () => {
         assert.equal(workerConstructorStub.prototype.postMessage.callCount, 10);
     });
 
-    it("#invokeRequest error scenario", async () => {
+    it("#invokeRequest error scenario", async function() {
         // Arrange
         const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
 
@@ -344,8 +347,8 @@ describe("ConcurrentWorkerSet", () => {
         assert.equal(workerConstructorStub.prototype.postMessage.callCount, 10);
     });
 
-    describe("log forwarding", () => {
-        it("The worker set recognizes the logging message.", () => {
+    describe("log forwarding", function() {
+        it("The worker set recognizes the logging message.", function() {
             assert.isTrue(
                 isLoggingMessage({
                     message: [`myLogger:`, "foo", "bar"],
@@ -355,7 +358,7 @@ describe("ConcurrentWorkerSet", () => {
             );
         });
 
-        it("The messages from the workers are logged.", async () => {
+        it("The messages from the workers are logged.", async function() {
             const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
 
             willExecuteWorkerScript(workerConstructorStub, self => {

--- a/@here/harp-mapview/test/DebugContextTest.ts
+++ b/@here/harp-mapview/test/DebugContextTest.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { debugContext } from "../lib/DebugContext";
 
 import { assert } from "chai";
 
-describe("debug-context", () => {
-    it("ok", () => {
+describe("debug-context", function() {
+    it("ok", function() {
         assert.isTrue(true);
 
         assert.isTrue(typeof debugContext === "object");

--- a/@here/harp-mapview/test/ImageCacheTest.ts
+++ b/@here/harp-mapview/test/ImageCacheTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
 import { ImageCache } from "../lib/image/ImageCache";
@@ -17,18 +20,18 @@ class ImageData {
     }
 }
 
-describe("MapViewImageCache", () => {
+describe("MapViewImageCache", function() {
     // tslint:disable-next-line:no-object-literal-type-assertion
     const mapView: MapView = {} as MapView;
 
-    it("#empty", () => {
+    it("#empty", function() {
         const cache = new MapViewImageCache(mapView);
         assert.equal(cache.numberOfNames, 0);
         assert.equal(cache.numberOfUrls, 0);
         assert.notExists(cache.findNames("xxx"));
     });
 
-    it("#registerImage", () => {
+    it("#registerImage", function() {
         const cache = new MapViewImageCache(mapView);
 
         const imageData = new ImageData(16, 16);
@@ -88,7 +91,7 @@ describe("MapViewImageCache", () => {
         });
     }
 
-    it("#clear", () => {
+    it("#clear", function() {
         const cache = new MapViewImageCache(mapView);
 
         const imageData = new ImageData(16, 16);
@@ -102,7 +105,7 @@ describe("MapViewImageCache", () => {
         assert.equal(cache.numberOfNames, 0);
     });
 
-    it("#add images", () => {
+    it("#add images", function() {
         const cache = new MapViewImageCache(mapView);
 
         const imageData1 = new ImageData(16, 16);
@@ -132,7 +135,7 @@ describe("MapViewImageCache", () => {
         assert.isTrue(cache.hasUrl("httpx://naxos.de-2"));
     });
 
-    it("#add images with same url but differing names", () => {
+    it("#add images with same url but differing names", function() {
         const cache = new MapViewImageCache(mapView);
 
         const imageData1 = new ImageData(16, 16);
@@ -157,7 +160,7 @@ describe("MapViewImageCache", () => {
         assert.deepEqual(cache.findNames("httpx://naxos.de"), ["testImage1", "testImage2"]);
     });
 
-    it("#add images with same name but differing urls", () => {
+    it("#add images with same name but differing urls", function() {
         const cache = new MapViewImageCache(mapView);
         assert.throws(() => {
             cache.registerImage("testImage", "httpx://naxos.de", undefined);
@@ -166,8 +169,8 @@ describe("MapViewImageCache", () => {
     });
 });
 
-describe("ImageCache", () => {
-    it("#instance", () => {
+describe("ImageCache", function() {
+    it("#instance", function() {
         const instance = ImageCache.instance;
         const instance2 = ImageCache.instance;
         assert.exists(instance);
@@ -175,14 +178,14 @@ describe("ImageCache", () => {
         instance.clearAll();
     });
 
-    it("#empty", () => {
+    it("#empty", function() {
         const instance = ImageCache.instance;
         assert.equal(instance.size, 0);
         const found = instance.findImage("xxx");
         assert.notExists(found);
     });
 
-    it("#registerImage", () => {
+    it("#registerImage", function() {
         // tslint:disable-next-line:no-object-literal-type-assertion
         const mapView: MapView = {} as MapView;
         const instance = ImageCache.instance;
@@ -241,7 +244,7 @@ describe("ImageCache", () => {
         });
     }
 
-    it("#clearAll", () => {
+    it("#clearAll", function() {
         // tslint:disable-next-line:no-object-literal-type-assertion
         const mapView: MapView = {} as MapView;
         const instance = ImageCache.instance;
@@ -254,7 +257,7 @@ describe("ImageCache", () => {
         assert.notExists(instance.findImage("testImage"));
     });
 
-    it("#dispose", () => {
+    it("#dispose", function() {
         // tslint:disable-next-line:no-object-literal-type-assertion
         const mapView: MapView = {} as MapView;
         const instance = ImageCache.instance;
@@ -266,7 +269,7 @@ describe("ImageCache", () => {
         assert.equal(ImageCache.instance.size, 0);
     });
 
-    it("#register same image in multiple MapViews", () => {
+    it("#register same image in multiple MapViews", function() {
         const instance = ImageCache.instance;
         instance.clearAll();
 
@@ -288,7 +291,7 @@ describe("ImageCache", () => {
         assert.equal(imageData1, testImage!.imageData);
     });
 
-    it("#register different images in multiple MapViews", () => {
+    it("#register different images in multiple MapViews", function() {
         const instance = ImageCache.instance;
         instance.clearAll();
 
@@ -314,7 +317,7 @@ describe("ImageCache", () => {
         assert.equal(imageData2, testImage2!.imageData);
     });
 
-    it("#clear images in multiple MapViews", () => {
+    it("#clear images in multiple MapViews", function() {
         const instance = ImageCache.instance;
         instance.clearAll();
 

--- a/@here/harp-mapview/test/MapViewFogTest.ts
+++ b/@here/harp-mapview/test/MapViewFogTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
 import { Theme } from "@here/harp-datasource-protocol";
@@ -11,8 +14,8 @@ import { SolidLineMaterial } from "@here/harp-materials";
 import { BoxGeometry, Fog, Mesh, Scene } from "three";
 import { MapViewFog } from "../lib/MapViewFog";
 
-describe("MapViewFog", () => {
-    it("adds fog if defined in the provided theme", () => {
+describe("MapViewFog", function() {
+    it("adds fog if defined in the provided theme", function() {
         const theme: Theme = {
             sky: { colorBottom: "#ffff12", colorTop: "", groundColor: "", type: "" },
             fog: { startRatio: 0.8 }
@@ -26,7 +29,7 @@ describe("MapViewFog", () => {
         assert.equal((scene.fog as Fog).color.getHexString(), "ffff12");
     });
 
-    it("handles fog disabling via MapViewFog#enabled", () => {
+    it("handles fog disabling via MapViewFog#enabled", function() {
         const theme: Theme = {
             sky: { colorBottom: "#ffff12", colorTop: "", groundColor: "", type: "" },
             fog: { startRatio: 0.8 }
@@ -39,7 +42,7 @@ describe("MapViewFog", () => {
         assert.equal(scene.fog, null);
     });
 
-    it("handles fog disabling if not defined in the provided theme", () => {
+    it("handles fog disabling if not defined in the provided theme", function() {
         const theme: Theme = {}; // Theme with no fog definition.
         const scene = new Scene();
         scene.fog = new Fog(0x000000); // Scene with fog.
@@ -49,7 +52,7 @@ describe("MapViewFog", () => {
         assert.equal(scene.fog, null); // Fog should be removed.
     });
 
-    it("handles RawShaderMaterial fog", () => {
+    it("handles RawShaderMaterial fog", function() {
         const scene = new Scene();
         const box = new Mesh(new BoxGeometry(1, 1, 1), new SolidLineMaterial());
         scene.fog = new Fog(0x000000);

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -10,6 +10,9 @@
 // tslint:disable:no-empty
 //    lots of stubs are needed which are just placeholders and are empty
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
@@ -24,7 +27,7 @@ import { FakeOmvDataSource } from "./FakeOmvDataSource";
 
 declare const global: any;
 
-describe("MapView", () => {
+describe("MapView", function() {
     const inNodeContext = typeof window === "undefined";
     let sandbox: sinon.SinonSandbox;
     let clearColorStub: sinon.SinonStub;
@@ -34,7 +37,7 @@ describe("MapView", () => {
     let fontStub: sinon.SinonStub;
     let mapView: MapView;
 
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox();
         clearColorStub = sandbox.stub();
         webGlStub = sandbox.stub(THREE, "WebGLRenderer").returns({
@@ -55,7 +58,7 @@ describe("MapView", () => {
         }
     });
 
-    afterEach(() => {
+    afterEach(function() {
         if (mapView !== undefined) {
             mapView.dispose();
         }
@@ -67,7 +70,7 @@ describe("MapView", () => {
         }
     });
 
-    it("Correctly sets geolocation and zoom", () => {
+    it("Correctly sets geolocation and zoom", function() {
         let coords: GeoCoordinates;
         let postionSpy: sinon.SinonSpy;
         let rotationSpy: sinon.SinonSpy;
@@ -104,7 +107,7 @@ describe("MapView", () => {
         expect(mapView.geoCenter.longitude).to.be.closeTo(coords.longitude, 0.000000000001);
     });
 
-    it("Correctly sets event listeners and handlers webgl context restored", () => {
+    it("Correctly sets event listeners and handlers webgl context restored", function() {
         const canvas = {
             width: 0,
             height: 0,
@@ -153,7 +156,7 @@ describe("MapView", () => {
         expect(dispatchEventSpy.getCall(2).args[0].type).to.be.equal(MapViewEventNames.ContextLost);
     });
 
-    it("Correctly sets and removes event listeners by API", () => {
+    it("Correctly sets and removes event listeners by API", function() {
         const restoreStub = sinon.stub();
         const lostStub = sinon.stub();
 
@@ -174,7 +177,7 @@ describe("MapView", () => {
         expect(lostStub.callCount).to.be.equal(1);
     });
 
-    it("supports #dispose", async () => {
+    it("supports #dispose", async function() {
         const canvas = {
             width: 0,
             height: 0,
@@ -195,7 +198,7 @@ describe("MapView", () => {
         mapView = undefined!;
     });
 
-    it("maintains vertical fov limit", () => {
+    it("maintains vertical fov limit", function() {
         const canvas = {
             width: 100,
             height: 1000,
@@ -208,7 +211,7 @@ describe("MapView", () => {
         expect(mapView.fov).to.be.closeTo(82.36449238608574, 0.00000000001);
     });
 
-    it("maintains horizontal fov limit", () => {
+    it("maintains horizontal fov limit", function() {
         const canvas = {
             width: 1000,
             height: 100,
@@ -221,7 +224,7 @@ describe("MapView", () => {
         expect(mapView.fov).to.be.closeTo(30.725626488233594, 0.00000000001);
     });
 
-    it("returns the fog through #fog getter", () => {
+    it("returns the fog through #fog getter", function() {
         const canvas = {
             width: 0,
             height: 0,

--- a/@here/harp-mapview/test/ScreenCollisionsTest.ts
+++ b/@here/harp-mapview/test/ScreenCollisionsTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { Math2D } from "@here/harp-utils";
 
 import { ScreenCollisions } from "../lib/ScreenCollisions";
@@ -21,8 +24,8 @@ function toBox2D(bounds: THREE.Box2): Math2D.Box {
     return tempGlyphBox2D;
 }
 
-describe("ScreenCollisions", () => {
-    it("properlys handle collision in test space", () => {
+describe("ScreenCollisions", function() {
+    it("properlys handle collision in test space", function() {
         const sc = new ScreenCollisions();
         sc.update(1608, 822);
 

--- a/@here/harp-mapview/test/SkyGradientTextureTest.ts
+++ b/@here/harp-mapview/test/SkyGradientTextureTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { Color, DataTexture } from "three";
 import {
@@ -39,9 +42,9 @@ function getSample(
     return sample;
 }
 
-describe("SkyGradientTexture", () => {
-    describe("SkyGradientTexture()", () => {
-        it("generates a texture and has a topColor and an bottomColor", () => {
+describe("SkyGradientTexture", function() {
+    describe("SkyGradientTexture()", function() {
+        it("generates a texture and has a topColor and an bottomColor", function() {
             const grad = new SkyGradientTexture(
                 new Color("#FF0000"),
                 new Color("#0000FF"),
@@ -63,7 +66,7 @@ describe("SkyGradientTexture", () => {
             assert.instanceOf(grad.texture, DataTexture, "is an instance of DataTexture");
         });
 
-        it("generates an interpolated texture", () => {
+        it("generates an interpolated texture", function() {
             const grad = new SkyGradientTexture(
                 new Color("#FF0000"),
                 new Color("#0000FF"),
@@ -81,7 +84,7 @@ describe("SkyGradientTexture", () => {
             assert.instanceOf(grad.texture, DataTexture, "is an instance of DataTexture");
         });
 
-        it("generates a texture with a given height", () => {
+        it("generates a texture with a given height", function() {
             const grad = new SkyGradientTexture(
                 new Color("#FF0000"),
                 new Color("#0000FF"),
@@ -108,8 +111,8 @@ describe("SkyGradientTexture", () => {
         });
     });
 
-    describe("update()", () => {
-        it("it updates the gradient with the given colors", () => {
+    describe("update()", function() {
+        it("it updates the gradient with the given colors", function() {
             const grad = new SkyGradientTexture(
                 new Color("#FFF000"),
                 new Color("#00F0FF"),
@@ -135,8 +138,8 @@ describe("SkyGradientTexture", () => {
         });
     });
 
-    describe("updateYOffset()", () => {
-        it("it updates the texture y-offset", () => {
+    describe("updateYOffset()", function() {
+        it("it updates the texture y-offset", function() {
             const grad = new SkyGradientTexture(
                 new Color("#FFF000"),
                 new Color("#00F0FF"),

--- a/@here/harp-mapview/test/StatisticsTest.ts
+++ b/@here/harp-mapview/test/StatisticsTest.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { MultiStageTimer, RingBuffer, SampledTimer, Statistics } from "../lib/Statistics";
 
-describe("mapview-statistics", () => {
-    it("Ringbuffer", () => {
+describe("mapview-statistics", function() {
+    it("Ringbuffer", function() {
         const rb = new RingBuffer<number>(10);
 
         assert.equal(rb.size, 0);
@@ -68,7 +71,7 @@ describe("mapview-statistics", () => {
         });
     });
 
-    it("init", () => {
+    it("init", function() {
         const stats = new Statistics();
         assert.isFalse(stats.enabled);
 
@@ -76,7 +79,7 @@ describe("mapview-statistics", () => {
         assert.isTrue(stats.enabled);
     });
 
-    it("createTimer", () => {
+    it("createTimer", function() {
         const stats = new Statistics();
 
         const startTimer = stats.createTimer("run");

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { GeoCoordinates, MathUtils, mercatorProjection } from "@here/harp-geoutils";
 import { expect } from "chai";
 import * as THREE from "three";
 import { MapView } from "../lib/MapView";
 import { MapViewUtils } from "../lib/Utils";
 
-describe("map-view#Utils", () => {
-    it("calculates zoom level", () => {
+describe("map-view#Utils", function() {
+    it("calculates zoom level", function() {
         const mapViewMock = {
             maxZoomLevel: 20,
             minZoomLevel: 1,
@@ -37,7 +40,7 @@ describe("map-view#Utils", () => {
         expect(result).to.be.closeTo(5.82, 0.05);
     });
 
-    it("converts target coordinates from XYZ to camera coordinates", () => {
+    it("converts target coordinates from XYZ to camera coordinates", function() {
         const xyzView = {
             zoom: 5,
             yaw: 3,
@@ -63,11 +66,11 @@ describe("map-view#Utils", () => {
         expect(cameraCoordinates.longitude).to.equal(-9.783274868705762);
     });
 
-    describe("converts zoom level to height and height to zoom level", () => {
+    describe("converts zoom level to height and height to zoom level", function() {
         const height = 1000;
         let mapViewMock: any;
 
-        beforeEach(() => {
+        beforeEach(function() {
             mapViewMock = {
                 maxZoomLevel: 20,
                 minZoomLevel: 1,
@@ -76,7 +79,7 @@ describe("map-view#Utils", () => {
             };
         });
 
-        it("ensures that both functions are inverse", () => {
+        it("ensures that both functions are inverse", function() {
             const zoomLevel = MapViewUtils.calculateZoomLevelFromHeight(height, { ...mapViewMock });
             const calculatedHeight = MapViewUtils.calculateDistanceToGroundFromZoomLevel(
                 mapViewMock,
@@ -86,7 +89,7 @@ describe("map-view#Utils", () => {
             expect(height).to.be.closeTo(calculatedHeight, Math.pow(10, -11));
         });
 
-        it("respect zoomLevelBias property", () => {
+        it("respect zoomLevelBias property", function() {
             const biasFactor = 4;
             mapViewMock.zoomLevelBias = 1;
             const heightNonBiased = MapViewUtils.calculateDistanceToGroundFromZoomLevel(
@@ -103,7 +106,7 @@ describe("map-view#Utils", () => {
         });
     });
 
-    it("calculates horizontal and vertical fov", () => {
+    it("calculates horizontal and vertical fov", function() {
         const vFov = 60;
         const hFov = MathUtils.radToDeg(
             MapViewUtils.calculateHorizontalFovByVerticalFov(MathUtils.degToRad(vFov), 0.9)
@@ -114,7 +117,7 @@ describe("map-view#Utils", () => {
         expect(vFov).to.be.closeTo(calculatedVFov, 0.00000000001);
     });
 
-    it("calculates memory usage", () => {
+    it("calculates memory usage", function() {
         const testObject1 = { str: "aaa", bool: true, num: 12, test: {} };
         const testObject2 = { num: 1, test: testObject1 };
         testObject1.test = testObject2;
@@ -122,7 +125,7 @@ describe("map-view#Utils", () => {
         expect(result).to.be.equal(26);
     });
 
-    it("calculates memory usage for circular references", () => {
+    it("calculates memory usage for circular references", function() {
         const testObject1 = { str: "aaa", bool: true, num: 12, test: {} };
         const testObject2 = { num: 1, test: {} };
         const testObject3 = { string: "bbb", test: {} };
@@ -133,7 +136,7 @@ describe("map-view#Utils", () => {
         expect(result).to.be.equal(32);
     });
 
-    it("calculates memory usage for arrays of values and arrays of objects", () => {
+    it("calculates memory usage for arrays of values and arrays of objects", function() {
         const testObject = {
             str: "aaa",
             bool: true,
@@ -147,7 +150,7 @@ describe("map-view#Utils", () => {
         expect(result).to.be.equal(228);
     });
 
-    it("estimate size of world with one cube", async () => {
+    it("estimate size of world with one cube", async function() {
         const scene: THREE.Scene = new THREE.Scene();
         const geometry = new THREE.BoxGeometry(1, 1, 1);
         const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
@@ -156,7 +159,7 @@ describe("map-view#Utils", () => {
         expect(MapViewUtils.estimateObjectSize(scene)).to.be.equal(4626);
     });
 
-    it("estimate size of world with 1000 cubes", async () => {
+    it("estimate size of world with 1000 cubes", async function() {
         const scene: THREE.Scene = new THREE.Scene();
         for (let i = 0; i < 1000; i++) {
             const geometry = new THREE.BoxGeometry(1, 1, 1);

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { TileKey } from "@here/harp-geoutils";
 import { assert } from "chai";
 import * as sinon from "sinon";
@@ -28,8 +31,8 @@ function createBerlinCenterCameraFromSamples() {
     return { camera, worldCenter };
 }
 
-describe("VisibleTileSet", () => {
-    it("#updateRenderList properly culls Berlin center example view", () => {
+describe("VisibleTileSet", function() {
+    it("#updateRenderList properly culls Berlin center example view", function() {
         const { camera, worldCenter } = createBerlinCenterCameraFromSamples();
         const vts = new VisibleTileSet(camera, MapViewDefaults);
         const zoomLevel = 15;
@@ -49,7 +52,7 @@ describe("VisibleTileSet", () => {
         assert.equal(renderedTiles.length, 0);
     });
 
-    it("#updateRenderList properly culls panorama of Berlin center", () => {
+    it("#updateRenderList properly culls panorama of Berlin center", function() {
         const worldCenter = new THREE.Vector3(21526192.124894984, 26932362.99119022, 0);
         const camera = new THREE.PerspectiveCamera();
         camera.aspect = 1.7541528239202657;
@@ -86,7 +89,7 @@ describe("VisibleTileSet", () => {
         assert.equal(renderedTiles.length, 0);
     });
 
-    it("#updateRenderList properly finds parent loaded tiles in Berlin center example view", () => {
+    it("#updateRenderList properly finds parent loaded tiles in Berlin center", function() {
         const { camera, worldCenter } = createBerlinCenterCameraFromSamples();
         const vts = new VisibleTileSet(camera, MapViewDefaults);
 
@@ -118,7 +121,7 @@ describe("VisibleTileSet", () => {
         assert.equal(renderedTiles[0].tileKey.mortonCode(), parentCode);
     });
 
-    it("#markTilesDirty properly handles cached & visible tiles", async () => {
+    it("#markTilesDirty properly handles cached & visible tiles", async function() {
         const { camera, worldCenter } = createBerlinCenterCameraFromSamples();
         const vts = new VisibleTileSet(camera, MapViewDefaults);
         const zoomLevel = 15;

--- a/@here/harp-mapview/test/WorkerBasedDecoderTest.ts
+++ b/@here/harp-mapview/test/WorkerBasedDecoderTest.ts
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import * as sinon from "sinon";
 
 import { ConcurrentWorkerSet } from "../lib/ConcurrentWorkerSet";
 import { WorkerBasedDecoder } from "../lib/WorkerBasedDecoder";
 
-describe("WorkerBasedDecoder", () => {
-    it("#dispose releases associates workerSet", () => {
+describe("WorkerBasedDecoder", function() {
+    it("#dispose releases associates workerSet", function() {
         const workerSetStub = sinon.createStubInstance<ConcurrentWorkerSet>(ConcurrentWorkerSet);
 
         const target = new WorkerBasedDecoder((workerSetStub as any) as ConcurrentWorkerSet, "foo");

--- a/@here/harp-mapview/test/WorkerLoaderTest.ts
+++ b/@here/harp-mapview/test/WorkerLoaderTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import * as sinon from "sinon";
 
@@ -17,9 +20,9 @@ declare const global: any;
 const workerDefined = typeof Worker !== "undefined" && typeof Blob !== "undefined";
 const describeWithWorker = workerDefined ? describe : xdescribe;
 
-describe("WorkerLoader", () => {
+describe("WorkerLoader", function() {
     let sandbox: sinon.SinonSandbox;
-    beforeEach(() => {
+    beforeEach(function() {
         sandbox = sinon.createSandbox();
         if (typeof window === "undefined") {
             // fake Worker constructor for node environment
@@ -27,7 +30,7 @@ describe("WorkerLoader", () => {
         }
     });
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
         if (typeof window === "undefined") {
             delete global.Worker;
@@ -38,7 +41,7 @@ describe("WorkerLoader", () => {
 
     const testWorkerUrl = getTestResourceUrl("harp-mapview", "test/resources/testWorker.js");
 
-    it("WorkerLoader falls back to blob / sync", async () => {
+    it("WorkerLoader falls back to blob / sync", async function() {
         // setup an environment in which any attempt to load worker from from non-blob URL
         // fails, so we check if WorkerLoader does it's job
         //
@@ -66,8 +69,8 @@ describe("WorkerLoader", () => {
         assert.equal(workerConstructorStub.firstCall.args[0], testWorkerUrl);
     });
 
-    describeWithWorker("real Workers integration", () => {
-        it("WorkerLoader falls back to blob / sync", async () => {
+    describeWithWorker("real Workers integration", function() {
+        it("WorkerLoader falls back to blob / sync", async function() {
             // setup an environment in which any attempt to load worker from from non-blob URL
             // fails, so we check if WorkerLoader does it's job
             //
@@ -101,7 +104,7 @@ describe("WorkerLoader", () => {
             assert(workerConstructorStub.secondCall.args[0].startsWith, "blob:");
         });
 
-        it("WorkerLoader falls back to blob / async", async () => {
+        it("WorkerLoader falls back to blob / async", async function() {
             // setup an environment in which any attempt to load worker from from non-blob URL
             // fails, so we check if WorkerLoader does it's job
             //

--- a/@here/harp-omv-datasource/test/OmvDataSourceTest.ts
+++ b/@here/harp-omv-datasource/test/OmvDataSourceTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import "@here/harp-fetch";
 import { TileKey } from "@here/harp-geoutils";
 import { DataProvider } from "@here/harp-mapview-decoder";
@@ -30,8 +33,8 @@ class MockDataProvider implements DataProvider {
     }
 }
 
-describe("DataProviders", () => {
-    it("Creates a OmvDataSource with a custom DataProvider", () => {
+describe("DataProviders", function() {
+    it("Creates a OmvDataSource with a custom DataProvider", function() {
         const mockDataProvider = new MockDataProvider();
         const omvDataSource = new OmvDataSource({
             decoder: new OmvTileDecoder(),
@@ -41,7 +44,7 @@ describe("DataProviders", () => {
         assert.isTrue(omvDataSource.dataProvider() instanceof MockDataProvider);
     });
 
-    it("Creates a OmvDataSource with a REST based DataProvider with proper params", () => {
+    it("Creates a OmvDataSource with a REST based DataProvider with proper params", function() {
         const omvDataSource = new OmvDataSource({
             decoder: new OmvTileDecoder(),
             baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
@@ -62,7 +65,7 @@ describe("DataProviders", () => {
         assert.equal(omvRestClientProvider.params.authenticationMethod, AuthenticationTypeMapboxV4);
     });
 
-    it("Creates OmvDataSource with custom DataProvider, ignoring other provider attributes", () => {
+    it("Creates OmvDataSource with custom DataProvider, ignoring other attributes", function() {
         const mockDataProvider = new MockDataProvider();
         const omvDataSource = new OmvDataSource({
             decoder: new OmvTileDecoder(),

--- a/@here/harp-omv-datasource/test/OmvRestClientTest.ts
+++ b/@here/harp-omv-datasource/test/OmvRestClientTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { DownloadManager } from "@here/harp-download-manager";
 import "@here/harp-fetch";
 import { TileKey } from "@here/harp-geoutils";
@@ -32,18 +35,18 @@ class MockDownloadManager extends DownloadManager {
 }
 const mockDownloadManager = new MockDownloadManager();
 
-describe("OmvRestClient", () => {
+describe("OmvRestClient", function() {
     let downloadSpy: sinon.SinonSpy;
 
-    beforeEach(() => {
+    beforeEach(function() {
         downloadSpy = sinon.spy(mockDownloadManager, "download");
     });
 
-    afterEach(() => {
+    afterEach(function() {
         downloadSpy.restore();
     });
 
-    it("generates proper Url with HEREV1 Format", async () => {
+    it("generates proper Url with HEREV1 Format", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://some.base.url",
             apiFormat: APIFormat.HereV1,
@@ -53,7 +56,7 @@ describe("OmvRestClient", () => {
         assert.equal(downloadSpy.args[0][0], "https://some.base.url/3/2/1/omv");
     });
 
-    it("generates proper Url with MapBox Format", async () => {
+    it("generates proper Url with MapBox Format", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
             apiFormat: APIFormat.MapboxV4,
@@ -67,7 +70,7 @@ describe("OmvRestClient", () => {
         );
     });
 
-    it("generates proper Url with TomTom Format", async () => {
+    it("generates proper Url with TomTom Format", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://a.tomtom.base.url",
             apiFormat: APIFormat.TomtomV1,
@@ -78,7 +81,7 @@ describe("OmvRestClient", () => {
         assert.equal(downloadSpy.args[0][0], "https://a.tomtom.base.url/3/2/1.pbf?key=123");
     });
 
-    it("generates proper Url with MapZen Format", async () => {
+    it("generates proper Url with MapZen Format", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://a.mapzen.base.url",
             apiFormat: APIFormat.MapzenV1,
@@ -89,7 +92,7 @@ describe("OmvRestClient", () => {
         assert.equal(downloadSpy.args[0][0], "https://a.mapzen.base.url/3/2/1.pbf?api_key=123");
     });
 
-    it("supports custom authentication method based on query string key", async () => {
+    it("supports custom authentication method based on query string key", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://some.base.url",
             apiFormat: APIFormat.HereV1,
@@ -104,7 +107,7 @@ describe("OmvRestClient", () => {
         assert.equal(downloadSpy.args[0][0], "https://some.base.url/3/2/1/omv?customKey=12345");
     });
 
-    it("generates authentication header with bearer token from a function", async () => {
+    it("generates authentication header with bearer token from a function", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://some.base.url",
             apiFormat: APIFormat.HereV1,

--- a/@here/harp-omv-datasource/test/OmvTest.ts
+++ b/@here/harp-omv-datasource/test/OmvTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { MapEnv } from "@here/harp-datasource-protocol";
 import {
     OmvFeatureFilter,
@@ -86,15 +89,15 @@ export class RoadsToRailroads implements OmvFeatureModifier {
 /**
  * FIXME: HARP-1152 Add unit tests for OmvFeatureFilterDescriptionBuilder
  */
-describe("OmvFeatureFilterDescriptionBuilder", () => {
-    it("setup", () => {
+describe("OmvFeatureFilterDescriptionBuilder", function() {
+    it("setup", function() {
         const filterBuilder = new OmvFeatureFilterDescriptionBuilder();
         const filterDescr = filterBuilder.createDescription();
 
         assert.isObject(filterDescr);
     });
 
-    it("addFilters", () => {
+    it("addFilters", function() {
         const filterBuilder = new OmvFeatureFilterDescriptionBuilder();
 
         // load roads only on levels 0-13
@@ -111,7 +114,7 @@ describe("OmvFeatureFilterDescriptionBuilder", () => {
         // * assert that there *is* road data
     });
 
-    it("addFilters2", () => {
+    it("addFilters2", function() {
         const filterBuilder = new OmvFeatureFilterDescriptionBuilder();
 
         filterBuilder.processLayer("road");

--- a/@here/harp-omv-datasource/test/OmvTomTomFeatureModifierTest.ts
+++ b/@here/harp-omv-datasource/test/OmvTomTomFeatureModifierTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { MapEnv } from "@here/harp-datasource-protocol";
 import { assert } from "chai";
 import { OmvFeatureFilterDescriptionBuilder } from "../lib/OmvDataFilter";
@@ -31,12 +34,12 @@ export class OmvTomTomModifierMock extends OmvTomTomFeatureModifier {
 /**
  * Add unit tests for OmvTomTomFeatureModifier
  */
-describe("OmvTomTomFeatureModifier", () => {
+describe("OmvTomTomFeatureModifier", function() {
     const filterBuilder = new OmvFeatureFilterDescriptionBuilder();
     const filterDescription = filterBuilder.createDescription();
     const tomTomFeatureModifier = new OmvTomTomModifierMock(filterDescription);
 
-    it("modify Landuse layers", () => {
+    it("modify Landuse layers", function() {
         assert.isObject(tomTomFeatureModifier);
 
         let env = new MapEnv({});
@@ -65,7 +68,7 @@ describe("OmvTomTomFeatureModifier", () => {
         assert.equal(env.entries.class, "industrial");
     });
 
-    it("modify water layers", () => {
+    it("modify water layers", function() {
         assert.isObject(tomTomFeatureModifier);
 
         let env = new MapEnv({});
@@ -79,7 +82,7 @@ describe("OmvTomTomFeatureModifier", () => {
         assert.equal(env.entries.$layer, "water");
     });
 
-    it("modify road layers", () => {
+    it("modify road layers", function() {
         assert.isObject(tomTomFeatureModifier);
 
         let env = new MapEnv({});

--- a/@here/harp-test-utils/test/TestDataUtilsTest.ts
+++ b/@here/harp-test-utils/test/TestDataUtilsTest.ts
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { loadTestResource } from "../index";
 
 // tslint:disable:only-arrow-functions
 
-describe("@here/harp-test-utils", () => {
+describe("@here/harp-test-utils", function() {
     describe("#loadTestResource", function() {
-        it(`loads static text file`, async () => {
+        it(`loads static text file`, async function() {
             const textFromFile = await loadTestResource(
                 "harp-test-utils",
                 "./test/resources/test.txt",

--- a/@here/harp-text-renderer/test/ContextualArabicConverterTest.ts
+++ b/@here/harp-text-renderer/test/ContextualArabicConverterTest.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
 import { ContextualArabicConverter } from "../lib/ContextualArabicConverter";
 
-describe("ContextualArabicConverter", () => {
+describe("ContextualArabicConverter", function() {
     const textA = ContextualArabicConverter.instance.convert("مصر");
     const codepointsA = [0xfee3, 0xfebc, 0xfeae];
     const textB = ContextualArabicConverter.instance.convert(
@@ -59,7 +62,7 @@ describe("ContextualArabicConverter", () => {
         0x002e
     ];
 
-    it("Arabic", () => {
+    it("Arabic", function() {
         let result = true;
         for (let i = 0; i < textA.length; ++i) {
             result = result && textA.charCodeAt(i) === codepointsA[i];
@@ -67,7 +70,7 @@ describe("ContextualArabicConverter", () => {
         assert(result);
     });
 
-    it("Latin-Arabic", () => {
+    it("Latin-Arabic", function() {
         let result = true;
         for (let i = 0; i < textB.length; ++i) {
             result = result && textB.charCodeAt(i) === codepointsB[i];

--- a/@here/harp-text-renderer/test/TextRendererTest.ts
+++ b/@here/harp-text-renderer/test/TextRendererTest.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
-describe("TextRendererTest", () => {
-    it("ok", () => {
+describe("TextRendererTest", function() {
+    it("ok", function() {
         assert(true);
     });
 });

--- a/@here/harp-utils/test/GroupedPriorityListTest.ts
+++ b/@here/harp-utils/test/GroupedPriorityListTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { GroupedPriorityList } from "../lib/GroupedPriorityList";
 
@@ -11,8 +14,8 @@ interface Item {
     priority: number;
 }
 
-describe("GroupedPriorityList", () => {
-    it("#add", () => {
+describe("GroupedPriorityList", function() {
+    it("#add", function() {
         const priorityList = new GroupedPriorityList<Item>();
 
         for (let i = 0; i < 100; i++) {
@@ -37,7 +40,7 @@ describe("GroupedPriorityList", () => {
         }
     });
 
-    it("#clear", () => {
+    it("#clear", function() {
         const priorityList = new GroupedPriorityList<Item>();
 
         for (let i = 0; i < 100; i++) {
@@ -51,7 +54,7 @@ describe("GroupedPriorityList", () => {
         assert.equal(priorityList.groups.size, 0);
     });
 
-    it("#remove", () => {
+    it("#remove", function() {
         const priorityList = new GroupedPriorityList<Item>();
 
         const element1 = { priority: 1 };
@@ -77,7 +80,7 @@ describe("GroupedPriorityList", () => {
         assert.isFalse(result1b);
     });
 
-    it("#merge", () => {
+    it("#merge", function() {
         const priorityList1 = new GroupedPriorityList<Item>();
         const priorityList2 = new GroupedPriorityList<Item>();
 
@@ -109,7 +112,7 @@ describe("GroupedPriorityList", () => {
         }
     });
 
-    it("#sortedGroups", () => {
+    it("#sortedGroups", function() {
         const priorityList = new GroupedPriorityList<Item>();
 
         for (let i = 99; i >= 0; i--) {

--- a/@here/harp-utils/test/LoggerManagerTest.ts
+++ b/@here/harp-utils/test/LoggerManagerTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import * as sinon from "sinon";
 
@@ -13,7 +16,7 @@ import { LoggerManager } from "../lib/Logger/LoggerManager";
 import { LoggerManagerImpl } from "../lib/Logger/LoggerManagerImpl";
 import { MultiChannel } from "../lib/Logger/MultiChannel";
 
-describe("LoggerManager", () => {
+describe("LoggerManager", function() {
     function printAll(logger: ILogger, msg: string) {
         logger.error(msg);
         logger.warn(msg);
@@ -23,7 +26,7 @@ describe("LoggerManager", () => {
         logger.trace(msg);
     }
 
-    it("Update All", () => {
+    it("Update All", function() {
         // Arrange
         const manager = new LoggerManagerImpl();
         const loggerA = manager.create("A");
@@ -39,7 +42,7 @@ describe("LoggerManager", () => {
         assert.equal(loggerB.level, LogLevel.Error);
     });
 
-    it("Update named loggers", () => {
+    it("Update named loggers", function() {
         // Arrange
         const manager = new LoggerManagerImpl();
         const loggerA = manager.create("A");
@@ -55,7 +58,7 @@ describe("LoggerManager", () => {
         assert.equal(loggerB.level, LogLevel.Trace);
     });
 
-    it("Override defaults", () => {
+    it("Override defaults", function() {
         // Arrange
         const manager = new LoggerManagerImpl();
 
@@ -70,7 +73,7 @@ describe("LoggerManager", () => {
         assert.equal(loggerB.level, LogLevel.Trace);
     });
 
-    it("Dispose logger", () => {
+    it("Dispose logger", function() {
         // Arrange
         const manager = new LoggerManagerImpl();
         const loggerA = manager.create("A");
@@ -87,7 +90,7 @@ describe("LoggerManager", () => {
         assert.equal(loggerB.level, LogLevel.Error);
     });
 
-    it("Create LoggerManager instance", () => {
+    it("Create LoggerManager instance", function() {
         // Arrange
         const manager = LoggerManager.instance;
 
@@ -95,12 +98,12 @@ describe("LoggerManager", () => {
         assert.exists(manager);
     });
 
-    it("Check default console channel", () => {
+    it("Check default console channel", function() {
         const manager = LoggerManager.instance;
         assert.equal(manager.channel instanceof ConsoleChannel, true);
     });
 
-    it("Replace default console channel", () => {
+    it("Replace default console channel", function() {
         const manager = LoggerManager.instance;
         const multiChannel = new MultiChannel();
         LoggerManager.instance.setChannel(multiChannel);
@@ -108,10 +111,10 @@ describe("LoggerManager", () => {
         assert.equal(manager.channel instanceof ConsoleChannel, false);
     });
 
-    describe("Check channel compliancy", () => {
+    describe("Check channel compliancy", function() {
         const sandbox = sinon.createSandbox();
 
-        it("Check channels logging abilities", () => {
+        it("Check channels logging abilities", function() {
             // Arrange
             const consoleChannel = LoggerManager.instance.channel;
             const stubs = sandbox.stub(consoleChannel);
@@ -129,7 +132,7 @@ describe("LoggerManager", () => {
             assert.isTrue(stubs.trace.calledWithMatch("foo:", "some message"));
         });
 
-        it("Check channels logging abilities after switching channels", () => {
+        it("Check channels logging abilities after switching channels", function() {
             // Arrange
             sandbox.restore();
             const oldChannel = LoggerManager.instance.channel;
@@ -160,7 +163,7 @@ describe("LoggerManager", () => {
             assert.isTrue(newChannelStub.trace.calledWithMatch("foo:", "some message"));
         });
 
-        it("Check MultiChannel logging abilities", () => {
+        it("Check MultiChannel logging abilities", function() {
             // Arrange
             const channel1 = new ConsoleChannel();
             const channel2 = new ConsoleChannel();

--- a/@here/harp-utils/test/LoggerTest.ts
+++ b/@here/harp-utils/test/LoggerTest.ts
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import * as sinon from "sinon";
 
 import { ILogger, LogLevel } from "../lib/Logger/ILogger";
 import { Logger } from "../lib/Logger/Logger";
 
-describe("Logger", () => {
+describe("Logger", function() {
     const sandbox = sinon.createSandbox();
 
     function printAll(logger: ILogger, msg: string) {
@@ -22,16 +25,16 @@ describe("Logger", () => {
         logger.trace(msg);
     }
 
-    afterEach(() => {
+    afterEach(function() {
         sandbox.restore();
     });
 
-    describe("Apply log level", () => {
-        afterEach(() => {
+    describe("Apply log level", function() {
+        afterEach(function() {
             sandbox.restore();
         });
 
-        it("check defaults", () => {
+        it("check defaults", function() {
             // Arrange
             const logger = new Logger("foo", console);
 
@@ -40,7 +43,7 @@ describe("Logger", () => {
             assert.equal(logger.level, LogLevel.Trace);
         });
 
-        it("error should be written to output", () => {
+        it("error should be written to output", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -59,7 +62,7 @@ describe("Logger", () => {
             assert.isFalse(stubs.trace.called);
         });
 
-        it("warning and error should be written to output ", () => {
+        it("warning and error should be written to output ", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -78,7 +81,7 @@ describe("Logger", () => {
             assert.isFalse(stubs.trace.called);
         });
 
-        it("info, warning, error should be written to output", () => {
+        it("info, warning, error should be written to output", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -97,7 +100,7 @@ describe("Logger", () => {
             assert.isFalse(stubs.trace.called);
         });
 
-        it("log, info, warning and error should be written", () => {
+        it("log, info, warning and error should be written", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -116,7 +119,7 @@ describe("Logger", () => {
             assert.isFalse(stubs.trace.called);
         });
 
-        it("debug, log, info, warning and error should be written", () => {
+        it("debug, log, info, warning and error should be written", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -135,7 +138,7 @@ describe("Logger", () => {
             assert.isFalse(stubs.trace.called);
         });
 
-        it("trace, debug, log, info, warning and error should be written", () => {
+        it("trace, debug, log, info, warning and error should be written", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -155,12 +158,12 @@ describe("Logger", () => {
         });
     });
 
-    describe("Enable / disable", () => {
-        afterEach(() => {
+    describe("Enable / disable", function() {
+        afterEach(function() {
             sandbox.restore();
         });
 
-        it("Enable all outputs", () => {
+        it("Enable all outputs", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -179,7 +182,7 @@ describe("Logger", () => {
             assert.isTrue(stubs.trace.calledOnce);
         });
 
-        it("Disable all outputs", () => {
+        it("Disable all outputs", function() {
             // Arrange
             const stubs = sandbox.stub(console);
 
@@ -198,7 +201,7 @@ describe("Logger", () => {
             assert.isFalse(stubs.trace.called);
         });
     });
-    it("Name is written to output", () => {
+    it("Name is written to output", function() {
         // Arrange
         const stubs = sandbox.stub(console);
         const logger = new Logger("foo", console, { enabled: true, level: LogLevel.Trace });

--- a/@here/harp-utils/test/OptionsUtilsTest.ts
+++ b/@here/harp-utils/test/OptionsUtilsTest.ts
@@ -4,20 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
 import { getOptionValue, mergeWithOptions } from "../lib/OptionsUtils";
 
-describe("OptionsUtils", () => {
-    describe("#getOptionValue", () => {
-        it("returns first defined", () => {
+describe("OptionsUtils", function() {
+    describe("#getOptionValue", function() {
+        it("returns first defined", function() {
             assert.equal(getOptionValue(), undefined);
             assert.equal(getOptionValue(undefined), undefined);
             assert.equal(getOptionValue(1), 1);
             assert.equal(getOptionValue(undefined, 2, 3), 2);
             assert.equal(getOptionValue(undefined, 2), 2);
         });
-        it("erases 'undefined' from type if last param is defined", () => {
+        it("erases 'undefined' from type if last param is defined", function() {
             const r1: number = getOptionValue(undefined, 2);
             assert.equal(r1, 2);
             const r2: number = getOptionValue(undefined, undefined, 3);
@@ -27,7 +30,7 @@ describe("OptionsUtils", () => {
         });
     });
 
-    describe("#mergeWithOptions", () => {
+    describe("#mergeWithOptions", function() {
         interface FooParams {
             useTextures: boolean;
             someString: string;
@@ -42,21 +45,21 @@ describe("OptionsUtils", () => {
             opacity: 0.8
         };
 
-        it("copy defaults if no options were passed", () => {
+        it("copy defaults if no options were passed", function() {
             assert.deepEqual(mergeWithOptions(FOO_DEFAULTS), FOO_DEFAULTS);
             assert.deepEqual(mergeWithOptions(FOO_DEFAULTS, {}), FOO_DEFAULTS);
             assert.deepEqual(mergeWithOptions(FOO_DEFAULTS, undefined), FOO_DEFAULTS);
             assert.deepEqual(mergeWithOptions(FOO_DEFAULTS, null!), FOO_DEFAULTS);
         });
-        it("doesn't return defaults", () => {
+        it("doesn't return defaults", function() {
             assert(mergeWithOptions(FOO_DEFAULTS) !== FOO_DEFAULTS);
         });
-        it("doesn't copy options not existing in template", () => {
+        it("doesn't copy options not existing in template", function() {
             // tslint:disable-next-line:no-object-literal-type-assertion
             const options: FooOptions = { someOtherOption: "a" } as FooOptions;
             assert.deepEqual(mergeWithOptions(FOO_DEFAULTS, options), FOO_DEFAULTS);
         });
-        it("copies basic options, ignores undefineds", () => {
+        it("copies basic options, ignores undefined", function() {
             assert.deepEqual(
                 mergeWithOptions(FOO_DEFAULTS, { opacity: 0.5, someString: undefined }),
                 {
@@ -66,7 +69,7 @@ describe("OptionsUtils", () => {
                 }
             );
         });
-        it("treats false, empty string and 0 as defined", () => {
+        it("treats false, empty string and 0 as defined", function() {
             assert.deepEqual(
                 mergeWithOptions(FOO_DEFAULTS, {
                     useTextures: false,
@@ -80,7 +83,7 @@ describe("OptionsUtils", () => {
                 }
             );
         });
-        it("doesn't copy undefineds when set, (as Object.assign does)", () => {
+        it("doesn't copy undefined when set, (as Object.assign does)", function() {
             assert.deepEqual(
                 mergeWithOptions(FOO_DEFAULTS, {
                     useTextures: undefined,
@@ -94,7 +97,7 @@ describe("OptionsUtils", () => {
             );
         });
 
-        it.skip("rationale: Object.assign and spread operator copy undefineds and nulls", () => {
+        it.skip("rationale: Object.assign and spread operator copy undefined & null", function() {
             const maskedNull: boolean = (null as any) as boolean;
             const maskedUndefined: boolean = (undefined as any) as boolean;
 

--- a/@here/harp-utils/test/PerformanceTimerTest.ts
+++ b/@here/harp-utils/test/PerformanceTimerTest.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { PerformanceTimer } from "../lib/PerformanceTimer";
 
-describe("PerformanceTimer", () => {
-    it("#now", () => {
+describe("PerformanceTimer", function() {
+    it("#now", function() {
         const t0 = PerformanceTimer.now();
         assert.isNumber(t0);
         assert.isAbove(t0, 0);

--- a/@here/harp-utils/test/UrlResolverTest.ts
+++ b/@here/harp-utils/test/UrlResolverTest.ts
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { defaultUrlResolver, setDefaultUrlResolver } from "../lib/UrlResolver";
 
-describe("UrlResolver", () => {
-    describe("global url resolver handling", () => {
+describe("UrlResolver", function() {
+    describe("global url resolver handling", function() {
         const fooResolver = (url: string) => {
             if (url.startsWith("foo-cdn:")) {
                 return "https://cdn.foo.com/res/" + url.substr(8);
@@ -16,15 +19,15 @@ describe("UrlResolver", () => {
             return url;
         };
 
-        afterEach(() => {
+        afterEach(function() {
             setDefaultUrlResolver(undefined);
         });
 
-        it("resolves normal urls without change", () => {
+        it("resolves normal urls without change", function() {
             assert.equal(defaultUrlResolver("https://x.y.com"), "https://x.y.com");
         });
 
-        it("#setDefaultUrlResolver registers and unregisters resolvers", () => {
+        it("#setDefaultUrlResolver registers and unregisters resolvers", function() {
             setDefaultUrlResolver(fooResolver);
             assert.equal(
                 defaultUrlResolver("foo-cdn:fonts/font.json"),

--- a/@here/harp-utils/test/UrlUtilsTest.ts
+++ b/@here/harp-utils/test/UrlUtilsTest.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import { baseUrl, getUrlOrigin, resolveReferenceUrl } from "../lib/UrlUtils";
 
-describe("UrlUtils", () => {
-    describe("#resolveReferenceUrl", () => {
-        it("correctly resolves relative child URL", () => {
+describe("UrlUtils", function() {
+    describe("#resolveReferenceUrl", function() {
+        it("correctly resolves relative child URL", function() {
             assert.equal(
                 resolveReferenceUrl("https://bar.com:999/foo", "bar.js"),
                 "https://bar.com:999/bar.js"
@@ -19,17 +22,17 @@ describe("UrlUtils", () => {
                 "https://bar.com/foo/bar.js"
             );
         });
-        it("correctly resolves origin-absolute URLs", () => {
+        it("correctly resolves origin-absolute URLs", function() {
             assert.equal(
                 resolveReferenceUrl("https://user@bar.com/foo/theme.json", "/bar.js"),
                 "https://user@bar.com/bar.js"
             );
         });
-        it("handles file: scheme", () => {
+        it("handles file: scheme", function() {
             assert.equal(resolveReferenceUrl("file://foo/", "bar.js"), "file://foo/bar.js");
             assert.equal(resolveReferenceUrl("file://foo/", "/bar.js"), "file:///bar.js");
         });
-        it("handles relative parent URL", () => {
+        it("handles relative parent URL", function() {
             assert.equal(
                 resolveReferenceUrl("resources/day.json", "font.json"),
                 "resources/font.json"
@@ -39,7 +42,7 @@ describe("UrlUtils", () => {
                 "/resources/font.json"
             );
         });
-        it("returns absolute URLs unchanged", () => {
+        it("returns absolute URLs unchanged", function() {
             assert.equal(
                 resolveReferenceUrl("https://spam.com", "https://bar.com/foo"),
                 "https://bar.com/foo"
@@ -48,23 +51,23 @@ describe("UrlUtils", () => {
         });
     });
 
-    describe("#baseUrl", () => {
-        it("removes leafs", () => {
+    describe("#baseUrl", function() {
+        it("removes leafs", function() {
             assert.equal(baseUrl("https://foo.com/themes/a.json"), "https://foo.com/themes/");
             assert.equal(baseUrl("https://foo.com/themes"), "https://foo.com/");
             assert.equal(baseUrl("themes/day.json"), "themes/");
         });
-        it("treats trailing / as location", () => {
+        it("treats trailing / as location", function() {
             assert.equal(baseUrl("https://foo.com/themes/"), "https://foo.com/themes/");
             assert.equal(baseUrl("themes/"), "themes/");
         });
-        it("standalone files are relative to current dir", () => {
+        it("standalone files are relative to current dir", function() {
             assert.equal(baseUrl("themes"), "./");
         });
     });
 
-    describe("#getUrlOrigin", () => {
-        it("extracts origin part of URL", () => {
+    describe("#getUrlOrigin", function() {
+        it("extracts origin part of URL", function() {
             assert.equal(getUrlOrigin("https://example.com/foo"), "https://example.com");
             assert.equal(getUrlOrigin("//example.com/"), "//example.com");
             assert.equal(getUrlOrigin("file:///etc/hosts"), "file://");

--- a/@here/harp-utils/test/WorkerChannelTest.ts
+++ b/@here/harp-utils/test/WorkerChannelTest.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 import * as sinon from "sinon";
 import { LogLevel } from "../lib/Logger/ILogger";
@@ -16,8 +19,8 @@ import {
 
 declare const global: any;
 
-describe("WorkerChannel", () => {
-    beforeEach(() => {
+describe("WorkerChannel", function() {
+    beforeEach(function() {
         if (typeof self === "undefined") {
             global.self = {
                 postMessage() {
@@ -27,13 +30,13 @@ describe("WorkerChannel", () => {
         }
     });
 
-    afterEach(() => {
+    afterEach(function() {
         if (Object.keys(self).length === 1) {
             delete global.self;
         }
     });
 
-    it("The WorkerChannel post messages with the exact format of IWorkerChannelMessage.", () => {
+    it("The WorkerChannel post messages with the format of IWorkerChannelMessage.", function() {
         const message1 = "My message : ";
         const message2 = "is original.";
         const loggerName = "myLogger";

--- a/@here/harp-webtile-datasource/test/WebTileTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileTest.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 import { assert } from "chai";
 
-describe("WebBoxTile", () => {
-    it("ok", () => {
+describe("WebBoxTile", function() {
+    it("ok", function() {
         assert.isTrue(true);
     });
 });


### PR DESCRIPTION
This fix changes the arrow functions used in Mocha run tests to classic function(). This is motivated by avoiding the possible problems when a test needs access to Mocha's context. See this [link](https://mochajs.org/#arrow-functions) for more details about why Mocha discourages using arrow functions.