### PR TITLE
MINOR: Enable depth write for ground plane.

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -1192,9 +1192,7 @@ export class Tile implements CachedResource {
         // TODO cache the material HARP-4207
         const material = new MapMeshBasicMaterial({
             color: colorHex,
-            visible: isVisible,
-            // All 2D ground geometry is rendered with renderOrder set and with depthTest === false.
-            depthTest: false
+            visible: isVisible
         });
         const plane = new THREE.Mesh(geometry, material);
         plane.position.copy(planeCenter);


### PR DESCRIPTION
This is needed to make sure that three.js objects that are added to the scene by the are depth tested properly.

Signed-off-by: Nino Kettlitz <1396039+ninok@users.noreply.github.com>