### PR TITLE
HARP-5717: Extend json schema

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -48,13 +48,13 @@ export interface BaseTechniqueParams {
      * Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the object start
      * fading out (opacity decreases).
      */
-    fadeNear?: number;
+    fadeNear?: MaybeInterpolatedProperty<number>;
 
     /**
      * Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the object has zero
      * opacity and stops fading out. A value of <= 0.0 disables fading.
      */
-    fadeFar?: number;
+    fadeFar?: MaybeInterpolatedProperty<number>;
 }
 
 export enum TextureCoordinateType {
@@ -78,8 +78,9 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      * Color of the feature in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
      * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.color.
+     * @format color-hex
      */
-    color?: string;
+    color?: MaybeInterpolatedProperty<string>;
     /**
      * A value of `true` creates a wireframe geometry. (May not be supported with all techniques).
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.wireframe.
@@ -96,7 +97,7 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      * diffuse. Default is `0.5`.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.roughness.
      */
-    roughness?: number;
+    roughness?: MaybeInterpolatedProperty<number>;
     /**
      * How much the material is like a metal. Nonmetallic materials such as wood or stone use `0.0`,
      * metallic ones use `1.0`, with nothing (usually) in between. Default is `0.5`. A value between
@@ -104,12 +105,12 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      * values are multiplied.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.metalness.
      */
-    metalness?: number;
+    metalness?: MaybeInterpolatedProperty<number>;
     /**
      * The material will not be rendered if the opacity is lower than this value.
      * See https://threejs.org/docs/#api/en/materials/Material.alphaTest.
      */
-    alphaTest?: number;
+    alphaTest?: MaybeInterpolatedProperty<number>;
     /**
      * Skip rendering clobbered pixels.
      * See https://threejs.org/docs/#api/en/materials/Material.depthTest.
@@ -126,18 +127,19 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      * opaque.
      * See https://threejs.org/docs/#api/en/materials/Material.opacity.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Emissive (light) color of the material, essentially a solid color unaffected by other
      * lighting. Default is black.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissive.
+     * @format color-hex
      */
-    emissive?: string;
+    emissive?: MaybeInterpolatedProperty<string>;
     /**
      * Intensity of the emissive light. Modulates the emissive color. Default is `1`.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissiveIntensity.
      */
-    emissiveIntensity?: number;
+    emissiveIntensity?: MaybeInterpolatedProperty<number>;
     /**
      * The index of refraction (IOR) of air (approximately 1) divided by the index of refraction of
      * the material. It is used with environment mapping modes `THREE.CubeRefractionMapping` and
@@ -145,7 +147,7 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      *  is `0.98`.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.refractionRatio.
      */
-    refractionRatio?: number;
+    refractionRatio?: MaybeInterpolatedProperty<number>;
 
     /**
      * Whether and how texture coordinates should be generated. No texture coordinates are
@@ -219,8 +221,9 @@ export interface PointTechniqueParams extends BaseTechniqueParams {
     /**
      * Color of a point in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color?: string;
+    color?: MaybeInterpolatedProperty<string>;
     /**
      * URL of a texture image to be loaded.
      */
@@ -234,7 +237,7 @@ export interface PointTechniqueParams extends BaseTechniqueParams {
      * For transparent lines, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Size of point in pixels.
      */
@@ -284,7 +287,7 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Priority of marker, defaults to `0`. Markers with highest priority get placed first.
      */
-    priority?: number;
+    priority?: MaybeInterpolatedProperty<number>;
     /**
      * Minimum zoomLevel at which to display the label text. No default.
      */
@@ -359,16 +362,6 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
      * graphics. Defaults to `true`.
      */
     iconIsOptional?: boolean;
-    /**
-     * Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the object start
-     * fading out (opacity decreases).
-     */
-    fadeNear?: number;
-    /**
-     * Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the object becomes
-     * transparent. A value of <= 0.0 disables fading.
-     */
-    fadeFar?: number;
     /**
      * Fading time for labels in seconds.
      */
@@ -465,22 +458,24 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Text color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color?: string;
+    color?: MaybeInterpolatedProperty<string>;
     /**
      * Text background color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
      * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    backgroundColor?: string;
+    backgroundColor?: MaybeInterpolatedProperty<string>;
     /**
      * For transparent text, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Background text opacity value.
      */
-    backgroundOpacity?: number;
+    backgroundOpacity?: MaybeInterpolatedProperty<number>;
     /**
      * Inter-glyph spacing (pixels). Scaled by `size`.
      */
@@ -523,8 +518,9 @@ export interface LineTechniqueParams extends BaseTechniqueParams {
     /**
      * Color of a line in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color: string;
+    color: MaybeInterpolatedProperty<string>;
     /**
      * Set to true if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -534,7 +530,7 @@ export interface LineTechniqueParams extends BaseTechniqueParams {
      * For transparent lines, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Width of line in pixels. WebGL implementations will normally render all lines with 1 pixel
      * width, and ignore this value.
@@ -548,8 +544,9 @@ export interface LineTechniqueParams extends BaseTechniqueParams {
 export interface SegmentsTechniqueParams extends BaseTechniqueParams {
     /**
      * Color of segments in a hexadecimal notation, for example: `"#e4e9ec"` or `"#fff"`.
+     * @format color-hex
      */
-    color: string;
+    color: MaybeInterpolatedProperty<string>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -559,7 +556,7 @@ export interface SegmentsTechniqueParams extends BaseTechniqueParams {
      * For transparent lines, set a value between `0.0` for fully transparent, to `1.0` for fully
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Width of a line in meters.
      */
@@ -594,29 +591,30 @@ export interface PolygonalTechniqueParams {
     /**
      * Sets the polygon offset factor. Default is 0.
      */
-    polygonOffsetFactor?: number;
+    polygonOffsetFactor?: MaybeInterpolatedProperty<number>;
 
     /**
      * Sets the polygon offset units. Default is 0.
      */
-    polygonOffsetUnits?: number;
+    polygonOffsetUnits?: MaybeInterpolatedProperty<number>;
 
     /**
      * Sets the polygon outline color.
+     * @format color-hex
      */
-    lineColor?: string;
+    lineColor?: MaybeInterpolatedProperty<string>;
 
     /**
      * Distance to the camera (0.0 = nearPlane, 1.0 = farPlane) at which the object edges start
      * fading out.
      */
-    lineFadeNear?: number;
+    lineFadeNear?: MaybeInterpolatedProperty<number>;
 
     /**
      * Distance to the camera (0.0 = nearPlane, 1.0 = farPlane) at which the object edges become
      * transparent. A value of <= 0.0 disables fading.
      */
-    lineFadeFar?: number;
+    lineFadeFar?: MaybeInterpolatedProperty<number>;
 }
 
 /**
@@ -638,8 +636,9 @@ export interface BasicExtrudedLineTechniqueParams
     /**
      * Color of a line in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color: string;
+    color: MaybeInterpolatedProperty<string>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -649,7 +648,7 @@ export interface BasicExtrudedLineTechniqueParams
      * For transparent lines, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Width of line in meters for different zoom levels.
      */
@@ -697,8 +696,9 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
     /**
      * Color of a line in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color: string;
+    color: MaybeInterpolatedProperty<string>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -708,7 +708,7 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      * For transparent lines, set a value between `0.0` for fully transparent, to `1.0` for fully
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     // TODO: Make pixel units default.
     /**
      * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
@@ -725,8 +725,9 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
     /**
      * Color of secondary line geometry in hexadecimal or CSS-style notation, for example:
      * `"#e4e9ec"`, `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    secondaryColor?: string;
+    secondaryColor?: MaybeInterpolatedProperty<string>;
     /**
      * Width of secondary line geometry in `metricUnit`s for different zoom levels.
      */
@@ -744,8 +745,9 @@ export interface DashedLineTechniqueParams extends BaseTechniqueParams, Polygona
     /**
      * Color of a line in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color: string;
+    color: MaybeInterpolatedProperty<string>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -755,7 +757,7 @@ export interface DashedLineTechniqueParams extends BaseTechniqueParams, Polygona
      * For transparent lines, set a value between `0.0` for fully transparent, to `1.0` for fully
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     // TODO: Make pixel units default.
     /**
      * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
@@ -786,8 +788,9 @@ export interface FillTechniqueParams extends BaseTechniqueParams, PolygonalTechn
     /**
      * Fill color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color?: string;
+    color?: MaybeInterpolatedProperty<string>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -797,7 +800,7 @@ export interface FillTechniqueParams extends BaseTechniqueParams, PolygonalTechn
      * For transparent lines, set a value between `0.0` for fully transparent, to `1.0` for fully
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * A value of `true` creates a wireframe geometry. (May not be supported with all techniques).
      */
@@ -828,8 +831,9 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
     /**
      * Fill color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    lineColor?: string;
+    lineColor?: MaybeInterpolatedProperty<string>;
     /**
      * Mix value between the lineColor(0.0) and the geometry's vertex colors(1.0).
      */
@@ -839,13 +843,13 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
      * Distance to the camera (0.0 = nearPlane, 1.0 = farPlane) at which the object edges start
      * fading out.
      */
-    lineFadeNear?: number;
+    lineFadeNear?: MaybeInterpolatedProperty<number>;
 
     /**
      * Distance to the camera (0.0 = nearPlane, 1.0 = farPlane) at which the object edges become
      * transparent. A value of <= 0.0 disables fading.
      */
-    lineFadeFar?: number;
+    lineFadeFar?: MaybeInterpolatedProperty<number>;
 
     /**
      * In some data sources, for example Tilezen, building extrusion information might be missing.
@@ -856,8 +860,9 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
     /**
      * Default color used if feature doesn't provide color attribute
      * and [[MapEnv]] did not return it too.
+     * @format color-hex
      */
-    defaultColor?: string;
+    defaultColor?: MaybeInterpolatedProperty<string>;
 
     /**
      * If `true`, the height of the extruded buildings will not be modified by the mercator
@@ -964,7 +969,7 @@ export interface TextTechniqueParams extends BaseTechniqueParams {
     /**
      * Priority of text, defaults to `0`. Elements with highest priority get placed first.
      */
-    priority?: number;
+    priority?: MaybeInterpolatedProperty<number>;
     /**
      * Minimal zoom level. If the current zoom level is smaller, the technique will not be used.
      */
@@ -1031,22 +1036,24 @@ export interface TextTechniqueParams extends BaseTechniqueParams {
     /**
      * Text color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    color?: string;
+    color?: MaybeInterpolatedProperty<string>;
     /**
      * Text background color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
      * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+     * @format color-hex
      */
-    backgroundColor?: string;
+    backgroundColor?: MaybeInterpolatedProperty<string>;
     /**
      * For transparent text, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
      */
-    opacity?: number;
+    opacity?: MaybeInterpolatedProperty<number>;
     /**
      * Background text opacity value.
      */
-    backgroundOpacity?: number;
+    backgroundOpacity?: MaybeInterpolatedProperty<number>;
     /**
      * Inter-glyph spacing (pixels). Scaled by `size`.
      */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -38,6 +38,7 @@ export interface Theme {
 
     /**
      * Color to be used as a clear background - no map objects.
+     * @format color-hex
      */
     clearColor?: string;
 
@@ -183,6 +184,214 @@ export interface BaseStyle {
     labelProperty?: string;
 }
 
+/**
+ *
+ * @defaultSnippets [
+ *     {
+ *         "label": "New solid-line",
+ *         "description": "Add a new 'solid-line' Styling Rule",
+ *         "body": {
+ *             "technique": "solid-line",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "lineWidth": "^${3:1}",
+ *                 "secondaryColor": "#$4ddd",
+ *                 "secondaryWidth": "^${5:2}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New dashed-line",
+ *         "description": "Add a new 'dashed-line' Styling Rule",
+ *         "body": {
+ *             "technique": "dashed-line",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "lineWidth": "^${3:1}",
+ *                 "gapSize": "^${4:10}",
+ *                 "dashSize": "^${5:10}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New fill",
+ *         "description": "Add a new 'fill' Styling Rule",
+ *         "body": {
+ *             "technique": "fill",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "lineWidth": "^${3:0}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New text",
+ *         "description": "Add a new 'text' Styling Rule",
+ *         "body": {
+ *             "technique": "text",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "size": "^${2:24}",
+ *                 "color": "#${3:fff}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New labeled-icon",
+ *         "description": "Add a new 'labeled-icon' marker styling",
+ *         "body": {
+ *             "technique": "labeled-icon",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "size": "^${2:24}",
+ *                 "color": "#${3:fff}",
+ *                 "backgroundSize": "^${4:32}",
+ *                 "backgroundColor": "#${5:aaa}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New line-marker",
+ *         "description": "Add a new 'line-marker' marker styling",
+ *         "body": {
+ *             "technique": "line-marker",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "size": "^${2:24}",
+ *                 "color": "#${3:fff}",
+ *                 "backgroundSize": "^${4:32}",
+ *                 "backgroundColor": "#${5:aaa}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New line",
+ *         "description": "Add a new 'line' Styling Rule",
+ *         "body": {
+ *             "technique": "line",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "lineWidth": "^${3:1}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New segments",
+ *         "description": "Add a new 'segments' Styling Rule",
+ *         "body": {
+ *             "technique": "segments",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "lineWidth": "^${3:1}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New standard",
+ *         "description": "Add a new 'standard' Styling Rule",
+ *         "body": {
+ *             "technique": "standard",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "roughness": "^${3:0.5}",
+ *                 "metalness": "^${4:0.5}",
+ *                 "emissive": "#${5:c44}",
+ *                 "emissiveIntensity": "^${6:0.8}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New extruded-line",
+ *         "description": "Add a new 'extruded-line' Styling Rule",
+ *         "body": {
+ *             "technique": "extruded-line",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "shading": "${2:standard}",
+ *                 "color": "#${3:fff}",
+ *                 "lineWidth": "^${4:1}",
+ *                 "caps": "${5:Circle}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New extruded-polygon",
+ *         "description": "Add a new 'extruded-polygon' Styling Rule",
+ *         "body": {
+ *             "technique": "extruded-polygon",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "roughness": "^${3:0.5}",
+ *                 "metalness": "^${4:0.5}",
+ *                 "emissive": "#${5:c44}",
+ *                 "emissiveIntensity": "^${6:0.8}",
+ *                 "lineWidth": "^${7:1}",
+ *                 "lineColor": "#${8:c0f}",
+ *                 "defaultHeight": "^${9:20}",
+ *                 "animateExtrusion": "^${10:true}",
+ *                 "animateExtrusionDuration": "^${11:300}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New none",
+ *         "description": "Add a new 'none' Styling Rule",
+ *         "body": {
+ *             "technique": "none",
+ *             "when": "$1",
+ *             "attr": {}
+ *         }
+ *     },
+ *     {
+ *         "label": "New shader",
+ *         "description": "Add a new 'shader' Styling Rule",
+ *         "body": {
+ *             "technique": "shader",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "primitive": "${2:mesh}",
+ *                 "params": {}
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New squares",
+ *         "description": "Add a new 'squares' point styling",
+ *         "body": {
+ *             "technique": "squares",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "size": "^${3:32}",
+ *                 "texture": "${4:url}",
+ *                 "enablePicking": "^${5:true}"
+ *             }
+ *         }
+ *     },
+ *     {
+ *         "label": "New circles",
+ *         "description": "Add a new 'circles' point styling",
+ *         "body": {
+ *             "technique": "circles",
+ *             "when": "$1",
+ *             "attr": {
+ *                 "color": "#${2:fff}",
+ *                 "size": "^${3:32}",
+ *                 "texture": "${4:url}",
+ *                 "enablePicking": "^${5:true}"
+ *             }
+ *         }
+ *     }
+ * ]
+ *
+ */
 export type Style =
     | SquaresStyle
     | CirclesStyle
@@ -198,6 +407,7 @@ export type Style =
     | StandardExtrudedLineStyle
     | ExtrudedPolygonStyle
     | ShaderStyle
+    | TerrainStyle
     | TextTechniqueStyle
     | NoneStyle;
 
@@ -333,18 +543,53 @@ export interface BaseLight {
 
 /**
  * Light type: ambient.
+ * @defaultSnippets [
+ *     {
+ *         "label": "New Ambient Light",
+ *         "description": "Adds a new Ambient Light",
+ *         "body": {
+ *             "type": "ambient",
+ *             "name": "${1:ambient light}",
+ *             "color": "#${2:fff}",
+ *             "intensity": "^${3:1}"
+ *         }
+ *     }
+ * ]
  */
 export interface AmbientLight extends BaseLight {
     type: "ambient";
+    /**
+     * @format color-hex
+     */
     color: string;
     intensity?: number;
 }
 
 /**
  * Light type: directional.
+ * @defaultSnippets [
+ *     {
+ *         "label": "New Directional Light",
+ *         "description": "Adds a new Directional Light",
+ *         "body": {
+ *             "type": "directional",
+ *             "name": "${1:directional-light$:1}",
+ *             "color": "#${2:fff}",
+ *             "intensity": "^${3:1}",
+ *             "direction": {
+ *                 "x": "^${4:1}",
+ *                 "y": "^${5:0}",
+ *                 "z": "^${6:0}"
+ *             }
+ *         }
+ *     }
+ * ]
  */
 export interface DirectionalLight extends BaseLight {
     type: "directional";
+    /**
+     * @format color-hex
+     */
     color: string;
     intensity: number;
     direction: Vector3Like;
@@ -364,7 +609,13 @@ export interface TextStyleDefinition {
     fontStyle?: "Regular" | "Bold" | "Italic" | "BoldItalic";
     fontVariant?: "Regular" | "AllCaps" | "SmallCaps";
     rotation?: number;
+    /**
+     * @format color-hex
+     */
     color?: string;
+    /**
+     * @format color-hex
+     */
     backgroundColor?: string;
     opacity?: number;
     backgroundOpacity?: number;
@@ -386,11 +637,20 @@ export interface TextStyleDefinition {
 export interface GradientSky {
     /** Sky type. */
     type: "gradient";
-    /** Color of the upper part of the gradient. */
+    /**
+     * Color of the upper part of the gradient.
+     * @format color-hex
+     */
     topColor: string;
-    /** Color of bottom part of the gradient. */
+    /**
+     * Color of bottom part of the gradient.
+     * @format color-hex
+     */
     bottomColor: string;
-    /** Color of the ground plane. */
+    /**
+     * Color of the ground plane.
+     * @format color-hex
+     */
     groundColor: string;
     /** Texture's gradient power. */
     monomialPower?: number;

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -11,7 +11,7 @@
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "build": "tsc",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS",
-        "generate-json-schema": "ts-json-schema-generator -c -p ./lib/Theme.ts -t Theme > theme.schema.json"
+        "generate-json-schema": "ts-json-schema-generator -c -p ./lib/Theme.ts -t Theme -k defaultSnippets > theme.schema.json"
     },
     "repository": {
         "type": "git",
@@ -36,7 +36,7 @@
         "mocha": "^6.1.4",
         "source-map-support": "^0.5.2",
         "three": "^0.104.0",
-        "ts-json-schema-generator": "^0.40.0",
+        "ts-json-schema-generator": "^0.42.0",
         "typescript": "^3.5",
         "typestring": "^2.9.2"
     },

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -6,6 +6,7 @@
 
 import {
     DecodedTile,
+    getPropertyValue,
     isPoiTechnique,
     isTextTechnique,
     PoiTechnique,
@@ -201,7 +202,7 @@ export class GeoJsonTile extends Tile {
             path,
             this.getRenderStyle(technique),
             this.getLayoutStyle(technique),
-            priority,
+            getPropertyValue(priority, this.mapView.zoomLevel),
             xOffset,
             yOffset,
             featureId
@@ -280,7 +281,7 @@ export class GeoJsonTile extends Tile {
             position,
             this.getRenderStyle(technique),
             this.getLayoutStyle(technique),
-            priority,
+            getPropertyValue(priority, this.mapView.zoomLevel),
             xOffset,
             yOffset,
             featureId
@@ -351,7 +352,7 @@ export class GeoJsonTile extends Tile {
             position,
             this.getRenderStyle(technique),
             this.getLayoutStyle(technique),
-            priority,
+            getPropertyValue(priority, this.mapView.zoomLevel),
             xOffset,
             yOffset,
             featureId

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -89,8 +89,7 @@
                     "size": 16,
                     "priority": 25,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 10
             },
@@ -165,8 +164,7 @@
                     "size": 16,
                     "priority": 20,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 13
             },
@@ -251,8 +249,7 @@
                     "size": 16,
                     "priority": 15,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 12
             },
@@ -375,8 +372,7 @@
                             "size": 16,
                             "priority": 15,
                             "fadeNear": 0.8,
-                            "fadeFar": 0.9,
-                            "clipping": false
+                            "fadeFar": 0.9
                         },
                         "renderOrder": 12
                     }
@@ -427,8 +423,7 @@
                             "size": 16,
                             "priority": 15,
                             "fadeNear": 0.8,
-                            "fadeFar": 0.9,
-                            "clipping": false
+                            "fadeFar": 0.9
                         },
                         "renderOrder": 12
                     }
@@ -445,8 +440,7 @@
                     "size": 12.8,
                     "priority": 25,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 10
             },
@@ -677,7 +671,6 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#2F444B",
-                    "secondaryColor": "#52676E",
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
@@ -699,26 +692,6 @@
                             2
                         ]
                     },
-                    "secondaryWidth": {
-                        "interpolation": "Linear",
-                        "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-                        "values": [
-                            10000,
-                            8000,
-                            7000,
-                            5000,
-                            3000,
-                            2000,
-                            1000,
-                            500,
-                            250,
-                            120,
-                            80,
-                            40,
-                            20,
-                            10
-                        ]
-                    },
                     "dashSize": {
                         "interpolation": "Cubic",
                         "zoomLevels": [10, 11, 12, 13, 14],
@@ -730,8 +703,7 @@
                         "values": [512, 256, 128, 64, 32]
                     }
                 },
-                "renderOrder": 4.1,
-                "secondaryRenderOrder": 4
+                "renderOrder": 4.1
             },
             {
                 "description": "disputed border line - text",

--- a/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
@@ -101,7 +101,6 @@
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'minor_road') && (((kind_detail == 'unclassified') || (kind_detail == 'residential')) || (kind_detail == 'service'))))",
                 "styles": [
                     {
-                        "category": "outline",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#C4BCA4",
@@ -117,7 +116,6 @@
                         "renderOrder": 11
                     },
                     {
-                        "category": "fill",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#DCD8CB",
@@ -140,8 +138,7 @@
                             "size": 16,
                             "priority": 15,
                             "fadeNear": 0.8,
-                            "fadeFar": 0.9,
-                            "clipping": false
+                            "fadeFar": 0.9
                         },
                         "renderOrder": 12
                     }
