### PR TITLE
HARP-5371: DataSource exposes getter/setter for storage level offset.

### DIFF
--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -296,6 +296,27 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
+     * The difference between storage level and display level of tile.
+     *
+     * Storage level offset is a value applied (added) to current zoom level giving
+     * a final tile level being displayed. This way we may differentate current
+     * zoom level from the storage level that is displayed, giving fine grained
+     * control over the tiles being decoded an displayed.
+     */
+    get storageLevelOffset() {
+        return this.m_storageLevelOffset;
+    }
+
+    /**
+     * Setup the relative offset between storage level and display level of tile.
+     *
+     * @param levelOffset Difference between zoom level and display level.
+     */
+    set storageLevelOffset(levelOffset: number) {
+        this.m_storageLevelOffset = levelOffset;
+    }
+
+    /**
      * Computes the zoom level to use for display.
      *
      * @param zoomLevel The zoom level of the [[MapView]].

--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -280,6 +280,7 @@ export class WebTileDataSource extends DataSource {
     constructor(private readonly m_options: WebTileDataSourceParameters) {
         super("webtile");
         this.cacheable = true;
+        this.storageLevelOffset = -1;
         this.m_resolution = getOptionValue(m_options.resolution, 512);
         this.m_ppi = getOptionValue(m_options.ppi, 320);
         this.m_tileBaseAddress = m_options.tileBaseAddress || WebTileDataSource.TILE_BASE_NORMAL;


### PR DESCRIPTION
This allows to update and read this property via MapView and thus
control level offsets in demo app.
WebTileDataSource should use default level offset set to -1 which
corresponds to 512 tile sizes used.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>