### PR TITLE
MINOR: Visual regression fix after #359 for berlin based themes.

### DIFF
--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -1082,7 +1082,7 @@
       {
         "description": "urban area",
         "when": "$layer ^= 'landuse' && (($geometryType ^= 'polygon') && (kind ^= 'urban_area'))",
-        "technique": "fill",
+        "technique": "none",
         "attr": {
           "color": {
             "interpolation": "Linear",

--- a/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
@@ -1088,7 +1088,7 @@
       {
         "description": "urban area",
         "when": "$layer ^= 'landuse' && (($geometryType ^= 'polygon') && (kind ^= 'urban_area'))",
-        "technique": "fill",
+        "technique": "none",
         "attr": {
           "color": {
             "interpolation": "Linear",

--- a/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
@@ -1117,7 +1117,7 @@
       {
         "description": "urban area",
         "when": "$layer ^= 'landuse' && (($geometryType ^= 'polygon') && (kind ^= 'urban_area'))",
-        "technique": "fill",
+        "technique": "none",
         "attr": {
           "color": {
             "interpolation": "Linear",


### PR DESCRIPTION
* Set technique to "none" for all 'urban_area' layers.
   Those layer were not applied previously, but after #359
   they get applied, which technically is the right behavior.
   I am setting the technique to "none" so we still have the structure for
   urban areas in place, in case we want to style them in the future.