### PR TITLE
Travis: generate a _config.yml for Jekyll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ jobs:
     - stage: test
       name: "Execute unit tests (node)"
       script: yarn test
-    - script: yarn run typedoc
+    - script: |
+        yarn run typedoc && \
+        echo -e 'include:\n  - "_*"' > doc/_config.yml
       name: "Build documentation"
       deploy:
         provider: pages


### PR DESCRIPTION
By default, Jekyll ignores all files starting with an underscore. Since
TypeDoc generates those, we need to explicitly include them in
_config.yml