### PR TITLE
HARP-6160: Improve the classification of outer/inner rings.

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -837,9 +837,13 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 }
 
                 // Repeat the process for all the inner rings (holes).
+                const outerRingWinding = ring.winding;
                 const holes: number[] = [];
-                for (; ringIndex < rings.length && rings[ringIndex].isInnerRing; ++ringIndex) {
-                    const current = rings[ringIndex];
+
+                // Iterate over the inner rings. The inner rings have the oppositve winding
+                // of the outer rings.
+                while (ringIndex < rings.length && rings[ringIndex].winding !== outerRingWinding) {
+                    const current = rings[ringIndex++];
                     holes.push(vertices.length / stride);
 
                     // As we are predicting the indexes before the vertices are added,

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -53,7 +53,7 @@ import { VTJsonDataAdapter } from "./VTJsonDataAdapter";
 const logger = LoggerManager.instance.create("OmvDecoder", { enabled: false });
 
 export class Ring {
-    readonly isOuterRing: boolean;
+    readonly winding: boolean;
 
     /**
      * Constructs a new [[Ring]].
@@ -70,11 +70,7 @@ export class Ring {
         readonly contourOutlines?: boolean[],
         readonly points: number[] = contour
     ) {
-        this.isOuterRing = this.area() < 0;
-    }
-
-    get isInnerRing(): boolean {
-        return !this.isOuterRing;
+        this.winding = this.area() < 0;
     }
 
     area(): number {

--- a/@here/harp-omv-datasource/lib/OmvTileInfoEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvTileInfoEmitter.ts
@@ -194,11 +194,15 @@ export class OmvTileInfoEmitter implements IOmvEmitter {
 
         for (const rings of polygons) {
             // rings are shared between techniques
+            if (rings.length === 0) {
+                continue;
+            }
+            const outerRingWinding = rings[0].winding;
             for (const aRing of rings) {
                 tileInfoWriter.addRingPoints(
                     this.m_tileInfo.polygonGroup,
                     aRing.contour,
-                    aRing.isOuterRing
+                    aRing.winding === outerRingWinding
                 );
             }
         }


### PR DESCRIPTION
Use the winding of the 1st ring of a polygon feature
to distinguish between inner and outer rings.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>