### PR TITLE
Fix performance test failure waiting for first frame complete event

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -226,11 +226,11 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
                         : this.m_options.copyrightInfo;
 
                 tile.setDecodedTile(tileLoader.decodedTile);
-                this.requestUpdate();
             } else {
                 // empty tiles are traditionally ignored and don't need decode
                 tile.forceHasGeometry(true);
             }
+            this.requestUpdate();
         });
     }
 


### PR DESCRIPTION
Always request an update after decoding empty tiles. Currently if the
the last tile decoded is empty the frame complete event will not fire
even though all visible tiles are loaded.