### PR TITLE
HARP-4350: TextStyle Instance Configuration.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -395,9 +395,22 @@ export interface MarkerTechnique extends BaseTechnique {
      */
     color?: string;
     /**
-     * Scaling factor of text.
+     * Text background color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
+     * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      */
-    scale?: number;
+    backgroundColor?: string;
+    /**
+     * Background text alpha (opacity) value.
+     */
+    backgroundAlpha?: number;
+    /**
+     * Size of the text (pixels).
+     */
+    size?: number;
+    /**
+     * Size of the text background (pixels).
+     */
+    backgroundSize?: number;
     /**
      * Horizontal offset (to the right) in screen pixels.
      */
@@ -960,17 +973,21 @@ export interface TextTechnique extends BaseTechnique {
      */
     backgroundColor?: string;
     /**
-     * Size of the background.
+     * Background text alpha (opacity) value.
      */
-    backgroundSize?: number;
+    backgroundAlpha?: number;
     /**
      * Priority of text, defaults to `0`. Elements with highest priority get placed first.
      */
     priority?: number;
     /**
-     * Scaling factor of text.
+     * Size of the text (pixels).
      */
-    scale?: number;
+    size?: number;
+    /**
+     * Size of the text background (pixels).
+     */
+    backgroundSize?: number;
     /**
      * Scaling factor of the text. Defaults to 0.5, reducing the size ot 50% in the distance.
      */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -1005,10 +1005,9 @@ export interface TextStyle {
     smallCaps?: boolean;
     bold?: boolean;
     oblique?: boolean;
-    bgMode?: string;
-    bgColor?: string;
-    bgFactor?: number;
-    bgAlpha?: number;
+    backgroundColor?: string;
+    backgroundSize?: number;
+    backgroundAlpha?: number;
     tracking?: number;
     fontCatalogName?: string;
     name?: string;

--- a/@here/harp-examples/resources/dayTwoFonts.json
+++ b/@here/harp-examples/resources/dayTwoFonts.json
@@ -11,43 +11,36 @@
         {
             "name": "firaStyle",
             "color": "#6d7477",
-            "bgMode": "Outline",
-            "bgColor": "#F7FBFD",
-            "bgFactor": 5.0,
-            "bgAlpha": 0.75,
+            "backgroundColor": "#F7FBFD",
+            "backgroundSize": 8,
+            "backgroundAlpha": 0.75,
             "fontName": "fira"
         },
         {
             "name": "TestStyle0",
             "color": "#6d7477",
-            "tracking": -3.0,
             "fontName": "fira"
         },
         {
             "name": "TestStyle1",
             "color": "#6d7477",
-            "bgMode": "Outline",
-            "bgColor": "#F7FBFD",
-            "bgFactor": 2.0,
-            "bgAlpha": 0.3,
-            "tracking": 3.0,
+            "backgroundColor": "#F7FBFD",
+            "backgroundSize": 8,
+            "backgroundAlpha": 1.0,
             "fontName": "fira"
         },
         {
             "name": "TestStyle2",
             "color": "#6d7477",
             "allCaps": true,
-            "tracking": -3.0,
             "fontName": "fira"
         },
         {
             "name": "TestStyle3",
             "color": "#6d7477",
-            "bgMode": "Glow",
-            "bgColor": "#F7FBFD",
-            "bgFactor": 2.0,
-            "bgAlpha": 1.0,
-            "tracking": 3.0,
+            "backgroundColor": "#F7FBFD",
+            "backgroundSize": 4,
+            "backgroundAlpha": 0.3,
             "allCaps": true,
             "smallCaps": true,
             "fontName": "fira"
@@ -1302,7 +1295,7 @@
                 "technique": "text",
                 "attr": {
                     "color": "#6d7477",
-                    "scale": 0.75,
+                    "size": 24,
                     "style": "firaStyle"
                 }
             },
@@ -1315,7 +1308,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#929292",
-                            "scale": 0.45,
+                            "size": 15,
                             "style": "firaStyle"
                         }
                     },
@@ -1323,7 +1316,7 @@
                         "when": "$layer == 'state_label' && $level >= 5",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.75,
+                            "size": 24,
                             "style": "firaStyle"
                         }
                     },
@@ -1332,7 +1325,7 @@
                         "technique": "text",
                         "attr": {
                             "useAbbreviation": true,
-                            "scale": 0.75,
+                            "size": 24,
                             "style": "firaStyle"
                         }
                     },
@@ -1340,7 +1333,7 @@
                         "when": "$layer == 'region_label'",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.7,
+                            "size": 22.5,
                             "style": "firaStyle"
                         }
                     },
@@ -1348,7 +1341,7 @@
                         "when": "$layer == 'county_label'",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.7,
+                            "size": 22.5,
                             "style": "firaStyle"
                         }
                     },
@@ -1357,7 +1350,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#505050",
-                            "scale": 0.7,
+                            "size": 22.5,
                             "style": "firaStyle"
                         }
                     },
@@ -1366,7 +1359,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#565660",
-                            "scale": 0.5,
+                            "size": 16,
                             "style": "firaStyle"
                         }
                     },
@@ -1375,7 +1368,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#565660",
-                            "scale": 0.5,
+                            "size": 16,
                             "style": "firaStyle"
                         }
                     },
@@ -1384,7 +1377,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#2c70c3",
-                            "scale": 0.45,
+                            "size": 15,
                             "style": "firaStyle"
                         }
                     },
@@ -1393,7 +1386,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#2c70c3",
-                            "scale": 0.5,
+                            "size": 16,
                             "style": "firaStyle"
                         }
                     },
@@ -1403,7 +1396,7 @@
                         "attr": {
                             "label": "house_num",
                             "color": "#7c969c",
-                            "scale": 0.4,
+                            "size": 13,
                             "minZoomLevel": 16,
                             "style": "firaStyle"
                         }
@@ -1412,7 +1405,7 @@
                         "when": "$layer == 'marine_label' && labelrank == 1",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.35,
+                            "size": 11,
                             "style": "firaStyle"
                         }
                     },
@@ -1420,7 +1413,7 @@
                         "when": "$layer == 'marine_label' && labelrank == 2",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.4,
+                            "size": 13,
                             "style": "firaStyle"
                         }
                     },
@@ -1428,7 +1421,7 @@
                         "when": "$layer == 'marine_label' && labelrank == 3",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.45,
+                            "size": 15,
                             "style": "firaStyle"
                         }
                     },
@@ -1437,7 +1430,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#2c70c3",
-                            "scale": 0.5,
+                            "size": 16,
                             "style": "firaStyle"
                         }
                     },
@@ -1445,7 +1438,7 @@
                         "when": "$layer == 'marine_label' && labelrank == 5",
                         "technique": "text",
                         "attr": {
-                            "scale": 0.55,
+                            "size": 15,
                             "style": "firaStyle"
                         }
                     },
