### PR TITLE
Remove faulty test-npm-packages.sh check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ jobs:
         npx ts-mocha -r tsconfig-paths/register ./@here/*/test/*.ts
         yarn test-browser --headless-firefox
         yarn test-browser --headless-chrome
-        if [ -z "${TRAVIS_TAG}" ] ; then
-          ./scripts/test-npm-packages.sh
-          git status # just in case test-npm-packages leaves some garbage
-        fi
 
     - name: "Build & Deploy"
       script: |


### PR DESCRIPTION
The script assumes that the repository versions and the versions in
npmjs.com match, which is not always true, for example after we bumped
the versions in preparation for publishing.

Since this is blocking publishing, we need to remove it until we find a
more correct solution to this problem.