### PR TITLE
HARP-4226: Implements the raycasting of points.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as THREE from "three";
-
 import { mercatorProjection, Projection, webMercatorProjection } from "@here/harp-geoutils";
-import { HighPrecisionLineMaterial } from "@here/harp-materials";
-import { applyTechniqueToMaterial, getMaterialConstructor, Technique } from "./Techniques";
+import { Technique } from "./Techniques";
 import { TileInfo } from "./TileInfo";
 
 /**
@@ -46,12 +43,6 @@ export interface TextPathGeometry {
     technique: number;
     featureId?: number;
 }
-
-/**
- * The data stored in Buffers' elements can be of the following elementary types: float, unsigned
- * integer (either 16-bit or 32-bit long)
- */
-export type BufferElementType = "float" | "uint16" | "uint32";
 
 /**
  * Returns an array with the data type specified as parameter.
@@ -132,6 +123,22 @@ export interface Geometry {
 }
 
 /**
+ * The data stored in Buffers' elements can be of the following elementary types: float, unsigned
+ * integer (either 16-bit or 32-bit long)
+ */
+export type BufferElementType = "float" | "uint16" | "uint32";
+
+/**
+ * Structured clone compliant WebGL buffer and its metadata.
+ */
+export interface BufferAttribute {
+    name: string;
+    buffer: ArrayBufferLike;
+    type: BufferElementType;
+    itemCount: number;
+}
+
+/**
  * Structured clone compliant version of a `three.js` geometry object with text to be rendered.
  * It is composed of buffers with metadata for text objects.
  */
@@ -160,16 +167,6 @@ export interface PoiGeometry {
 }
 
 /**
- * Structured clone compliant WebGL buffer and its metadata.
- */
-export interface BufferAttribute {
-    name: string;
-    buffer: ArrayBufferLike;
-    type: BufferElementType;
-    itemCount: number;
-}
-
-/**
  * Structured clone compliant WebGL group object and its metadata.
  * Its purpose is to make working with groups of objects easier.
  */
