### PR TITLE
Consume public build badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# harp.gl [![Build Status](https://travis-ci.com/heremaps/harp.gl.svg?token=XqJjRxFbW25Pc73LNRB9&branch=master)](https://travis-ci.com/heremaps/harp.gl)
+# harp.gl [![Build Status](https://travis-ci.com/heremaps/harp.gl.svg?branch=master)](https://travis-ci.com/heremaps/harp.gl)
 
 `harp.gl` is an _experimental and work in progress_ open-source 3D map rendering engine.
 


### PR DESCRIPTION
Since the repository is public, we can consume the public icon

Signed-off-by: Harald Fernengel <harald.fernengel@here.com>