### PR TITLE
MINOR: Fix numerous console warnings.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -25,7 +25,8 @@ export type Technique =
     | ExtrudedPolygonTechnique
     | ShaderTechnique
     | LandmarkTechnique
-    | TextTechnique;
+    | TextTechnique
+    | NoneTechnique;
 
 /**
  * Techniques are used to specify how a geometry is drawn on the canvas.
@@ -86,6 +87,16 @@ export interface BaseTechnique {
      * opacity and stops fading out. A value of <= 0.0 disables fading.
      */
     fadeFar?: CaseProperty<number>;
+}
+
+/**
+ * The technique to keep a style description without triggering a decoding for it.
+ */
+export interface NoneTechnique extends BaseTechnique {
+    /**
+     * Name of technique. Is used in the theme file.
+     */
+    name: "none";
 }
 
 /**

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -194,6 +194,7 @@ export function getObjectConstructor(technique: Technique): ObjectConstructor | 
         case "text":
         case "labeled-icon":
         case "line-marker":
+        case "none":
             return undefined;
     }
 }
@@ -259,6 +260,7 @@ export function getMaterialConstructor(technique: Technique): MaterialConstructo
         case "text":
         case "labeled-icon":
         case "line-marker":
+        case "none":
             return undefined;
     }
 }

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -483,7 +483,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
 
                 const count = indices.length - start;
                 groups.push({ start, count, technique: techniqueIndex, featureId });
-            } else {
+            } else if (techniqueName !== "none") {
                 logger.warn(
                     `OmvDecodedTileEmitter#processLineFeature: Invalid line technique
                      ${techniqueName} for layer: ${env.entries.$layer} `


### PR DESCRIPTION
This fixes the thousands of console warning thwarting our perfs.

- The styles (day, reducedDay, reducedNight) all use a `"none"` technique name that has no match in our techniques. This PR introduces a `NoneTechnique` for this style. Note sure it is the correct solution. Thoughts @blazejkroll ?
- The problem arises in the Omv decoder, which is checking all the possible line techniques for lines decoding, and is throwing an error if none is found. This PR prevents throwing the error if the new `NoneTechnique` is found.