@@ -1454,7 +1447,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#2c70c3",
-                            "scale": 0.6,
+                            "size": 19,
                             "style": "firaStyle"
                         }
                     },

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -49,7 +49,7 @@ export interface GeoJsonTileObject extends TileObject {
  */
 interface LabeledIconParams {
     priority: number;
-    scale: number;
+    size: number;
     xOffset: number;
     yOffset: number;
     mayOverlap: boolean;
@@ -70,7 +70,7 @@ interface LabeledIconParams {
  */
 const DEFAULT_LABELED_ICON: Readonly<LabeledIconParams> = {
     priority: 1000,
-    scale: 0.5,
+    size: 16,
     xOffset: 0.0,
     yOffset: 0.0,
     mayOverlap: false,
@@ -176,7 +176,7 @@ export class GeoJsonTile extends Tile {
      * Add a label available for mouse picking at the given path.
      *
      * @param path Path of the text path.
-     * @param tec Technique in use.
+     * @param technique Technique in use.
      * @param geojsonProperties Properties defined by the user.
      */
     private addTextPath(
@@ -187,33 +187,18 @@ export class GeoJsonTile extends Tile {
     ) {
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
-        const scale = technique.scale === undefined ? DEFAULT_LABELED_ICON.scale : technique.scale;
         const xOffset =
             technique.xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : technique.xOffset;
         const yOffset =
             technique.yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : technique.yOffset;
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
-        const color = new THREE.Color(technique.color);
-        const backgroundColor = new THREE.Color(technique.backgroundColor);
-        const renderStyle = this.getRenderStyle(
-            scale,
-            technique,
-            color,
-            FontUnit.Pixel,
-            backgroundColor
-        ).params;
-        renderStyle.backgroundOpacity = 1;
-        const layoutStyle = this.getLayoutStyle(technique).params;
-
-        // XYZ project does not allow transparency so far for text.
-        renderStyle.backgroundOpacity = 1;
 
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             path,
-            { ...renderStyle },
-            { ...layoutStyle },
+            this.getRenderStyle(technique),
+            this.getLayoutStyle(technique),
             priority,
             xOffset,
             yOffset,
@@ -269,7 +254,7 @@ export class GeoJsonTile extends Tile {
      * Add a label available for mouse picking at the given position.
      *
      * @param position position of the labeled Icon, in world coordinate.
-     * @param tec Technique in use.
+     * @param technique Technique in use.
      * @param geojsonProperties Properties defined by the user.
      */
     private addText(
@@ -280,36 +265,18 @@ export class GeoJsonTile extends Tile {
     ) {
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
-        const scale = technique.scale === undefined ? DEFAULT_LABELED_ICON.scale : technique.scale;
         const xOffset =
             technique.xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : technique.xOffset;
         const yOffset =
             technique.yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : technique.yOffset;
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
-        const color = new THREE.Color(technique.color);
-        const backgroundColor = new THREE.Color(technique.backgroundColor);
-
-        const renderStyle = this.getRenderStyle(
-            scale,
-            technique,
-            color,
-            FontUnit.Pixel,
-            backgroundColor,
-            technique.backgroundSize,
-            text
-        ).params;
-
-        // XYZ project does not allow transparency so far for text.
-        renderStyle.backgroundOpacity = 1;
-
-        const layoutStyle = this.getLayoutStyle(technique).params;
 
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             position,
-            { ...renderStyle },
-            { ...layoutStyle },
+            this.getRenderStyle(technique),
+            this.getLayoutStyle(technique),
             priority,
             xOffset,
             yOffset,
@@ -358,14 +325,13 @@ export class GeoJsonTile extends Tile {
      * Add a POI available for mouse picking at the given position.
      *
      * @param position position of the labeled Icon, in world coordinate.
-     * @param tec Technique in use.
+     * @param technique Technique in use.
      * @param geojsonProperties Properties defined by the user.
      */
     private addPoi(position: THREE.Vector2, technique: PoiTechnique, geojsonProperties?: {}) {
         const label = DEFAULT_LABELED_ICON.label;
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
-        const scale = technique.scale === undefined ? DEFAULT_LABELED_ICON.scale : technique.scale;
         const xOffset =
             technique.xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : technique.xOffset;
         const yOffset =
@@ -376,7 +342,7 @@ export class GeoJsonTile extends Tile {
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(label),
             position,
-            this.getRenderStyle(scale, technique),
+            this.getRenderStyle(technique),
             this.getLayoutStyle(technique),
             priority,
             xOffset,

--- a/@here/harp-map-theme/resources/day.json
+++ b/@here/harp-map-theme/resources/day.json
@@ -8,38 +8,34 @@
     ],
     "defaultTextStyle": {
         "color": "#6d7477",
-        "bgMode": "Outline",
-        "bgColor": "#F7FBFD",
-        "bgFactor": 5,
-        "bgAlpha": 0.5,
+        "backgroundColor": "#F7FBFD",
+        "backgroundSize": 8,
+        "backgroundAlpha": 0.5,
         "fontCatalogName": "fira"
     },
     "textStyles": [
         {
             "name": "smallSign",
             "color": "#000000",
-            "bgMode": "Outline",
-            "bgColor": "#000000",
-            "bgFactor": 1.5,
-            "bgAlpha": 0.5,
+            "backgroundColor": "#000000",
+            "backgroundSize": 10,
+            "backgroundAlpha": 0.5,
             "fontCatalogName": "fira"
         },
         {
             "name": "smallSignLight",
             "color": "#ffffff",
-            "bgMode": "Outline",
-            "bgColor": "#ffffff",
-            "bgFactor": 1.5,
-            "bgAlpha": 0.5,
+            "backgroundColor": "#ffffff",
+            "backgroundSize": 10,
+            "backgroundAlpha": 0.5,
             "fontCatalogName": "fira"
         },
         {
             "name": "placeMarker",
             "color": "#60FF60",
-            "bgMode": "Outline",
-            "bgColor": "#202020",
-            "bgFactor": 3.5,
-            "bgAlpha": 0.5,
+            "backgroundColor": "#202020",
+            "backgroundSize": 16,
+            "backgroundAlpha": 0.5,
             "fontCatalogName": "fira"
         }
     ],
@@ -140,7 +136,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -192,7 +188,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -245,7 +241,7 @@
                                 "attr": {
                                     "color": "#565660",
                                     "textLabel": "kind_detail",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 15.0
                                 }
                             },
@@ -297,7 +293,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -351,7 +347,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 25.0
                                 }
                             },
@@ -461,7 +457,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 35.0
                                 }
                             },
@@ -633,7 +629,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 25.0
                                 }
                             },
@@ -769,7 +765,7 @@
                                         "technique": "text",
                                         "attr": {
                                             "color": "#2c70c3",
-                                            "scale": 0.45,
+                                            "size": 14.5,
                                             "oblique": true,
                                             "priority": -40
                                         }
@@ -853,7 +849,7 @@
                         "clipping": false,
                         "attr": {
                             "color": "#2c70c3",
-                            "scale": 0.45,
+                            "size": 14.5,
                             "priority": -50
                         },
                         "styles": [
@@ -866,7 +862,7 @@
                                 "when": "kind == 'ocean'",
                                 "technique": "text",
                                 "attr": {
-                                    "scale": 0.7,
+                                    "size": 0.7,
                                     "priority": -45
                                 }
                             },
@@ -874,12 +870,12 @@
                                 "when": "kind == 'sea'",
                                 "technique": "text",
                                 "attr": {
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.35 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "maxLevel": 5, "value": 0.5 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 13 },
+                                        { "maxLevel": 5, "value": 16 },
+                                        { "value": 19 }
                                     ],
                                     "priority": -50
                                 }
@@ -888,11 +884,11 @@
                                 "description": "lakes (on high level, only biggest lakes)",
                                 "when": "kind == 'lake' || has(area)",
                                 "attr": {
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.3 },
-                                        { "maxLevel": 4, "value": 0.35 },
-                                        { "value": 0.4 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 9.5 },
+                                        { "maxLevel": 4, "value": 11 },
+                                        { "value": 13 }
                                     ],
                                     "priority": [{ "maxLevel": 1, "value": -100 }, { "value": -30 }]
                                 },
@@ -1139,7 +1135,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#3D3B3C",
-                            "scale": 0.5,
+                            "size": 16,
                             "priority": 100
                         }
                     }
