### PR TITLE
MINOR: Add missing initialization of the tiler service in Yeoman generator

### DIFF
--- a/@here/generator-harp.gl/generators/app/templates/decoder.ts
+++ b/@here/generator-harp.gl/generators/app/templates/decoder.ts
@@ -10,6 +10,7 @@ declare let self: Worker & {
 
 self.importScripts("three.min.js");
 
-import { OmvTileDecoderService } from "@here/harp-omv-datasource/index-worker";
+import { OmvTileDecoderService, OmvTilerService } from "@here/harp-omv-datasource/index-worker";
 
 OmvTileDecoderService.start();
+OmvTilerService.start();


### PR DESCRIPTION
The missing tiler service was leading to the geojson data provider to not work.
It would be hard for the user to know these details, so the tiler service should always be started.