### PR TITLE
MINOR: Restrict the type of the exported symbol sphereProjection.

### DIFF
--- a/@here/harp-geoutils/lib/projection/SphereProjection.ts
+++ b/@here/harp-geoutils/lib/projection/SphereProjection.ts
@@ -378,4 +378,4 @@ class SphereProjection extends Projection {
     }
 }
 
-export const sphereProjection = new SphereProjection();
+export const sphereProjection: Projection = new SphereProjection();


### PR DESCRIPTION
To correctly incapsulate the projection APIs, the symbol
`sphereProjection` should be exported as type `Projection` and not as
`SphereProjection`.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>