### PR TITLE
Optimize size of harp-examples dist.

### DIFF
--- a/@here/harp-examples/webpack.config.js
+++ b/@here/harp-examples/webpack.config.js
@@ -99,6 +99,13 @@ const browserConfig = merge(commonConfig, {
     entry: webpackEntries,
     output: {
         filename: "[name]_bundle.js"
+    },
+    optimization: {
+        splitChunks: {
+            chunks: "all",
+            minSize: 1000,
+            name: "common",
+        }
     }
 });
 
@@ -118,7 +125,7 @@ browserConfig.plugins = Object.keys(browserConfig.entry).map(
     chunk =>
     new HtmlWebpackPlugin({
         template: "template/example.html",
-        chunks: ["common_chunks", chunk],
+        chunks: ["common", chunk],
         filename: `${chunk}.html`
     })
 );


### PR DESCRIPTION
Use SplitChunksPlugin to gather common code into `common` chunk and
space by not emitting same code in every example bundle.