### PR TITLE
HARP-4947: Added XYZ Vector Tiles

### DIFF
--- a/@here/harp-examples/codebrowser.html
+++ b/@here/harp-examples/codebrowser.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>harp.gl | examples</title>
+    <title><strong>harp.gl</strong> examples</title>
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <meta charset="utf-8">
 </head>

--- a/@here/harp-examples/config.ts
+++ b/@here/harp-examples/config.ts
@@ -9,3 +9,6 @@ export const appId = "devportal-demo-20180625";
 
 /** @hidden */
 export const appCode = "9v2BkviRwi9Ot26kp2IysQ";
+
+/** @hidden */
+export const accessToken = "AYlqpxvwl7C8tSVG22lX2lg";

--- a/@here/harp-examples/example-browser.ts
+++ b/@here/harp-examples/example-browser.ts
@@ -128,7 +128,7 @@ function exampleBrowser(exampleDefinitions: ExampleDefinitions) {
         const baseTitle = "<strong>harp.gl</strong> examples";
         document.title = exampleName ? `${exampleName} - harp.gl examples` : `harp.gl examples`;
 
-        titleHeader.innerHTML = exampleName ? `"<strong>harp.gl</strong> examples` : `${baseTitle}`;
+        titleHeader.innerHTML = exampleName ? `<strong>harp.gl</strong> examples` : `${baseTitle}`;
 
         subtitle.textContent = exampleName || "";
     }

--- a/@here/harp-examples/src/camera_free.ts
+++ b/@here/harp-examples/src/camera_free.ts
@@ -15,6 +15,7 @@ import {
 } from "@here/harp-mapview";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
+import { accessToken } from "../config";
 
 // Import the gesture handlers from the three.js additional libraries.
 // The controls are not in common.js they explictly require a
