### PR TITLE
HARP-5847: Remove SharedArrayBuffer reference.

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvUtils.ts
+++ b/@here/harp-omv-datasource/lib/OmvUtils.ts
@@ -8,7 +8,11 @@
  * @hidden
  */
 export function isArrayBufferLike(data: any): data is ArrayBufferLike {
-    return data instanceof ArrayBuffer || data instanceof SharedArrayBuffer;
+    if (typeof SharedArrayBuffer !== "undefined") {
+        return data instanceof ArrayBuffer || data instanceof SharedArrayBuffer;
+    } else {
+        return data instanceof ArrayBuffer;
+    }
 }
 
 /**


### PR DESCRIPTION
Geojson and custom features are meeting the `SharedArrayBuffer` check, which is undefined everywhere but in Chrome. 