### PR TITLE
MINOR: Limit default number of decoders to maximum of 4

### DIFF
--- a/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
+++ b/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
@@ -9,6 +9,7 @@ import {
     IWorkerChannelMessage,
     LoggerManager,
     LogLevel,
+    MathUtils,
     WORKERCHANNEL_MSG_TYPE
 } from "@here/harp-utils";
 
@@ -42,7 +43,7 @@ export interface ConcurrentWorkerSetOptions {
     /**
      * The number of Web Workers for processing data.
      *
-     * Defaults to `navigator.hardwareConcurrency` or [[DEFAULT_WORKER_COUNT]].
+     * Defaults to CLAMP(`navigator.hardwareConcurrency` - 1, 1, 4) or [[DEFAULT_WORKER_COUNT]].
      */
     workerCount?: number;
 }
@@ -157,7 +158,8 @@ export class ConcurrentWorkerSet {
         const workerCount = getOptionValue(
             this.m_options.workerCount,
             typeof navigator !== "undefined" && navigator.hardwareConcurrency !== undefined
-                ? Math.max(1, navigator.hardwareConcurrency) // we need to have at least one worker
+                ? // We need to have at least one worker
+                  MathUtils.clamp(navigator.hardwareConcurrency - 1, 1, 4)
                 : undefined,
             DEFAULT_WORKER_COUNT
         );

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -229,7 +229,7 @@ export interface MapViewOptions {
 
     /**
      * The number of Web Workers used to decode data. The default is
-     * `navigator.hardwareConcurrency`.
+     * CLAMP(`navigator.hardwareConcurrency` - 1, 1, 4).
      */
     decoderCount?: number;
 


### PR DESCRIPTION
* Reduce heap usage, since all workers have a copy of code and data

Signed-off-by: Stefan Dachwitz <StefanDachwitz@users.noreply.github.com>