### PR TITLE
Add redirect from examples on short url

### DIFF
--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+    </head>
+    <body>
+      <script>
+         window.location.href = "http://harp.gl.s3-website-us-east-1.amazonaws.com/docs/master/examples/";
+      </script>
+    </body>
+</html>


### PR DESCRIPTION
This enables https://harp.gl/examples to redirect to examples page