### PR TITLE
HARP-5900 Add satellite tiles example

### DIFF
--- a/@here/harp-examples/README.md
+++ b/@here/harp-examples/README.md
@@ -38,6 +38,7 @@ We can group the examples by several categories, looking at what kind of feature
 1. [Display an interactive map of Italy](src/datasource_geojson_styling_game.ts) on a reduced map style that showcases picking and using GeoJSON Data that relies on [geojson-datasource](../harp-geojson-datasource/README.md).
 1. [Show OMV Data](src/hello.ts) with our default map style.
 1. [Render raster map tiles](src/datasource_webtile.ts) using the [webtile-datasource](../harp-webtile-datasource/README.md).
+1. [Render satellite tiles](src/datasource_satellitetile.ts) using the [webtile-datasource](../harp-webtile-datasource/README.md).
 1. [Show OSM MVT Data](src/datasource_xyzmvt.ts) with our default map style.
 
 ### Styling

--- a/@here/harp-examples/src/datasource_satellitetile.ts
+++ b/@here/harp-examples/src/datasource_satellitetile.ts
@@ -14,20 +14,20 @@ import { appCode, appId } from "../config";
 /**
  * A simple example using the webtile data source. Tiles are retrieved from
  * ```
- * https://1.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/${level}/${column}/${row}/512/png8?app_id=${appId}&app_code=${appCode}
+ * https://1.aerial.maps.api.here.com/maptile/2.1/maptile/newest/satellite.day/${level}/${column}/${row}/512/png8?app_id=${appId}&app_code=${appCode}
  * ```
  *
  * A [[WebTileDataSource]] is created with specified applications' appId and appCode passed
  * as [[WebTileDataSourceOptions]]
  * ```typescript
- * [[include:harp_gl_datasource_webtile_1.ts]]
+ * [[include:harp_gl_datasource_satellitetile_1.ts]]
  * ```
  * Then added to the [[MapView]]
  * ```typescript
- * [[include:harp_gl_datasource_webtile_2.ts]]
+ * [[include:harp_gl_datasource_satellitetile_2.ts]]
  * ```
  */
-export namespace WebTileDataSourceExample {
+export namespace SatelliteDataSourceExample {
     // creates a new MapView for the HTMLCanvasElement of the given id
     export function initializeMapView(id: string): MapView {
         const canvas = document.getElementById(id) as HTMLCanvasElement;
@@ -60,17 +60,17 @@ export namespace WebTileDataSourceExample {
 
     const mapView = initializeMapView("mapCanvas");
 
-    // snippet:harp_gl_datasource_webtile_1.ts
+    // snippet:harp_gl_datasource_satellitetile_1.ts
     const webTileDataSource = new WebTileDataSource({
         appId,
         appCode,
-        ppi: 320
+        tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE
     });
-    // end:harp_gl_datasource_webtile_1.ts
+    // end:harp_gl_datasource_satellitetile_1.ts
 
     mapView.geoCenter = new GeoCoordinates(40.702, -74.01154);
 
-    // snippet:harp_gl_datasource_webtile_2.ts
+    // snippet:harp_gl_datasource_satellitetile_2.ts
     mapView.addDataSource(webTileDataSource);
-    // end:harp_gl_datasource_webtile_2.ts
+    // end:harp_gl_datasource_satellitetile_2.ts
 }

--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -282,7 +282,7 @@ export class WebTileDataSource extends DataSource {
         this.cacheable = true;
         this.storageLevelOffset = -1;
         this.m_resolution = getOptionValue(m_options.resolution, 512);
-        this.m_ppi = getOptionValue(m_options.ppi, 320);
+        this.m_ppi = getOptionValue(m_options.ppi, -1);
         this.m_tileBaseAddress = m_options.tileBaseAddress || WebTileDataSource.TILE_BASE_NORMAL;
     }
 
@@ -299,7 +299,7 @@ export class WebTileDataSource extends DataSource {
     }
 
     get maxZoomLevel(): number {
-        return 19;
+        return 20;
     }
 
     setLanguages(languages?: string[]): void {
@@ -322,9 +322,11 @@ export class WebTileDataSource extends DataSource {
             `https://${server}.${this.m_tileBaseAddress}/` +
             `${level}/${column}/${row}/${this.m_resolution}/png8` +
             `?app_id=${appId}&app_code=${appCode}` +
-            `&ppi=${this.m_ppi}` +
             getOptionValue(this.m_options.additionalRequestParameters, "");
 
+        if (this.m_ppi !== -1) {
+            url += `&ppi=${this.m_ppi}`;
+        }
         if (this.m_languages !== undefined && this.m_languages[0] !== undefined) {
             url += `&lg=${this.m_languages[0]}`;
         }


### PR DESCRIPTION
Add `ppi` to request only if explicitly initialized with a value, otherwise satellite tiles do not work.
Change valid zoom levels of web tiles from 1 to 20.
Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>