### PR TITLE
HARP-5949: Default language support.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -726,7 +726,7 @@ export class MapView extends THREE.EventDispatcher {
 
         this.m_options.enableStatistics = this.m_options.enableStatistics === true;
 
-        this.m_languages = this.m_options.languages || MapViewUtils.getBrowserLanguages();
+        this.m_languages = this.m_options.languages;
 
         if (
             !isProduction &&
@@ -1103,6 +1103,7 @@ export class MapView extends THREE.EventDispatcher {
         this.m_tileDataSources.forEach((dataSource: DataSource) => {
             dataSource.setLanguages(this.m_languages);
         });
+        this.clearTileCache();
         this.update();
     }
 


### PR DESCRIPTION
Avoid calling ``MapViewUtils.getBrowserLanguages()`` implicitly when no language settings are set, since ``navigator.languages`` and ``navigator.language`` return unconsistent values across browsers (i.e. chrome treats your configured languages as an array and doesn't care about which one you've actually set).