@@ -159,13 +156,11 @@
                     "size": 16,
                     "priority": 15,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 12
             },
             {
-                "category": "fill",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'major_road') && (kind_detail == 'secondary')))",
                 "technique": "solid-line",
                 "attr": {
@@ -198,14 +193,12 @@
                     "size": 16,
                     "priority": 20,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 13
             },
             {
                 "description": "tertiary",
-                "category": "outline",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'major_road') && kind_detail in ['primary','tertiary']))",
                 "technique": "solid-line",
                 "attr": {
@@ -223,7 +216,6 @@
             },
             {
                 "description": "tertiary",
-                "category": "fill",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'major_road') && kind_detail in ['primary','tertiary']))",
                 "technique": "solid-line",
                 "attr": {
@@ -251,14 +243,12 @@
                     "size": 16,
                     "priority": 25,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 10
             },
             {
                 "description": "primary",
-                "category": "outline",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'highway') && ((kind_detail == 'motorway') || (kind_detail == 'primary'))))",
                 "technique": "solid-line",
                 "attr": {
@@ -276,7 +266,6 @@
             },
             {
                 "description": "primary",
-                "category": "fill",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'highway') && ((kind_detail == 'motorway') || (kind_detail == 'primary'))))",
                 "technique": "solid-line",
                 "attr": {
@@ -304,8 +293,7 @@
                     "size": 14.4,
                     "priority": 25,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 10
             },
