### PR TITLE
HARP-5678: Added texture coordinates to extruded-polygon technique

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -57,27 +57,44 @@ export interface BaseTechniqueParams {
     fadeFar?: number;
 }
 
+export enum TextureCoordinateType {
+    /**
+     * Texture coordinates are in tile space.
+     * SW of the tile will have (0,0) and NE will have (1,1).
+     */
+    TileSpace = "tile-space",
+    /**
+     * Texture coordinates are in equirectangular space.
+     * (u, v) = ( (longitude+180) / 360, (latitude+90) / 180).
+     */
+    EquirectangularSpace = "equirectangular-space"
+}
+
 /**
  * Standard technique paraneters.
  */
-export interface BaseStandardTechniqueParams extends BaseTechniqueParams {
+export interface StandardTechniqueParams extends BaseTechniqueParams {
     /**
-     * Color of a line in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
-     * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * Color of the feature in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
+     * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.color.
      */
     color?: string;
     /**
      * A value of `true` creates a wireframe geometry. (May not be supported with all techniques).
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.wireframe.
      */
     wireframe?: boolean;
     /**
      * If `vertexColors` is `true`, every vertex has color information, which is interpolated
      * between vertices.
+     * See https://threejs.org/docs/#api/en/materials/Material.vertexColors.
      */
     vertexColors?: boolean;
     /**
      * How rough the material appears. `0.0` means a smooth mirror reflection. `1.0` means fully
      * diffuse. Default is `0.5`.
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.roughness.
      */
     roughness?: number;
     /**
@@ -85,33 +102,40 @@ export interface BaseStandardTechniqueParams extends BaseTechniqueParams {
      * metallic ones use `1.0`, with nothing (usually) in between. Default is `0.5`. A value between
      * `0.0` and `1.0` can be used for a rusty metal look. If `metalnessMap` is also provided, both
      * values are multiplied.
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.metalness.
      */
     metalness?: number;
     /**
      * The material will not be rendered if the opacity is lower than this value.
+     * See https://threejs.org/docs/#api/en/materials/Material.alphaTest.
      */
     alphaTest?: number;
     /**
      * Skip rendering clobbered pixels.
+     * See https://threejs.org/docs/#api/en/materials/Material.depthTest.
      */
     depthTest?: boolean;
     /**
      * Set to 'true' if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
+     * See https://threejs.org/docs/#api/en/materials/Material.transparent.
      */
     transparent?: boolean;
     /**
      * For transparent lines, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
+     * See https://threejs.org/docs/#api/en/materials/Material.opacity.
      */
     opacity?: number;
     /**
      * Emissive (light) color of the material, essentially a solid color unaffected by other
      * lighting. Default is black.
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissive.
      */
     emissive?: string;
     /**
      * Intensity of the emissive light. Modulates the emissive color. Default is `1`.
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissiveIntensity.
      */
     emissiveIntensity?: number;
     /**
@@ -119,20 +143,73 @@ export interface BaseStandardTechniqueParams extends BaseTechniqueParams {
      * the material. It is used with environment mapping modes `THREE.CubeRefractionMapping` and
      * `THREE.EquirectangularRefractionMapping`. The refraction ratio should not exceed `1`. Default
      *  is `0.98`.
+     * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.refractionRatio.
      */
     refractionRatio?: number;
 
     /**
-     * Control rendering of depth prepass before the actual geometry.
-     *
-     * Depth prepass is a method to render translucent meshes, hence only the visible front faces of
-     * a mesh are actually rendered, removing artifacts caused by blending with internal faces of
-     * the mesh. This method is used for drawing translucent buildings over map background.
-     *
-     * By default, each [[DataSource]] determines how/if enable the depth pre-pass. A value of
-     * `false` forcefully disables depth prepass.
+     * Whether and how texture coordinates should be generated. No texture coordinates are
+     * generated if `undefined`.
+     * Should be set if any texture assigned (e.g. `map`, `normalMap`, ...).
      */
-    enableDepthPrePass?: boolean;
+    textureCoordinateType?: TextureCoordinateType;
+
+    /*
+     * URL or texture buffer that should be used as color map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.map
+     */
+    map?: string | TextureBuffer;
+    mapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as normal map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.normalMap
+     */
+    normalMap?: string | TextureBuffer;
+    normalMapType?: number;
+    normalMapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as displacement map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.displacementMap
+     */
+    displacementMap?: string | TextureBuffer;
+    displacementMapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as roughness map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.roughnessMap
+     */
+    roughnessMap?: string | TextureBuffer;
+    roughnessMapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as emissive map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissiveMap
+     */
+    emissiveMap?: string | TextureBuffer;
+    emissiveMapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as bump map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.bumpMap
+     */
+    bumpMap?: string | TextureBuffer;
+    bumpMapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as metalness map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.metalnessMap
+     */
+    metalnessMap?: string | TextureBuffer;
+    metalnessMapProperties?: TextureProperties;
+
+    /**
+     * URL or texture buffer that should be used as alpha map. See:
+     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.alphaMap
+     */
+    alphaMap?: string | TextureBuffer;
+    alphaMapProperties?: TextureProperties;
 }
 
 /**
@@ -565,7 +642,7 @@ export interface BasicExtrudedLineTechniqueParams
  * Declares a a geometry as a standard extruded line.
  */
 export interface StandardExtrudedLineTechniqueParams
-    extends BaseStandardTechniqueParams,
+    extends StandardTechniqueParams,
         PolygonalTechniqueParams {
     /**
      * A value determining the shading technique. Valid values are `"basic"` and `"standard"`.
@@ -707,12 +784,7 @@ export interface FillTechniqueParams extends BaseTechniqueParams, PolygonalTechn
 /**
  * Technique used to draw a geometry as an extruded polygon, for example extruded buildings.
  */
-export interface ExtrudedPolygonTechniqueParams extends BaseStandardTechniqueParams {
-    /**
-     * Derived property that has first priority in use for rendering.
-     * In case property is absent class will try to get color from the [[MapEnv]].
-     */
-    color?: string;
+export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams {
     /**
      * Renders the footprint lines if set to 'true'.
      */
@@ -782,6 +854,18 @@ export interface ExtrudedPolygonTechniqueParams extends BaseStandardTechniquePar
      * Duration of the building's extrusion in milliseconds
      */
     animateExtrusionDuration?: number;
+
+    /**
+     * Control rendering of depth prepass before the actual geometry.
+     *
+     * Depth prepass is a method to render translucent meshes, hence only the visible front faces of
+     * a mesh are actually rendered, removing artifacts caused by blending with internal faces of
+     * the mesh. This method is used for drawing translucent buildings over map background.
+     *
+     * By default, each [[DataSource]] determines how/if enable the depth pre-pass. A value of
+     * `false` forcefully disables depth prepass.
+     */
+    enableDepthPrePass?: boolean;
 }
 
 export interface ShaderTechniqueMaterialParameters {
@@ -806,84 +890,11 @@ export interface ShaderTechniqueParams extends BaseTechniqueParams {
 }
 
 /**
- * Technique used to render a geometry with a texture.
- * When using this technique, the datasource will produce texture coordinates in
- * local tile space (i.e. [0,0] at south-west and [1,1] at north-east tile corner).
- */
-export interface StandardTexturedTechniqueParams extends BaseStandardTechniqueParams {
-    /**
-     * Render texture if available.
-     *
-     * Defaults to true if `map` is available for mesh.
-     *
-     * May be used to forcefully disable textures in theme even if textures are available.
-     */
-    renderTexture?: boolean;
-
-    /**
-     * URL or texture buffer that should be used as color map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.map
-     */
-    map?: string | TextureBuffer;
-    mapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as normal map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.normalMap
-     */
-    normalMap?: string | TextureBuffer;
-    normalMapType?: number;
-    normalMapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as displacement map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.displacementMap
-     */
-    displacementMap?: string | TextureBuffer;
-    displacementMapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as roughness map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.roughnessMap
-     */
-    roughnessMap?: string | TextureBuffer;
-    roughnessMapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as emissive map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissiveMap
-     */
-    emissiveMap?: string | TextureBuffer;
-    emissiveMapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as bump map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.bumpMap
-     */
-    bumpMap?: string | TextureBuffer;
-    bumpMapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as metalness map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.metalnessMap
-     */
-    metalnessMap?: string | TextureBuffer;
-    metalnessMapProperties?: TextureProperties;
-
-    /**
-     * URL or texture buffer that should be used as alpha map. See:
-     * https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.alphaMap
-     */
-    alphaMap?: string | TextureBuffer;
-    alphaMapProperties?: TextureProperties;
-}
-
-/**
  * Technique used to render a terrain geometry with a texture.
  * When using this technique, the datasource will produce texture coordinates in
  * local tile space (i.e. [0,0] at south-west and [1,1] at north-east tile corner).
  */
-export interface TerrainTechniqueParams extends StandardTexturedTechniqueParams {
+export interface TerrainTechniqueParams extends StandardTechniqueParams {
     /**
      * Colors to be applied at different heights (as a results of a `displacementMap`).
      */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-    BaseStandardTechniqueParams,
     BasicExtrudedLineTechniqueParams,
     DashedLineTechniqueParams,
     ExtrudedPolygonTechniqueParams,
@@ -16,7 +15,7 @@ import {
     ShaderTechniqueParams,
     SolidLineTechniqueParams,
     StandardExtrudedLineTechniqueParams,
-    StandardTexturedTechniqueParams,
+    StandardTechniqueParams,
     TerrainTechniqueParams,
     TextTechniqueParams
 } from "./TechniqueParams";
@@ -194,7 +193,6 @@ export type Style =
     | DashedLineStyle
     | FillStyle
     | StandardStyle
-    | StandardTexturedStyle
     | BasicExtrudedLineStyle
     | StandardExtrudedLineStyle
     | ExtrudedPolygonStyle
@@ -277,12 +275,7 @@ export interface FillStyle extends BaseStyle {
 
 export interface StandardStyle extends BaseStyle {
     technique: "standard";
-    attr?: Partial<BaseStandardTechniqueParams>;
-}
-
-export interface StandardTexturedStyle extends BaseStyle {
-    technique: "standard-textured";
-    attr?: Partial<StandardTexturedTechniqueParams>;
+    attr?: Partial<StandardTechniqueParams>;
 }
 
 export interface TerrainStyle extends BaseStyle {

--- a/@here/harp-examples/src/hello_textured_areas.ts
+++ b/@here/harp-examples/src/hello_textured_areas.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Theme } from "@here/harp-datasource-protocol";
+import { TextureCoordinateType, Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, CopyrightInfo, MapView, ThemeLoader } from "@here/harp-mapview";
@@ -74,7 +74,7 @@ West</a>.</p>`;
                 const styleSet = theme.styles[styleSetName];
                 styleSet.forEach(style => {
                     if (style.description === "urban area") {
-                        style.technique = "standard-textured";
+                        style.technique = "standard";
                         style.attr = {
                             color: "#ffffff",
                             map: urbanAreaTexture,
@@ -83,10 +83,11 @@ West</a>.</p>`;
                                 repeatV: 10,
                                 wrapS: "repeat",
                                 wrapT: "repeat"
-                            }
+                            },
+                            textureCoordinateType: TextureCoordinateType.TileSpace
                         };
                     } else if (style.description === "park") {
-                        style.technique = "standard-textured";
+                        style.technique = "standard";
                         style.attr = {
                             color: "#ffffff",
                             map: parkTexture,
@@ -95,7 +96,8 @@ West</a>.</p>`;
                                 repeatV: 5,
                                 wrapS: "repeat",
                                 wrapT: "repeat"
-                            }
+                            },
+                            textureCoordinateType: TextureCoordinateType.TileSpace
                         };
                     } else if (style.description === "building_geometry") {
                         // Disable extruded buildings to reduce noise.

--- a/@here/harp-mapview-decoder/lib/TileDecoderService.ts
+++ b/@here/harp-mapview-decoder/lib/TileDecoderService.ts
@@ -5,9 +5,8 @@
  */
 
 import {
+    addBuffersToTransferList,
     getProjection,
-    isStandardTexturedTechnique,
-    isTextureBuffer,
     ITileDecoder,
     WorkerDecoderProtocol
 } from "@here/harp-datasource-protocol";
@@ -100,23 +99,7 @@ export class TileDecoderService extends WorkerService {
             });
 
             decodedTile.techniques.forEach(technique => {
-                if (isStandardTexturedTechnique(technique)) {
-                    if (isTextureBuffer(technique.map)) {
-                        if (technique.map.buffer instanceof ArrayBuffer) {
-                            transferList.push(technique.map.buffer);
-                        }
-                    }
-                    if (isTextureBuffer(technique.normalMap)) {
-                        if (technique.normalMap.buffer instanceof ArrayBuffer) {
-                            transferList.push(technique.normalMap.buffer);
-                        }
-                    }
-                    if (isTextureBuffer(technique.displacementMap)) {
-                        if (technique.displacementMap.buffer instanceof ArrayBuffer) {
-                            transferList.push(technique.displacementMap.buffer);
-                        }
-                    }
-                }
+                addBuffersToTransferList(technique, transferList);
             });
 
             return {

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -11,10 +11,11 @@ import {
     isExtrudedPolygonTechnique,
     isInterpolatedProperty,
     isShaderTechnique,
-    isStandardTexturedTechnique,
+    isStandardTechnique,
     isTerrainTechnique,
     isTextureBuffer,
     Technique,
+    TEXTURE_PROPERTY_KEYS,
     TextureProperties
 } from "@here/harp-datasource-protocol";
 import {
@@ -31,16 +32,6 @@ import { Circles, Squares } from "./MapViewPoints";
 import { toPixelFormat, toTextureDataType, toTextureFilter, toWrappingMode } from "./ThemeHelpers";
 
 const logger = LoggerManager.instance.create("DecodedTileHelpers");
-const TEXTURE_PROPERTY_KEYS = [
-    "map",
-    "normalMap",
-    "displacementMap",
-    "roughnessMap",
-    "emissiveMap",
-    "alphaMap",
-    "metalnessMap",
-    "bumpMap"
-];
 
 const DEFAULT_SKIP_PROPERTIES = [
     ...TEXTURE_PROPERTY_KEYS,
@@ -123,7 +114,11 @@ export function createMaterial(
 
     material.depthTest = isExtrudedPolygonTechnique(technique) && technique.depthTest !== false;
 
-    if (isStandardTexturedTechnique(technique) || isTerrainTechnique(technique)) {
+    if (
+        isStandardTechnique(technique) ||
+        isTerrainTechnique(technique) ||
+        isExtrudedPolygonTechnique(technique)
+    ) {
         TEXTURE_PROPERTY_KEYS.forEach((texturePropertyName: string) => {
             const textureProperty = (technique as any)[texturePropertyName];
             if (textureProperty === undefined) {
@@ -277,7 +272,6 @@ export function getObjectConstructor(technique: Technique): ObjectConstructor | 
     switch (technique.name) {
         case "extruded-line":
         case "standard":
-        case "standard-textured":
         case "terrain":
         case "extruded-polygon":
         case "fill":
@@ -359,7 +353,6 @@ export function getMaterialConstructor(technique: Technique): MaterialConstructo
                 : MapMeshBasicMaterial;
 
         case "standard":
-        case "standard-textured":
         case "terrain":
         case "extruded-polygon":
             return MapMeshStandardMaterial;

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BaseStandardTechniqueParams } from "@here/harp-datasource-protocol";
+import { ExtrudedPolygonTechniqueParams } from "@here/harp-datasource-protocol";
 import { chainCallbacks } from "@here/harp-utils";
 import * as THREE from "three";
 
@@ -22,7 +22,7 @@ export const DEPTH_PRE_PASS_STENCIL_MASK = 0x01;
  *
  * @param technique [[BaseStandardTechnique]] instance to be checked
  */
-export function isRenderDepthPrePassEnabled(technique: BaseStandardTechniqueParams) {
+export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechniqueParams) {
     return (
         technique.enableDepthPrePass !== false &&
         technique.opacity !== undefined &&

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -20,11 +20,10 @@ import {
     isFillTechnique,
     isSolidLineTechnique,
     isSquaresTechnique,
-    isStandardTechnique,
-    isStandardTexturedTechnique,
     isTerrainTechnique,
     isTextTechnique,
     LineMarkerTechnique,
+    needsVertexNormals,
     PoiTechnique,
     SolidLineTechnique,
     StandardExtrudedLineTechnique,
@@ -1354,13 +1353,7 @@ export class Tile implements CachedResource {
                     bufferGeometry.setIndex(getBufferAttribute(srcGeometry.index));
                 }
 
-                if (
-                    (!bufferGeometry.getAttribute("normal") &&
-                        (isStandardTechnique(technique) ||
-                            isStandardTexturedTechnique(technique) ||
-                            isTerrainTechnique(technique))) ||
-                    (isExtrudedLineTechnique(technique) && technique.shading === "standard")
-                ) {
+                if (!bufferGeometry.getAttribute("normal") && needsVertexNormals(technique)) {
                     bufferGeometry.computeVertexNormals();
                 }
 

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -64,15 +64,6 @@ describe("Tile Creation", function() {
             assert.isTrue(new ExtrudedLineCtor() instanceof THREE.Mesh);
         }
 
-        const LandmarkCtor = getObjectConstructor({
-            name: "standard-textured",
-            renderOrder: 0
-        });
-        assert.isFunction(LandmarkCtor);
-        if (LandmarkCtor !== undefined) {
-            assert.isTrue(new LandmarkCtor() instanceof THREE.Mesh);
-        }
-
         const StandardCtor = getObjectConstructor({ name: "standard", renderOrder: 0 });
         assert.isFunction(StandardCtor);
         if (StandardCtor !== undefined) {

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -248,14 +248,12 @@ export class OmvDecoder implements IGeometryProcessor {
                 this.m_gatherRoadSegments
             );
         }
-
         for (const adapter of this.m_dataAdapters.values()) {
             if (adapter.canProcess(data)) {
                 adapter.process(data, tileKey, geoBox);
                 break;
             }
         }
-
         const decodedTile = this.m_decodedTileEmitter.getDecodedTile();
 
         if (this.m_createTileInfo) {
@@ -407,7 +405,6 @@ export class OmvDecoder implements IGeometryProcessor {
         }
 
         const featureId = env.lookup("$id") as number | undefined;
-
         if (this.m_decodedTileEmitter) {
             this.m_decodedTileEmitter.processPolygonFeature(
                 layer,

--- a/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -7,7 +7,12 @@
 // tslint:disable:only-arrow-functions
 // Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import { GeometryType, isStandardTexturedTechnique, Style } from "@here/harp-datasource-protocol";
+import {
+    GeometryType,
+    isStandardTechnique,
+    Style,
+    TextureCoordinateType
+} from "@here/harp-datasource-protocol";
 import { MapEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
 import {
     GeoCoordinates,
@@ -56,8 +61,11 @@ describe("OmvDecodedTileEmitter", function() {
 
         const styleSet: Style[] = [
             {
-                technique: "standard-textured",
-                when: "1"
+                when: "1",
+                technique: "standard",
+                attr: {
+                    textureCoordinateType: TextureCoordinateType.TileSpace
+                }
             }
         ];
 
@@ -81,9 +89,9 @@ describe("OmvDecodedTileEmitter", function() {
 
         assert.equal(techniques.length, 1, "only one technique created");
         assert.equal(
-            isStandardTexturedTechnique(techniques[0]),
+            isStandardTechnique(techniques[0]),
             true,
-            "created technique is standard textured technique"
+            "created technique is standard technique"
         );
         assert.equal(geometries.length, 1, "only one geometry created");
         assert.equal(geometries[0].type, GeometryType.Polygon, "geometry is a polygon");


### PR DESCRIPTION
* Introduced textureCoordinateType for "extruded-polygon" and "standard" technique
* Removed obsolete "standard-textured" technique

Signed-off-by: Nino Kettlitz <1396039+ninok@users.noreply.github.com>