### PR TITLE
MINOR: Add XYZ Space as APIFormat

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -110,7 +110,23 @@ export enum APIFormat {
      *
      * Default authentication method used: [[AuthenticationTypeTomTomV1]].
      */
-    TomtomV1
+    TomtomV1,
+
+    /**
+     * Use the REST API format of XYZ Space Vector Tile API in OMV format.
+     *
+     * Usage:
+     * `<OmvRestClientParams.baseUrl>/hub/spaces/<space-id>/tile/web/<zoom>_<X>_<Y>.mvt?access_token=<OmvRestClientParams.authenticationCode>`
+     *
+     * Format definition:
+     * `http|s://<base-url>/hub/spaces/{spaceId}/tile/web/{z}_{x}_{y}.mvt?access_token={access_token}`
+     *
+     * Sample URL:
+     * `https://xyz.api.here.com/hub/spaces/your-space-id/tile/web/{z}_{x}_{y}.mvt?access_token=your-access-token`
+     *
+     * Default authentication method used: [[AuthenticationTypeAccessToken]].
+     */
+    XYZSpace
 }
 // tslint:enable:max-line-length
 
@@ -301,6 +317,7 @@ export class OmvRestClient implements DataProvider {
             case APIFormat.MapboxV4:
             case APIFormat.XYZOMV:
             case APIFormat.XYZMVT:
+            case APIFormat.XYZSpace:
             case APIFormat.XYZJson:
                 return AuthenticationTypeAccessToken;
             case APIFormat.TomtomV1:
@@ -347,7 +364,9 @@ export class OmvRestClient implements DataProvider {
      * Get actual tile URL depending on configured API format.
      */
     private dataUrl(tileKey: TileKey): string {
-        let path = `/${tileKey.level}/${tileKey.column}/${tileKey.row}`;
+        let path = [`/${tileKey.level}`, tileKey.column, tileKey.row].join(
+            this.params.apiFormat === APIFormat.XYZSpace ? "_" : "/"
+        );
         switch (this.params.apiFormat) {
             case APIFormat.HereV1:
             case APIFormat.XYZOMV:
@@ -361,6 +380,9 @@ export class OmvRestClient implements DataProvider {
                 break;
             case APIFormat.XYZJson:
                 path += ".json";
+                break;
+            case APIFormat.XYZSpace:
+                path += ".mvt";
                 break;
             case APIFormat.TomtomV1:
                 path += ".pbf";


### PR DESCRIPTION
Add an XYZ Space as an APIFormat to be used within OmvDataSource. This enables a developer to visualize data from an XYZ Space, using the .mvt endpoint from XYZ. Example endpoint:

```
https://xyz.api.here.com/hub/spaces/your-space-id/tile/web/{z}_{x}_{y}.mvt?access_token=your-access-token
```

Example of adding data from XYZ Space to map:
```
const xyzDataSource = new OmvDataSource({
   baseUrl: "https://xyz.api.here.com/hub/spaces/2vDrakce/tile/web",
   apiFormat: APIFormat.XYZSpace,
   styleSetName: "geojson",
   maxZoomLevel: 17,
   authenticationCode: "your-access-token"
});
map.addDataSource(xyzDataSource);
```
