### PR TITLE
HARP-3919: Add iconVerticalAlignment & iconHorizontalAlignment

### DIFF
--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -412,6 +412,16 @@ export class TextElement {
     horizontalAlignment: TextHorizontalAlignment = TextHorizontalAlignment.Center;
 
     /**
+     * Vertical alignment of text relative to icon height.
+     */
+    iconVerticalAlignment: TextVerticalAlignment = TextVerticalAlignment.Center;
+
+    /**
+     * Horizontal alignment of text relative to icon height.
+     */
+    iconHorizontalAlignment: TextHorizontalAlignment = TextHorizontalAlignment.Center;
+
+    /**
      * Horizontal separation between the glyphs in this `TextElement`.
      */
     private m_trackingFactor: number = 0;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1476,6 +1476,16 @@ export class TextElementsRenderer {
                     tempTextBounds.w = scaledTextWidth;
                     tempTextBounds.h = scaledTextHeight * 2.0;
 
+                    if (poiInfo !== undefined) {
+                      if (poiInfo.computedWidth !== undefined) {
+                        tempTextBounds.x -= poiInfo.computedWidth * (textElement.iconHorizontalAlignment - 0.5);
+                      }
+
+                      if (poiInfo.computedHeight !== undefined) {
+                        tempTextBounds.y -= poiInfo.computedHeight * (textElement.iconVerticalAlignment - 0.5);
+                      }
+                    }
+
                     // Adjust the label positioning to match its bounding box.
                     tempOffset.x = tempTextBounds.x;
                     tempOffset.y = tempTextBounds.y + scaledTextHeight;


### PR DESCRIPTION
This one is a part of HARP-3919

It introduces `iconVerticalAlignment` & `iconHorizontalAlignment` properties of `TextElement` class that make possible aligning of text to icon borders.