@@ -70,9 +71,10 @@ export namespace FreeCameraApp_DebugingToolExample {
                 .attach(this.mapView)
                 .setDefaults([
                     {
-                        id: "openstreetmap.org",
-                        label: "OpenStreetMap contributors",
-                        link: "https://www.openstreetmap.org/copyright"
+                        id: "here.com",
+                        label: "HERE",
+                        link: "https://legal.here.com/terms",
+                        year: 2019
                     }
                 ]);
 
@@ -101,10 +103,11 @@ export namespace FreeCameraApp_DebugingToolExample {
          */
         start() {
             const omvDataSource = new OmvDataSource({
-                baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-                apiFormat: APIFormat.XYZMVT,
+                baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+                apiFormat: APIFormat.XYZOMV,
                 styleSetName: "tilezen",
-                maxZoomLevel: 17
+                maxZoomLevel: 17,
+                authenticationCode: accessToken
             });
 
             const debugTileDataSource = new DebugTileDataSource(webMercatorTilingScheme);
@@ -125,7 +128,7 @@ export namespace FreeCameraApp_DebugingToolExample {
 
             this.mapView.scene.add(pointOfView);
 
-            pointOfView.position.set(0, -3000, 3000);
+            pointOfView.position.set(0, -1500, 1500);
 
             this.mapView.pointOfView = pointOfView;
 

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -10,6 +10,7 @@ import { GeoCoordinates, TileKey } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { DataProvider } from "@here/harp-mapview-decoder";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { accessToken } from "../config";
 import * as geojson from "../resources/italy.json";
 
 /**
@@ -80,9 +81,10 @@ export namespace GeoJsonStylingGame {
         .attach(mapView)
         .setDefaults([
             {
-                id: "openstreetmap.org",
-                label: "OpenStreetMap contributors",
-                link: "https://www.openstreetmap.org/copyright"
+                id: "here.com",
+                label: "HERE",
+                link: "https://legal.here.com/terms",
+                year: 2019
             }
         ]);
     mapView.camera.position.set(1900000, 3350000, 2500000); // Europe.
@@ -93,10 +95,11 @@ export namespace GeoJsonStylingGame {
     });
 
     const baseMap = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-        apiFormat: APIFormat.XYZMVT,
+        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17
+        maxZoomLevel: 17,
+        authenticationCode: accessToken
     });
     mapView.addDataSource(baseMap);
     // end:initmapview.ts

--- a/@here/harp-examples/src/hello.ts
+++ b/@here/harp-examples/src/hello.ts
@@ -8,6 +8,7 @@ import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { accessToken } from "../config";
 
 /**
  * MapView initialization sequence enables setting all the necessary elements on a map  and returns
@@ -74,9 +75,10 @@ export namespace HelloWorldExample {
             .attach(sampleMapView)
             .setDefaults([
                 {
-                    id: "openstreetmap.org",
-                    label: "OpenStreetMap contributors",
-                    link: "https://www.openstreetmap.org/copyright"
+                    id: "here.com",
+                    label: "HERE",
+                    link: "https://legal.here.com/terms",
+                    year: 2019
                 }
             ]);
 
@@ -108,10 +110,11 @@ export namespace HelloWorldExample {
 
     // snippet:harp_gl_hello_world_example_4.ts
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-        apiFormat: APIFormat.XYZMVT,
+        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17
+        maxZoomLevel: 17,
+        authenticationCode: accessToken
     });
     // end:harp_gl_hello_world_example_4.ts
 

--- a/@here/harp-examples/src/multiview_triple-view.ts
+++ b/@here/harp-examples/src/multiview_triple-view.ts
@@ -8,6 +8,7 @@ import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, MapViewUtils } from "@here/harp-mapview";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { accessToken } from "../config";
 
 /**
  * An example showing triple map view build with 3 [[MapView]]s each with a different theme and/or
@@ -178,9 +179,10 @@ export namespace TripleViewExample {
             .attach(sampleMapView)
             .setDefaults([
                 {
-                    id: "openstreetmap.org",
-                    label: "OpenStreetMap contributors",
-                    link: "https://www.openstreetmap.org/copyright"
+                    id: "here.com",
+                    label: "HERE",
+                    link: "https://legal.here.com/terms",
+                    year: 2019
                 }
             ]);
         sampleMapView.camera.position.set(0, 0, 800);
@@ -228,10 +230,11 @@ export namespace TripleViewExample {
 
     // snippet:harp_gl_multiview_tripleView_2.ts
     const xyzDataSourceParams = {
-        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-        apiFormat: APIFormat.XYZMVT,
+        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17
+        maxZoomLevel: 17,
+        authenticationCode: accessToken
     };
     const dataSources = {
         omvDataSource1: new OmvDataSource(xyzDataSourceParams),

--- a/@here/harp-omv-datasource/README.md
+++ b/@here/harp-omv-datasource/README.md
@@ -11,8 +11,41 @@ such as road names or city names, and other kinds of data that are typically pas
 
 Each tile is encoded using [Protobuf](https://github.com/google/protobuf).
 
+## REST Clients
+
+### HERE Vector Tiles
+
+REST service implemented with `APIFormat.HereV1` in `OmvRestClient.ts`.
+
 The HERE Vector Tile Service allows you to request tiles containing vector data
 using content from the [HERE Open Location Platform](https://openlocation.here.com/).
 
 HERE provides global coverage and updates the data continuously.
 For more information about our map content, see the [HERE Map Content Guidelines](https://repo.platform.here.com/artifactory/open-location-platform-docs/Data_Specifications/HERE_Map_Content/).
+
+### HERE XYZ
+
+REST services implemented with `APIFormat.XYZMVT`, `APIFormat.XYZJson` and `APIFormat.XYZOMV` in `OmvRestClient.ts`.
+
+The HERE XYZ Services offer three variants:
+
+* MVT: offer [Open Street Map Data](https://www.openstreetmap.org) tiles in MVT Format.
+* JSON: offer [Open Street Map Data](https://www.openstreetmap.org) tiles in JSON Format.
+* OMV: offer HERE Data tiles in OMV Format. The data source is the same as in the [HERE Vector Tiles](#here-vector-tiles).
+
+You can find more about the HERE XYZ Services [here](https://www.here.xyz/).
+
+### Mapbox Vector Tiles
+
+REST service implemented with `APIFormat.MapboxV4` in `OmvRestClient.ts`.
+
+You can find more information [here](https://docs.mapbox.com/vector-tiles/reference/).
+
+## Tom Tom Vector Tiles
+
+You can find more information [here](https://developer.tomtom.com/maps-api/maps-api-documentation-vector/tile).
+
+## Usage of REST APIs and authentication
+
+It is not within the scope of `harp.gl` to provide credentials to all of the services implemented above, but following the links you can do it by yourself.
+On our [Getting Started Guide](../../docs/GettingStartedGuide.md) there is more information about getting credentials for HERE Services.

--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -77,6 +77,22 @@ export enum APIFormat {
     XYZJson,
 
     /**
+     * Use the REST API format of XYZ Vector Tile API in OMV format.
+     *
+     * Usage:
+     * `<OmvRestClientParams.baseUrl>/tiles/herebase.02/<zoom>/<X>/<Y>/omv?access_token=<OmvRestClientParams.authenticationCode>`
+     *
+     * Format definition:
+     * `http|s://<base-url>/tiles/herebase.02/{z}/{x}/{y}/{format}?access_token={access_token}`
+     *
+     * Sample URL:
+     * `https://xyz.api.here.com/tiles/osmbase/herebase.02/14/2649/6338/omv?access_token=your-xyz-access-token`
+     *
+     * Default authentication method used: [[AuthenticationTypeMapboxV4]].
+     */
+    XYZOMV,
+
+    /**
      * Use the REST API format of Tomtoms Vector Tile API v1.
      *
      * Usage:
@@ -283,6 +299,7 @@ export class OmvRestClient implements DataProvider {
             case APIFormat.HereV1:
                 return AuthenticationTypeBearer;
             case APIFormat.MapboxV4:
+            case APIFormat.XYZOMV:
                 return AuthenticationTypeMapboxV4;
             case APIFormat.XYZMVT:
             case APIFormat.XYZJson:
@@ -334,6 +351,7 @@ export class OmvRestClient implements DataProvider {
         let path = `/${tileKey.level}/${tileKey.column}/${tileKey.row}`;
         switch (this.params.apiFormat) {
             case APIFormat.HereV1:
+            case APIFormat.XYZOMV:
                 path += "/omv";
                 break;
             case APIFormat.MapboxV4:

--- a/@here/harp-omv-datasource/test/OmvRestClientTest.ts
+++ b/@here/harp-omv-datasource/test/OmvRestClientTest.ts
@@ -81,6 +81,20 @@ describe("OmvRestClient", function() {
         assert.equal(downloadSpy.args[0][0], "https://a.tomtom.base.url/3/2/1.pbf?key=123");
     });
 
+    it("generates proper Url with XYZ OMV Format", async function() {
+        const restClient = new OmvRestClient({
+            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            apiFormat: APIFormat.XYZOMV,
+            authenticationCode: async () => "123",
+            downloadManager: mockDownloadManager
+        });
+        await restClient.getTile(new TileKey(6338, 2649, 14));
+        assert.equal(
+            downloadSpy.args[0][0],
+            "https://xyz.api.here.com/tiles/herebase.02/14/2649/6338/omv?access_token=123"
+        );
+    });
+
     it("supports custom authentication method based on query string key", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://some.base.url",

--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -4,3 +4,17 @@
 
 To begin with, we suggest taking a look at our most basic example, the equivalent of a `hello_world` in
 the [examples package](../@here/harp-examples/README.md)
+
+# HERE Credentials
+
+In order to use some of the HERE Services, such as XYZ or Map Tile API, you would need to register and generate credentials.
+
+First, you need to become a [HERE Developer](https://www.here.xyz/getting-started/).
+
+Afterwards, depending on which service do you want, you might need different credentials.
+
+For Map Tile API, which is needed for the webtile examples, you need to generate a pair of `app_id` and `app_code`, that you can do directly from your Developer Dashboard, see a step-by-step guide [here](https://www.here.xyz/getting-started/).
+
+For XYZ Vector Tiles, you need an `access_token` that you can generate yourself from the [Token Manager](https://xyz.api.here.com/token-ui/).
+
+These credentials need to be passed to the Service in order to retrieve tiles, please see the examples to check how it is done.


### PR DESCRIPTION
Add new REST Service for XYZ Vector Tiles.
Extend README to include information for all existing Vector Data providers.
Add information about credentials on Getting Started Guide.
Add demo `access_token` to config.ts
Migrate examples to new service.
Fix typo on example browser title.

Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>