@@ -356,7 +344,6 @@
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'path') && (kind_detail in ['pedestrian','path','footway'] || landuse_kind in ['park','residential','footway','garden','pedestrian','grass','allotments','forest','cemetery','natural_wood'])))",
                 "styles": [
                     {
-                        "category": "outline",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#D2C9B1",
@@ -368,7 +355,6 @@
                         "renderOrder": 10.3
                     },
                     {
-                        "category": "fill",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#CFCBBE",
@@ -389,8 +375,7 @@
                             "size": 16,
                             "priority": 15,
                             "fadeNear": 0.8,
-                            "fadeFar": 0.9,
-                            "clipping": false
+                            "fadeFar": 0.9
                         },
                         "renderOrder": 12
                     }
@@ -423,12 +408,11 @@
             },
             {
                 "description": "Railway+S-Bahn background",
-                "category": "outline",
                 "when": "$layer == 'roads' && (((($geometryType ^= 'line') && (kind == 'rail')) && kind_detail in ['rail','light_rail','tram']) && !(is_tunnel))",
                 "technique": "solid-line",
                 "attr": {
                     "color": "#AEA691",
-                    "xclipping": false,
+                    "clipping": false,
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [13, 14.6, 15],
@@ -439,12 +423,11 @@
             },
             {
                 "description": "Railway+S-Bahn background",
-                "category": "outline",
                 "when": "$layer == 'roads' && (((($geometryType ^= 'line') && (kind == 'rail')) && kind_detail in ['rail','light_rail','tram']) && is_tunnel)",
                 "technique": "solid-line",
                 "attr": {
                     "color": "#B3AA92",
-                    "xclipping": false,
+                    "clipping": false,
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [13, 14],
@@ -459,7 +442,7 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#9B9789",
-                    "xclipping": false,
+                    "clipping": false,
                     "dashSize": 1,
                     "gapSize": {
                         "interpolation": "Discrete",
@@ -481,7 +464,7 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#D5D1C4",
-                    "xclipping": false,
+                    "clipping": false,
                     "dashSize": {
                         "interpolation": "Discrete",
                         "zoomLevels": [10, 11, 12, 13, 14, 15, 16],
@@ -524,7 +507,6 @@
             },
             {
                 "description": "country border",
-                "category": "outline",
                 "when": "$layer ^= 'boundaries' && (($geometryType ^= 'line') && (kind == 'country'))",
                 "technique": "solid-line",
                 "attr": {
@@ -554,7 +536,6 @@
             },
             {
                 "description": "country border",
-                "category": "fill",
                 "when": "$layer ^= 'boundaries' && (($geometryType ^= 'line') && (kind == 'country'))",
                 "technique": "solid-line",
                 "attr": {
@@ -585,7 +566,6 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#8B8676",
-                    "secondaryColor": "#A7A291",
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
@@ -607,26 +587,6 @@
                             2
                         ]
                     },
-                    "secondaryWidth": {
-                        "interpolation": "Linear",
-                        "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-                        "values": [
-                            10000,
-                            8000,
-                            7000,
-                            5000,
-                            3000,
-                            2000,
-                            1000,
-                            500,
-                            250,
-                            120,
-                            80,
-                            40,
-                            20,
-                            10
-                        ]
-                    },
                     "dashSize": {
                         "interpolation": "Cubic",
                         "zoomLevels": [10, 11, 12, 13, 14],
@@ -638,8 +598,7 @@
                         "values": [512, 256, 128, 64, 32]
                     }
                 },
-                "renderOrder": 4.1,
-                "secondaryRenderOrder": 4
+                "renderOrder": 4.1
             },
             {
                 "description": "disputed border line - text",
@@ -655,7 +614,6 @@
             },
             {
                 "description": "region border",
-                "category": "outline",
                 "when": "$layer ^= 'boundaries' && (($geometryType ^= 'line') && (kind == 'region'))",
                 "technique": "solid-line",
                 "attr": {
@@ -887,7 +845,6 @@
                     "fontVariant": "SmallCaps",
                     "opacity": 0.8,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -910,7 +867,6 @@
                     "fontVariant": "SmallCaps",
                     "opacity": 0.8,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -933,7 +889,6 @@
                     "fontVariant": "SmallCaps",
                     "opacity": 0.8,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -975,7 +930,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -996,7 +950,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1017,7 +970,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1038,7 +990,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1059,7 +1010,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1080,7 +1030,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1101,7 +1050,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1122,7 +1070,6 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1161,19 +1108,9 @@
                     "size": 14.4,
                     "opacity": 0.6,
                     "minZoomLevel": 17,
-                    "roughness": 1.95,
-                    "metalness": 0.85,
-                    "emissive": "#E7E7E3",
-                    "emissiveIntensity": 0.625,
-                    "footprint": true,
-                    "maxSlope": 0.9,
                     "lineWidth": 1,
-                    "lineColor": "#908D7D",
-                    "lineColorMix": 0.5,
                     "fadeNear": 0.9,
-                    "fadeFar": 1,
-                    "lineFadeNear": 0.25,
-                    "lineFadeFar": 1
+                    "fadeFar": 1
                 },
                 "renderOrder": 100
             }

--- a/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
@@ -101,7 +101,6 @@
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'minor_road') && (((kind_detail == 'unclassified') || (kind_detail == 'residential')) || (kind_detail == 'service'))))",
                 "styles": [
                     {
-                        "category": "outline",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#535557",
@@ -118,7 +117,6 @@
                     },
                     {
                         "description": "residential",
-                        "category": "fill",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#3B3D3F",
@@ -143,8 +141,7 @@
                             "size": 16,
                             "priority": 15,
                             "fadeNear": 0.8,
-                            "fadeFar": 0.9,
-                            "clipping": false
+                            "fadeFar": 0.9
                         },
                         "renderOrder": 12
                     }
