### PR TITLE
MINOR: Free ExtendedTileInfoVisitor memory after use

### DIFF
--- a/@here/harp-datasource-protocol/lib/TileInfo.ts
+++ b/@here/harp-datasource-protocol/lib/TileInfo.ts
@@ -702,6 +702,7 @@ class ExtendedTileInfoPolygonAccessorImpl implements ExtendedTileInfoPolygonAcce
     isOuterRing(ringIndex: number): boolean {
         assert(ringIndex >= 0);
         assert(ringIndex < this.numRings);
+        assert(this.polygons !== undefined);
         if (ringIndex < 0 || ringIndex >= this.numRings || this.polygons === undefined) {
             throw new Error("ExtendedTileInfoPolygonAccessor: Invalid ring index");
         }
@@ -717,6 +718,7 @@ class ExtendedTileInfoPolygonAccessorImpl implements ExtendedTileInfoPolygonAcce
     } {
         assert(ringIndex >= 0);
         assert(ringIndex < this.numRings);
+        assert(this.polygons !== undefined);
         if (ringIndex < 0 || ringIndex >= this.numRings || this.polygons === undefined) {
             throw new Error("ExtendedTileInfoPolygonAccessor: Invalid ring index");
         }


### PR DESCRIPTION
* would keep the latest info request until the next info is requested