### PR TITLE
MapView: fix first FrameComplete event.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2037,7 +2037,11 @@ export class MapView extends THREE.EventDispatcher {
         // particular camera set up is not compatible with the debug camera.
         const debugCameraActive = this.m_pointOfView !== undefined;
 
-        if (this.m_textElementsRenderer === undefined || debugCameraActive) {
+        if (
+            this.m_textElementsRenderer === undefined ||
+            !this.m_textElementsRenderer.ready ||
+            debugCameraActive
+        ) {
             return;
         }
 


### PR DESCRIPTION
TextElementsRenderer is fully initialized and can be used for
label layout only when all font catalogs are loaded.

Introduce `#ready` property and use it to prevent initial
label placement until in MapView until font catalog is loaded.