### PR TITLE
MINOR: Resolved double TextStyle definition in Theme definition

### DIFF
--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -43,7 +43,7 @@ export interface Theme {
     /**
      * Define the default text style for styling labels and texts.
      */
-    defaultTextStyle?: TextStyle;
+    defaultTextStyle?: TextStyleDefinition;
 
     /**
      * Define the lightning available on the three.js scene.
@@ -68,7 +68,7 @@ export interface Theme {
     /**
      * Define the style to render different types of text used on the map.
      */
-    textStyles?: TextStyle[];
+    textStyles?: TextStyleDefinition[];
 
     /**
      * List available fonts to be used while rendering text.
@@ -363,7 +363,7 @@ export interface DirectionalLight extends BaseLight {
 /**
  * Various text styles used with labels and texts.
  */
-export interface TextStyle {
+export interface TextStyleDefinition {
     color?: string;
     allCaps?: boolean;
     smallCaps?: boolean;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -3,7 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { LineMarkerTechnique, TextStyle, Theme } from "@here/harp-datasource-protocol";
+import { LineMarkerTechnique, TextStyleDefinition, Theme } from "@here/harp-datasource-protocol";
 import {
     AdditionParameters,
     DEFAULT_TEXT_CANVAS_LAYER,
@@ -615,7 +615,10 @@ export class TextElementsRenderer {
         this.m_defaultStyle.fontCatalog = defaultFontCatalogName!;
     }
 
-    private createTextElementStyle(style: TextStyle, styleName: string): TextElementStyle {
+    private createTextElementStyle(
+        style: TextStyleDefinition,
+        styleName: string
+    ): TextElementStyle {
         return {
             name: styleName,
             fontCatalog: getOptionValue(style.fontCatalogName, DEFAULT_FONT_CATALOG_NAME),


### PR DESCRIPTION
* TextStyle was defined twice, but each TextStyle definition has
   a different purpose. Renamed TextStyle to TextStyleDefinition inside
   the Theme definition. TextStyleDefinition defines the TextStyle resource,
   where TextStyle defines one instance of a TextStyle for an item on the map.