### PR TITLE
MINOR: Remove extra calls to set/cancelTimeout from render loop.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1872,7 +1872,7 @@ export class MapView extends THREE.EventDispatcher {
             });
         }
 
-        this.checkCameraMoved();
+        this.m_movementDetector.checkCameraMoved(this, time);
 
         // The camera used to render the scene.
         const camera = this.m_pointOfView !== undefined ? this.m_pointOfView : this.m_camera;
@@ -2158,10 +2158,6 @@ export class MapView extends THREE.EventDispatcher {
         if (!this.animating) {
             setTimeout(() => this.update(), 0);
         }
-    }
-
-    private checkCameraMoved(): boolean {
-        return this.m_movementDetector.checkCameraMoved(this);
     }
 
     /**


### PR DESCRIPTION
setTimeout / cancelTimeout pair is quite slow on Chrome / Linux.

It's used in CameraMovemendDetector, on my computer each `checkCameraMoved` takes like 0.2-0.35ms (which is lot for such a simple functionality) which constitutes to like 2-2.7% of CPU time when rendering like 2-3 seconds of panning.

This fix reduces `checkCameraMoved` overhead from `>2%` to around `0.3%` of CPU time.
Measured on Chrome / Linux.

