### PR TITLE
HARP-5193: ZoomLevel replace with more precise calculation

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -517,7 +517,6 @@ export class MapView extends THREE.EventDispatcher {
     private m_pointOfView?: THREE.PerspectiveCamera;
 
     private m_tempVector3: THREE.Vector3 = new THREE.Vector3();
-    private m_tempQuat: THREE.Quaternion = new THREE.Quaternion();
     private m_pixelToWorld?: number;
     private m_pixelRatio?: number;
 
@@ -1760,13 +1759,10 @@ export class MapView extends THREE.EventDispatcher {
 
         this.m_pixelToWorld = undefined;
 
-        this.m_tempQuat.setFromAxisAngle(EYE_INVERSE, -this.camera.rotation.z);
-
-        // "any" used to fix missing .angleTo() ts error
-        const cameraAngle = (this.camera.quaternion as any).angleTo(this.m_tempQuat);
+        const cameraPitch = MapViewUtils.extractYawPitchRoll(this.camera.quaternion).pitch;
 
         const distance = Math.min(
-            Math.abs(this.camera.position.z) / Math.cos(cameraAngle),
+            Math.abs(this.camera.position.z) / Math.cos(cameraPitch),
             this.camera.position.z * 2
         );
 

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -28,9 +28,6 @@ export namespace MapViewUtils {
     const rotationMatrix = new THREE.Matrix4();
     const unprojectionMatrix = new THREE.Matrix4();
     const rayCaster = new THREE.Raycaster();
-    const tempQuat = new THREE.Quaternion();
-
-    const EYE_INVERSE = new THREE.Vector3(0, 0, -1);
 
     /**
      * Yaw rotation as quaternion. Declared as a const to avoid object re-creation in certain
@@ -224,13 +221,10 @@ export namespace MapViewUtils {
         mapView: MapView,
         zoomLevel: number
     ): number {
-        tempQuat.setFromAxisAngle(EYE_INVERSE, -mapView.camera.rotation.z);
-
-        // "any" used to fix missing .angleTo() ts error
-        const cameraAngle = (mapView.camera.quaternion as any).angleTo(tempQuat);
+        const cameraPitch = extractYawPitchRoll(mapView.camera.quaternion).pitch;
 
         const tileSize = EarthConstants.EQUATORIAL_CIRCUMFERENCE / Math.pow(2, zoomLevel);
-        return ((mapView.focalLength * tileSize) / 256) * Math.cos(cameraAngle);
+        return ((mapView.focalLength * tileSize) / 256) * Math.cos(cameraPitch);
     }
 
     /**


### PR DESCRIPTION
**General description of a fix:** camera pitch calculation behaves much more precise rather than angle between quats.