### PR TITLE
HARP-3920: Implement untiled datasource logic.

### DIFF
--- a/@here/harp-mapview-decoder/index.ts
+++ b/@here/harp-mapview-decoder/index.ts
@@ -7,4 +7,5 @@
 export * from "./lib/DataProvider";
 export * from "./lib/TileDataSource";
 export * from "./lib/TileLoader";
+export * from "./lib/UntiledDataProvider";
 export * from "./lib/ThemedTileDecoder";

--- a/@here/harp-mapview-decoder/lib/DataProvider.ts
+++ b/@here/harp-mapview-decoder/lib/DataProvider.ts
@@ -14,6 +14,11 @@ import { TileKey } from "@here/harp-geoutils";
  */
 export interface DataProvider {
     /**
+     * Helps determine whether the class implemented is an [[UntiledDataProvider]].
+     */
+    isUntiled?: boolean;
+
+    /**
      * Connect to the data source. Returns a promise to wait for successful (or failed) connection.
      *
      * @returns A promise which is resolved when the connection has been established.

--- a/@here/harp-mapview-decoder/lib/UntiledDataProvider.ts
+++ b/@here/harp-mapview-decoder/lib/UntiledDataProvider.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017-2018 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TileKey } from "@here/harp-geoutils";
+import { DataProvider } from "./DataProvider";
+
+/**
+ * Provides a general way of issuing untiled data into a [[TileDataSource]].
+ */
+export class UntiledDataProvider implements DataProvider {
+    isUntiled = true;
+
+    /**
+     * The root tile the data should be added to.
+     */
+    rootTileKey: TileKey = new TileKey(0, 0, 0);
+
+    constructor(public data: {} = {}) {}
+
+    ready(): boolean {
+        return true;
+    }
+
+    // tslint:disable-next-line:no-empty
+    async connect(): Promise<void> {}
+
+    async getTile(): Promise<{}> {
+        return this.data;
+    }
+}


### PR DESCRIPTION
This PR addresses the numerous duplicates in the verity examples used to show custom, local, untiled data in a MapView. It moves this duplicated code from the examples to a standard class `UntiledDataProvider` and brings small changes in the `TileDataSource` logic.