@@ -1204,7 +1200,7 @@
                                 "attr": {
                                     "priority": 100,
                                     "color": "#393939",
-                                    "scale": 0.4
+                                    "size": 13
                                 }
                             }
                         ]
@@ -1263,7 +1259,7 @@
                                 "attr": {
                                     "priority": 90,
                                     "color": "#393939",
-                                    "scale": 0.4
+                                    "size": 13
                                 }
                             }
                         ]
@@ -1276,7 +1272,7 @@
                 "renderOrder": 7,
                 "attr": {
                     "color": "#6d7477",
-                    "scale": 0.85,
+                    "size": 27,
                     "priority": 200
                 }
             },
@@ -1466,7 +1462,9 @@
                         "technique": "text",
                         "attr": {
                             "opacity": 0.6,
-                            "scale": [{ "value": 0.5 }]
+                            "size": [
+                                { "value": 16 }
+                            ]
                         }
                     }
                 ]
@@ -1499,12 +1497,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 100,
-                                    "scale": [
-                                        { "maxLevel": 1, "value": 0.35 },
-                                        { "maxLevel": 2, "value": 0.4 },
-                                        { "maxLevel": 3, "value": 0.6 },
-                                        { "maxLevel": 3, "value": 0.7 },
-                                        { "value": 0.8 }
+                                    "size": [
+                                        { "maxLevel": 1, "value": 11 },
+                                        { "maxLevel": 2, "value": 13 },
+                                        { "maxLevel": 3, "value": 19 },
+                                        { "maxLevel": 4, "value": 22.5 },
+                                        { "value": 25.5 }
                                     ]
                                 }
                             },
@@ -1514,12 +1512,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 100,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.25 },
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.4 },
-                                        { "maxLevel": 4, "value": 0.5 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 8 },
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 13 },
+                                        { "maxLevel": 4, "value": 16 },
+                                        { "value": 19 }
                                     ]
                                 }
                             },
@@ -1528,12 +1526,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 90,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.2 },
-                                        { "maxLevel": 2, "value": 0.35 },
-                                        { "maxLevel": 3, "value": 0.3 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "value": 0.5 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 6.5 },
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 13 },
+                                        { "value": 16 }
                                     ]
                                 }
                             }
@@ -1543,11 +1541,11 @@
                         "when": "kind in ['region']",
                         "technique": "none",
                         "attr": {
-                            "scale": [
-                                { "maxLevel": 3, "value": 0.3 },
-                                { "maxLevel": 4, "value": 0.34 },
-                                { "maxLevel": 5, "value": 0.4 },
-                                { "value": 0.45 }
+                            "size": [
+                                { "maxLevel": 3, "value": 9.5 },
+                                { "maxLevel": 4, "value": 11 },
+                                { "maxLevel": 5, "value": 13 },
+                                { "value": 15 }
                             ],
                             "priority": 65,
                             "color": [
@@ -1568,17 +1566,17 @@
                                 "when": "population > 10000000 || has(country_capital)",
                                 "attr": {
                                     "priority": 61,
-                                    "scale": [
-                                        { "maxLevel": 1, "value": 0.3 },
-                                        { "maxLevel": 2, "value": 0.35 },
-                                        { "maxLevel": 3, "value": 0.4 },
-                                        { "maxLevel": 4, "value": 0.45 },
-                                        { "maxLevel": 5, "value": 0.5 },
-                                        { "maxLevel": 6, "value": 0.6 },
-                                        { "maxLevel": 7, "value": 0.7 },
-                                        { "maxLevel": 8, "value": 0.8 },
-                                        { "maxLevel": 9, "value": 0.9 },
-                                        { "value": 1 }
+                                    "size": [
+                                        { "maxLevel": 1, "value": 9.5 },
+                                        { "maxLevel": 2, "value": 11 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 15 },
+                                        { "maxLevel": 5, "value": 16 },
+                                        { "maxLevel": 6, "value": 19 },
+                                        { "maxLevel": 7, "value": 22.5 },
+                                        { "maxLevel": 8, "value": 25.5 },
+                                        { "maxLevel": 9, "value": 29 },
+                                        { "value": 32 }
                                     ]
                                 },
                                 "styles": [
@@ -1602,17 +1600,17 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 60,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.35 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "maxLevel": 5, "value": 0.45 },
-                                        { "maxLevel": 6, "value": 0.5 },
-                                        { "maxLevel": 7, "value": 0.6 },
-                                        { "maxLevel": 8, "value": 0.7 },
-                                        { "maxLevel": 9, "value": 0.8 },
-                                        { "maxLevel": 10, "value": 0.9 },
-                                        { "value": 1 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 11 },
+                                        { "maxLevel": 5, "value": 15 },
+                                        { "maxLevel": 6, "value": 16 },
+                                        { "maxLevel": 7, "value": 19 },
+                                        { "maxLevel": 8, "value": 22.5 },
+                                        { "maxLevel": 9, "value": 25.5 },
+                                        { "maxLevel": 10, "value": 29 },
+                                        { "value": 32 }
                                     ]
                                 }
                             },
@@ -1622,15 +1620,15 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 59,
-                                    "scale": [
-                                        { "maxLevel": 4, "value": 0.35 },
-                                        { "maxLevel": 5, "value": 0.4 },
-                                        { "maxLevel": 6, "value": 0.5 },
-                                        { "maxLevel": 7, "value": 0.6 },
-                                        { "maxLevel": 8, "value": 0.7 },
-                                        { "maxLevel": 9, "value": 0.75 },
-                                        { "maxLevel": 10, "value": 0.8 },
-                                        { "value": 0.85 }
+                                    "size": [
+                                        { "maxLevel": 4, "value": 9.55 },
+                                        { "maxLevel": 5, "value": 11 },
+                                        { "maxLevel": 6, "value": 16 },
+                                        { "maxLevel": 7, "value": 19 },
+                                        { "maxLevel": 8, "value": 22.5 },
+                                        { "maxLevel": 9, "value": 24 },
+                                        { "maxLevel": 10, "value": 25.5 },
+                                        { "value": 27 }
                                     ]
                                 }
                             },