@@ -179,99 +176,6 @@ export interface Group {
     technique: number;
     renderOrderOffset?: number;
     featureId?: number;
-}
-
-/**
- * The structure of the options to pass into [[createMaterial]].
- */
-export interface MaterialOptions {
-    /**
-     * The shader [[Technique]] to choose.
-     */
-    technique: Technique;
-
-    /**
-     * The active zoom level at material creation for zoom-dependent properties.
-     */
-    level?: number;
-
-    /**
-     * Properties to skip.
-     *
-     * @see [[applyTechniqueToMaterial]]
-     */
-    skipExtraProps?: string[];
-
-    /**
-     * `RawShaderMaterial` instances need to know about the fog at instantiation in order to avoid
-     * recompiling them manually later (ThreeJS does not update fog for `RawShaderMaterial`s).
-     */
-    fog?: boolean;
-}
-
-/**
- * Create a material, depending on the rendering technique provided in the options.
- *
- * @param options The material options the subsequent functions need.
- *
- * @returns new material instance that matches `technique.name`
- */
-export function createMaterial(options: MaterialOptions): THREE.Material | undefined {
-    const Constructor = getMaterialConstructor(options.technique);
-
-    const settings: { [key: string]: any } = {};
-
-    if (Constructor === undefined) {
-        return undefined;
-    }
-
-    if (
-        Constructor.prototype instanceof THREE.RawShaderMaterial &&
-        Constructor !== HighPrecisionLineMaterial
-    ) {
-        settings.fog = options.fog;
-    }
-
-    const material = new Constructor(settings);
-
-    if (options.technique.id !== undefined) {
-        material.name = options.technique.id;
-    }
-
-    if (options.technique.name === "extruded-polygon") {
-        material.flatShading = true;
-    }
-
-    material.depthTest =
-        options.technique.name === "extruded-polygon" && options.technique.depthTest !== false;
-
-    if (options.technique.name === "shader") {
-        // special case for ShaderTechnique.
-        // The shader technique takes the argument from its `params' member.
-        const params = options.technique.params as { [key: string]: any };
-        Object.getOwnPropertyNames(params).forEach(property => {
-            const prop = property as keyof (typeof params);
-            if (prop === "name") {
-                // skip reserved property names
-                return;
-            }
-            const m = material as any;
-            if (m[prop] instanceof THREE.Color) {
-                m[prop].set(params[prop]);
-            } else {
-                m[prop] = params[prop];
-            }
-        });
-    } else {
-        applyTechniqueToMaterial(
-            options.technique,
-            material,
-            options.level,
-            options.skipExtraProps
-        );
-    }
-
-    return material;
 }
 
 /**
@@ -302,33 +206,6 @@ export function getProjectionName(projection: Projection): string | never {
         return "webMercator";
     }
     throw new Error("Unknown projection");
-}
-
-/**
- * Returns a [[THREE.BufferAttribute]] created from a provided [[BufferAttribute]] object.
- *
- * @param attribute BufferAttribute a WebGL compliant buffer
- */
-export function getBufferAttribute(attribute: BufferAttribute): THREE.BufferAttribute {
-    switch (attribute.type) {
-        case "float":
-            return new THREE.BufferAttribute(
-                new Float32Array(attribute.buffer),
-                attribute.itemCount
-            );
-        case "uint16":
-            return new THREE.BufferAttribute(
-                new Uint16Array(attribute.buffer),
-                attribute.itemCount
-            );
-        case "uint32":
-            return new THREE.BufferAttribute(
-                new Uint32Array(attribute.buffer),
-                attribute.itemCount
-            );
-        default:
-            throw new Error(`unsupported buffer of type ${attribute.type}`);
-    } // switch
 }
 
 /**

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -1,44 +1,43 @@
 {
-  "name": "@here/harp-datasource-protocol",
-  "version": "0.2.66",
-  "description": "Datasource protocol",
-  "main": "index.js",
-  "typings": "index",
-  "directories": {
-    "test": "test"
-  },
-  "scripts": {
-    "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-    "build": "tsc",
-    "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com:heremaps/harp.gl.git"
-  },
-  "author": {
-    "name": "HERE Europe B.V.",
-    "url": "https://here.com"
-  },
-  "license": "Apache-2.0",
-  "dependencies": {
-    "@here/harp-geoutils": "^0.2.40",
-    "@here/harp-lines": "^0.1.20",
-    "@here/harp-materials": "^0.1.0",
-    "@here/harp-utils": "^0.1.0"
-  },
-  "devDependencies": {
-    "@types/chai": "^4.1.2",
-    "@types/mocha": "^5.2.5",
-    "@types/three": "0.92.24",
-    "chai": "^4.0.2",
-    "cross-env": "^5.2.0",
-    "mocha": "^5.2.0",
-    "source-map-support": "^0.5.2",
-    "three": "^0.99.0",
-    "typescript": "~3.2.1"
-  },
-  "peerDependencies": {
-    "three": "^0.99.0"
-  }
+    "name": "@here/harp-datasource-protocol",
+    "version": "0.2.66",
+    "description": "Datasource protocol",
+    "main": "index.js",
+    "typings": "index",
+    "directories": {
+        "test": "test"
+    },
+    "scripts": {
+        "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
+        "build": "tsc",
+        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com:heremaps/harp.gl.git"
+    },
+    "author": {
+        "name": "HERE Europe B.V.",
+        "url": "https://here.com"
+    },
+    "license": "Apache-2.0",
+    "dependencies": {
+        "@here/harp-geoutils": "^0.2.40",
+        "@here/harp-lines": "^0.1.20",
+        "@here/harp-utils": "^0.1.0"
+    },
+    "devDependencies": {
+        "@types/chai": "^4.1.2",
+        "@types/mocha": "^5.2.5",
+        "@types/three": "0.92.24",
+        "chai": "^4.0.2",
+        "cross-env": "^5.2.0",
+        "mocha": "^5.2.0",
+        "source-map-support": "^0.5.2",
+        "three": "^0.99.0",
+        "typescript": "~3.2.1"
+    },
+    "peerDependencies": {
+        "three": "^0.99.0"
+    }
 }

--- a/@here/harp-geojson-datasource/lib/GeoJsonGeometryCreator.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonGeometryCreator.ts
@@ -204,8 +204,11 @@ export class GeoJsonGeometryCreator {
         techniqueIndex: number
     ): GeoJsonTextGeometry {
         const labelProperty = geometryData.labelProperty! as string;
-        const properties = geometryData.points.geojsonProperties[0];
-        const text = (properties as any)[labelProperty].toString();
+        const stringCatalog = geometryData.points.geojsonProperties
+            .map((properties: any) => {
+                return properties[labelProperty].toString();
+            })
+            .reverse();
         return {
             positions: {
                 name: "position",
@@ -215,7 +218,7 @@ export class GeoJsonGeometryCreator {
             },
             technique: techniqueIndex,
             texts: [0],
-            stringCatalog: [text],
+            stringCatalog,
             objInfos: geometryData.points.geojsonProperties
         };
     }

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -6,20 +6,24 @@
 
 import {
     DecodedTile,
-    getBufferAttribute,
     isPoiTechnique,
     isTextTechnique,
     PoiTechnique,
     TextTechnique
 } from "@here/harp-datasource-protocol";
-import { DEFAULT_TEXT_DISTANCE_SCALE, TextElement, Tile, TileObject } from "@here/harp-mapview";
+import {
+    DEFAULT_TEXT_DISTANCE_SCALE,
+    getBufferAttribute,
+    TextElement,
+    Tile,
+    TileObject
+} from "@here/harp-mapview";
 import * as THREE from "three";
 import {
     GeoJsonPoiGeometry,
     GeoJsonTextGeometry,
     GeoJsonTextPathGeometry
 } from "./GeoJsonGeometryCreator";
-
 /**
  * The data that is contained in a [[GeoJsonTileObject]].
  */