@@ -163,13 +160,11 @@
                     "size": 16,
                     "priority": 15,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 12
             },
             {
-                "category": "fill",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'major_road') && (kind_detail == 'secondary')))",
                 "technique": "solid-line",
                 "attr": {
@@ -204,14 +199,12 @@
                     "size": 12.8,
                     "priority": 20,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 13
             },
             {
                 "description": "tertiary",
-                "category": "outline",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'major_road') && kind_detail in ['primary','tertiary']))",
                 "technique": "solid-line",
                 "attr": {
@@ -229,7 +222,6 @@
             },
             {
                 "description": "tertiary",
-                "category": "fill",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'major_road') && kind_detail in ['primary','tertiary']))",
                 "technique": "solid-line",
                 "attr": {
@@ -257,14 +249,12 @@
                     "size": 16,
                     "priority": 25,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 10
             },
             {
                 "description": "primary",
-                "category": "outline",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'highway') && ((kind_detail == 'motorway') || (kind_detail == 'primary'))))",
                 "technique": "solid-line",
                 "attr": {
@@ -282,7 +272,6 @@
             },
             {
                 "description": "primary",
-                "category": "fill",
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'highway') && ((kind_detail == 'motorway') || (kind_detail == 'primary'))))",
                 "technique": "solid-line",
                 "attr": {
@@ -310,8 +299,7 @@
                     "size": 12.8,
                     "priority": 25,
                     "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "clipping": false
+                    "fadeFar": 0.9
                 },
                 "renderOrder": 10
             },