@@ -1640,16 +1638,16 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 58,
-                                    "scale": [
-                                        { "maxLevel": 4, "value": 0.3 },
-                                        { "maxLevel": 5, "value": 0.35 },
-                                        { "maxLevel": 6, "value": 0.4 },
-                                        { "maxLevel": 7, "value": 0.5 },
-                                        { "maxLevel": 8, "value": 0.6 },
-                                        { "maxLevel": 9, "value": 0.65 },
-                                        { "maxLevel": 10, "value": 0.7 },
-                                        { "maxLevel": 11, "value": 0.75 },
-                                        { "value": 0.8 }
+                                    "size": [
+                                        { "maxLevel": 4, "value": 9.5 },
+                                        { "maxLevel": 5, "value": 11 },
+                                        { "maxLevel": 6, "value": 13 },
+                                        { "maxLevel": 7, "value": 16 },
+                                        { "maxLevel": 8, "value": 19 },
+                                        { "maxLevel": 9, "value": 21 },
+                                        { "maxLevel": 10, "value": 22.5 },
+                                        { "maxLevel": 11, "value": 24 },
+                                        { "value": 25.5 }
                                     ]
                                 }
                             },
@@ -1659,11 +1657,11 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 57,
-                                    "scale": [
-                                        { "maxLevel": 10, "value": 0.5 },
-                                        { "maxLevel": 11, "value": 0.6 },
-                                        { "maxLevel": 12, "value": 0.7 },
-                                        { "value": 0.75 }
+                                    "size": [
+                                        { "maxLevel": 10, "value": 16 },
+                                        { "maxLevel": 11, "value": 19 },
+                                        { "maxLevel": 12, "value": 22.5 },
+                                        { "value": 24 }
                                     ]
                                 }
                             },
@@ -1673,12 +1671,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 56,
-                                    "scale": [
-                                        { "maxLevel": 11, "value": 0.5 },
-                                        { "maxLevel": 12, "value": 0.55 },
-                                        { "maxLevel": 13, "value": 0.6 },
-                                        { "maxLevel": 14, "value": 0.65 },
-                                        { "value": 0.7 }
+                                    "size": [
+                                        { "maxLevel": 11, "value": 16 },
+                                        { "maxLevel": 12, "value": 17.5 },
+                                        { "maxLevel": 13, "value": 19 },
+                                        { "maxLevel": 14, "value": 21 },
+                                        { "value": 22.5 }
                                     ]
                                 }
                             },
@@ -1688,12 +1686,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 50,
-                                    "scale": [
-                                        { "maxLevel": 11, "value": 0.4 },
-                                        { "maxLevel": 12, "value": 0.45 },
-                                        { "maxLevel": 13, "value": 0.5 },
-                                        { "maxLevel": 14, "value": 0.55 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 11, "value": 13 },
+                                        { "maxLevel": 12, "value": 15 },
+                                        { "maxLevel": 13, "value": 16 },
+                                        { "maxLevel": 14, "value": 17.5 },
+                                        { "value": 19 }
                                     ]
                                 }
                             }
@@ -1706,7 +1704,7 @@
                 "when": "$layer == 'pois'",
                 "attr": {
                     "color": "#929292",
-                    "scale": 0.45,
+                    "size": 14.5,
                     "poiTable": "omvPoiTable"
                 },
                 "styles": [
@@ -1718,7 +1716,7 @@
                             "poiTable": "tzPoiTable",
                             "poiNameField": "kind",
                             "iconScale": 1,
-                            "scale": 0.5,
+                            "size": 16,
                             "yOffset": 24,
                             "textIsOptional": true,
                             "iconIsOptional": false,
@@ -1773,7 +1771,7 @@
                                 "attr": {
                                     "color": "#A9A9A9",
                                     "label": "addr_housenumber",
-                                    "scale": 0.45,
+                                    "size": 15,
                                     "opacity": 0.6,
                                     "minZoomLevel": 17
                                 }

--- a/@here/harp-map-theme/resources/reducedDay.json
+++ b/@here/harp-map-theme/resources/reducedDay.json
@@ -8,10 +8,9 @@
     ],
     "defaultTextStyle": {
         "color": "#6d7477",
-        "bgMode": "Outline",
-        "bgColor": "#ffffff",
-        "bgFactor": 10,
-        "bgAlpha": 0.75,
+        "backgroundColor": "#ffffff",
+        "backgroundSize": 8,
+        "backgroundAlpha": 0.75,
         "fontCatalogName": "fira"
     },
     "textStyles": [],
@@ -102,7 +101,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -154,7 +153,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -208,7 +207,7 @@
                                 "attr": {
                                     "color": "#565660",
                                     "textLabel": "kind_detail",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 15.0
                                 }
                             },
@@ -260,7 +259,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -314,7 +313,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 25.0
                                 }
                             },
@@ -424,7 +423,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 35.0
                                 }
                             },
@@ -596,7 +595,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 25.0
                                 }
                             },
@@ -716,7 +715,7 @@
                                         "when": "!has(is_tunnel)",
                                         "technique": "text",
                                         "attr": {
-                                            "scale": 0.45,
+                                            "size": 15,
                                             "oblique": true,
                                             "priority": -40
                                         }
@@ -800,7 +799,7 @@
                         "renderOrder": 120,
                         "clipping": false,
                         "attr": {
-                            "scale": 0.45,
+                            "size": 15,
                             "priority": -50
                         },
                         "styles": [
@@ -813,7 +812,7 @@
                                 "when": "kind == 'ocean'",
                                 "technique": "text",
                                 "attr": {
-                                    "scale": 0.7,
+                                    "size": 22.5,
                                     "priority": -45
                                 }
                             },
@@ -821,12 +820,12 @@
                                 "when": "kind == 'sea'",
                                 "technique": "text",
                                 "attr": {
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.35 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "maxLevel": 5, "value": 0.5 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 13 },
+                                        { "maxLevel": 5, "value": 16 },
+                                        { "value": 19 }
                                     ],
                                     "priority": -50
                                 }
@@ -835,11 +834,11 @@
                                 "description": "lakes (on high level, only biggest lakes)",
                                 "when": "kind == 'lake' || has(area)",
                                 "attr": {
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.3 },
-                                        { "maxLevel": 4, "value": 0.35 },
-                                        { "value": 0.4 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 9.5 },
+                                        { "maxLevel": 4, "value": 11 },
+                                        { "value": 13 }
                                     ],
                                     "priority": [
                                         { "maxLevel": 1, "value": -100 },
@@ -993,7 +992,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#3D3B3C",
-                            "scale": 0.5,
+                            "size": 16,
                             "priority": 100
                         }
                     }
@@ -1034,7 +1033,7 @@
                                 "attr": {
                                     "priority": 100,
                                     "color": "#393939",
-                                    "scale": 0.4
+                                    "size": 13
                                 }
                             }
                         ]
@@ -1068,7 +1067,7 @@
                                 "attr": {
                                     "priority": 90,
                                     "color": "#393939",
-                                    "scale": 0.4
+                                    "size": 13
                                 }
                             }
                         ]
@@ -1081,7 +1080,7 @@
                 "renderOrder": 7,
                 "attr": {
                     "color": "#6d7477",
-                    "scale": 0.85,
+                    "size": 27,
                     "priority": 200
                 }
             },
@@ -1246,8 +1245,8 @@
                         "technique": "text",
                         "attr": {
                             "opacity": 0.6,
-                            "scale": [
-                                { "value": 0.5 }
+                            "size": [
+                                { "value": 16 }
                             ]
                         }
                     }
