### PR TITLE
Publish documentation only for stable releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,12 @@ jobs:
 
 deploy:
   - provider: script
-    script: echo npx lerna publish -y from-git
+    script:
+      - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
+      - |
+          if ./scripts/git-is-first-tag.sh "$TRAVIS_TAG" ; then \
+              echo npx lerna publish -y from-git ; \
+          fi
     skip_cleanup: true
     on:
       tags: true

--- a/scripts/git-is-first-tag.sh
+++ b/scripts/git-is-first-tag.sh
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+
+#
+# Simple script that returns 0 if a given tag is the
+# first tag for the sha it is pointing to.
+#
+
+tag="$1"
+
+if [ -z "$tag" ] ; then
+    echo "Please provide a tag"
+    exit 1
+fi
+
+sha=$(git rev-list -n1 "$tag")
+allTags=$(git tag --points-at "$sha")
+
+case "$allTags" in
+    $tag*)
+        echo Tag $tag is the first tag of commit $sha
+        exit 0
+        ;;
+    *)
+        echo Tag $tag is not the first tag of commit $sha
+        exit 1
+        ;;
+esac
+


### PR DESCRIPTION
Travis treats tags as branches, so we need to whitelist v1.2.3 tags in
order to reach the deployment step.

Signed-off-by: Harald Fernengel <harald.fernengel@here.com>