### PR TITLE
HARP-2104: Fix typedoc module mapping.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tslint": "^5.11.1",
     "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.14.2",
+    "typedoc-plugin-external-module-map": "^1.0.0",
     "typescript": "^3.3.0",
     "webpack": "^4.28.3",
     "webpack-cli": "^3.1.0",

--- a/typedoc.json
+++ b/typedoc.json
@@ -8,6 +8,7 @@
         "**/map-component/*.ts",
         "**/test/**/*.ts",
         "**/scripts/*.ts",
+        "**/@here/generator-harp.gl/**/*.ts",
         "**/+(*Test.ts|index_node.ts|index-worker.ts|*_generated.ts|publish-npm.ts|changelog.ts|doc-snippets.ts)"
     ],
     "includes": "dist/doc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5775,6 +5775,11 @@ typedoc-default-themes@^0.5.0:
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
   integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
 
+typedoc-plugin-external-module-map@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-external-module-map/-/typedoc-plugin-external-module-map-1.0.0.tgz#7021d0e2bc9a98b7266f4ea2eab593b7c63802ce"
+  integrity sha512-OtlTOmanX0yqRYUVLBuGSBjrffLLAjWNn8mqh6k6FkvfXAIIe3Yfg0kCeKZDN/65v4dt3MJ9AuGXTGLPue3Kqg==
+
 typedoc@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.14.2.tgz#769f457f4f9e4bdb8b5f3b177c86b6a31d8c3dc3"


### PR DESCRIPTION
* re-add `typedoc-plugin-external-module-map` responsible for cleaning up of layout in our typedoc
* ignore code in `@here/generator-harp.gl`