@@ -1282,12 +1281,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 100,
-                                    "scale": [
-                                        { "maxLevel": 1, "value": 0.35 },
-                                        { "maxLevel": 2, "value": 0.4 },
-                                        { "maxLevel": 3, "value": 0.6 },
-                                        { "maxLevel": 3, "value": 0.7 },
-                                        { "value": 0.8 }
+                                    "size": [
+                                        { "maxLevel": 1, "value": 11 },
+                                        { "maxLevel": 2, "value": 13 },
+                                        { "maxLevel": 3, "value": 19 },
+                                        { "maxLevel": 4, "value": 22.5 },
+                                        { "value": 25.5 }
                                     ]
                                 }
                             },
@@ -1297,12 +1296,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 100,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.25 },
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.4 },
-                                        { "maxLevel": 4, "value": 0.5 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 8 },
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 13 },
+                                        { "maxLevel": 4, "value": 16 },
+                                        { "value": 19 }
                                     ]
                                 }
                             },
@@ -1311,12 +1310,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 90,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.2 },
-                                        { "maxLevel": 2, "value": 0.35 },
-                                        { "maxLevel": 3, "value": 0.3 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "value": 0.5 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 6.5 },
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 13 },
+                                        { "value": 16 }
                                     ]
                                 }
                             }
@@ -1326,11 +1325,11 @@
                         "when": "kind in ['region']",
                         "technique": "none",
                         "attr": {
-                            "scale": [
-                                { "maxLevel": 3, "value": 0.3 },
-                                { "maxLevel": 4, "value": 0.34 },
-                                { "maxLevel": 5, "value": 0.4 },
-                                { "value": 0.45 }
+                            "size": [
+                                { "maxLevel": 3, "value": 9.5 },
+                                { "maxLevel": 4, "value": 11 },
+                                { "maxLevel": 5, "value": 13 },
+                                { "value": 15 }
                             ],
                             "priority": 65,
                             "color": [
@@ -1351,17 +1350,17 @@
                                 "when": "population > 10000000 || has(country_capital)",
                                 "attr": {
                                     "priority": 61,
-                                    "scale": [
-                                        { "maxLevel": 1, "value": 0.3 },
-                                        { "maxLevel": 2, "value": 0.35 },
-                                        { "maxLevel": 3, "value": 0.4 },
-                                        { "maxLevel": 4, "value": 0.45 },
-                                        { "maxLevel": 5, "value": 0.5 },
-                                        { "maxLevel": 6, "value": 0.6 },
-                                        { "maxLevel": 7, "value": 0.7 },
-                                        { "maxLevel": 8, "value": 0.8 },
-                                        { "maxLevel": 9, "value": 0.9 },
-                                        { "value": 1 }
+                                    "size": [
+                                        { "maxLevel": 1, "value": 9.5 },
+                                        { "maxLevel": 2, "value": 11 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 15 },
+                                        { "maxLevel": 5, "value": 16 },
+                                        { "maxLevel": 6, "value": 19 },
+                                        { "maxLevel": 7, "value": 22.5 },
+                                        { "maxLevel": 8, "value": 25.5 },
+                                        { "maxLevel": 9, "value": 29 },
+                                        { "value": 32 }
                                     ]
                                 },
                                 "styles": [
@@ -1384,17 +1383,17 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 60,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.35 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "maxLevel": 5, "value": 0.45 },
-                                        { "maxLevel": 6, "value": 0.5 },
-                                        { "maxLevel": 7, "value": 0.6 },
-                                        { "maxLevel": 8, "value": 0.7 },
-                                        { "maxLevel": 9, "value": 0.8 },
-                                        { "maxLevel": 10, "value": 0.9 },
-                                        { "value": 1 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 11 },
+                                        { "maxLevel": 5, "value": 15 },
+                                        { "maxLevel": 6, "value": 16 },
+                                        { "maxLevel": 7, "value": 19 },
+                                        { "maxLevel": 8, "value": 22.5 },
+                                        { "maxLevel": 9, "value": 25.5 },
+                                        { "maxLevel": 10, "value": 29 },
+                                        { "value": 32 }
                                     ]
                                 }
                             },
@@ -1404,15 +1403,15 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 59,
-                                    "scale": [
-                                        { "maxLevel": 4, "value": 0.35 },
-                                        { "maxLevel": 5, "value": 0.4 },
-                                        { "maxLevel": 6, "value": 0.5 },
-                                        { "maxLevel": 7, "value": 0.6 },
-                                        { "maxLevel": 8, "value": 0.7 },
-                                        { "maxLevel": 9, "value": 0.75 },
-                                        { "maxLevel": 10, "value": 0.8 },
-                                        { "value": 0.85 }
+                                    "size": [
+                                        { "maxLevel": 4, "value": 9.55 },
+                                        { "maxLevel": 5, "value": 11 },
+                                        { "maxLevel": 6, "value": 16 },
+                                        { "maxLevel": 7, "value": 19 },
+                                        { "maxLevel": 8, "value": 22.5 },
+                                        { "maxLevel": 9, "value": 24 },
+                                        { "maxLevel": 10, "value": 25.5 },
+                                        { "value": 27 }
                                     ]
                                 }
                             },
@@ -1422,16 +1421,16 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 58,
-                                    "scale": [
-                                        { "maxLevel": 4, "value": 0.3 },
-                                        { "maxLevel": 5, "value": 0.35 },
-                                        { "maxLevel": 6, "value": 0.4 },
-                                        { "maxLevel": 7, "value": 0.5 },
-                                        { "maxLevel": 8, "value": 0.6 },
-                                        { "maxLevel": 9, "value": 0.65 },
-                                        { "maxLevel": 10, "value": 0.7 },
-                                        { "maxLevel": 11, "value": 0.75 },
-                                        { "value": 0.8 }
+                                    "size": [
+                                        { "maxLevel": 4, "value": 9.5 },
+                                        { "maxLevel": 5, "value": 11 },
+                                        { "maxLevel": 6, "value": 13 },
+                                        { "maxLevel": 7, "value": 16 },
+                                        { "maxLevel": 8, "value": 19 },
+                                        { "maxLevel": 9, "value": 21 },
+                                        { "maxLevel": 10, "value": 22.5 },
+                                        { "maxLevel": 11, "value": 24 },
+                                        { "value": 25.5 }
                                     ]
                                 }
                             },
@@ -1441,11 +1440,11 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 57,
-                                    "scale": [
-                                        { "maxLevel": 10, "value": 0.5 },
-                                        { "maxLevel": 11, "value": 0.6 },
-                                        { "maxLevel": 12, "value": 0.7 },
-                                        { "value": 0.75 }
+                                    "size": [
+                                        { "maxLevel": 10, "value": 16 },
+                                        { "maxLevel": 11, "value": 19 },
+                                        { "maxLevel": 12, "value": 22.5 },
+                                        { "value": 24 }
                                     ]
                                 }
                             },
@@ -1455,12 +1454,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 56,
-                                    "scale": [
-                                        { "maxLevel": 11, "value": 0.5 },
-                                        { "maxLevel": 12, "value": 0.55 },
-                                        { "maxLevel": 13, "value": 0.6 },
-                                        { "maxLevel": 14, "value": 0.65 },
-                                        { "value": 0.7 }
+                                    "size": [
+                                        { "maxLevel": 11, "value": 16 },
+                                        { "maxLevel": 12, "value": 17.5 },
+                                        { "maxLevel": 13, "value": 19 },
+                                        { "maxLevel": 14, "value": 21 },
+                                        { "value": 22.5 }
                                     ]
                                 }
                             },