--- a/@here/harp-mapview/index.ts
+++ b/@here/harp-mapview/index.ts
@@ -6,8 +6,10 @@
 
 export * from "./lib/CameraMovementDetector";
 export * from "./lib/ColorCache";
+export * from "./lib/MapViewPoints";
 export * from "./lib/composing";
 export * from "./lib/DataSource";
+export * from "./lib/DecodedTileHelpers";
 export * from "./lib/image/Image";
 export * from "./lib/image/ImageCache";
 export * from "./lib/image/MapViewImageCache";

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    BufferAttribute,
+    getPropertyValue,
+    isCaseProperty,
+    Technique
+} from "@here/harp-datasource-protocol";
+import {
+    CirclePointsMaterial,
+    DashedLineMaterial,
+    HighPrecisionLineMaterial,
+    MapMeshBasicMaterial,
+    MapMeshStandardMaterial,
+    SolidLineMaterial
+} from "@here/harp-materials";
+import * as THREE from "three";
+import { Circles, Squares } from "./MapViewPoints";
+
+/**
+ * The structure of the options to pass into [[createMaterial]].
+ */
+export interface MaterialOptions {
+    /**
+     * The shader [[Technique]] to choose.
+     */
+    technique: Technique;
+
+    /**
+     * The active zoom level at material creation for zoom-dependent properties.
+     */
+    level?: number;
+
+    /**
+     * Properties to skip.
+     *
+     * @see [[applyTechniqueToMaterial]]
+     */
+    skipExtraProps?: string[];
+
+    /**
+     * `RawShaderMaterial` instances need to know about the fog at instantiation in order to avoid
+     * recompiling them manually later (ThreeJS does not update fog for `RawShaderMaterial`s).
+     */
+    fog?: boolean;
+}
+
+/**
+ * Create a material, depending on the rendering technique provided in the options.
+ *
+ * @param options The material options the subsequent functions need.
+ *
+ * @returns new material instance that matches `technique.name`
+ */
+export function createMaterial(options: MaterialOptions): THREE.Material | undefined {
+    const Constructor = getMaterialConstructor(options.technique);
+
+    const settings: { [key: string]: any } = {};
+
+    if (Constructor === undefined) {
+        return undefined;
+    }
+
+    if (
+        Constructor.prototype instanceof THREE.RawShaderMaterial &&
+        Constructor !== HighPrecisionLineMaterial
+    ) {
+        settings.fog = options.fog;
+    }
+
+    const material = new Constructor(settings);
+
+    if (options.technique.id !== undefined) {
+        material.name = options.technique.id;
+    }
+
+    if (options.technique.name === "extruded-polygon") {
+        material.flatShading = true;
+    }
+
+    material.depthTest =
+        options.technique.name === "extruded-polygon" && options.technique.depthTest !== false;
+
+    if (options.technique.name === "shader") {
+        // special case for ShaderTechnique.
+        // The shader technique takes the argument from its `params' member.
+        const params = options.technique.params as { [key: string]: any };
+        Object.getOwnPropertyNames(params).forEach(property => {
+            const prop = property as keyof (typeof params);
+            if (prop === "name") {
+                // skip reserved property names
+                return;
+            }
+            const m = material as any;
+            if (m[prop] instanceof THREE.Color) {
+                m[prop].set(params[prop]);
+            } else {
+                m[prop] = params[prop];
+            }
+        });
+    } else {
+        applyTechniqueToMaterial(
+            options.technique,
+            material,
+            options.level,
+            options.skipExtraProps
+        );
+    }
+
+    return material;
+}
+
+/**
+ * Returns a [[THREE.BufferAttribute]] created from a provided [[BufferAttribute]] object.
+ *
+ * @param attribute BufferAttribute a WebGL compliant buffer
+ */
+export function getBufferAttribute(attribute: BufferAttribute): THREE.BufferAttribute {
+    switch (attribute.type) {
+        case "float":
+            return new THREE.BufferAttribute(
+                new Float32Array(attribute.buffer),
+                attribute.itemCount
+            );
+        case "uint16":
+            return new THREE.BufferAttribute(
+                new Uint16Array(attribute.buffer),
+                attribute.itemCount
+            );
+        case "uint32":
+            return new THREE.BufferAttribute(
+                new Uint32Array(attribute.buffer),
+                attribute.itemCount
+            );
+        default:
+            throw new Error(`unsupported buffer of type ${attribute.type}`);
+    } // switch
+}
+
+/**
+ * The default `three.js` object used with a specific technique.
+ */
+export interface ObjectConstructor {
+    new (
+        geometry?: THREE.Geometry | THREE.BufferGeometry,
+        material?: THREE.Material
+    ): THREE.Object3D;
+}
+
+/**
+ * Gets the default `three.js` object constructor associated with the given technique.
+ *
+ * @param technique The technique.
+ */
+export function getObjectConstructor(technique: Technique): ObjectConstructor | undefined {
+    switch (technique.name) {
+        case "extruded-line":
+        case "standard":
+        case "standard-textured":
+        case "landmark":
+        case "extruded-polygon":
+        case "fill":
+        case "solid-line":
+        case "dashed-line":
+            return THREE.Mesh as ObjectConstructor;
+
+        case "circles":
+            return Circles as ObjectConstructor;
+        case "squares":
+            return Squares as ObjectConstructor;
+
+        case "line":
+            return THREE.LineSegments as ObjectConstructor;
+
+        case "segments":
+            return THREE.LineSegments as ObjectConstructor;
+
+        case "shader": {
+            switch (technique.primitive) {
+                case "line":
+                    return THREE.Line as ObjectConstructor;
+                case "segments":
+                    return THREE.LineSegments as ObjectConstructor;
+                case "point":
+                    return THREE.Points as ObjectConstructor;
+                case "mesh":
+                    return THREE.Mesh as ObjectConstructor;
+                default:
+                    return undefined;
+            }
+        }
+
+        case "text":
+        case "labeled-icon":
+        case "line-marker":
+            return undefined;
+    }
+}
+
+/**
+ * Non material properties of [[BaseTechnique]]
+ */
+export const BASE_TECHNIQUE_NON_MATERIAL_PROPS = [
+    "name",
+    "id",
+    "renderOrder",
+    "renderOrderBiasProperty",
+    "renderOrderBiasGroup",
+    "renderOrderBiasRange",
+    "transient"
+];
+
+/**
+ * Generic material type constructor.
+ */
+export type MaterialConstructor = new (params?: {}) => THREE.Material;
+
+/**
+ * Returns a [[MaterialConstructor]] basing on provided technique object.
+ *
+ * @param technique [[Technique]] object which the material will be based on.
+ */
+export function getMaterialConstructor(technique: Technique): MaterialConstructor | undefined {
+    switch (technique.name) {
+        case "extruded-line":
+            return technique.shading === "standard"
+                ? MapMeshStandardMaterial
+                : MapMeshBasicMaterial;
+
+        case "standard":
+        case "standard-textured":
+        case "landmark":
+        case "extruded-polygon":
+            return MapMeshStandardMaterial;
+
+        case "solid-line":
+            return SolidLineMaterial;
+
+        case "dashed-line":
+            return DashedLineMaterial;
+
+        case "fill":
+            return MapMeshBasicMaterial;
+
+        case "squares":
+            return THREE.PointsMaterial;
+
+        case "circles":
+            return CirclePointsMaterial;
+
+        case "line":
+        case "segments":
+            return THREE.LineBasicMaterial;
+
+        case "shader":
+            return THREE.ShaderMaterial;
+
+        case "text":
+        case "labeled-icon":
+        case "line-marker":
+            return undefined;
+    }
+}
+
+/**
+ * Apply generic technique parameters to material.
+ *
+ * Skips non-material [[Technique]] props:
+ *  * [[BaseTechnique]] props,
+ *  * `name` which is used as discriminator for technique types,
+ *  * props starting with `_`
+ *  * props found `skipExtraProps`
+ *
+ * `THREE.Color` properties are supported.
+ *
+ * @param technique technique from where params are copied
+ * @param material target material
+ * @param level optional, tile zoom level for zoom-level dependent props
+ * @param skipExtraProps optional, skipped props
+ */
+export function applyTechniqueToMaterial(
+    technique: Technique,
+    material: THREE.Material,
+    level?: number,
+    skipExtraProps?: string[]
+) {
+    Object.getOwnPropertyNames(technique).forEach(propertyName => {
+        if (
+            propertyName.startsWith("_") ||
+            BASE_TECHNIQUE_NON_MATERIAL_PROPS.indexOf(propertyName) !== -1 ||
+            (skipExtraProps !== undefined && skipExtraProps.indexOf(propertyName) !== -1)
+        ) {
+            return;
+        }
+        const prop = propertyName as keyof (typeof technique);
+        const m = material as any;
+        let value = technique[prop];
+        if (typeof m[prop] === "undefined") {
+            return;
+        }
+        if (level !== undefined && isCaseProperty<any>(value)) {
+            value = getPropertyValue<any>(value, level);
+        }
+        if (m[prop] instanceof THREE.Color) {
+            m[prop].set(value);
+        } else {
+            m[prop] = value;
+        }
+    });
+}

