### PR TITLE
HARP-6097: Project directly from mercator coords to spherical globe.

### DIFF
--- a/@here/harp-geoutils/test/ProjectionTest.ts
+++ b/@here/harp-geoutils/test/ProjectionTest.ts
@@ -11,6 +11,7 @@ import { Box3Like } from "../lib/math/Box3Like";
 import { Vector3Like } from "../lib/math/Vector3Like";
 import { identityProjection } from "../lib/projection/IdentityProjection";
 import { mercatorProjection } from "../lib/projection/MercatorProjection";
+import { Projection } from "../lib/projection/Projection";
 import { sphereProjection } from "../lib/projection/SphereProjection";
 import { webMercatorProjection } from "../lib/projection/WebMercatorProjection";
 import { mercatorTilingScheme } from "../lib/tiling/MercatorTilingScheme";
@@ -96,21 +97,62 @@ describe("Mercator", function() {
         assert.approximately(coords.longitudeInRadians, unprojected.longitudeInRadians, EPSILON);
     });
 
-    it("reproject mercator to sphere", function() {
-        const geoPos = new GeoCoordinates(52.504951, 13.371806, 12);
+    (function() {
+        const geoPoints: GeoCoordinates[] = [
+            new GeoCoordinates(52.504951, 13.371806, 12),
+            new GeoCoordinates(52.504951, 13.371806, -12),
+            new GeoCoordinates(52.504951, 13.371806, 0),
+            new GeoCoordinates(52.504951, 13.371806),
 
-        // geo coordinates projected to sphere.
-        const projectedPoint = sphereProjection.projectPoint(geoPos);
+            new GeoCoordinates(46.64943616335024, 2.4169921875, 43213),
+            new GeoCoordinates(43.54854811091288, 12.12890625, 43233),
+            new GeoCoordinates(47.60616304386873, 14.1064453125, 43213),
+            new GeoCoordinates(50.65294336725707, 4.658203125, 132),
+            new GeoCoordinates(47.1598400130443, 9.5361328125, 64),
+            new GeoCoordinates(43.73935207915471, 7.3828125, 5423),
+            new GeoCoordinates(43.96119063892024, 12.4365234375, -3234),
+            new GeoCoordinates(63.07486569058662, 26.3232421875, 100),
+            new GeoCoordinates(64.39693778132846, 17.7099609375, 548954),
+            new GeoCoordinates(55.67758441108951, 10.01953125, 2),
+            new GeoCoordinates(47.189712464484195, 19.3798828125, 0),
+            new GeoCoordinates(7.536764322084082, 134.560546875),
+            new GeoCoordinates(15.199386048559994, 145.72265625, 5485),
+            new GeoCoordinates(33.943359946578816, 35.859375, 33),
+            new GeoCoordinates(32.58384932565661, 54.2724609375, 43.23343),
+            new GeoCoordinates(-34.95799531086792, 150.556640625, 2223.444),
+            new GeoCoordinates(-13.79540620313281, -55.107421875, 10.2)
+        ];
 
-        // geo coordinates projected to mercator.
-        const mercatorPoint = mercatorProjection.projectPoint(geoPos);
+        const sourceProjections: Array<[string, Projection]> = [
+            ["mercator", mercatorProjection],
+            ["webMercator", webMercatorProjection]
+        ];
 
-        // a position in mercator space reprojected using sphereProjection.
-        const reprojectedPoint = sphereProjection.reprojectPoint(mercatorProjection, mercatorPoint);
-        assert.approximately(projectedPoint.x, reprojectedPoint.x, EPSILON);
-        assert.approximately(projectedPoint.y, reprojectedPoint.y, EPSILON);
-        assert.approximately(projectedPoint.z, reprojectedPoint.z, EPSILON);
-    });
+        sourceProjections.forEach(([sourceProjectionName, sourceProjection]) => {
+            geoPoints.forEach(geoPos => {
+                const altitudeDescr = geoPos.altitude !== undefined ? `, ${geoPos.altitude}` : "";
+                const pointDescr = `(${geoPos.latitude}, ${geoPos.longitude}${altitudeDescr})`;
+
+                it(`reproject ${pointDescr} from ${sourceProjectionName} to sphere`, function() {
+                    // geo coordinates projected to sphere.
+                    const projectedPoint = sphereProjection.projectPoint(geoPos);
+
+                    // geo coordinates projected to mercator.
+                    const mercatorPoint = sourceProjection.projectPoint(geoPos);
+
+                    // a position in mercator space reprojected using sphereProjection.
+                    const reprojectedPoint = sphereProjection.reprojectPoint(
+                        sourceProjection,
+                        mercatorPoint
+                    );
+
+                    assert.approximately(projectedPoint.x, reprojectedPoint.x, EPSILON);
+                    assert.approximately(projectedPoint.y, reprojectedPoint.y, EPSILON);
+                    assert.approximately(projectedPoint.z, reprojectedPoint.z, EPSILON);
+                });
+            });
+        });
+    })();
 
     it("project outside normal range", function() {
         const coords = new GeoCoordinates(52.504951, 373.371806);


### PR DESCRIPTION
Reimplement `SphereProjection.reprojectPoint` to support fast
reprojection from WEB Mercator coordinates to spherical globe.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>