@@ -362,7 +350,6 @@
                 "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'path') && (kind_detail in ['pedestrian','path','footway'] || landuse_kind in ['park','residential','footway','garden','pedestrian','grass','allotments','forest','cemetery','natural_wood'])))",
                 "styles": [
                     {
-                        "category": "outline",
                         "technique": "solid-line",
                         "attr": {
                             "color": "#5D5F62",
@@ -374,7 +361,6 @@
                         "renderOrder": 10.3
                     },
                     {
-                        "category": "fill",
                         "when": "$layer == 'roads' && ((kind != 'rail') && ((kind == 'path') && (kind_detail in ['pedestrian','path','footway'] || landuse_kind in ['park','residential','footway','garden','pedestrian','grass','allotments','forest','cemetery','natural_wood'])))",
                         "technique": "solid-line",
                         "attr": {
@@ -396,8 +382,7 @@
                             "size": 16,
                             "priority": 15,
                             "fadeNear": 0.8,
-                            "fadeFar": 0.9,
-                            "clipping": false
+                            "fadeFar": 0.9
                         },
                         "renderOrder": 12
                     }
@@ -430,12 +415,11 @@
             },
             {
                 "description": "Railway+S-Bahn background",
-                "category": "outline",
                 "when": "$layer == 'roads' && (((($geometryType ^= 'line') && (kind == 'rail')) && kind_detail in ['rail','light_rail','tram']) && !(is_tunnel))",
                 "technique": "solid-line",
                 "attr": {
                     "color": "#6A6C6F",
-                    "xclipping": false,
+                    "clipping": false,
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [13, 14.6, 15],
@@ -446,12 +430,11 @@
             },
             {
                 "description": "Railway+S-Bahn background",
-                "category": "outline",
                 "when": "$layer == 'roads' && (((($geometryType ^= 'line') && (kind == 'rail')) && kind_detail in ['rail','light_rail','tram']) && is_tunnel)",
                 "technique": "solid-line",
                 "attr": {
                     "color": "#6A6C6F",
-                    "xclipping": false,
+                    "clipping": false,
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [13, 21],
@@ -466,7 +449,7 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#7B7E81",
-                    "xclipping": false,
+                    "clipping": false,
                     "dashSize": {
                         "interpolation": "Discrete",
                         "zoomLevels": [10, 11, 12, 13, 14, 15, 20],
@@ -492,7 +475,7 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#454648",
-                    "xclipping": false,
+                    "clipping": false,
                     "dashSize": {
                         "interpolation": "Discrete",
                         "zoomLevels": [10, 11, 12, 13, 14, 15, 16],
@@ -535,7 +518,6 @@
             },
             {
                 "description": "country border",
-                "category": "outline",
                 "when": "$layer ^= 'boundaries' && (($geometryType ^= 'line') && (kind == 'country'))",
                 "technique": "solid-line",
                 "attr": {
@@ -565,7 +547,6 @@
             },
             {
                 "description": "country border",
-                "category": "fill",
                 "when": "$layer ^= 'boundaries' && (($geometryType ^= 'line') && (kind == 'country'))",
                 "technique": "solid-line",
                 "attr": {
@@ -596,7 +577,6 @@
                 "technique": "dashed-line",
                 "attr": {
                     "color": "#2E3234",
-                    "secondaryColor": "#373A3C",
                     "lineWidth": {
                         "interpolation": "Linear",
                         "zoomLevels": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
@@ -618,26 +598,6 @@
                             2
                         ]
                     },
-                    "secondaryWidth": {
-                        "interpolation": "Linear",
-                        "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-                        "values": [
-                            10000,
-                            8000,
-                            7000,
-                            5000,
-                            3000,
-                            2000,
-                            1000,
-                            500,
-                            250,
-                            120,
-                            80,
-                            40,
-                            20,
-                            10
-                        ]
-                    },
                     "dashSize": {
                         "interpolation": "Cubic",
                         "zoomLevels": [10, 11, 12, 13, 14],
@@ -649,8 +609,7 @@
                         "values": [512, 256, 128, 64, 32]
                     }
                 },
-                "renderOrder": 4.1,
-                "secondaryRenderOrder": 4
+                "renderOrder": 4.1
             },
             {
                 "description": "disputed border line - text",
@@ -666,7 +625,6 @@
             },
             {
                 "description": "region border",
-                "category": "outline",
                 "when": "$layer ^= 'boundaries' && (($geometryType ^= 'line') && (kind == 'region'))",
                 "technique": "solid-line",
                 "attr": {
@@ -902,7 +860,6 @@
                     "fontVariant": "SmallCaps",
                     "opacity": 0.8,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -925,7 +882,6 @@
                     "fontVariant": "SmallCaps",
                     "opacity": 0.8,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -948,7 +904,6 @@
                     "fontVariant": "SmallCaps",
                     "opacity": 0.8,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -991,7 +946,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1012,7 +966,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1033,7 +986,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1054,7 +1006,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1075,7 +1026,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1096,7 +1046,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1117,7 +1066,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1138,7 +1086,6 @@
                     "backgroundColor": "#000000",
                     "backgroundOpacity": 0.5,
                     "textFadeTime": 0.75,
-                    "iconFadeTime": 0.5,
                     "fadeNear": 0.8,
                     "fadeFar": 0.9
                 },
@@ -1177,19 +1124,9 @@
                     "size": 14.4,
                     "opacity": 0.6,
                     "minZoomLevel": 17,
-                    "roughness": 1.95,
-                    "metalness": 0.85,
-                    "emissive": "#1F2020",
-                    "emissiveIntensity": 0.625,
-                    "footprint": true,
-                    "maxSlope": 0.9,
                     "lineWidth": 1,
-                    "lineColor": "#070707",
-                    "lineColorMix": 0.5,
                     "fadeNear": 0.9,
-                    "fadeFar": 1,
-                    "lineFadeNear": 0.25,
-                    "lineFadeFar": 1
+                    "fadeFar": 1
                 },
                 "renderOrder": 100
             }

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -2046,11 +2046,13 @@ export class Tile implements CachedResource {
     private getPolygonFadingParams(
         technique: FillTechnique | ExtrudedPolygonTechnique
     ): PolygonFadingParameters {
-        let color: string | number = EdgeMaterial.DEFAULT_COLOR;
+        let color: string | number | undefined;
         let colorMix = EdgeMaterial.DEFAULT_COLOR_MIX;
 
+        const displayZoomLevel = this.mapView.zoomLevel;
+
         if (technique.lineColor !== undefined) {
-            color = technique.lineColor;
+            color = getPropertyValue(technique.lineColor, displayZoomLevel);
             if (isExtrudedPolygonTechnique(technique)) {
                 const extrudedPolygonTechnique = technique as ExtrudedPolygonTechnique;
                 colorMix =
@@ -2059,7 +2061,6 @@ export class Tile implements CachedResource {
                         : EdgeMaterial.DEFAULT_COLOR_MIX;
             }
         }
-        const displayZoomLevel = this.mapView.zoomLevel;
 
         const fadeNear =
             technique.fadeNear !== undefined
@@ -2078,6 +2079,10 @@ export class Tile implements CachedResource {
             technique.lineFadeFar !== undefined
                 ? getPropertyValue(technique.lineFadeFar, displayZoomLevel)
                 : fadeFar;
+
+        if (color === undefined) {
+            color = EdgeMaterial.DEFAULT_COLOR;
+        }
 
         return {
             color,

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -467,7 +467,7 @@ export class PoiManager {
                 positions,
                 this.getRenderStyle(tile.dataSource.name, technique),
                 this.getLayoutStyle(tile.dataSource.name, technique),
-                priority,
+                getPropertyValue(priority, displayZoomLevel),
                 technique.xOffset !== undefined ? technique.xOffset : 0.0,
                 technique.yOffset !== undefined ? technique.yOffset : 0.0,
                 featureId,

--- a/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
+++ b/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DecodedTile, isTextTechnique } from "@here/harp-datasource-protocol";
+import { DecodedTile, getPropertyValue, isTextTechnique } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils/lib/tiling/TileKey";
 import { DataSource, TextElement } from "@here/harp-mapview";
 import { debugContext } from "@here/harp-mapview/lib/DebugContext";
@@ -74,6 +74,7 @@ export class OmvDebugLabelsTile extends OmvTile {
         // allow limiting to specific names and/or index. There can be many paths with the same text
         const textFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.TEXT");
         const indexFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.INDEX");
+        const zoomLevel = this.mapView.zoomLevel;
 
         if (this.preparedTextPaths !== undefined) {
             const tooManyPaths = this.preparedTextPaths.length > 500;
@@ -84,7 +85,10 @@ export class OmvDebugLabelsTile extends OmvTile {
                     continue;
                 }
                 if (technique.color !== undefined) {
-                    colorMap.set(textPath.technique, new THREE.Color(technique.color));
+                    colorMap.set(
+                        textPath.technique,
+                        new THREE.Color(getPropertyValue(technique.color, zoomLevel))
+                    );
                 }
 
                 const text = textPath.text;
@@ -133,7 +137,7 @@ export class OmvDebugLabelsTile extends OmvTile {
                                     new THREE.Vector3(x, y, z),
                                     textRenderStyle,
                                     textLayoutStyle,
-                                    technique.priority || 0,
+                                    getPropertyValue(technique.priority || 0, zoomLevel),
                                     technique.xOffset || 0.0,
                                     technique.yOffset || 0.0
                                 );

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -19,6 +19,7 @@ import {
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
     isFillTechnique,
+    isInterpolatedPropertyDefinition,
     isLineMarkerTechnique,
     isLineTechnique,
     isPoiTechnique,
@@ -1008,11 +1009,13 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
             if (isExtrudedPolygonTechnique(technique) && technique.vertexColors === true) {
                 const positionCount = (positions.length - basePosition) / 3;
                 const color = new THREE.Color(
-                    this.isColorStringValid(technique.color)
+                    isInterpolatedPropertyDefinition(technique.color)
+                        ? getPropertyValue(technique.color, this.m_decodeInfo.tileKey.level)
+                        : this.isColorStringValid(technique.color)
                         ? technique.color
                         : this.isColorStringValid(env.lookup("color") as string)
                         ? (env.lookup("color") as string)
-                        : technique.defaultColor
+                        : getPropertyValue(technique.defaultColor, this.m_decodeInfo.tileKey.level)
                 );
 
                 for (let i = 0; i < positionCount; ++i) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,6 +1232,11 @@ commander@^2.12.1, commander@^2.18.0, commander@^2.19.0, commander@~2.19.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commander@~2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -2595,10 +2600,22 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.3:
+glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@~7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -6219,15 +6236,15 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-ts-json-schema-generator@^0.40.0:
-  version "0.40.0"
-  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-0.40.0.tgz#a2147675c94f022df14004a659c0b75a2e595425"
-  integrity sha512-VkxzG2fBVzu5Ohv6UXa6g43GGq3d/ejeZHetvMbLDFJZ2xPOEKglMLAQbZ8aX6WAE7cdhhSum8S5BnDMqB045Q==
+ts-json-schema-generator@^0.42.0:
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-0.42.0.tgz#6990b71d2ad5ec3cd95842a18c360b7e272172c9"
+  integrity sha512-UAfnxm4u10t3HC81DUPFgyIiXpa5XHotNlUEPqbhdoiW+MU+MYNtPCgeU/VK/F+mBmw6uPow+5VCEUNZYwMupQ==
   dependencies:
-    commander "~2.19.0"
-    glob "~7.1.3"
+    commander "~2.20.0"
+    glob "~7.1.4"
     json-stable-stringify "^1.0.1"
-    typescript "^3.3.1"
+    typescript "~3.4.5"
 
 ts-loader@^5.2.1:
   version "5.3.3"
@@ -6392,6 +6409,11 @@ typescript@^3.5:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
   integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+
+typescript@~3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 typestring@^2.9.2:
   version "2.9.2"


### PR DESCRIPTION
Extend json scheme to support editing in monaco editor/map-editor

Fix theme and technique interfaces;
Fix priority interpolation;
Add color format to enable colorpicker in editor;
Export defaultSnippets to json schema;
Cleanup berlin_tilezen theme files;

Signed-off-by: Oleksii Kanishchev <ext-oleksii.kanishchev@here.com>