### PR TITLE
Cache eviction happens when last requested

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1897,21 +1897,16 @@ export class MapView extends THREE.EventDispatcher {
 
         const renderList = this.m_visibleTiles.dataSourceTileList;
 
-        renderList.forEach(({ zoomLevel, renderedTiles, visibleTiles, numTilesLoading }) => {
-            // The visible tiles may not actually be rendered, but they have to stay in the cache
-            // for the next frame.
-            visibleTiles.forEach(tile => {
-                tile.frameNumLastVisible = this.m_frameNumber;
-            });
+        renderList.forEach(({ zoomLevel, renderedTiles }) => {
             renderedTiles.forEach(tile => {
                 this.renderTileObjects(tile, zoomLevel);
+                //We know that rendered tiles are visible (in the view frustum), so we update the
+                //frame number, note we don't do this for the visibleTiles because some may still be
+                //loading (and therefore aren't visible in the sense of being seen on the screen).
+                //Note also, this number isn't currently used anywhere so should be considered to be
+                //removed in the future (though could be good for debugging purposes).
                 tile.frameNumLastVisible = this.m_frameNumber;
             });
-        });
-
-        // Update the visibility flag on every tile in the cache, so it does not get evicted.
-        this.forEachCachedTile(tile => {
-            tile.isVisible = tile.frameNumLastVisible === this.m_frameNumber;
         });
 
         if (currentFrameEvent !== undefined) {


### PR DESCRIPTION
- Cache eviction is now controlled by when the tile was last requested,
and not whether the tile is visible.
- "visibleTiles" renamed because it was a bit confusing as there are
tiles which are not visible in the visibleTiles list because they are
still loading.