### PR TITLE
HARP-5577: Only publish from 'release' branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 branches:
   only:
     - master
-    - /^@here\/.*/
+    - release
 
 # upgrade yarn to a more recent version
 before_install:
@@ -31,10 +31,8 @@ jobs:
         npx ts-mocha -r tsconfig-paths/register ./@here/*/test/*.ts
         yarn test-browser --headless-firefox
         yarn test-browser --headless-chrome
-        if [ -z "${TRAVIS_TAG}" ] ; then
-          ./scripts/test-npm-packages.sh
-          git status # just in case test-npm-packages leaves some garbage
-        fi
+        ./scripts/test-npm-packages.sh
+        git status # just in case test-npm-packages leaves some garbage
     - name: "Build & Deploy"
       script: |
         set -ex
@@ -49,17 +47,13 @@ jobs:
         local-dir: dist
         github-token: $GITHUB_TOKEN
         on:
-          branch: master
-          tags: true
+          branch: release
+
 deploy:
   - provider: script
     script:
       - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
-      - |
-          if ./scripts/git-is-first-tag.sh "$TRAVIS_TAG" ; then \
-              npx lerna publish -y from-git ; \
-          fi
+      - npx lerna publish -y from-git
     skip_cleanup: true
     on:
-      tags: true
-      branch: master
+      branch: release


### PR DESCRIPTION
Due to limitations of the GitHub API, pushing more than three tags at a
time does not trigger Travis CI's tag filter.

Thus, we must change our 'release' trigger. For now, pushing to a
special 'release' branch will trigger releases. The RM should only ever
fast-forward changes into the 'release' branch, which will automagically
trigger a release to github-pages and to npmjs.com