### PR TITLE
Increase timeout of long test to reduce flakines

### DIFF
--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -160,6 +160,7 @@ describe("map-view#Utils", function() {
     });
 
     it("estimate size of world with 1000 cubes", async function() {
+        this.timeout(4000);
         const scene: THREE.Scene = new THREE.Scene();
         for (let i = 0; i < 1000; i++) {
             const geometry = new THREE.BoxGeometry(1, 1, 1);


### PR DESCRIPTION
The "estimate size of world with 1000 cubes" takes 1.5 seconds and
sometimes timeouts when CI runners are loaded too much.