### PR TITLE
HARP-5103: Reduce TextCanvas memory usage.

### DIFF
--- a/@here/harp-examples/src/textcanvas_dynamic.ts
+++ b/@here/harp-examples/src/textcanvas_dynamic.ts
@@ -359,6 +359,7 @@ export namespace TextCanvasDynamicExample {
                 textCanvas = new TextCanvas({
                     renderer: webglRenderer,
                     fontCatalog: loadedFontCatalog,
+                    minGlyphCount: 16,
                     maxGlyphCount: characterCount
                 });
                 loadedFontCatalog.loadCharset(textSample, textRenderStyle).then(() => {

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -362,6 +362,14 @@ export interface MapViewOptions {
     collisionDebugCanvas?: HTMLCanvasElement;
 
     /**
+     * Optional initial number of glyphs (characters) for labels. In situations with limited,
+     * available memory, decreasing this number may be beneficial.
+     *
+     * @default `1024`
+     */
+    minNumGlyphs?: number;
+
+    /**
      * Optional limit of number of glyphs (characters) for labels. In situations with limited,
      * available memory, decreasing this number may be beneficial.
      *
@@ -2347,6 +2355,7 @@ export class MapView extends THREE.EventDispatcher {
                 this,
                 this.m_screenCollisions,
                 this.m_screenProjector,
+                this.m_options.minNumGlyphs,
                 this.m_options.maxNumGlyphs,
                 this.m_theme,
                 this.m_options.maxNumVisibleLabels,

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -186,7 +186,12 @@ class PoiRenderBuffer {
             layer = this.textCanvas.getLayer(renderOrder);
         }
 
-        bufferBatch = new PoiRenderBufferBatch(this.mapView, layer!.scene, imageItem, renderOrder);
+        bufferBatch = new PoiRenderBufferBatch(
+            this.mapView,
+            layer!.storage.scene,
+            imageItem,
+            renderOrder
+        );
         bufferBatch.init();
         batchSet.set(renderOrder, mappedIndex);
         this.batches.push(bufferBatch);

--- a/@here/harp-text-canvas/lib/rendering/FontCatalog.ts
+++ b/@here/harp-text-canvas/lib/rendering/FontCatalog.ts
@@ -517,6 +517,9 @@ export class FontCatalog {
         font: Font
     ): Promise<GlyphData> {
         const json = await this.loadBlock(block, font, fontStyle);
+        if (json === undefined) {
+            return this.m_replacementGlyph;
+        }
 
         const sourceGlyphData = (json.chars as SrcGlyphData[]).find(char => char.id === codePoint);
         const assetsPath = this.getAssetsPath(fontStyle, font);

--- a/@here/harp-text-canvas/lib/rendering/TextMaterials.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextMaterials.ts
@@ -66,13 +66,13 @@ const SdfShaderChunks = {
 Object.assign(THREE.ShaderChunk, SdfShaderChunks);
 
 const clearVertexSource: string = `
-    attribute vec4 position;
+    attribute vec2 position;
 
     uniform mat4 modelViewMatrix;
     uniform mat4 projectionMatrix;
 
     void main() {
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position.xyz, 1.0);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position.xy, 0.0, 1.0);
     }`;
 
 const clearFragmentSource: string = `
@@ -84,8 +84,8 @@ const clearFragmentSource: string = `
     }`;
 
 const copyVertexSource: string = `
-    attribute vec4 position;
-    attribute vec3 uv;
+    attribute vec3 position;
+    attribute vec2 uv;
 
     uniform mat4 modelViewMatrix;
     uniform mat4 projectionMatrix;
@@ -93,8 +93,8 @@ const copyVertexSource: string = `
     varying vec3 vUv;
 
     void main() {
-        vUv = vec3(uv.xy, position.w);
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position.xyz, 1.0);
+        vUv = vec3(uv.xy, position.z);
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position.xy, 0.0, 1.0);
     }`;
 
 const copyFragmentSource: string = `

--- a/@here/harp-text-canvas/test/TextCanvasTest.ts
+++ b/@here/harp-text-canvas/test/TextCanvasTest.ts
@@ -177,6 +177,7 @@ describe("TextCanvas", () => {
         textCanvas = new TextCanvas({
             renderer: webglRenderer as THREE.WebGLRenderer,
             fontCatalog: loadedFontCatalog,
+            minGlyphCount: 16,
             maxGlyphCount: 16
         });
 
@@ -260,11 +261,11 @@ describe("TextCanvas", () => {
         assert.strictEqual(position.x, 88.5);
         assert.strictEqual(position.y, 0.0);
         assert.strictEqual(position.z, 0.0);
-        assert.strictEqual(textCanvas.getLayer(0)!.geometry.drawCount, textSample.length);
+        assert.strictEqual(textCanvas.getLayer(0)!.storage.drawCount, textSample.length);
     });
     it("Is cleared.", () => {
         textCanvas.clear();
-        assert.strictEqual(textCanvas.getLayer(0)!.geometry.drawCount, 0.0);
+        assert.strictEqual(textCanvas.getLayer(0)!.storage.drawCount, 0.0);
     });
     it("Fails when adding too many characters.", () => {
         let resultA = true;


### PR DESCRIPTION
* Optimized ``GlyphTextureCache`` internal buffers to only store attributes relevant to glyph copy/clear operations.
* Modified ``TextGeometry`` to be dinamically resized, also reducing the initial allocation size.