@@ -1470,12 +1469,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 50,
-                                    "scale": [
-                                        { "maxLevel": 11, "value": 0.4 },
-                                        { "maxLevel": 12, "value": 0.45 },
-                                        { "maxLevel": 13, "value": 0.5 },
-                                        { "maxLevel": 14, "value": 0.55 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 11, "value": 13 },
+                                        { "maxLevel": 12, "value": 15 },
+                                        { "maxLevel": 13, "value": 16 },
+                                        { "maxLevel": 14, "value": 17.5 },
+                                        { "value": 19 }
                                     ]
                                 }
                             }
@@ -1523,7 +1522,7 @@
                                 "attr": {
                                     "color": "#A9A9A9",
                                     "label": "addr_housenumber",
-                                    "scale": 0.45,
+                                    "size": 15,
                                     "opacity": 0.6,
                                     "minZoomLevel": 17
                                 }

--- a/@here/harp-map-theme/resources/reducedNight.json
+++ b/@here/harp-map-theme/resources/reducedNight.json
@@ -8,12 +8,12 @@
     ],
     "defaultTextStyle": {
         "color": "#8b98a1",
-        "bgMode": "Outline",
-        "bgColor": "#000000",
-        "bgFactor": 0.5,
-        "bgAlpha": 0.5,
+        "backgroundColor": "#000000",
+        "backgroundSize": 8,
+        "backgroundAlpha": 0.5,
         "fontCatalogName": "fira"
     },
+    "textStyles": [],
     "lights": [
         {
             "type": "ambient",
@@ -41,16 +41,6 @@
                 "y": 0,
                 "z": 1
             }
-        }
-    ],
-    "textStyles": [
-        {
-            "name": "placeMarker",
-            "color": "#60FF60",
-            "outlineColor": "#202020",
-            "outlineFactor": 3.5,
-            "outlineAlpha": 0.5,
-            "fontCatalogName": "fira"
         }
     ],
     "styles": {
@@ -99,7 +89,7 @@
                         "attr": {
                             "label": "text",
                             "textMayOverlap": true,
-                            "scale": 0.5,
+                            "size": 16,
                             "imageTexture": "custom-icon",
                             "screenHeight": 32,
                             "iconYOffset": 16,
@@ -166,7 +156,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#708497",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -218,7 +208,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#66788a",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -272,7 +262,7 @@
                                 "attr": {
                                     "color": "#6d8193",
                                     "textLabel": "kind_detail",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 15.0
                                 }
                             },
@@ -324,7 +314,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#778ca1",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 20.0
                                 }
                             },
@@ -378,7 +368,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#8ca5bd",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 25.0
                                 }
                             },
@@ -488,7 +478,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#8ca5bd",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 35.0
                                 }
                             },
@@ -660,7 +650,7 @@
                                 "technique": "text",
                                 "attr": {
                                     "color": "#565660",
-                                    "scale": 0.5,
+                                    "size": 16,
                                     "priority": 25.0
                                 }
                             },
@@ -772,7 +762,7 @@
                                         "when": "!has(is_tunnel)",
                                         "technique": "text",
                                         "attr": {
-                                            "scale": 0.45,
+                                            "size": 15,
                                             "oblique": true,
                                             "priority": -40
                                         }
@@ -837,7 +827,7 @@
                         "renderOrder": 120,
                         "clipping": false,
                         "attr": {
-                            "scale": 0.45,
+                            "size": 15,
                             "priority": -50
                         },
                         "styles": [
@@ -850,7 +840,7 @@
                                 "when": "kind == 'ocean'",
                                 "technique": "text",
                                 "attr": {
-                                    "scale": 0.7,
+                                    "size": 22.5,
                                     "priority": -45
                                 }
                             },
@@ -858,12 +848,12 @@
                                 "when": "kind == 'sea'",
                                 "technique": "text",
                                 "attr": {
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.35 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "maxLevel": 5, "value": 0.5 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 13 },
+                                        { "maxLevel": 5, "value": 16 },
+                                        { "value": 19 }
                                     ],
                                     "priority": -50
                                 }
@@ -872,7 +862,7 @@
                                 "description": "lakes (on high level, only biggest lakes)",
                                 "when": "kind == 'lake' || has(area)",
                                 "attr": {
-                                    "scale": [
+                                    "size": [
                                         { "maxLevel": 2, "value": 0.3 },
                                         { "maxLevel": 3, "value": 0.3 },
                                         { "maxLevel": 4, "value": 0.35 },
@@ -1030,7 +1020,7 @@
                         "technique": "text",
                         "attr": {
                             "color": "#3D3B3C",
-                            "scale": 0.5,
+                            "size": 16,
                             "priority": 100
                         }
                     }
@@ -1071,7 +1061,7 @@
                                 "attr": {
                                     "priority": 100,
                                     "color": "#393939",
-                                    "scale": 0.4
+                                    "size": 13
                                 }
                             }
                         ]
@@ -1105,7 +1095,7 @@
                                 "attr": {
                                     "priority": 90,
                                     "color": "#393939",
-                                    "scale": 0.4
+                                    "size": 13
                                 }
                             }
                         ]
@@ -1118,7 +1108,7 @@
                 "renderOrder": 7,
                 "attr": {
                     "color": "#6d7477",
-                    "scale": 0.85,
+                    "size": 27,
                     "priority": 200
                 }
             },
@@ -1263,8 +1253,8 @@
                         "technique": "text",
                         "attr": {
                             "opacity": 0.6,
-                            "scale": [
-                                { "value": 0.5 }
+                            "size": [
+                                { "value": 16 }
                             ]
                         }
                     }
@@ -1299,12 +1289,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 100,
-                                    "scale": [
-                                        { "maxLevel": 1, "value": 0.35 },
-                                        { "maxLevel": 2, "value": 0.4 },
-                                        { "maxLevel": 3, "value": 0.6 },
-                                        { "maxLevel": 3, "value": 0.7 },
-                                        { "value": 0.8 }
+                                    "size": [
+                                        { "maxLevel": 1, "value": 11 },
+                                        { "maxLevel": 2, "value": 13 },
+                                        { "maxLevel": 3, "value": 19 },
+                                        { "maxLevel": 4, "value": 22.5 },
+                                        { "value": 25.5 }
                                     ]
                                 }
                             },
@@ -1314,12 +1304,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 100,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.25 },
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.4 },
-                                        { "maxLevel": 4, "value": 0.5 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 8 },
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 13 },
+                                        { "maxLevel": 4, "value": 16 },
+                                        { "value": 19 }
                                     ]
                                 }
                             },
@@ -1328,12 +1318,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 90,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.2 },
-                                        { "maxLevel": 2, "value": 0.35 },
-                                        { "maxLevel": 3, "value": 0.3 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "value": 0.5 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 6.5 },
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 13 },
+                                        { "value": 16 }
                                     ]
                                 }
                             }
