### PR TITLE
HARP-5283: Allow skipping labels that are too small to be displayed a…

### DIFF
--- a/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
+++ b/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
@@ -23,6 +23,8 @@ import { Projection, TileKey } from "@here/harp-geoutils";
  */
 export abstract class ThemedTileDecoder implements ITileDecoder {
     languages?: string[];
+    m_storageLevelOffset: number = 0;
+
     protected m_styleSetEvaluator?: StyleSetEvaluator;
     abstract connect(): Promise<void>;
 
@@ -58,6 +60,9 @@ export abstract class ThemedTileDecoder implements ITileDecoder {
         }
         if (languages !== undefined) {
             this.languages = languages;
+        }
+        if (options !== undefined && options.storageLevelOffset !== undefined) {
+            this.m_storageLevelOffset = options.storageLevelOffset;
         }
     }
 

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -147,6 +147,10 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
             );
         }
 
+        this.m_decoder.configure(undefined, undefined, {
+            storageLevelOffset: this.m_options.storageLevelOffset
+        });
+
         this.cacheable = true;
     }
 

--- a/@here/harp-mapview/lib/ScreenProjector.ts
+++ b/@here/harp-mapview/lib/ScreenProjector.ts
@@ -8,8 +8,12 @@ import * as THREE from "three";
 
 /**
  * @hidden
+ * Handles the projection of world coordinates to screen coordinates.
  */
 export class ScreenProjector {
+    static tempV2 = new THREE.Vector2();
+    static tempV3 = new THREE.Vector3();
+
     private readonly m_projectionViewMatrix = new THREE.Matrix4();
     private readonly m_viewMatrix = new THREE.Matrix4();
     private readonly m_cameraPosition = new THREE.Vector3();
@@ -21,27 +25,33 @@ export class ScreenProjector {
     // tslint:disable-next-line:no-unused-variable
     private m_farClipPlane: number = 0;
 
+    /**
+     * Height of the screen.
+     */
     get width(): number {
         return this.m_width;
     }
 
+    /**
+     * Width of the screen.
+     */
     get height(): number {
         return this.m_height;
     }
 
-    projectVector(source: THREE.Vector3 | THREE.Vector4): typeof source {
-        source.x -= this.m_center.x + this.m_cameraPosition.x;
-        source.y -= this.m_center.y + this.m_cameraPosition.y;
-        source.z -= this.m_center.z + this.m_cameraPosition.z;
-        source.applyMatrix4(this.m_projectionViewMatrix);
-        return source;
-    }
-
+    /**
+     * Apply current projectionViewMatrix of the camera to project the source vector into screen
+     * coordinates.
+     *
+     * @param {(THREE.Vector3 | THREE.Vector4)} source The source vector to project.
+     * @param {THREE.Vector3} target The target vector.
+     * @returns {THREE.Vector3} The projected vector (the parameter 'target').
+     */
     project(
         source: THREE.Vector3,
         target: THREE.Vector2 = new THREE.Vector2()
     ): THREE.Vector2 | undefined {
-        const p = this.projectVector(source.clone());
+        const p = this.projectVector(source, ScreenProjector.tempV3);
         if (p.z > 0 && p.z < 1) {
             target.set((p.x * this.m_width) / 2, (p.y * this.m_height) / 2);
             return target;
@@ -49,6 +59,60 @@ export class ScreenProjector {
         return undefined;
     }
 
+    /**
+     * Apply current projectionViewMatrix of the camera to project the source vector. Stores result
+     * in NDC in the target vector.
+     *
+     * @param {(THREE.Vector3 | THREE.Vector4)} source The source vector to project.
+     * @param {THREE.Vector3} target The target vector.
+     * @returns {THREE.Vector3} The projected vector (the parameter 'target').
+     */
+    projectVector(source: THREE.Vector3 | THREE.Vector4, target: THREE.Vector3): THREE.Vector3 {
+        target.x = source.x - this.m_center.x - this.m_cameraPosition.x;
+        target.y = source.y - this.m_center.y - this.m_cameraPosition.y;
+        target.z = source.z - this.m_center.z - this.m_cameraPosition.z;
+        target.applyMatrix4(this.m_projectionViewMatrix);
+        return target;
+    }
+
+    /**
+     * Project the 3D source point to a 2D screen point.
+     *
+     * @param {THREE.Vector3} source Point to project.
+     * @param {THREE.Vector2} target 2D screen point to initialize.
+     * @returns {(THREE.Vector2 | undefined)} Result or `undefined` if point is not between near and
+     *      far plane.
+     */
+    projectInPlace(source: THREE.Vector3, target: THREE.Vector2): THREE.Vector2 | undefined {
+        const p = this.projectVector(source, ScreenProjector.tempV3);
+        if (p.z > 0 && p.z < 1) {
+            target.set((p.x * this.m_width) / 2, (p.y * this.m_height) / 2);
+            return target;
+        }
+        return undefined;
+    }
+
+    /**
+     * Fast test to check if projected point is on screen.
+     *
+     * @returns {boolean} `true` if point is on screen, `false` otherwise.
+     */
+    onScreen(source: THREE.Vector3): boolean {
+        const p = this.projectVector(source, ScreenProjector.tempV3);
+        if (p.z > 0 && p.z < 1) {
+            return p.x >= -1 && p.x <= 1 && p.y >= -1 && p.y <= 1;
+        }
+        return false;
+    }
+
+    /**
+     * Update the `ScreenProjector` with the latest values of the screen and the camera.
+     *
+     * @param {THREE.Camera} camera The current camera.
+     * @param {THREE.Vector3} center Center of the world.
+     * @param {number} width Width of screen/canvas.
+     * @param {number} height Height of screen/canvas.
+     */
     update(camera: THREE.Camera, center: THREE.Vector3, width: number, height: number) {
         this.m_width = width;
         this.m_height = height;

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -452,6 +452,13 @@ export class TextElement {
      */
     textBufferObject?: TextBufferObject;
 
+    /**
+     * @hidden
+     * If `true`, the estimated bounding box of the path is too small for the label to fit, so it is
+     * being ignored for rendering in the latest frame.
+     */
+    dbgPathTooSmall?: boolean;
+
     private m_poiInfo?: PoiInfo;
 
     /**

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -111,6 +111,12 @@ export interface OmvDataSourceParameters {
     gatherRoadSegments?: boolean;
 
     /**
+     * If not set to `false`, very short text labels will be skipped during decoding based on a
+     * heuristic.
+     */
+    skipShortLabels?: boolean;
+
+    /**
      * A description for the feature filter that can be safely passed down to the web workers. It
      * has to be generated with the help of the [[OmvFeatureFilterDescriptionBuilder]] (to guarantee
      * correctness). This parameter gets applied to the decoder used in the [[OmvDataSource]]
@@ -197,7 +203,9 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
             gatherFeatureIds: this.m_params.gatherFeatureIds === true,
             createTileInfo: this.m_params.createTileInfo === true,
             gatherRoadSegments: this.m_params.gatherRoadSegments === true,
-            featureModifierId: this.m_params.featureModifierId
+            featureModifierId: this.m_params.featureModifierId,
+            skipShortLabels: this.m_params.skipShortLabels,
+            storageLevelOffset: getOptionValue(m_params.storageLevelOffset, -2)
         };
 
         this.tileBackgroundIsVisible = true;

--- a/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
@@ -138,6 +138,17 @@ export interface OmvDecoderOptions {
     gatherRoadSegments?: boolean;
 
     /**
+     * Optional storage level offset for [[Tile]]s. Default is -2.
+     */
+    storageLevelOffset?: number;
+
+    /**
+     * If not set to `false` very short text labels will be skipped during decoding based on a
+     * heuristic.
+     */
+    skipShortLabels?: boolean;
+
+    /**
      * A description for the feature filter which can be safely passed down to the web workers.
      * It has to be generated with the help of the [[OmvFeatureFilterDescriptionBuilder]] (to
      * guarantee the correctness).


### PR DESCRIPTION
Allow skipping labels that are too small to be displayed at current display settings. 

Signed-off-by: Stefan Dachwitz <StefanDachwitz@users.noreply.github.com>