--- a/@here/harp-mapview/lib/MapViewPoints.ts
+++ b/@here/harp-mapview/lib/MapViewPoints.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+import { PickingRaycaster } from "./PickingRaycaster";
+
+/**
+ * `MapViewPoints` is a class to extend for the `"circles"` and `"squares"` [[Technique]]s to
+ * implement raycasting of [[THREE.Points]] as expected in [[MapView]], that is in screen space. It
+ * copies the behaviour of the `raycast` method in [[THREE.Points]] and dispatches it to its
+ * children classes, [[Circles]] and [[Squares]], who hold the intersection testing in the
+ * `testPoint` method. This class also has the ability to dismiss the testing via the
+ * `enableRayTesting` flag.
+ *
+ * Its main motivation is to handle the point styles of XYZ projects.
+ *
+ * @see https://github.com/mrdoob/three.js/blob/master/src/objects/Points.js
+ */
+export abstract class MapViewPoints extends THREE.Points {
+    /**
+     * This allows to discard the ray testing.
+     */
+    enableRayTesting: boolean = true;
+
+    /**
+     * Implements the intersection testing in screen space between the drawn points and the ray. The
+     * drawing of the points being different between [[Circles]] and [[Squares]], this method is
+     * implemented in these child classes.
+     *
+     * @param point The point to test.
+     * @param screenPosition The point position on screen.
+     * @param pickCoordinates The picking position on screen.
+     * @param index The index of the point in the [[THREE.Geometry]].
+     * @param distance The distance between the point and the ray origin.
+     * @param intersects The results array.
+     */
+    abstract testPoint(
+        point: THREE.Vector3,
+        screenPosition: THREE.Vector2,
+        pickCoordinates: THREE.Vector2,
+        index: number,
+        distance: number,
+        intersects: THREE.Intersection[]
+    ): void;
+
+    /**
+     * This method is similar to the original method `raycast` in [[THREE.Points]] except that it
+     * then calls the tailored `testPoint` method in the children classes to test intersections
+     * depending on whether the points are circles or squares, which [[THREE.Points]] cannot do.
+     *
+     * @param raycaster The raycaster.
+     * @param intersects The array to fill with the results.
+     */
+    raycast(raycaster: PickingRaycaster, intersects: THREE.Intersection[]) {
+        if (!this.enableRayTesting) {
+            return;
+        }
+
+        const geometry = this.geometry;
+        const matrixWorld = this.matrixWorld;
+        const screenCoords = raycaster.ray.origin
+            .clone()
+            .add(raycaster.ray.direction)
+            .project(raycaster.mapView.camera);
+        const { clientWidth, clientHeight } = raycaster.mapView.canvas;
+        const mouseCoords = new THREE.Vector2(
+            Math.ceil(((screenCoords.x + 1) / 2) * clientWidth),
+            Math.ceil(((1 - screenCoords.y) / 2) * clientHeight)
+        );
+
+        if (geometry instanceof THREE.BufferGeometry) {
+            const point = new THREE.Vector3();
+            const index = geometry.index;
+            const attributes = geometry.attributes;
+            const positions = attributes.position.array;
+            if (index !== null) {
+                const indices = index.array;
+                for (let i = 0, il = indices.length; i < il; i++) {
+                    const a = indices[i];
+                    point.fromArray(positions as number[], a * 3);
+                    const pointInfo = getPointInfo(
+                        point,
+                        matrixWorld,
+                        raycaster,
+                        clientWidth,
+                        clientHeight
+                    );
+                    if (pointInfo.pointIsOnScreen) {
+                        this.testPoint(
+                            point,
+                            pointInfo.absoluteScreenPosition!,
+                            mouseCoords,
+                            i,
+                            pointInfo.distance!,
+                            intersects
+                        );
+                    }
+                }
+            } else {
+                for (let i = 0, l = positions.length / 3; i < l; i++) {
+                    point.fromArray(positions as number[], i * 3);
+                    const pointInfo = getPointInfo(
+                        point,
+                        matrixWorld,
+                        raycaster,
+                        clientWidth,
+                        clientHeight
+                    );
+                    if (pointInfo.pointIsOnScreen) {
+                        this.testPoint(
+                            point,
+                            pointInfo.absoluteScreenPosition!,
+                            mouseCoords,
+                            i,
+                            pointInfo.distance!,
+                            intersects
+                        );
+                    }
+                }
+            }
+        } else {
+            const vertices = geometry.vertices;
+            for (let index = 0; index < vertices.length; index++) {
+                const point = vertices[index];
+                const pointInfo = getPointInfo(
+                    point,
+                    matrixWorld,
+                    raycaster,
+                    clientWidth,
+                    clientHeight
+                );
+                if (pointInfo.pointIsOnScreen) {
+                    this.testPoint(
+                        point,
+                        pointInfo.absoluteScreenPosition!,
+                        mouseCoords,
+                        index,
+                        pointInfo.distance!,
+                        intersects
+                    );
+                }
+            }
+        }
+    }
+}
+
+function getPointInfo(
+    point: THREE.Vector3,
+    matrixWorld: THREE.Matrix4,
+    raycaster: PickingRaycaster,
+    width: number,
+    height: number
+): {
+    pointIsOnScreen: boolean;
+    absoluteScreenPosition?: THREE.Vector2;
+    distance?: number;
+} {
+    const worldPosition = point.clone();
+    worldPosition.applyMatrix4(matrixWorld);
+    const distance = worldPosition.distanceTo(raycaster.ray.origin);
+    worldPosition.project(raycaster.mapView.camera);
+    const relativeScreenPosition = new THREE.Vector2(worldPosition.x, worldPosition.y);
+    const pointIsOnScreen =
+        relativeScreenPosition.x < 1 &&
+        relativeScreenPosition.x > -1 &&
+        relativeScreenPosition.y < 1 &&
+        relativeScreenPosition.y > -1;
+    if (pointIsOnScreen) {
+        worldPosition.x = ((worldPosition.x + 1) / 2) * width;
+        worldPosition.y = ((1 - worldPosition.y) / 2) * height;
+        const absoluteScreenPosition = new THREE.Vector2(worldPosition.x, worldPosition.y);
+        return {
+            absoluteScreenPosition,
+            pointIsOnScreen,
+            distance
+        };
+    }
+    return {
+        pointIsOnScreen
+    };
+}
+
+/**
+ * Point object that implements the raycasting of circles in screen space.
+ */
+export class Circles extends MapViewPoints {
+    testPoint(
+        point: THREE.Vector3,
+        screenPosition: THREE.Vector2,
+        pickCoordinates: THREE.Vector2,
+        index: number,
+        distance: number,
+        intersects: THREE.Intersection[]
+    ) {
+        const dx = screenPosition.x - pickCoordinates.x;
+        const dy = screenPosition.y - pickCoordinates.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const radius = (this.material as THREE.PointsMaterial).size / 2;
+
+        if (dist <= radius) {
+            intersects.push({
+                point,
+                distance,
+                index,
+                object: this
+            });
+        }
+    }
+}
+
+/**
+ * Point object that implements the raycasting of squares in screen space.
+ */
+export class Squares extends MapViewPoints {
+    testPoint(
+        point: THREE.Vector3,
+        screenPosition: THREE.Vector2,
+        pickCoordinates: THREE.Vector2,
+        index: number,
+        distance: number,
+        intersects: THREE.Intersection[]
+    ) {
+        const dx = screenPosition.x - pickCoordinates.x;
+        const dy = screenPosition.y - pickCoordinates.y;
+        const halfSize = (this.material as THREE.PointsMaterial).size / 2;
+
+        if (Math.abs(dx) <= halfSize && Math.abs(dy) <= halfSize) {
+            intersects.push({
+                point,
+                distance,
+                index,
+                object: this
+            });
+        }
+    }
+}

