### PR TITLE
HARP-5760: Outline Batching bugfix.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -105,7 +105,7 @@ export interface Geometry {
     vertexAttributes: BufferAttribute[];
     interleavedVertexAttributes?: InterleavedBufferAttribute[];
     index?: BufferAttribute;
-    edgeIndex?: BufferAttribute | BufferAttribute[];
+    edgeIndex?: BufferAttribute;
     groups: Group[];
     uuid?: string;
 

--- a/@here/harp-datasource-protocol/lib/IMeshBuffers.ts
+++ b/@here/harp-datasource-protocol/lib/IMeshBuffers.ts
@@ -25,7 +25,7 @@ export interface IMeshBuffers {
     /**
      * Array that stores the indices of the mesh edges.
      */
-    readonly edgeIndices: number[] | number[][];
+    readonly edgeIndices: number[];
 
     /**
      * Optional list of feature IDs. Currently only Number is supported, will fail if features have

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -1636,41 +1636,38 @@ export class Tile implements CachedResource {
 
                 // Add the fill area edges as a separate geometry.
                 if (hasFillOutlines) {
-                    const edgeIndexBuffers = srcGeometry.edgeIndex! as BufferAttribute[];
-                    for (const edgeIndexBufferAttribute of edgeIndexBuffers) {
-                        const outlineGeometry = new THREE.BufferGeometry();
-                        outlineGeometry.addAttribute(
-                            "position",
-                            bufferGeometry.getAttribute("position")
-                        );
-                        outlineGeometry.setIndex(getBufferAttribute(edgeIndexBufferAttribute));
+                    const outlineGeometry = new THREE.BufferGeometry();
+                    outlineGeometry.addAttribute(
+                        "position",
+                        bufferGeometry.getAttribute("position")
+                    );
+                    outlineGeometry.setIndex(getBufferAttribute(srcGeometry.edgeIndex!));
 
-                        const fillTechnique = technique as FillTechnique;
+                    const fillTechnique = technique as FillTechnique;
 
-                        const fadingParams = this.getPolygonFadingParams(fillTechnique);
+                    const fadingParams = this.getPolygonFadingParams(fillTechnique);
 
-                        // Configure the edge material based on the theme values.
-                        const materialParams: EdgeMaterialParameters = {
-                            color: fadingParams.color,
-                            colorMix: fadingParams.colorMix,
-                            fadeNear: fadingParams.lineFadeNear,
-                            fadeFar: fadingParams.lineFadeFar
-                        };
-                        const outlineMaterial = new EdgeMaterial(materialParams);
-                        const outlineObj = new THREE.LineSegments(outlineGeometry, outlineMaterial);
-                        outlineObj.renderOrder = object.renderOrder + 0.1;
+                    // Configure the edge material based on the theme values.
+                    const materialParams: EdgeMaterialParameters = {
+                        color: fadingParams.color,
+                        colorMix: fadingParams.colorMix,
+                        fadeNear: fadingParams.lineFadeNear,
+                        fadeFar: fadingParams.lineFadeFar
+                    };
+                    const outlineMaterial = new EdgeMaterial(materialParams);
+                    const outlineObj = new THREE.LineSegments(outlineGeometry, outlineMaterial);
+                    outlineObj.renderOrder = object.renderOrder + 0.1;
 
-                        FadingFeature.addRenderHelper(
-                            outlineObj,
-                            fadingParams.lineFadeNear,
-                            fadingParams.lineFadeFar,
-                            true,
-                            false
-                        );
+                    FadingFeature.addRenderHelper(
+                        outlineObj,
+                        fadingParams.lineFadeNear,
+                        fadingParams.lineFadeFar,
+                        true,
+                        false
+                    );
 
-                        this.registerTileObject(outlineObj);
-                        objects.push(outlineObj);
-                    }
+                    this.registerTileObject(outlineObj);
+                    objects.push(outlineObj);
                 }
 
                 // Add the fill area edges as a separate geometry.


### PR DESCRIPTION
Based on the results of #507 , fixed batching for ``fill`` outlines, which were previously rendered with a unique draw call per-feature.