### PR TITLE
Remove test resources root

### DIFF
--- a/@here/harp-test-utils/lib/TestDataUtils.web.ts
+++ b/@here/harp-test-utils/lib/TestDataUtils.web.ts
@@ -10,12 +10,13 @@ import { LoggerManager } from "@here/harp-utils";
 
 const logger = LoggerManager.instance.create("TestDataUtils");
 
+declare const TEST_RESOURCES_DIR: string | undefined;
+
 /**
  * Base path from which test resources are loaded.
-
  * @hidden
  */
-export const testResourcesRoot = "../dist/test/";
+export const testResourcesRoot = TEST_RESOURCES_DIR === undefined ? "" : TEST_RESOURCES_DIR;
 
 /**
  * Get URL of test resource.
@@ -26,7 +27,7 @@ export const testResourcesRoot = "../dist/test/";
  * @param fileName: file relative to module path (e.g. `test/resources/berlin.bin)`
  */
 export function getTestResourceUrl(module: string, fileName: string) {
-    return testResourcesRoot + "/" + module + "/" + fileName;
+    return testResourcesRoot + module + "/" + fileName;
 }
 
 /**


### PR DESCRIPTION
Do not hard code paths. Instead, resources should be made available
relative to the test