### PR TITLE
HARP-4374: RenderComposer API [WIP]

### DIFF
--- a/@here/harp-mapview/lib/composing/RenderComposer.ts
+++ b/@here/harp-mapview/lib/composing/RenderComposer.ts
@@ -1,0 +1,113 @@
+import { MapViewOptions } from "../MapView";
+import { MSAARenderPass, MSAASampling } from "./MSAARenderPass";
+
+import * as THREE from "three";
+// import "three/examples/js/shaders/CopyShader";
+// import "three/examples/js/postprocessing/EffectComposer";
+// import "three/examples/js/postprocessing/RenderPass";
+// import "three/examples/js/postprocessing/ShaderPass";
+
+const DEFAULT_CLEAR_COLOR = 0xefe9e1;
+
+interface InitializationData {
+    options: MapViewOptions;
+}
+
+const DEFAULT_DYNAMIC_MSAA_SAMPLING_LEVEL = MSAASampling.Level_1;
+const DEFAULT_STATIC_MSAA_SAMPLING_LEVEL = MSAASampling.Level_4;
+
+export class RenderComposer {
+    renderer: THREE.WebGLRenderer;
+    private m_running: boolean = false;
+    private m_mapViews: Map<any, any> = new Map();
+    private m_animationFrameHandle: number | undefined;
+    // public composer: THREE.EffectComposer;
+
+    constructor() {
+        // ...
+    }
+
+    registerMapView(mapView: any, renderFunc: any) {
+        this.m_mapViews.set(mapView, renderFunc);
+    }
+
+    requestUpdate(mapView: any) {
+        if (!this.m_running) {
+            return;
+        }
+
+        this.cancelUpdate();
+        this.m_animationFrameHandle = requestAnimationFrame(this.update.bind(this, mapView));
+    }
+
+    cancelUpdate() {
+        if (this.m_animationFrameHandle !== undefined) {
+            cancelAnimationFrame(this.m_animationFrameHandle);
+        }
+    }
+
+    before(data: InitializationData) {
+        const { options } = data;
+
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: options.canvas,
+            antialias: options.enableNativeWebglAntialias !== false,
+            alpha: options.alpha,
+            preserveDrawingBuffer: options.preserveDrawingBuffer === true
+        });
+
+        this.renderer.autoClear = false;
+        this.renderer.info.autoReset = false;
+
+        // const msaaPass = new MSAARenderPass();
+
+        // this.composer = new THREE.EffectComposer(this.renderer);
+        // msaaPass.enabled = true;
+        // msaaPass.renderToScreen = true;
+        // this.composer.addPass(msaaPass);
+
+        this.renderer.setClearColor(DEFAULT_CLEAR_COLOR);
+    }
+
+    resize(width: number, height: number) {
+        this.renderer.setSize(width, height, false);
+        this.renderer.setPixelRatio(window.devicePixelRatio);
+    }
+
+    render(
+        scene: THREE.Scene,
+        camera: THREE.PerspectiveCamera | THREE.OrthographicCamera,
+        isStaticFrame: boolean
+    ) {
+        const renderer = this.renderer;
+
+        const isHighDpiDevice = renderer.getPixelRatio() > 1.1; // On desktop IE11 is ~1.01.
+
+        // 1. First pass (and only for the map part) : base scene render.
+        if (isHighDpiDevice) {
+            // On smartphones, discard AAs as the pixel ratio already stands for this and also makes
+            // AA passes much more expensive.
+            renderer.render(scene, camera);
+        } else {
+            // TODO: Render with custom MSAA effect applied.
+            renderer.render(scene, camera);
+        }
+    }
+
+    start() {
+        this.m_running = true;
+
+        for (const mapView of this.m_mapViews.keys()) {
+            mapView.drawFrame();
+        }
+    }
+
+    stop() {
+        this.m_running = false;
+    }
+
+    private update(mapView: any, time: number) {
+        this.m_mapViews.get(mapView)(time);
+        // this.m_mapViews.forEach((renderFunc: any) => renderFunc(time));
+    }
+}

--- a/@here/harp-mapview/lib/composing/index.ts
+++ b/@here/harp-mapview/lib/composing/index.ts
@@ -11,4 +11,5 @@ export {
     MapRenderingManager
 } from "./MapRenderingManager";
 export { IPass, Pass } from "./Pass";
+export { RenderComposer } from "./RenderComposer";
 export { MSAARenderPass, MSAASampling } from "./MSAARenderPass";


### PR DESCRIPTION
> **Warning!** This feature is **not** yet complete/approved. Pull-request is made for API discussion
> **UPD:** The task is currently **postponed**.

`RenderComposer` is a class that handles rendering loop for single or multiple `MapView`s. It's purpose is to bring developer more control over MapView rendering without breaking key optimizations and open possibilities of using renderTargets, compositiong & postprocessing

**Current approach** (This might be changed in future!)
 - `RenderComposer` (only key methods are described)
   -  `#before()` - WebGLRenderer setup, preparings (depending on `m_options` of MapView)
   - `#render()` - Rendering MapView to canvas/renderTarget. Executed per each MapView.
   - `#resize()` - Emitted by MapView, should be overwrited in case you have custom renderTargets
   - `#requestUpdate/cancelUpdate` - This lifecycle methods give you more control over render loop.

You can create a custom version of `RenderComposer` by extending it and overwriting lifecycle methods. (just like in React.js you do with render, componentDidMount, etc...)

**TODOs** (might be changed as well)
 - [ ] make render MapView-dependent
 - [ ] write an example
 - [ ] Cleanup (remove commented code, add typings, tests)
