### PR TITLE
add XYZ Space as APIFormat to OmvDataSource

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -364,13 +364,9 @@ export class OmvRestClient implements DataProvider {
      * Get actual tile URL depending on configured API format.
      */
     private dataUrl(tileKey: TileKey): string {
-        const path =
-           [`/${tileKey.level}`,tileKey.column,tileKey.row]
-           .join(
-               this.params.apiFormat === APIFormat.XYZSpace ?
-                    "_"
-                    : "/"
-           );
+        const path = [`/${tileKey.level}`, tileKey.column, tileKey.row].join(
+            this.params.apiFormat === APIFormat.XYZSpace ? "_" : "/"
+        );
         switch (this.params.apiFormat) {
             case APIFormat.HereV1:
             case APIFormat.XYZOMV:
@@ -386,8 +382,8 @@ export class OmvRestClient implements DataProvider {
                 path += ".json";
                 break;
             case APIFormat.XYZSpace:
-               path += ".mvt";
-               break;
+                path += ".mvt";
+                break;
             case APIFormat.TomtomV1:
                 path += ".pbf";
                 break;

--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -110,7 +110,23 @@ export enum APIFormat {
      *
      * Default authentication method used: [[AuthenticationTypeTomTomV1]].
      */
-    TomtomV1
+    TomtomV1,
+
+    /**
+     * Use the REST API format of XYZ Space Vector Tile API in OMV format.
+     *
+     * Usage:
+     * `<OmvRestClientParams.baseUrl>/hub/spaces/<space-id>/tile/web/<zoom>_<X>_<Y>.mvt?access_token=<OmvRestClientParams.authenticationCode>`
+     *
+     * Format definition:
+     * `http|s://<base-url>/hub/spaces/{spaceId}/tile/web/{z}_{x}_{y}.mvt?access_token={access_token}`
+     *
+     * Sample URL:
+     * `https://xyz.api.here.com/hub/spaces/your-space-id/tile/web/{z}_{x}_{y}.mvt?access_token=your-access-token`
+     *
+     * Default authentication method used: [[AuthenticationTypeAccessToken]].
+     */
+    XYZSpace
 }
 // tslint:enable:max-line-length
 
@@ -301,6 +317,8 @@ export class OmvRestClient implements DataProvider {
             case APIFormat.MapboxV4:
             case APIFormat.XYZOMV:
             case APIFormat.XYZMVT:
+            case APIFormat.XYZSpace:
+               return AuthenticationTypeAccessToken;
             case APIFormat.XYZJson:
                 return AuthenticationTypeAccessToken;
             case APIFormat.TomtomV1:
@@ -348,6 +366,9 @@ export class OmvRestClient implements DataProvider {
      */
     private dataUrl(tileKey: TileKey): string {
         let path = `/${tileKey.level}/${tileKey.column}/${tileKey.row}`;
+        if (this.params.apiFormat === APIFormat.XYZSpace) {
+           path = `/${tileKey.level}_${tileKey.column}_${tileKey.row}`;
+        }
         switch (this.params.apiFormat) {
             case APIFormat.HereV1:
             case APIFormat.XYZOMV:
@@ -362,6 +383,9 @@ export class OmvRestClient implements DataProvider {
             case APIFormat.XYZJson:
                 path += ".json";
                 break;
+            case APIFormat.XYZSpace:
+               path += ".mvt";
+               break;
             case APIFormat.TomtomV1:
                 path += ".pbf";
                 break;

--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -318,7 +318,6 @@ export class OmvRestClient implements DataProvider {
             case APIFormat.XYZOMV:
             case APIFormat.XYZMVT:
             case APIFormat.XYZSpace:
-               return AuthenticationTypeAccessToken;
             case APIFormat.XYZJson:
                 return AuthenticationTypeAccessToken;
             case APIFormat.TomtomV1:
@@ -365,10 +364,13 @@ export class OmvRestClient implements DataProvider {
      * Get actual tile URL depending on configured API format.
      */
     private dataUrl(tileKey: TileKey): string {
-        let path = `/${tileKey.level}/${tileKey.column}/${tileKey.row}`;
-        if (this.params.apiFormat === APIFormat.XYZSpace) {
-           path = `/${tileKey.level}_${tileKey.column}_${tileKey.row}`;
-        }
+        const path =
+           [`/${tileKey.level}`,tileKey.column,tileKey.row]
+           .join(
+               this.params.apiFormat === APIFormat.XYZSpace ?
+                    "_"
+                    : "/"
+           );
         switch (this.params.apiFormat) {
             case APIFormat.HereV1:
             case APIFormat.XYZOMV:

--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -364,7 +364,7 @@ export class OmvRestClient implements DataProvider {
      * Get actual tile URL depending on configured API format.
      */
     private dataUrl(tileKey: TileKey): string {
-        const path = [`/${tileKey.level}`, tileKey.column, tileKey.row].join(
+        let path = [`/${tileKey.level}`, tileKey.column, tileKey.row].join(
             this.params.apiFormat === APIFormat.XYZSpace ? "_" : "/"
         );
         switch (this.params.apiFormat) {


### PR DESCRIPTION
Add an XYZ Space as an `APIFormat` to be used within `OmvDataSource`. This enables a developer to visualize data from an XYZ Space, using the `.mvt` endpoint from XYZ. Example endpoint: 

```
https://xyz.api.here.com/hub/spaces/your-space-id/tile/web/{z}_{x}_{y}.mvt?access_token=your-access-token
```

Example of adding data from XYZ Space to map:
```
const xyzDataSource = new OmvDataSource({
   baseUrl: "https://xyz.api.here.com/hub/spaces/2vDrakce/tile/web",
   apiFormat: APIFormat.XYZSpace,
   styleSetName: "geojson",
   maxZoomLevel: 17,
   authenticationCode: "your-access-token"
});
map.addDataSource(xyzDataSource);
```