### PR TITLE
Use explicit typings in webworker

### DIFF
--- a/@here/harp-examples/decoder/decoder.ts
+++ b/@here/harp-examples/decoder/decoder.ts
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-declare let self: Worker & {
-    importScripts(..._scripts: string[]): void;
-};
+/// <reference types="typescript/lib/lib.webworker" />
 
 self.importScripts("three.min.js");
 


### PR DESCRIPTION
Rather than declaring our Worker type, include TypeScript's types.