### PR TITLE
HARP-4531: Fix getLastFrameStatistics to return latest frame value

### DIFF
--- a/@here/harp-mapview/lib/Statistics.ts
+++ b/@here/harp-mapview/lib/Statistics.ts
@@ -9,7 +9,7 @@ const logger = LoggerManager.instance.create("Statistics");
 
 /**
  * A simple ring buffer to store the last `n` values of the timer. The buffer works on
- * a Last-In-First-Out (LIFO) basis.
+ * a First-In-First-Out (FIFO) basis.
  */
 export class RingBuffer<T> {
     buffer: T[];
@@ -69,7 +69,7 @@ export class RingBuffer<T> {
     }
 
     /**
-     * Obtains the latest element (LIFO). May throw an exception if a buffer underrun occurs.
+     * Obtains the oldest element (FIFO). May throw an exception if a buffer underrun occurs.
      * Before calling this method, make sure that `size > 0`.
      */
     deq(): T {
@@ -91,7 +91,7 @@ export class RingBuffer<T> {
     }
 
     /**
-     * Obtains the latest element (LIFO) without removing it. Throws an exception if a buffer is
+     * Obtains the oldest element (FIFO) without removing it. Throws an exception if a buffer is
      * empty. Before calling this method, make sure that `size > 0`.
      */
     get top(): T {
@@ -100,6 +100,22 @@ export class RingBuffer<T> {
         }
 
         return this.buffer[this.tail];
+    }
+
+    /**
+     * Obtains the latest element (LIFO) without removing it. Throws an exception if a buffer is
+     * empty. Before calling this method, make sure that `size > 0`.
+     */
+    get bottom(): T {
+        if (this.size === 0) {
+            throw new Error("Ringbuffer underrun");
+        }
+
+        let previous = this.head - 1;
+        if (previous < 0) {
+            previous = this.capacity - 1;
+        }
+        return this.buffer[previous];
     }
 
     /**
@@ -1074,7 +1090,7 @@ export class PerformanceStatistics {
         });
 
         for (const [name, buffer] of this.m_frameEvents.frameEntries) {
-            frames[name] = buffer.top;
+            frames[name] = buffer.bottom;
         }
         plainObject.messages = this.m_frameEvents.messages.asArray();
         return plainObject;

--- a/@here/harp-mapview/test/StatisticsTest.ts
+++ b/@here/harp-mapview/test/StatisticsTest.ts
@@ -41,6 +41,7 @@ describe("mapview-statistics", function() {
         rb.enq(7);
         assert.equal(rb.size, 3);
         assert.equal(rb.top, 5);
+        assert.equal(rb.bottom, 7);
         assert.equal(rb.deq(), 5);
         assert.equal(rb.deq(), 6);
         assert.equal(rb.deq(), 7);
@@ -68,6 +69,7 @@ describe("mapview-statistics", function() {
         rb.enq(99, 100);
 
         assert.equal(rb.top, 92);
+        assert.equal(rb.bottom, 100);
         assert.equal(rb.deq(), 92);
         assert.equal(rb.deq(), 93);
         assert.equal(rb.deq(), 94);
@@ -86,6 +88,41 @@ describe("mapview-statistics", function() {
             // tslint:disable-next-line:no-unused-expression
             rb.top;
         });
+        assert.throws(() => {
+            // tslint:disable-next-line:no-unused-expression
+            rb.bottom;
+        });
+
+        rb.clear();
+        rb.enq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+        assert.equal(rb.deq(), 2);
+        assert.equal(rb.deq(), 3);
+        assert.equal(rb.size, 8);
+        assert.equal(rb.top, 4);
+        assert.equal(rb.bottom, 11);
+        rb.enq(12);
+        assert.equal(rb.size, 9);
+        assert.equal(rb.top, 4);
+        assert.equal(rb.bottom, 12);
+        rb.enq(13);
+        assert.equal(rb.size, 10);
+        assert.equal(rb.top, 4);
+        assert.equal(rb.bottom, 13);
+        rb.enq(14);
+        assert.equal(rb.size, 10);
+        assert.equal(rb.top, 5);
+        assert.equal(rb.bottom, 14);
+        assert.equal(rb.deq(), 5);
+        assert.equal(rb.deq(), 6);
+        assert.equal(rb.deq(), 7);
+        assert.equal(rb.deq(), 8);
+        assert.equal(rb.deq(), 9);
+        assert.equal(rb.deq(), 10);
+        assert.equal(rb.deq(), 11);
+        assert.equal(rb.deq(), 12);
+        assert.equal(rb.deq(), 13);
+        assert.equal(rb.deq(), 14);
+        assert.equal(rb.size, 0);
     });
 
     it("init", function() {
@@ -418,6 +455,10 @@ describe("mapview-statistics", function() {
         assert.equal(arrayA[1], 150);
         assert.equal(arrayB[0], 0);
         assert.equal(arrayB[1], 200);
+
+        const frameStats = stats.getLastFrameStatistics();
+        assert.equal(frameStats.frames.a, 150);
+        assert.equal(frameStats.frames.b, 200);
     });
 
     it("add PerformanceStatistics appResults", function() {


### PR DESCRIPTION
RingBuffer implementation is actually FIFO, comments updated.
  Added "bottom" method for retrieving latest element, expanded test coverage.