@@ -1343,11 +1333,11 @@
                         "when": "kind in ['region']",
                         "technique": "none",
                         "attr": {
-                            "scale": [
-                                { "maxLevel": 3, "value": 0.3 },
-                                { "maxLevel": 4, "value": 0.34 },
-                                { "maxLevel": 5, "value": 0.4 },
-                                { "value": 0.45 }
+                            "size": [
+                                { "maxLevel": 3, "value": 9.5 },
+                                { "maxLevel": 4, "value": 11 },
+                                { "maxLevel": 5, "value": 13 },
+                                { "value": 15 }
                             ],
                             "priority": 65,
                             "color": [
@@ -1368,17 +1358,17 @@
                                 "when": "population > 10000000 || has(country_capital)",
                                 "attr": {
                                     "priority": 61,
-                                    "scale": [
-                                        { "maxLevel": 1, "value": 0.3 },
-                                        { "maxLevel": 2, "value": 0.35 },
-                                        { "maxLevel": 3, "value": 0.4 },
-                                        { "maxLevel": 4, "value": 0.45 },
-                                        { "maxLevel": 5, "value": 0.5 },
-                                        { "maxLevel": 6, "value": 0.6 },
-                                        { "maxLevel": 7, "value": 0.7 },
-                                        { "maxLevel": 8, "value": 0.8 },
-                                        { "maxLevel": 9, "value": 0.9 },
-                                        { "value": 1 }
+                                    "size": [
+                                        { "maxLevel": 1, "value": 9.5 },
+                                        { "maxLevel": 2, "value": 11 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 15 },
+                                        { "maxLevel": 5, "value": 16 },
+                                        { "maxLevel": 6, "value": 19 },
+                                        { "maxLevel": 7, "value": 22.5 },
+                                        { "maxLevel": 8, "value": 25.5 },
+                                        { "maxLevel": 9, "value": 29 },
+                                        { "value": 32 }
                                     ]
                                 },
                                 "styles": [
@@ -1401,17 +1391,17 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 60,
-                                    "scale": [
-                                        { "maxLevel": 2, "value": 0.3 },
-                                        { "maxLevel": 3, "value": 0.35 },
-                                        { "maxLevel": 4, "value": 0.4 },
-                                        { "maxLevel": 5, "value": 0.45 },
-                                        { "maxLevel": 6, "value": 0.5 },
-                                        { "maxLevel": 7, "value": 0.6 },
-                                        { "maxLevel": 8, "value": 0.7 },
-                                        { "maxLevel": 9, "value": 0.8 },
-                                        { "maxLevel": 10, "value": 0.9 },
-                                        { "value": 1 }
+                                    "size": [
+                                        { "maxLevel": 2, "value": 9.5 },
+                                        { "maxLevel": 3, "value": 11 },
+                                        { "maxLevel": 4, "value": 11 },
+                                        { "maxLevel": 5, "value": 15 },
+                                        { "maxLevel": 6, "value": 16 },
+                                        { "maxLevel": 7, "value": 19 },
+                                        { "maxLevel": 8, "value": 22.5 },
+                                        { "maxLevel": 9, "value": 25.5 },
+                                        { "maxLevel": 10, "value": 29 },
+                                        { "value": 32 }
                                     ]
                                 }
                             },
@@ -1421,15 +1411,15 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 59,
-                                    "scale": [
-                                        { "maxLevel": 4, "value": 0.35 },
-                                        { "maxLevel": 5, "value": 0.4 },
-                                        { "maxLevel": 6, "value": 0.5 },
-                                        { "maxLevel": 7, "value": 0.6 },
-                                        { "maxLevel": 8, "value": 0.7 },
-                                        { "maxLevel": 9, "value": 0.75 },
-                                        { "maxLevel": 10, "value": 0.8 },
-                                        { "value": 0.85 }
+                                    "size": [
+                                        { "maxLevel": 4, "value": 9.55 },
+                                        { "maxLevel": 5, "value": 11 },
+                                        { "maxLevel": 6, "value": 16 },
+                                        { "maxLevel": 7, "value": 19 },
+                                        { "maxLevel": 8, "value": 22.5 },
+                                        { "maxLevel": 9, "value": 24 },
+                                        { "maxLevel": 10, "value": 25.5 },
+                                        { "value": 27 }
                                     ]
                                 }
                             },
@@ -1439,16 +1429,16 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 58,
-                                    "scale": [
-                                        { "maxLevel": 4, "value": 0.3 },
-                                        { "maxLevel": 5, "value": 0.35 },
-                                        { "maxLevel": 6, "value": 0.4 },
-                                        { "maxLevel": 7, "value": 0.5 },
-                                        { "maxLevel": 8, "value": 0.6 },
-                                        { "maxLevel": 9, "value": 0.65 },
-                                        { "maxLevel": 10, "value": 0.7 },
-                                        { "maxLevel": 11, "value": 0.75 },
-                                        { "value": 0.8 }
+                                    "size": [
+                                        { "maxLevel": 4, "value": 9.5 },
+                                        { "maxLevel": 5, "value": 11 },
+                                        { "maxLevel": 6, "value": 13 },
+                                        { "maxLevel": 7, "value": 16 },
+                                        { "maxLevel": 8, "value": 19 },
+                                        { "maxLevel": 9, "value": 21 },
+                                        { "maxLevel": 10, "value": 22.5 },
+                                        { "maxLevel": 11, "value": 24 },
+                                        { "value": 25.5 }
                                     ]
                                 }
                             },
@@ -1458,11 +1448,11 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 57,
-                                    "scale": [
-                                        { "maxLevel": 10, "value": 0.5 },
-                                        { "maxLevel": 11, "value": 0.6 },
-                                        { "maxLevel": 12, "value": 0.7 },
-                                        { "value": 0.75 }
+                                    "size": [
+                                        { "maxLevel": 10, "value": 16 },
+                                        { "maxLevel": 11, "value": 19 },
+                                        { "maxLevel": 12, "value": 22.5 },
+                                        { "value": 24 }
                                     ]
                                 }
                             },
@@ -1472,12 +1462,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 56,
-                                    "scale": [
-                                        { "maxLevel": 11, "value": 0.5 },
-                                        { "maxLevel": 12, "value": 0.55 },
-                                        { "maxLevel": 13, "value": 0.6 },
-                                        { "maxLevel": 14, "value": 0.65 },
-                                        { "value": 0.7 }
+                                    "size": [
+                                        { "maxLevel": 11, "value": 16 },
+                                        { "maxLevel": 12, "value": 17.5 },
+                                        { "maxLevel": 13, "value": 19 },
+                                        { "maxLevel": 14, "value": 21 },
+                                        { "value": 22.5 }
                                     ]
                                 }
                             },
@@ -1487,12 +1477,12 @@
                                 "final": true,
                                 "attr": {
                                     "priority": 50,
-                                    "scale": [
-                                        { "maxLevel": 11, "value": 0.4 },
-                                        { "maxLevel": 12, "value": 0.45 },
-                                        { "maxLevel": 13, "value": 0.5 },
-                                        { "maxLevel": 14, "value": 0.55 },
-                                        { "value": 0.6 }
+                                    "size": [
+                                        { "maxLevel": 11, "value": 13 },
+                                        { "maxLevel": 12, "value": 15 },
+                                        { "maxLevel": 13, "value": 16 },
+                                        { "maxLevel": 14, "value": 17.5 },
+                                        { "value": 19 }
                                     ]
                                 }
                             }