--- a/@here/harp-mapview/lib/PickingRaycaster.ts
+++ b/@here/harp-mapview/lib/PickingRaycaster.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+import { MapView } from "./MapView";
+
+/**
+ * Raycasting points is not supported as necessary in Three.js. This class extends a
+ * [[THREE.Raycaster]] except that it holds a reference to [[MapView]] allowing to access the
+ * camera and the renderer from [[MapViewPoints]], in order to project the points in screen space.
+ */
+export class PickingRaycaster extends THREE.Raycaster {
+    /**
+     * Constructs a `MapViewRaycaster`. It keeps a reference to [[MapView]] in order to access the
+     * active camera when calling the custom method `raycastPoints`.
+     *
+     * @param m_mapView the active [[MapView]].
+     */
+    constructor(public mapView: MapView) {
+        super();
+    }
+}

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -6,18 +6,12 @@
 
 // tslint:disable:only-arrow-functions
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
-
-import { createMaterial } from "../lib/DecodedTile";
-import { getObjectConstructor, ShaderTechnique } from "../lib/Techniques";
-
+import { ShaderTechnique } from "@here/harp-datasource-protocol";
 import { assert } from "chai";
 import * as THREE from "three";
+import { createMaterial, getObjectConstructor } from "./../lib/DecodedTileHelpers";
 
