### PR TITLE
HARP-5432 Remove z component from mesh

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -1300,6 +1300,14 @@ export class Tile implements CachedResource {
     diffuseColor *= texelColor;
 #endif`
                         );
+
+                        // We remove the displacement map from manipulating the vertices, it is
+                        // however still required for the pixel shader, so it can't be directly
+                        // removed.
+                        shader.vertexShader = shader.vertexShader.replace(
+                            "#include <displacementmap_vertex>",
+                            ""
+                        );
                     };
                 }
 


### PR DESCRIPTION
The z component is required to do ray casting on the CPU, however on the
GPU we use a displacement map to do this, so we zero the z value.