@@ -1521,7 +1511,7 @@
                                 "attr": {
                                     "color": "#A9A9A9",
                                     "label": "addr_housenumber",
-                                    "scale": 0.45,
+                                    "size": 15,
                                     "opacity": 0.6,
                                     "minZoomLevel": 17
                                 }

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -501,6 +501,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_textRenderStyleCache = new TextRenderStyleCache();
     private m_textLayoutStyleCache = new TextLayoutStyleCache();
     private m_defaultTextColor = new THREE.Color(0, 0, 0);
+    private m_defaultTextBgColor = new THREE.Color(1, 1, 1);
     private m_overlayTextElements?: TextElement[] = [];
 
     private m_forceCameraAspect: number | undefined = undefined;
@@ -1040,6 +1041,20 @@ export class MapView extends THREE.EventDispatcher {
      */
     set defaultTextColor(color: THREE.Color) {
         this.m_defaultTextColor.set(color);
+    }
+
+    /**
+     * The color used to draw the background of text elements.
+     */
+    get defaultTextBackgroundColor() {
+        return this.m_defaultTextBgColor;
+    }
+
+    /**
+     * The color used to draw the background of text elements.
+     */
+    set defaultTextBackgroundColor(color: THREE.Color) {
+        this.m_defaultTextBgColor.set(color);
     }
 
     /**

--- a/@here/harp-mapview/lib/poi/BoxBuffer.ts
+++ b/@here/harp-mapview/lib/poi/BoxBuffer.ts
@@ -60,22 +60,6 @@ const NUM_UV_VALUES_PER_VERTEX = 4;
 const NUM_INDEX_VALUES_PER_VERTEX = 1;
 
 /**
- * Rendering mode of the text background elements.
- */
-export enum TextBackgroundMode {
-    Outline = 0.0,
-    Glow = 1.0
-}
-
-/**
- * Rendering mode of the text background elements (string representation).
- */
-export enum TextBackgroundModeStrings {
-    Outline = "Outline",
-    Glow = "Glow"
-}
-
-/**
  * SubClass of [[THREE.Mesh]] to identify meshes that have been created by [[BoxBuffer]] and
  * [[TextBuffer]]. Add the isEmpty flag to quickly test for empty meshes.
  */

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -510,6 +510,10 @@ export class TextElementsRenderer {
         if (this.m_defaultStyle.renderParams.color !== undefined) {
             this.m_mapView.defaultTextColor = this.m_defaultStyle.renderParams.color;
         }
+        if (this.m_defaultStyle.renderParams.backgroundColor !== undefined) {
+            // tslint:disable-next-line:max-line-length
+            this.m_mapView.defaultTextBackgroundColor = this.m_defaultStyle.renderParams.backgroundColor;
+        }
     }
 
     private createTextElementStyle(style: TextStyle, styleName: string): TextElementStyle {
@@ -518,9 +522,9 @@ export class TextElementsRenderer {
             fontCatalog: getOptionValue(style.fontCatalogName, DEFAULT_FONT_CATALOG_NAME),
             renderParams: {
                 fontSize: {
-                    unit: FontUnit.Percent,
-                    size: 50.0,
-                    backgroundSize: style.bgFactor !== undefined ? style.bgFactor * 3.0 : 0.0
+                    unit: FontUnit.Pixel,
+                    size: 16.0,
+                    backgroundSize: style.backgroundSize || 0
                 },
                 fontVariant:
                     style.smallCaps === true
@@ -541,10 +545,10 @@ export class TextElementsRenderer {
                         ? ColorCache.instance.getColor(style.color)
                         : undefined,
                 backgroundColor:
-                    style.bgColor !== undefined
-                        ? ColorCache.instance.getColor(style.bgColor)
+                    style.backgroundColor !== undefined
+                        ? ColorCache.instance.getColor(style.backgroundColor)
                         : undefined,
-                backgroundOpacity: style.bgAlpha
+                backgroundOpacity: style.backgroundAlpha
             },
             layoutParams: {
                 tracking: style.tracking,

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -23,7 +23,7 @@ const MAX_ZOOM_LEVEL = 100;
  * [[TextStyle]] id for the default value inside a [[TextRenderStyleCache]] or a
  * [[TextLayoutStyleCache]].
  */
-export const DEFAULT_TEXT_STYLE_CACHE_ID = -1;
+export const DEFAULT_TEXT_STYLE_CACHE_ID = "Default";
 
 /**
  * Calculates the [[TextStyle]] id that identifies either a [[TextRenderStyle]] or a
@@ -35,15 +35,19 @@ export const DEFAULT_TEXT_STYLE_CACHE_ID = -1;
  *
  * @returns [[TextStyle]] id.
  */
-export function computeStyleCacheId(technique: Technique, zoomLevel: number) {
-    return technique._renderOrderAuto! * MAX_ZOOM_LEVEL + zoomLevel;
+export function computeStyleCacheId(
+    datasourceName: string,
+    technique: Technique,
+    zoomLevel: number
+): string {
+    return `${datasourceName}_${technique._renderOrderAuto!}_${zoomLevel}`;
 }
 
 /**
  * Cache storing [[MapView]]'s [[TextRenderStyle]]s.
  */
 export class TextRenderStyleCache {
-    private m_map: Map<number, TextRenderStyle> = new Map();
+    private m_map: Map<string, TextRenderStyle> = new Map();
     constructor() {
         this.m_map.set(
             DEFAULT_TEXT_STYLE_CACHE_ID,
@@ -64,11 +68,11 @@ export class TextRenderStyleCache {
         return this.m_map.size;
     }
 
-    get(id: number): TextRenderStyle | undefined {
+    get(id: string): TextRenderStyle | undefined {
         return this.m_map.get(id);
     }
 
-    set(id: number, value: TextRenderStyle): void {
+    set(id: string, value: TextRenderStyle): void {
         this.m_map.set(id, value);
     }
 
@@ -94,7 +98,7 @@ export class TextRenderStyleCache {
  * Cache storing [[MapView]]'s [[TextLayoutStyle]]s.
  */
 export class TextLayoutStyleCache {
-    private m_map: Map<number, TextLayoutStyle> = new Map();
+    private m_map: Map<string, TextLayoutStyle> = new Map();
     constructor() {
         this.m_map.set(
             DEFAULT_TEXT_STYLE_CACHE_ID,
@@ -109,11 +113,11 @@ export class TextLayoutStyleCache {
         return this.m_map.size;
     }
 
-    get(id: number): TextLayoutStyle | undefined {
+    get(id: string): TextLayoutStyle | undefined {
         return this.m_map.get(id);
     }
 
-    set(id: number, value: TextLayoutStyle): void {
+    set(id: string, value: TextLayoutStyle): void {
         this.m_map.set(id, value);
     }
 


### PR DESCRIPTION
* Allow individual ``TextStyle`` instances to have all properties stylable.
* Removed ``bgMode``.
* Renamed ``scale`` (``size``) and ``bgFactor`` (``bgSize``) as they're now specified in pixel units (updated themes to reflect this).