### PR TITLE
HARP-5577 Simplify travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,11 +37,6 @@ jobs:
         set -ex
         yarn run build
         yarn run typedoc
-        cp ./docs/index.html ./dist
-        cp ./LICENSE ./dist/doc
-        cp -R ./docs ./dist/doc/docs
-        rm ./dist/examples/resources/fonts/.gitignore
-        rm ./dist/examples/resources/fonts/.npmignore
         echo -e 'include:\n  - "_*"' > dist/_config.yml
       deploy:
         provider: pages

--- a/@here/harp-examples/webpack.config.js
+++ b/@here/harp-examples/webpack.config.js
@@ -179,7 +179,9 @@ browserConfig.plugins.push(
             toType: "dir"
         },
         require.resolve("three/build/three.min.js")
-    ])
+        ],
+        { ignore: ['*.npmignore','*.gitignore'] }
+    )
 );
 
 module.exports = [decoderConfig, browserConfig, codeBrowserConfig, exampleBrowserConfig];

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "start-tests": "webpack-dev-server -d --config webpack.tests.config.js",
         "test-browser": "ts-node -- ./scripts/with-http-server.ts -C dist/test -p 8079 -- mocha-webdriver-runner http://localhost:8079/index.html",
         "build-tests": "webpack -d --config webpack.tests.config.js",
-        "typedoc": "ts-node ./scripts/doc-snippets.ts && typedoc --options typedoc.json",
+        "typedoc": "ts-node ./scripts/doc-snippets.ts && typedoc --disableOutputCheck --options typedoc.json",
         "tslint": "tslint --project tsconfig.json",
         "prettier": "prettier -l '**/*.ts' '**/*.tsx' '**/*.json'",
         "prettier:fix": "prettier --write '**/*.ts' '**/*.tsx' '**/*.json'"

--- a/scripts/doc-snippets.ts
+++ b/scripts/doc-snippets.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from "fs";
+import * as fse from "fs-extra";
 import * as glob from "glob";
 import * as path from "path";
 
@@ -48,7 +49,12 @@ const mkpath = require("mkpath");
 
 const sdkDir = path.resolve(__dirname, "..");
 const outDir = path.resolve(sdkDir, "dist/doc-snippets");
+const distOutDir = path.resolve(sdkDir, "dist/doc");
+const distDocsOutDir = path.resolve(distOutDir, "docs");
+
 mkpath.sync(outDir);
+mkpath.sync(distOutDir);
+mkpath.sync(distDocsOutDir);
 
 const sourceFiles = glob.sync(sdkDir + "/@here/harp-examples/**/*.{ts,tsx,html}");
 
@@ -83,3 +89,6 @@ for (const sourceFile of sourceFiles) {
 }
 
 fs.copyFileSync(path.join(sdkDir, "LICENSE"), path.join(outDir, "LICENSE"));
+fs.copyFileSync(path.join(sdkDir, "docs/index.html"), "dist/index.html");
+fs.copyFileSync(path.join(sdkDir, "LICENSE"), path.join(distOutDir, "LICENSE"));
+fse.copySync(path.join(sdkDir, "docs"), distDocsOutDir);


### PR DESCRIPTION
* Exclude .gitignore and .npmignore when building examples
* Copy LICENSE and files under docs/ folder before running typedoc


Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>