### PR TITLE
HARP-4805:

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,7 @@
 The team behind the [harp.gl](https://github.com/heremaps/harp.gl) gratefully accepts contributions via
 [pull requests](https://help.github.com/articles/about-pull-requests/) filed against the
 [GitHub project](https://github.com/heremaps/harp.gl/pulls). As part of filing a pull request we ask you to
-accept our [Contributor License Agreement](https://gist.github.com/heremaps-bot/dcb932a07b424f8ed68341054e7e3a53) (CLA)
-to grant us rights to your contribution.
+sign off the [Developer Certificate of Origin](https://developercertificate.org/) (DCO).
 
 In order to maintain a high software quality standard, we strongly prefer contributions to follow these rules:
 


### PR DESCRIPTION
Update the CONTRIBUTING.md guidelines so that it uses DCO instead of CLA.