-describe("DataSourceProtocol", function() {
-    it("ok", function() {
-        assert.isTrue(true);
-    });
-
+describe("Tile Creation", function() {
     it("ShaderTechnique", function() {
         const technique: ShaderTechnique = {
             name: "shader",

--- a/@here/harp-materials/lib/CirclePointsMaterial.ts
+++ b/@here/harp-materials/lib/CirclePointsMaterial.ts
@@ -47,7 +47,9 @@ export interface CirclePointsMaterialParameters extends THREE.ShaderMaterialPara
 const DEFAULT_CIRCLE_SIZE = 1;
 
 /**
- * Material designed to render circle points.
+ * Material designed to render circle points. Note that it is always transparent since the circle
+ * shape is created with an alpha channel to benefit an antialising that a mere `discard` could
+ * not bring.
  */
 export class CirclePointsMaterial extends ShaderMaterial {
     isCirclePointsMaterial: true;
@@ -72,6 +74,7 @@ export class CirclePointsMaterial extends ShaderMaterial {
         this.type = "CirclePointsMaterial";
         this.vertexShader = vertexShader;
         this.fragmentShader = fragmentShader;
+        this.transparent = true;
 
         this.m_size = parameters.size || DEFAULT_CIRCLE_SIZE;
         this.m_color = new Color();


### PR DESCRIPTION
#### This PR allows to click on the points used in the XYZ styles. 
<hr>

### :link: Links: 
- related changes to be +2-ed on Gerrit
- [testing the raycasting on points in the TryMe](https://render-verity.jenkins.release.in.here.com/job/verity-sdk-pre-submit/1231/Try_Me/verity-examples/index.html?space=https://xyz.api.here.com/hub/spaces/GpDz7i1T/tile/quadkey/1?margin=20&clip=false&access_token=AbdfoIN9SSSqqnc58TXPK9g#dist/xyz_show_space.html). 
<hr>

### :information_source: Overview 
The raycasting of points was not happening as expected for XYZ in ThreeJS. With XYZ, points can be squares or circles, and can be duplicated for outlining purposes. This commit solves the problematic by testing intersections in screen space and allowing to discard the testing on duplicate point sets.
<hr>

### :warning: Note
Some methods have been moved from `here-datasource-protocol` to `here-mapview/lib/DecodedTileHelpers.ts`to avoid circular dependencies:
- `getObjectConstructor`
- `getMaterialContructor`
- `applyTechniqueToMaterial`
- `createMaterial`
- `getBufferAttribute`
- and some associated interfaces.

Same for the related tests.
