### PR TITLE
HARP-4840: Improve Interactive Render Performance

### DIFF
--- a/@here/harp-mapview/lib/composing/LowResRenderPass.ts
+++ b/@here/harp-mapview/lib/composing/LowResRenderPass.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { CopyMaterial, CopyShader } from "@here/harp-materials";
+import * as THREE from "three";
+
+import { Pass } from "./Pass";
+
+/**
+ * The `LowResRenderPass` renders the scene at a lower resolution into an internal
+ * `WebGLRenderTarget`, and then copies the result into the frame buffer. The size of the internal
+ * buffer is determined by the current frame buffer size multiplied by `pixelRatio`.
+ *
+ * @note Since no anti-aliasing is applied during dynamic rendering, visual artifacts may be
+ * visible.
+ */
+export class LowResRenderPass extends Pass {
+    private m_renderTarget: THREE.WebGLRenderTarget | null = null;
+    private readonly m_localCamera: THREE.OrthographicCamera = new THREE.OrthographicCamera(
+        -1,
+        1,
+        1,
+        -1,
+        0,
+        1
+    );
+    private readonly m_quadScene: THREE.Scene = new THREE.Scene();
+    private readonly m_quadUniforms: { [uniformName: string]: THREE.IUniform } =
+        CopyShader.uniforms;
+    private readonly m_quadMaterial: THREE.ShaderMaterial = new CopyMaterial(this.m_quadUniforms);
+    private readonly m_quad: THREE.Mesh = new THREE.Mesh(
+        new THREE.PlaneBufferGeometry(2, 2),
+        this.m_quadMaterial
+    );
+    private m_pixelRatio: number | undefined;
+    private m_savedWidth = 0;
+    private m_savedHeight = 0;
+
+    /**
+     * The constructor for `LowResRenderPass`. It builds an internal scene with a camera looking at
+     * a quad.
+     *
+     * @param lowResPixelRatio The `pixelRatio` determines the resolution of the internal
+     *  `WebGLRenderTarget`. Values between 0.5 and `window.devicePixelRatio` can be tried to give
+     * good results. A value of `undefined` disables the low res render pass. The value should not
+     * be larger than`window.devicePixelRatio`.
+     */
+    constructor(public lowResPixelRatio?: number) {
+        super();
+        this.m_quad.frustumCulled = false;
+        this.m_quadScene.add(this.m_quad);
+        this.m_pixelRatio = lowResPixelRatio;
+    }
+
+    /**
+     * Releases all used resources.
+     */
+    dispose() {
+        this.m_quadMaterial.dispose();
+        this.m_quad.geometry.dispose();
+        if (this.m_renderTarget !== null) {
+            this.m_renderTarget.dispose();
+            this.m_renderTarget = null;
+        }
+    }
+
+    /**
+     * If a value is specified, a low resolution render pass is used to render the scene into a
+     * low resolution render target, before it is copied to the screen.
+     *
+     * A value of `undefined` disables the low res render pass. The value should not be larger than
+     * `window.devicePixelRatio`.
+     *
+     * @default `undefined`
+     */
+    set pixelRatio(ratio: number | undefined) {
+        this.m_pixelRatio = ratio;
+        if (this.m_renderTarget && this.pixelRatio !== undefined) {
+            this.m_renderTarget.setSize(
+                Math.floor(this.m_savedWidth * this.pixelRatio),
+                Math.floor(this.m_savedHeight * this.pixelRatio)
+            );
+        }
+    }
+
+    get pixelRatio(): number | undefined {
+        return this.m_pixelRatio;
+    }
+
+    /**
+     * The render function of `LowResRenderPass`. It renders the whole scene into an internal
+     * `WebGLRenderTarget` instance with a lower resolution, using the passed in `WebGLRenderer`.
+     * The low resolution image is then copied to the `writeBuffer`, which is `undefined` in case it
+     * is the screen.
+     *
+     * @param renderer The ThreeJS WebGLRenderer instance to render the scene with.
+     * @param scene The ThreeJS Scene instance to render the scene with.
+     * @param camera The ThreeJS Camera instance to render the scene with.
+     * @param writeBuffer A ThreeJS WebGLRenderTarget instance to render the scene to.
+     * @param readBuffer A ThreeJS WebGLRenderTarget instance to render the scene.
+     */
+    render(
+        renderer: THREE.WebGLRenderer,
+        scene: THREE.Scene,
+        camera: THREE.PerspectiveCamera | THREE.OrthographicCamera,
+        writeBuffer: THREE.WebGLRenderTarget | undefined,
+        readBuffer: THREE.WebGLRenderTarget
+    ) {
+        if (!this.enabled || this.pixelRatio === undefined) {
+            return;
+        }
+
+        // Initiates the local render target with the read buffer's dimensions, if not available.
+        if (this.m_renderTarget === null) {
+            this.m_savedWidth = readBuffer.width;
+            this.m_savedHeight = readBuffer.height;
+            this.m_renderTarget = new THREE.WebGLRenderTarget(
+                Math.floor(this.m_savedWidth * this.pixelRatio),
+                Math.floor(this.m_savedHeight * this.pixelRatio),
+                {
+                    minFilter: THREE.LinearFilter,
+                    magFilter: THREE.LinearFilter,
+                    format: THREE.RGBAFormat,
+                    depthBuffer: true,
+                    stencilBuffer: true
+                }
+            );
+            this.m_renderTarget.texture.name = "LowResRenderPass.sample";
+        }
+
+        this.m_quadUniforms.tDiffuse.value = this.m_renderTarget.texture;
+        this.m_quadUniforms.opacity.value = 1.0;
+
+        // Render into the low resolution internal render target.
+        renderer.render(scene, camera, this.m_renderTarget, true);
+
+        // Render the low resolution target into the screen.
+        renderer.render(
+            this.m_quadScene,
+            this.m_localCamera,
+            this.renderToScreen ? undefined : writeBuffer,
+            true
+        );
+    }
+
+    /**
+     * Resize the internal render target to match the new size specified. The size of internal
+     * buffer depends on the `pixelRatio`.
+     *
+     * @param width New width to apply to the render target.
+     * @param height New height to apply to the render target.
+     */
+    setSize(width: number, height: number) {
+        this.m_savedWidth = width;
+        this.m_savedHeight = height;
+        if (this.m_renderTarget && this.pixelRatio !== undefined) {
+            this.m_renderTarget.setSize(
+                Math.floor(width * this.pixelRatio),
+                Math.floor(height * this.pixelRatio)
+            );
+        }
+    }
+}

