### PR TITLE
HARP-6099: Subdivide tiles in the world space of their tiling scheme.

### DIFF
--- a/@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier.ts
@@ -4,109 +4,52 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Face3, Geometry, Vector3 } from "three";
+import { Projection, sphereProjection } from "@here/harp-geoutils";
+import { Vector3 } from "three";
+import { SubdivisionModifier } from "./SubdivisionModifier";
+
+const VERTEX_POSITION_CACHE = [new Vector3(), new Vector3(), new Vector3()];
 
 /**
  * The [[SphericalGeometrySubdivisionModifier]] subdivides triangle mesh geometries positioned
  * on the surface of a sphere centered at `(0, 0, 0)`.
  */
-export class SphericalGeometrySubdivisionModifier {
+export class SphericalGeometrySubdivisionModifier extends SubdivisionModifier {
     /**
      * Constructs a new [[SphericalGeometrySubdivisionModifier]].
      *
      * @param angle The maximum angle in radians between two vertices and the origin.
+     * @param projection The projection that defines the world space of this geometry.
      */
-    constructor(readonly angle: number) {}
+    constructor(readonly angle: number, readonly projection: Projection = sphereProjection) {
+        super();
+    }
 
-    /**
-     * Subdivides the faces of the given [[THREE.Geometry]].
-     *
-     * This method modifies (in-place) the vertices and the faces of the geometry.
-     * Please note that only the vertex position attribute is changed
-     * by this modifier. Normals, UVs, and vertex colors are left unmodified.
-     *
-     * @param geometry The [[THREE.Geometry]] to subdivide.
-     */
-    modify(geometry: Geometry): Geometry {
-        const { vertices, faces } = geometry;
+    protected shouldSplitTriangle(a: Vector3, b: Vector3, c: Vector3): number | undefined {
+        const aa = sphereProjection.reprojectPoint(this.projection, a, VERTEX_POSITION_CACHE[0]);
+        const bb = sphereProjection.reprojectPoint(this.projection, b, VERTEX_POSITION_CACHE[1]);
+        const cc = sphereProjection.reprojectPoint(this.projection, c, VERTEX_POSITION_CACHE[2]);
 
-        // A cache containing the indices of the vertices added
-        // when subdiving the faces of the geometry.
-        const cache = new Map<string, number>();
+        const alpha = aa.angleTo(bb);
+        const beta = bb.angleTo(cc);
+        const gamma = cc.angleTo(aa);
 
-        /**
-         * Returns the index of the vertex positioned in the middle
-         * of the given vertices.
-         */
-        function middleVertex(i: number, j: number): number {
-            // build a unique `key` for the pair of indices `(i, j)`.
-            const key = `${Math.min(i, j)}_${Math.max(i, j)}`;
+        // find the maximum angle
+        const m = Math.max(alpha, Math.max(beta, gamma));
 
-            const h = cache.get(key);
-
-            if (h !== undefined) {
-                // nothing to do, a vertex in the middle of (i, j) was already created.
-                return h;
-            }
-
-            // the position of the new vertex.
-            const p = new Vector3();
-            p.addVectors(vertices[i], vertices[j]);
-            p.multiplyScalar(0.5);
-
-            // the index of the new vertex.
-            const index = vertices.length;
-            vertices.push(p);
-
-            // cache the position of the new vertex.
-            cache.set(key, index);
-
-            return index;
+        // split the triangle if needed.
+        if (m < this.angle) {
+            return undefined;
         }
 
-        // The resulting triangles.
-        const subdividedFaces: Face3[] = [];
-
-        while (true) {
-            const face = faces.shift();
-
-            if (!face) {
-                break;
-            }
-
-            // get the vertices of the current triangle.
-            const [a, b, c] = [vertices[face.a], vertices[face.b], vertices[face.c]];
-
-            // get the angles
-            const [alpha, beta, gamma] = [a.angleTo(b), b.angleTo(c), c.angleTo(a)];
-
-            // find the maximum angle
-            const m = Math.max(alpha, Math.max(beta, gamma));
-
-            // split the triangle if needed.
-            if (m <= this.angle) {
-                subdividedFaces.push(face);
-            } else if (alpha === m) {
-                const d = middleVertex(face.a, face.b);
-                faces.push(new Face3(face.a, d, face.c));
-                faces.push(new Face3(d, face.b, face.c));
-            } else if (beta === m) {
-                const d = middleVertex(face.b, face.c);
-                faces.push(new Face3(face.a, face.b, d));
-                faces.push(new Face3(face.a, d, face.c));
-            } else if (gamma === m) {
-                const d = middleVertex(face.c, face.a);
-                faces.push(new Face3(face.a, face.b, d));
-                faces.push(new Face3(d, face.b, face.c));
-            } else {
-                throw new Error("failed to subdivide the given geometry");
-            }
+        if (m === alpha) {
+            return 0;
+        } else if (m === beta) {
+            return 1;
+        } else if (m === gamma) {
+            return 2;
         }
 
-        geometry.faces = subdividedFaces;
-        geometry.verticesNeedUpdate = true;
-        geometry.elementsNeedUpdate = true;
-
-        return geometry;
+        throw new Error("failed to split triangle");
     }
 }

--- a/@here/harp-geometry/lib/SubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/SubdivisionModifier.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Face3, Geometry, Vector2, Vector3 } from "three";
+
+/**
+ * The [[SubdivisionModifier]] subdivides triangle mesh geometries.
+ */
+export abstract class SubdivisionModifier {
+    /**
+     * Constructs a new [[SubdivisionModifier]].
+     */
+    constructor() {
+        // nothing to do
+    }
+
+    /**
+     * Subdivides the faces of the given [[THREE.Geometry]].
+     *
+     * This method modifies (in-place) the vertices and the faces of the geometry.
+     * Please note that only the vertex position and their UV coordinates are subdivided.
+     * Normals, vertex colors and other attributes are left unmodified.
+     *
+     * @param geometry The [[THREE.Geometry]] to subdivide.
+     */
+    modify(geometry: Geometry): Geometry {
+        const { vertices, faces: faceWorkList, faceVertexUvs: oldUvs } = geometry;
+
+        // A cache containing the indices of the vertices added
+        // when subdiving the faces of the geometry.
+        const cache = new Map<string, number>();
+
+        /**
+         * Returns the index of the vertex positioned in the middle
+         * of the given vertices.
+         */
+        function middleVertex(i: number, j: number): number {
+            // build a unique `key` for the pair of indices `(i, j)`.
+            const key = `${Math.min(i, j)}_${Math.max(i, j)}`;
+
+            const h = cache.get(key);
+
+            if (h !== undefined) {
+                // nothing to do, a vertex in the middle of (i, j) was already created.
+                return h;
+            }
+
+            // the position of the new vertex.
+            const p = new Vector3();
+            p.lerpVectors(vertices[i], vertices[j], 0.5);
+
+            // the index of the new vertex.
+            const index = vertices.length;
+            vertices.push(p);
+            // cache the position of the new vertex.
+            cache.set(key, index);
+
+            return index;
+        }
+
+        // The resulting triangles.
+        const newFaces: Face3[] = [];
+        const newFaceVertexUvs: Vector2[][] = [];
+
+        const uvWorkList = oldUvs[0];
+        const hasUvs = oldUvs !== undefined && oldUvs.length > 0 && uvWorkList.length > 0;
+
+        while (true) {
+            const face = faceWorkList.shift();
+
+            if (face === undefined) {
+                break;
+            }
+
+            let uvs!: Vector2[];
+
+            if (hasUvs) {
+                uvs = uvWorkList.shift()!;
+            }
+
+            const edgeToSplit = this.shouldSplitTriangle(
+                vertices[face.a],
+                vertices[face.b],
+                vertices[face.c]
+            );
+
+            switch (edgeToSplit) {
+                case 0: {
+                    const d = middleVertex(face.a, face.b);
+                    faceWorkList.push(new Face3(face.a, d, face.c));
+                    faceWorkList.push(new Face3(d, face.b, face.c));
+                    if (hasUvs) {
+                        const t = new Vector2().lerpVectors(uvs[0], uvs[1], 0.5);
+                        uvWorkList.push([uvs[0], t, uvs[2]], [t, uvs[1], uvs[2]]);
+                    }
+                    break;
+                }
+
+                case 1: {
+                    const d = middleVertex(face.b, face.c);
+                    faceWorkList.push(new Face3(face.a, face.b, d));
+                    faceWorkList.push(new Face3(face.a, d, face.c));
+                    if (hasUvs) {
+                        const t = new Vector2().lerpVectors(uvs[1], uvs[2], 0.5);
+                        uvWorkList.push([uvs[0], uvs[1], t], [uvs[0], t, uvs[2]]);
+                    }
+                    break;
+                }
+
+                case 2: {
+                    const d = middleVertex(face.c, face.a);
+                    faceWorkList.push(new Face3(face.a, face.b, d));
+                    faceWorkList.push(new Face3(d, face.b, face.c));
+                    if (hasUvs) {
+                        const t = new Vector2().lerpVectors(uvs[2], uvs[0], 0.5);
+                        uvWorkList.push([uvs[0], uvs[1], t], [t, uvs[1], uvs[2]]);
+                    }
+                    break;
+                }
+
+                case undefined: {
+                    newFaces.push(face);
+                    if (hasUvs) {
+                        newFaceVertexUvs.push(uvs);
+                    }
+                    break;
+                }
+
+                default:
+                    throw new Error("failed to subdivide the given geometry");
+            } // switch
+        }
+
+        geometry.faces = newFaces;
+        geometry.verticesNeedUpdate = true;
+        geometry.elementsNeedUpdate = true;
+
+        if (hasUvs) {
+            geometry.faceVertexUvs[0] = newFaceVertexUvs;
+            geometry.uvsNeedUpdate = true;
+        }
+
+        return geometry;
+    }
+
+    /**
+     * Returns if the given triangle should be subdivide.
+     *
+     * Implementations of this function should return the index of
+     * the edge of the triangle to split (0, 1, or 2) or undefined if
+     * the triangle doesn't need to be subdivided.
+     *
+     * @param a The position of the first vertex of the triangle.
+     * @param b The position of the second vertex of the triangle.
+     * @param c The position of the third vertex of the triangle.
+     */
+    protected abstract shouldSplitTriangle(a: Vector3, b: Vector3, c: Vector3): number | undefined;
+}

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -51,7 +51,6 @@ import earcut from "earcut";
 import * as THREE from "three";
 
 import {
-    EarthConstants,
     equirectangularProjection,
     mercatorProjection,
     ProjectionType,
@@ -894,11 +893,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
 
                         for (let i = 0; i < vertices.length; i += stride) {
                             geom.vertices.push(
-                                new THREE.Vector3(
-                                    vertices[i],
-                                    vertices[i + 1],
-                                    vertices[i + 2]
-                                ).add(this.m_decodeInfo.center)
+                                new THREE.Vector3(points[i], points[i + 1], points[i + 2])
                             );
                         }
                         for (let i = 0; i < triangles.length; i += 3) {
@@ -919,7 +914,8 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
 
                         // FIXME(HARP-5700): Subdivison modifer ignores texture coordinates.
                         const modifier = new SphericalGeometrySubdivisionModifier(
-                            THREE.Math.degToRad(10)
+                            THREE.Math.degToRad(10),
+                            mercatorProjection
                         );
 
                         modifier.modify(geom);
@@ -928,8 +924,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                         triangles.length = 0;
 
                         geom.vertices.forEach(p => {
-                            p.normalize();
-                            p.multiplyScalar(EarthConstants.EQUATORIAL_RADIUS);
+                            this.projection.reprojectPoint(mercatorProjection, p, p);
                             p.sub(this.m_decodeInfo.center);
                             vertices.push(p.x, p.y, p.z);
                             if (texCoordType !== undefined) {


### PR DESCRIPTION
This change generalizes the subdividion modifier so it can be used
to subdivide geometries in their world space.

Subdividing in the world space of the data ensures that no geometry
crossing the tile boundaries is introduced while subdividing, also
it makes possible to generate texture coordinates for the new vertices.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>