### PR TITLE
HARP-5484: Buildings should be shown at all available storage levels.

### DIFF
--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -1700,8 +1700,8 @@
         "final": true
       },
       {
-        "description": "building_level_>=15",
-        "when": "$layer ^= 'buildings' && (($level >= 15) && ($geometryType ^= 'polygon'))",
+        "description": "building_geometry",
+        "when": "$layer ^= 'buildings' && ($geometryType ^= 'polygon')",
         "technique": "extruded-polygon",
         "attr": {
           "color": "#EDE7E1",
@@ -1725,7 +1725,7 @@
       },
       {
         "description": "building_address",
-        "when": "$layer ^= 'buildings' && (($level >= 15) && (((kind ^= 'address') && ($geometryType ^= 'point')) && label_placement))",
+        "when": "$layer ^= 'buildings' && (((kind ^= 'address') && ($geometryType ^= 'point')) && label_placement)",
         "technique": "text",
         "attr": {
           "color": "#A9A9A9",

--- a/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
@@ -1706,8 +1706,8 @@
         "final": true
       },
       {
-        "description": "building_level_>=15",
-        "when": "$layer ^= 'buildings' && (($level >= 15) && ($geometryType ^= 'polygon'))",
+        "description": "building_geometry",
+        "when": "$layer ^= 'buildings' && ($geometryType ^= 'polygon')",
         "technique": "extruded-polygon",
         "attr": {
           "color": "#F2ECE0",
@@ -1731,7 +1731,7 @@
       },
       {
         "description": "building_address",
-        "when": "$layer ^= 'buildings' && (($level >= 15) && (((kind ^= 'address') && ($geometryType ^= 'point')) && label_placement))",
+        "when": "$layer ^= 'buildings' && (((kind ^= 'address') && ($geometryType ^= 'point')) && label_placement)",
         "technique": "text",
         "attr": {
           "color": "#C0BDB1",

--- a/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
@@ -1738,8 +1738,8 @@
         "final": true
       },
       {
-        "description": "building_level_>=15",
-        "when": "$layer ^= 'buildings' && (($level >= 15) && ($geometryType ^= 'polygon'))",
+        "description": "building_geometry",
+        "when": "$layer ^= 'buildings' && ($geometryType ^= 'polygon')",
         "technique": "extruded-polygon",
         "attr": {
           "color": "#7C7F81",
@@ -1763,7 +1763,7 @@
       },
       {
         "description": "building_address",
-        "when": "$layer ^= 'buildings' && (($level >= 15) && (((kind ^= 'address') && ($geometryType ^= 'point')) && label_placement))",
+        "when": "$layer ^= 'buildings' && (((kind ^= 'address') && ($geometryType ^= 'point')) && label_placement)",
         "technique": "text",
         "attr": {
           "color": "#131313",


### PR DESCRIPTION
Themes fix, the styles should not filter buildings. Remove the `$level`
condition from all styles relevant for the buildings polygon data.