--- a/@here/harp-mapview/lib/composing/MSAARenderPass.ts
+++ b/@here/harp-mapview/lib/composing/MSAARenderPass.ts
@@ -3,17 +3,9 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { CopyShader, MSAAMaterial } from "@here/harp-materials";
-import {
-    LinearFilter,
-    Mesh,
-    OrthographicCamera,
-    PlaneBufferGeometry,
-    RGBAFormat,
-    Scene,
-    WebGLRenderTarget
-} from "three";
+import * as THREE from "three";
+
 import { Pass } from "./Pass";
 
 /**
@@ -52,7 +44,7 @@ export class MSAARenderPass extends Pass {
     samplingLevel: MSAASampling = MSAASampling.Level_1;
 
     private m_renderTarget: THREE.WebGLRenderTarget | null = null;
-    private readonly m_localCamera: THREE.OrthographicCamera = new OrthographicCamera(
+    private readonly m_localCamera: THREE.OrthographicCamera = new THREE.OrthographicCamera(
         -1,
         1,
         1,
@@ -60,12 +52,12 @@ export class MSAARenderPass extends Pass {
         0,
         1
     );
-    private readonly m_quadScene: THREE.Scene = new Scene();
+    private readonly m_quadScene: THREE.Scene = new THREE.Scene();
     private readonly m_quadUniforms: { [uniformName: string]: THREE.IUniform } =
         CopyShader.uniforms;
     private readonly m_quadMaterial: THREE.ShaderMaterial = new MSAAMaterial(this.m_quadUniforms);
-    private readonly m_quad: THREE.Mesh = new Mesh(
-        new PlaneBufferGeometry(2, 2),
+    private readonly m_quad: THREE.Mesh = new THREE.Mesh(
+        new THREE.PlaneBufferGeometry(2, 2),
         this.m_quadMaterial
     );
 
@@ -125,10 +117,10 @@ export class MSAARenderPass extends Pass {
 
         // Initiates the local render target with the read buffer's dimensions, if not available.
         if (this.m_renderTarget === null) {
-            this.m_renderTarget = new WebGLRenderTarget(readBuffer.width, readBuffer.height, {
-                minFilter: LinearFilter,
-                magFilter: LinearFilter,
-                format: RGBAFormat
+            this.m_renderTarget = new THREE.WebGLRenderTarget(readBuffer.width, readBuffer.height, {
+                minFilter: THREE.LinearFilter,
+                magFilter: THREE.LinearFilter,
+                format: THREE.RGBAFormat
             });
             this.m_renderTarget.texture.name = "MSAARenderPass.sample";
         }
@@ -136,7 +128,8 @@ export class MSAARenderPass extends Pass {
 
         const offsets = MSAARenderPass.OffsetVectors[this.samplingLevel];
 
-        const oldClearColor = renderer.getClearColor().getHex();
+        const rendererClearColor = renderer.getClearColor();
+        const oldClearColor = rendererClearColor !== undefined ? rendererClearColor.getHex() : 0;
 
         // The method `camera.setViewOffset` will be called in the next loop. In order to maintain
         // its usability externally (like for the triple view in mosaic demo) we must cache the
@@ -197,7 +190,7 @@ export class MSAARenderPass extends Pass {
                 this.renderToScreen ? undefined : writeBuffer,
                 i === 0
             );
-            if (i === 0) {
+            if (i === 0 && rendererClearColor !== undefined) {
                 renderer.setClearColor(oldClearColor);
             }
         }

--- a/@here/harp-mapview/lib/composing/Pass.ts
+++ b/@here/harp-mapview/lib/composing/Pass.ts
@@ -63,7 +63,7 @@ export interface IPass {
  * These only are proper shader passes.
  */
 export class Pass implements IPass {
-    enabled: boolean = true;
+    enabled: boolean = false;
     renderToScreen: boolean = false;
     // tslint:disable-next-line:no-unused-variable
     setSize(width: number, height: number) {

--- a/@here/harp-materials/index.ts
+++ b/@here/harp-materials/index.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from "./lib/CopyShader";
+export * from "./lib/CopyMaterial";
 export * from "./lib/DashedLineMaterial";
 export * from "./lib/EdgeMaterial";
 export * from "./lib/MapMeshMaterials";

--- a/@here/harp-materials/lib/CopyMaterial.ts
+++ b/@here/harp-materials/lib/CopyMaterial.ts
@@ -3,6 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as THREE from "three";
 
 /**
  * The base shader to use for [[MapView]]'s composing passes, like [[MSAAMaterial]].
@@ -28,3 +29,27 @@ export const CopyShader: THREE.Shader = {
         gl_FragColor = opacity * texel;
     }`
 };
+
+/**
+ * The material is used for composing.
+ */
+export class CopyMaterial extends THREE.ShaderMaterial {
+    /**
+     * The constructor of `CopyMaterial`.
+     *
+     * @param uniforms The [[CopyShader]]'s uniforms.
+     */
+    constructor(uniforms: { [uniformName: string]: THREE.IUniform }) {
+        super({
+            name: "CopyMaterial",
+            uniforms,
+            vertexShader: CopyShader.vertexShader,
+            fragmentShader: CopyShader.fragmentShader,
+            premultipliedAlpha: true,
+            transparent: false,
+            blending: THREE.NoBlending,
+            depthTest: false,
+            depthWrite: false
+        });
+    }
+}

--- a/@here/harp-materials/lib/MSAAMaterial.ts
+++ b/@here/harp-materials/lib/MSAAMaterial.ts
@@ -3,14 +3,14 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as THREE from "three";
 
-import { AdditiveBlending, ShaderMaterial } from "three";
-import { CopyShader } from "./CopyShader";
+import { CopyShader } from "./CopyMaterial";
 
 /**
  * The material to use for the quad of the [[MSAARenderPass]] in the composing.
  */
-export class MSAAMaterial extends ShaderMaterial {
+export class MSAAMaterial extends THREE.ShaderMaterial {
     /**
      * The constructor of `MSAAMaterial`.
      *
@@ -23,7 +23,7 @@ export class MSAAMaterial extends ShaderMaterial {
             fragmentShader: CopyShader.fragmentShader,
             premultipliedAlpha: true,
             transparent: true,
-            blending: AdditiveBlending,
+            blending: THREE.AdditiveBlending,
             depthTest: false,
             depthWrite: false
         });


### PR DESCRIPTION
Allows reducing the resolution during animations and interactions. Uses a render pass to render the normal map content (not icons or text) into a lower resolution render target, and copies the results into the framebuffer.