### PR TITLE
Load test resources directly from package directory

### DIFF
--- a/@here/harp-mapview/test/ImageCacheTest.ts
+++ b/@here/harp-mapview/test/ImageCacheTest.ts
@@ -52,12 +52,12 @@ describe("MapViewImageCache", function() {
     });
 
     if (typeof document !== "undefined") {
-        it("#addImage", done => {
+        it("#addImage", async function() {
             const cache = new MapViewImageCache(mapView);
             cache.clear();
 
             const imageName = "headshot.png";
-            const imageUrl = "../dist/test/harp-mapview/test/resources/headshot.png";
+            const imageUrl = "../dist/test/@here/harp-mapview/test/resources/headshot.png";
 
             const promise = cache.addImage(imageName, imageUrl, true);
 
@@ -68,25 +68,15 @@ describe("MapViewImageCache", function() {
 
             assert.isTrue(promise instanceof Promise);
 
-            try {
-                if (promise instanceof Promise) {
-                    promise
-                        .then(() => {
-                            const loadedImageItem = cache.findImageByName(imageName);
-                            assert.exists(loadedImageItem);
-                            assert.isDefined(loadedImageItem!.imageData);
-                            assert.isTrue(loadedImageItem!.loaded);
-                            const image = loadedImageItem!.imageData!;
-                            assert.equal(image.width, 37);
-                            assert.equal(image.height, 36);
-                            done();
-                        })
-                        .catch(ex => {
-                            assert.fail(ex);
-                        });
-                }
-            } catch (ex) {
-                assert.fail(ex);
+            if (promise instanceof Promise) {
+                await promise;
+                const loadedImageItem = cache.findImageByName(imageName);
+                assert.exists(loadedImageItem);
+                assert.isDefined(loadedImageItem!.imageData);
+                assert.isTrue(loadedImageItem!.loaded);
+                const image = loadedImageItem!.imageData!;
+                assert.equal(image.width, 37);
+                assert.equal(image.height, 36);
             }
         });
     }
@@ -204,13 +194,13 @@ describe("ImageCache", function() {
     });
 
     if (typeof document !== "undefined") {
-        it("#addImage", done => {
+        it("#addImage", async function() {
             // tslint:disable-next-line:no-object-literal-type-assertion
             const mapView: MapView = {} as MapView;
             const instance = ImageCache.instance;
             instance.clearAll();
 
-            const imageUrl = "../dist/test/harp-mapview/test/resources/headshot.png";
+            const imageUrl = "../dist/test/@here/harp-mapview/test/resources/headshot.png";
 
             const promise = instance.addImage(mapView, imageUrl, true);
 
@@ -221,25 +211,15 @@ describe("ImageCache", function() {
 
             assert.isTrue(promise instanceof Promise);
 
-            try {
-                if (promise instanceof Promise) {
-                    promise
-                        .then(() => {
-                            const loadedImageItem = instance.findImage(imageUrl);
-                            assert.exists(loadedImageItem);
-                            assert.isDefined(loadedImageItem!.imageData);
-                            assert.isTrue(loadedImageItem!.loaded);
-                            const image = loadedImageItem!.imageData!;
-                            assert.equal(image.width, 37);
-                            assert.equal(image.height, 36);
-                            done();
-                        })
-                        .catch(ex => {
-                            assert.fail(ex);
-                        });
-                }
-            } catch (ex) {
-                assert.fail(ex);
+            if (promise instanceof Promise) {
+                await promise;
+                const loadedImageItem = instance.findImage(imageUrl);
+                assert.exists(loadedImageItem);
+                assert.isDefined(loadedImageItem!.imageData);
+                assert.isTrue(loadedImageItem!.loaded);
+                const image = loadedImageItem!.imageData!;
+                assert.equal(image.width, 37);
+                assert.equal(image.height, 36);
             }
         });
     }

--- a/@here/harp-mapview/test/WorkerLoaderTest.ts
+++ b/@here/harp-mapview/test/WorkerLoaderTest.ts
@@ -39,7 +39,7 @@ describe("WorkerLoader", function() {
         WorkerLoader.directlyFallbackToBlobBasedLoading = false;
     });
 
-    const testWorkerUrl = getTestResourceUrl("harp-mapview", "test/resources/testWorker.js");
+    const testWorkerUrl = getTestResourceUrl("@here/harp-mapview", "test/resources/testWorker.js");
 
     it("WorkerLoader falls back to blob / sync", async function() {
         // setup an environment in which any attempt to load worker from from non-blob URL

--- a/@here/harp-test-utils/lib/TestDataUtils.ts
+++ b/@here/harp-test-utils/lib/TestDataUtils.ts
@@ -85,7 +85,8 @@ export function loadTestResourceNode(
     fileName: string,
     type: "arraybuffer" | "text" | "json"
 ): Promise<any> {
-    const filePath = path.join("dist", "test", module, fileName);
+    const modulePath = path.dirname(require.resolve(module + "/package.json"));
+    const filePath = path.join(modulePath, fileName);
 
     return new Promise((resolve, reject) => {
         const encoding = type === "arraybuffer" ? null : "utf-8";

--- a/@here/harp-test-utils/test/TestDataUtilsTest.ts
+++ b/@here/harp-test-utils/test/TestDataUtilsTest.ts
@@ -16,7 +16,7 @@ describe("@here/harp-test-utils", function() {
     describe("#loadTestResource", function() {
         it(`loads static text file`, async function() {
             const textFromFile = await loadTestResource(
-                "harp-test-utils",
+                "@here/harp-test-utils",
                 "./test/resources/test.txt",
                 "text"
             );
@@ -26,7 +26,7 @@ describe("@here/harp-test-utils", function() {
         });
         it(`loads static json file`, async function() {
             const jsonFromFile = await loadTestResource(
-                "harp-test-utils",
+                "@here/harp-test-utils",
                 "./test/resources/test.json",
                 "json"
             );
@@ -36,7 +36,7 @@ describe("@here/harp-test-utils", function() {
         });
         it(`loads static binary file`, async function() {
             const bufferResult = await loadTestResource(
-                "harp-test-utils",
+                "@here/harp-test-utils",
                 "./test/resources/test.bin",
                 "arraybuffer"
             );

--- a/@here/harp-text-canvas/test/FontCatalogTest.ts
+++ b/@here/harp-text-canvas/test/FontCatalogTest.ts
@@ -67,23 +67,23 @@ describe("FontCatalog", () => {
     let fontCatalog: FontCatalog;
     it("Creates an instance successfully.", async () => {
         const catalogJson = await loadJSON(
-            getTestResourceUrl("harp-text-canvas", "resources/fonts/Default_FontCatalog.json")
+            getTestResourceUrl("@here/harp-text-canvas", "resources/fonts/Default_FontCatalog.json")
         );
         const replacementJson = await loadJSON(
             getTestResourceUrl(
-                "harp-text-canvas",
+                "@here/harp-text-canvas",
                 "resources/fonts/Default_Assets/Extra/Specials.json"
             )
         );
         const replacementTexture = await loadTexture(
             getTestResourceUrl(
-                "harp-text-canvas",
+                "@here/harp-text-canvas",
                 "resources/fonts/Default_Assets/Extra/Specials.png"
             )
         );
 
         fontCatalog = new FontCatalog(
-            getTestResourceUrl("harp-text-canvas", "resources/fonts"),
+            getTestResourceUrl("@here/harp-text-canvas", "resources/fonts"),
             catalogJson.name,
             catalogJson.type,
             catalogJson.size,

--- a/@here/harp-text-canvas/test/TextCanvasTest.ts
+++ b/@here/harp-text-canvas/test/TextCanvasTest.ts
@@ -60,23 +60,23 @@ describe("TextCanvas", () => {
     let textCanvas: TextCanvas;
     it("Creates an instance successfully.", async () => {
         const catalogJson = await loadJSON(
-            getTestResourceUrl("harp-text-canvas", "resources/fonts/Default_FontCatalog.json")
+            getTestResourceUrl("@here/harp-text-canvas", "resources/fonts/Default_FontCatalog.json")
         );
         const replacementJson = await loadJSON(
             getTestResourceUrl(
-                "harp-text-canvas",
+                "@here/harp-text-canvas",
                 "resources/fonts/Default_Assets/Extra/Specials.json"
             )
         );
         const replacementTexture = await loadTexture(
             getTestResourceUrl(
-                "harp-text-canvas",
+                "@here/harp-text-canvas",
                 "resources/fonts/Default_Assets/Extra/Specials.png"
             )
         );
 
         const loadedFontCatalog = new FontCatalog(
-            getTestResourceUrl("harp-text-canvas", "resources/fonts"),
+            getTestResourceUrl("@here/harp-text-canvas", "resources/fonts"),
             catalogJson.name,
             catalogJson.type,
             catalogJson.size,

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -140,16 +140,16 @@ syncFiles({
     "harp-map-theme",
     "harp-text-canvas"
 ].forEach(module => {
-    mkpath.sync(`dist/test/${module}/resources`);
-    mkpath.sync(`dist/test/${module}/test/resources`);
+    mkpath.sync(`dist/test/@here/${module}/resources`);
+    mkpath.sync(`dist/test/@here/${module}/test/resources`);
 
     syncDirsIfNeeded({
         sourceDir: `../@here/${module}/resources`,
-        destDir: `../dist/test/${module}/resources`
+        destDir: `../dist/test/@here/${module}/resources`
     });
 
     syncDirsIfNeeded({
         sourceDir: `../@here/${module}/test/resources`,
-        destDir: `../dist/test/${module}/test/resources`
+        destDir: `../dist/test/@here/${module}/test/resources`
     });
 });


### PR DESCRIPTION
In order to prepare for the removal of the postinstall magic, test
resource files are directly loaded from their package (using
require.resolve()) rather than from some magic dist directory