### PR TITLE
Revert "HARP-5432 Normal vectors are now the projection's surface normal."

### DIFF
--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -319,7 +319,11 @@ export function isShaderTechnique(technique: Technique): technique is ShaderTech
  * @param technique Technique to check.
  */
 export function needsVertexNormals(technique: Technique): boolean {
-    return isStandardTechnique(technique) || isStandardExtrudedLineTechnique(technique);
+    return (
+        isStandardTechnique(technique) ||
+        isTerrainTechnique(technique) ||
+        isStandardExtrudedLineTechnique(technique)
+    );
 }
 
 /**


### PR DESCRIPTION
Reverts heremaps/harp.gl#470

As mentioned by @ninok, this isn't needed.