### PR TITLE
HARP-3860: Fix XYZ Project labels.

### DIFF
--- a/@here/harp-geojson-datasource/lib/GeoJsonGeometryCreator.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonGeometryCreator.ts
@@ -209,11 +209,9 @@ export class GeoJsonGeometryCreator {
         techniqueIndex: number
     ): GeoJsonTextGeometry {
         const labelProperty = geometryData.labelProperty! as string;
-        const stringCatalog = geometryData.points.geojsonProperties
-            .map((properties: any) => {
-                return properties[labelProperty].toString();
-            })
-            .reverse();
+        const stringCatalog = geometryData.points.geojsonProperties.map((properties: any) => {
+            return properties[labelProperty].toString();
+        });
         return {
             positions: {
                 name: "position",

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -236,13 +236,15 @@ export class GeoJsonTile extends Tile {
     private addTexts(geometry: GeoJsonTextGeometry, technique: TextTechnique) {
         const attribute = getBufferAttribute(geometry.positions);
 
-        const currentVertexCache = new THREE.Vector2();
-
         for (let index = 0; index < attribute.count; index++) {
-            currentVertexCache.set(attribute.getX(index), attribute.getY(index));
+            const currentVertexCache = new THREE.Vector2(
+                attribute.getX(index),
+                attribute.getY(index)
+            );
+
             const properties =
                 geometry.objInfos !== undefined ? geometry.objInfos[index] : undefined;
-            const text = geometry.stringCatalog![geometry.texts[0]] as string;
+            const text = geometry.stringCatalog![index] as string;
             this.addText(currentVertexCache, text, technique, properties);
         }
     }
@@ -289,14 +291,10 @@ export class GeoJsonTile extends Tile {
             technique.mayOverlap === undefined
                 ? DEFAULT_LABELED_ICON.iconMayOverlap
                 : technique.mayOverlap;
-        const reserveSpace =
-            technique.reserveSpace === undefined
-                ? DEFAULT_LABELED_ICON.textReserveSpace
-                : technique.reserveSpace;
         const distanceScale = DEFAULT_TEXT_DISTANCE_SCALE;
 
         textElement.mayOverlap = mayOverlap;
-        textElement.reserveSpace = reserveSpace;
+        textElement.reserveSpace = false;
         textElement.distanceScale = distanceScale;
 
         this.addUserTextElement(textElement);
@@ -364,15 +362,16 @@ export class GeoJsonTile extends Tile {
                 ? DEFAULT_LABELED_ICON.textReserveSpace
                 : technique.iconReserveSpace;
         const distanceScale = DEFAULT_TEXT_DISTANCE_SCALE;
-
-        textElement.mayOverlap = mayOverlap;
-        textElement.reserveSpace = reserveSpace;
-        textElement.distanceScale = distanceScale;
-
         const alwaysOnTop =
             technique.alwaysOnTop === undefined
                 ? DEFAULT_LABELED_ICON.alwaysOnTop
                 : technique.alwaysOnTop;
+
+        textElement.mayOverlap = mayOverlap;
+        textElement.reserveSpace = reserveSpace;
+        textElement.distanceScale = distanceScale;
+        textElement.alwaysOnTop = alwaysOnTop;
+
         const textIsOptional =
             technique.textIsOptional === undefined
                 ? DEFAULT_LABELED_ICON.textIsOptional
@@ -401,8 +400,6 @@ export class GeoJsonTile extends Tile {
             reserveSpace,
             featureId
         };
-
-        textElement.alwaysOnTop = alwaysOnTop;
 
         this.addUserTextElement(textElement);
     }

--- a/@here/harp-geojson-datasource/test/GeoJsonTest.ts
+++ b/@here/harp-geojson-datasource/test/GeoJsonTest.ts
@@ -259,13 +259,13 @@ describe("@here-geojson-datasource", () => {
         assert.deepEqual(result0, expectedResult0);
 
         // Text paths for lines.
-        const text3Coords = userTextElements[3].points as THREE.Vector2[];
+        const text3Coords = userTextElements[2].points as THREE.Vector2[];
         const result3 = {
             x1: text3Coords[0].x,
             y1: text3Coords[0].y,
             x2: text3Coords[1].x,
             y2: text3Coords[1].y,
-            text: userTextElements[3].text
+            text: userTextElements[2].text
         };
         const expectedResult3 = {
             text: "blablabla",
@@ -277,16 +277,16 @@ describe("@here-geojson-datasource", () => {
         assert.deepEqual(result3, expectedResult3);
 
         // Texts for polygons.
-        const text2Coords = userTextElements[2].points as THREE.Vector2;
+        const text2Coords = userTextElements[1].points as THREE.Vector2;
         const result2 = {
             x: text2Coords.x,
             y: text2Coords.y,
-            text: userTextElements[2].text
+            text: userTextElements[1].text
         };
         const expectedResult2 = {
             text: "blablablabla",
             x: 18492950,
-            y: -18307436
+            y: -18307488
         };
         assert.deepEqual(result2, expectedResult2);
     });


### PR DESCRIPTION
This PR should fix the discrepancies between the text handling in the XYZ viewer and in H4W. You can use the following URL to look at what an example looks like in XYZ: https://xyz.here.com/viewer/?project_id=d7ca4056-ef28-412b-aca5-ba999d0714bb. Then copy/paste it to our `xyz_project_view` example on the pre-submit's TryMe instance associated to this PR. The lines should still be different and we can have some additional labels where polygons are split between different tiles, but we should not miss labels anymore.