### PR TITLE
HARP-4859: Improve tile request queue

### DIFF
--- a/@here/harp-download-manager/src/DownloadManager.ts
+++ b/@here/harp-download-manager/src/DownloadManager.ts
@@ -107,7 +107,11 @@ export class DownloadManager {
                 return response;
             }
         } catch (err) {
-            if (err.hasOwnProperty("isCancelled") || retryCount > maxRetries) {
+            if (
+                err.hasOwnProperty("isCancelled") ||
+                (err.hasOwnProperty("name") && err.name === "AbortError") ||
+                retryCount > maxRetries
+            ) {
                 throw err;
             }
         }

--- a/@here/harp-mapview-decoder/lib/TileLoader.ts
+++ b/@here/harp-mapview-decoder/lib/TileLoader.ts
@@ -159,7 +159,7 @@ export class TileLoader {
     /**
      * Return `true` if [[Tile]] is still loading, `false` otherwise.
      */
-    isFinished(): boolean {
+    get isFinished(): boolean {
         return (
             this.state === TileLoaderState.Ready ||
             this.state === TileLoaderState.Canceled ||

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1900,9 +1900,20 @@ export class MapView extends THREE.EventDispatcher {
         const renderList = this.m_visibleTiles.dataSourceTileList;
 
         renderList.forEach(({ zoomLevel, renderedTiles, visibleTiles, numTilesLoading }) => {
+            // The visible tiles may not actually be rendered, but they have to stay in the cache
+            // for the next frame.
+            visibleTiles.forEach(tile => {
+                tile.frameNumLastVisible = this.m_frameNumber;
+            });
             renderedTiles.forEach(tile => {
                 this.renderTileObjects(tile, zoomLevel);
+                tile.frameNumLastVisible = this.m_frameNumber;
             });
+        });
+
+        // Update the visibility flag on every tile in the cache, so it does not get evicted.
+        this.forEachCachedTile(tile => {
+            tile.isVisible = tile.frameNumLastVisible === this.m_frameNumber;
         });
 
         if (currentFrameEvent !== undefined) {

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -11,7 +11,7 @@ import { TileKey } from "@here/harp-geoutils";
 import { assert } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
-import { MapViewDefaults } from "../lib/MapView";
+import { MapView, MapViewDefaults } from "../lib/MapView";
 import { Tile } from "../lib/Tile";
 import { VisibleTileSet } from "../lib/VisibleTileSet";
 import { FakeOmvDataSource } from "./FakeOmvDataSource";
@@ -31,6 +31,12 @@ function createBerlinCenterCameraFromSamples() {
     return { camera, worldCenter };
 }
 
+class FakeMapView {
+    get frameNumber(): number {
+        return 0;
+    }
+}
+
 describe("VisibleTileSet", function() {
     it("#updateRenderList properly culls Berlin center example view", function() {
         const { camera, worldCenter } = createBerlinCenterCameraFromSamples();
@@ -38,6 +44,8 @@ describe("VisibleTileSet", function() {
         const zoomLevel = 15;
         const storageLevel = 14;
         const ds = new FakeOmvDataSource();
+
+        ds.attach(new FakeMapView() as MapView);
 
         const renderList = vts.updateRenderList(worldCenter, zoomLevel, storageLevel, [ds]);
 
@@ -72,6 +80,8 @@ describe("VisibleTileSet", function() {
         const storageLevel = 14;
         const ds = new FakeOmvDataSource();
 
+        ds.attach(new FakeMapView() as MapView);
+
         const renderList = vts.updateRenderList(worldCenter, zoomLevel, storageLevel, [ds]);
 
         assert.equal(renderList.length, 1);
@@ -96,6 +106,8 @@ describe("VisibleTileSet", function() {
         const zoomLevel = 15;
         const storageLevel = 14;
         const dataSource = new FakeOmvDataSource();
+
+        dataSource.attach(new FakeMapView() as MapView);
 
         // same as first found code few lines below
         const parentCode = TileKey.parentMortonCode(371506851);
@@ -127,6 +139,8 @@ describe("VisibleTileSet", function() {
         const zoomLevel = 15;
         const storageLevel = 14;
         const ds = new FakeOmvDataSource();
+
+        ds.attach(new FakeMapView() as MapView);
 
         const renderList = vts.updateRenderList(worldCenter, zoomLevel, storageLevel, [ds]);
 


### PR DESCRIPTION
* allow early cancel of tiles that are loading but have become invisible
  (culled due to camera movement)
* detect culled tiles during geometry creation (cancelled)
* mark visible tiles as non-evictable in the cache to reduce thrashing
* add some lifee-cycle values in Tile for future evaluation
  (have been used for debugging)