### PR TITLE
HARP-4231: Move POI labels above the icon

### DIFF
--- a/@here/harp-map-theme/resources/day.json
+++ b/@here/harp-map-theme/resources/day.json
@@ -1727,7 +1727,7 @@
                             "poiNameField": "kind",
                             "iconScale": 1,
                             "scale": 0.5,
-                            "yOffset": -22,
+                            "yOffset": 24,
                             "textIsOptional": true,
                             "iconIsOptional": false,
                             "renderTextDuringMovements": false,


### PR DESCRIPTION
The text should appear above the icon, as requested by cartography.