### PR TITLE
Makefile based build orchestrator for development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 dist/
 doc/
 test-npm-packages-app/
+.tasks/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+#
+# Usage
+#    make <script from package.json>
+#
+# Runs all tasks from package.json in correct order and deps, so this can be parallelized.
+# (Good results observed up to -j4).
+#
+# By default, all output of successfull command is skipped, to enable it set VERBOSE env variable
+# like this:
+#
+#    VERBOSE=1 make
+
+tasks = \
+	tslint prettier \
+	test \
+	build-examples \
+	build-bundle \
+	build-tests \
+	test-browser-chrome test-browser-firefox \
+	typedoc
+
+default: $(tasks)
+
+# custom targets and
+build: build-examples build-bundle
+test: test-browser
+test-browser: test-browser-chrome test-browser-firefox
+
+app_sources_ts=$(shell find @here/*/src -name "*.ts")
+lib_sources_ts=$(shell find @here/*/lib -name "*.ts" | egrep -v ".d.ts") $(shell find @here/*/index*.ts)
+test_sources_ts=$(shell find test @here/*/test -name "*.ts")
+
+all_sources=$(lib_sources_ts) $(test_sources_ts) $(app_sources_ts)
+
+# dependencies definitions
+.tasks/build-examples: $(test_sources_ts) .tasks/build-bundle
+.tasks/build-bundle: $(lib_sources_ts)
+
+.tasks/tslint: $(all_sources)
+.tasks/typedoc: $(lib_sources_ts)
+.tasks/prettier: $(all_sources)
+
+.tasks/test: $(lib_sources_ts) $(test_sources_ts)
+.tasks/build-tests: $(lib_sources_ts) $(test_sources_ts)
+
+# custom tasks, should be added to package.json actually
+.tasks/test-browser-chrome: build-tests
+	@./scripts/ci-task.sh $@ yarn test-browser --headless-firefox
+
+.tasks/test-browser-firefox: build-tests
+	@./scripts/ci-task.sh $@ yarn test-browser --headless-chrome
+
+# workaround, firefox depend on chrome tests, so we don't run in parallel and we have problem with
+# EADDRINUSE
+.tasks/test-browser-firefox: .tasks/test-browser-chrome
+
+.tasks/%: package.json
+	@./scripts/ci-task.sh $@ yarn run $(@F)
+
+$(tasks): %: .tasks/%

--- a/scripts/ci-task.sh
+++ b/scripts/ci-task.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+readonly task_tag_file="$1"
+shift
+
+[ -e $task_tag_file ] && rm -f $task_tag_file
+
+readonly task_name=$(basename $task_tag_file)
+readonly tmp_file=$(mktemp)
+
+echo "${task_name}: ..." >&2
+if ( "$@" ; ) > "$tmp_file" 2>&1 ; then
+    mkdir -p $(dirname $task_tag_file)
+    touch $task_tag_file
+    if [ -n "$VERBOSE" ] ; then
+        echo "${task_name}: output" >&2
+        cat $tmp_file >&2
+        echo "${task_name}: ... ok" >&2
+    fi
+    rm -f $tmp_file
+    exit 0
+else
+    readonly r="$?"
+    echo "${task_name}: $@ failed, output follows" >&2
+    cat $tmp_file >&2
+    echo "${task_name}: ... fail" >&2
+    rm $tmp_file
+    exit $r
+fi


### PR DESCRIPTION
This is draft idea, how we can ease pre-checks before stuff is pushed to review.

Our development pipeline is getting bigger and bigger there are like 8 tasks executed for each build in CI, which are hard-coded in `.travis.yml` and thus not available directly for developer before he pushes to review.

This makefile, does the same with
 - simple usage: `make -j4`
 - hides output of successful steps (outputs is dumped only in case of failure)
 - parallel build support
 - basic dependency resolution - will not rebuild examples, if you play with tests and vice versa

This "old-fashioned" can run CI" tasks in on developer machine in around 1 minute, thanks to fact that is is parallelizable (yes, `make -j4` works).

Yes, `make` is not available on windows - but there is no proper build orchestrator that can do proper dependency resolution for out-of-box parallel build support.
