### PR TITLE
HARP-6101: Clear loader cache in TileDataSource(s).

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -118,7 +118,7 @@ const maxLevelTileLoaderCache = 3;
 export class TileDataSource<TileType extends Tile> extends DataSource {
     protected readonly logger = LoggerManager.instance.create("TileDataSource");
     protected readonly m_decoder: ITileDecoder;
-    private readonly m_tileLoaderCache: LRUCache<number, TileLoader>;
+    protected readonly m_tileLoaderCache: LRUCache<number, TileLoader>;
     private m_isReady: boolean = false;
 
     /**

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -219,6 +219,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
         if (styleSet === undefined) {
             return;
         }
+        this.m_tileLoaderCache.clear();
         this.decoder.configure(styleSet, languages, this.m_decoderOptions);
         this.mapView.markTilesDirty(this);
     }


### PR DESCRIPTION
Clear cache when changing style set.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>