### PR TITLE
HARP-6204: Use OBBs instead of AABBs to represent tile bounds.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -14,6 +14,7 @@ import {
 } from "@here/harp-geoutils";
 import { Technique } from "./Techniques";
 import { TileInfo } from "./TileInfo";
+import { OrientedBox3 } from "@here/harp-geometry";
 
 /**
  * This object has geometry data in the form of geometries buffers ready to be used by WebGL.
@@ -28,6 +29,13 @@ export interface DecodedTile {
     poiGeometries?: PoiGeometry[];
     tileInfo?: TileInfo;
     decodeTime?: number; // time used to decode (in ms)
+
+    /**
+     * The default bounding box in [[Tile]] is based on the geo box of the tile.
+     * For data-sources that have 3d data this is not sufficient so the data-source can provide a
+     * more accurate bounding box once the data is decoded.
+     */
+    boundingBox?: OrientedBox3;
 
     /**
      * Tile data Copyright holder identifiers.

--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { OrientedBox3 } from "@here/harp-geometry";
 import {
     equirectangularProjection,
     mercatorProjection,
@@ -14,7 +15,6 @@ import {
 } from "@here/harp-geoutils";
 import { Technique } from "./Techniques";
 import { TileInfo } from "./TileInfo";
-import { OrientedBox3 } from "@here/harp-geometry";
 
 /**
  * This object has geometry data in the form of geometries buffers ready to be used by WebGL.

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -24,6 +24,7 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
+        "@here/harp-geometry": "^0.2.4",
         "@here/harp-geoutils": "^0.4.3",
         "@here/harp-lines": "^0.3.3",
         "@here/harp-utils": "^0.2.7"

--- a/@here/harp-geojson-datasource/lib/GeoJsonDecoder.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonDecoder.ts
@@ -12,11 +12,11 @@ import {
 } from "@here/harp-datasource-protocol";
 
 import { StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+import { OrientedBox3 } from "@here/harp-geometry";
 import { Projection, TileKey, webMercatorTilingScheme } from "@here/harp-geoutils";
 import { ThemedTileDecoder, WorkerServiceManager } from "@here/harp-mapview-decoder/index-worker";
 import { TileDecoderService } from "@here/harp-mapview-decoder/lib/TileDecoderService";
 import { LoggerManager } from "@here/harp-utils";
-import * as THREE from "three";
 import { GeoJsonGeometryCreator, GeoJsonTileGeometries } from "./GeoJsonGeometryCreator";
 import { ExtendedTile } from "./GeoJsonParser";
 
@@ -147,10 +147,8 @@ class GeoJsonDecoder {
 
     private getTileCenter(tileKey: TileKey) {
         const geoBox = webMercatorTilingScheme.getGeoBox(tileKey);
-        const tileBounds = this.m_projection.projectBox(geoBox, new THREE.Box3());
-        const center = new THREE.Vector3();
-        tileBounds.getCenter(center);
-        return center;
+        const tileBounds = this.m_projection.projectBox(geoBox, new OrientedBox3());
+        return tileBounds.position;
     }
 
     private getTileInfo(extendedTile: ExtendedTile): ExtendedTileInfo {

--- a/@here/harp-geojson-datasource/package.json
+++ b/@here/harp-geojson-datasource/package.json
@@ -26,6 +26,7 @@
     "dependencies": {
         "@here/harp-datasource-protocol": "^0.4.3",
         "@here/harp-fetch": "^0.3.6",
+        "@here/harp-geometry": "^0.2.4",
         "@here/harp-geoutils": "^0.4.3",
         "@here/harp-lines": "^0.3.3",
         "@here/harp-mapview": "^0.9.4",

--- a/@here/harp-geometry/lib/OrientedBox3.ts
+++ b/@here/harp-geometry/lib/OrientedBox3.ts
@@ -67,6 +67,18 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
+     * Copies the values of `other` to this [[OrientedBox3]].
+     * @param other The other [[OrientedBox3]] to copy.
+     */
+    copy(other: OrientedBox3) {
+        this.position.copy(other.position);
+        this.xAxis.copy(other.xAxis);
+        this.yAxis.copy(other.yAxis);
+        this.zAxis.copy(other.zAxis);
+        this.extents.copy(other.extents);
+    }
+
+    /**
      * Gets the center position of this [[OrientedBox3]].
      *
      * @param center The returned center position.

--- a/@here/harp-geometry/lib/OrientedBox3.ts
+++ b/@here/harp-geometry/lib/OrientedBox3.ts
@@ -67,6 +67,24 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
+     * Gets the center position of this [[OrientedBox3]].
+     *
+     * @param center The returned center position.
+     */
+    getCenter(center = new Vector3()): Vector3 {
+        return center.copy(this.position);
+    }
+
+    /**
+     * Gets the size of this [[OrientedBox3]].
+     *
+     * @param size The returned size.
+     */
+    getSize(size = new Vector3()): Vector3 {
+        return size.copy(this.extents).multiplyScalar(2);
+    }
+
+    /**
      * Gets the orientation matrix of this `OrientedBox3`.
      * @param matrix The output orientation matrix.
      */
@@ -98,5 +116,42 @@ export class OrientedBox3 implements OrientedBox3Like {
         }
 
         return true;
+    }
+
+    /**
+     * Returns the distance from this [[OrientedBox3]] and the given `point`.
+     *
+     * @param point A point.
+     */
+    distanceToPoint(point: Vector3): number {
+        return Math.sqrt(this.distanceToPointSquared(point));
+    }
+
+    /**
+     * Returns the squared distance from this [[OrientedBox3]] and the given `point`.
+     *
+     * @param point A point.
+     */
+    distanceToPointSquared(point: Vector3): number {
+        const d = new Vector3();
+        d.subVectors(point, this.position);
+
+        const lengths = [d.dot(this.xAxis), d.dot(this.yAxis), d.dot(this.zAxis)];
+
+        let result = 0;
+
+        for (let i = 0; i < 3; ++i) {
+            const length = lengths[i];
+            const extent = this.extents.getComponent(i);
+            if (length < -extent) {
+                const dd = extent + length;
+                result = dd * dd;
+            } else if (length > extent) {
+                const dd = length - extent;
+                result += dd * dd;
+            }
+        }
+
+        return result;
     }
 }

--- a/@here/harp-geometry/lib/OrientedBox3.ts
+++ b/@here/harp-geometry/lib/OrientedBox3.ts
@@ -67,6 +67,15 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
+     * Create a copy of this [[OrientedBoundingBox]].
+     */
+    clone(): OrientedBox3 {
+        const newBox = new OrientedBox3();
+        newBox.copy(this);
+        return newBox;
+    }
+
+    /**
      * Copies the values of `other` to this [[OrientedBox3]].
      * @param other The other [[OrientedBox3]] to copy.
      */

--- a/@here/harp-geometry/lib/OrientedBox3.ts
+++ b/@here/harp-geometry/lib/OrientedBox3.ts
@@ -166,7 +166,7 @@ export class OrientedBox3 implements OrientedBox3Like {
             const extent = this.extents.getComponent(i);
             if (length < -extent) {
                 const dd = extent + length;
-                result = dd * dd;
+                result += dd * dd;
             } else if (length > extent) {
                 const dd = length - extent;
                 result += dd * dd;

--- a/@here/harp-geometry/test/OrientedBox3Test.ts
+++ b/@here/harp-geometry/test/OrientedBox3Test.ts
@@ -148,4 +148,39 @@ describe("OrientedBox3", function() {
 
         assert.equal(visibleTiles.length, 2);
     });
+    describe("distance", function() {
+        it("point inside has zero distance", function() {
+            const box = new OrientedBox3(
+                new THREE.Vector3(),
+                new THREE.Matrix4(),
+                new THREE.Vector3(10, 10, 10)
+            );
+
+            assert.equal(box.distanceToPoint(new THREE.Vector3()), 0);
+        });
+        it("points on each side", function() {
+            const box = new OrientedBox3(
+                new THREE.Vector3(),
+                new THREE.Matrix4(),
+                new THREE.Vector3(10, 10, 10)
+            );
+
+            assert.equal(box.distanceToPoint(new THREE.Vector3(20, 0, 0)), 10);
+            assert.equal(box.distanceToPoint(new THREE.Vector3(-20, 0, 0)), 10);
+            assert.equal(box.distanceToPoint(new THREE.Vector3(0, 20, 0)), 10);
+            assert.equal(box.distanceToPoint(new THREE.Vector3(0, -20, 0)), 10);
+            assert.equal(box.distanceToPoint(new THREE.Vector3(0, 0, 20)), 10);
+            assert.equal(box.distanceToPoint(new THREE.Vector3(0, 0, -20)), 10);
+        });
+        it("arbitrary points", function() {
+            const box = new OrientedBox3(
+                new THREE.Vector3(),
+                new THREE.Matrix4(),
+                new THREE.Vector3(10, 10, 10)
+            );
+
+            assert.equal(box.distanceToPoint(new THREE.Vector3(20, 20, 20)), Math.sqrt(300));
+            assert.equal(box.distanceToPoint(new THREE.Vector3(-20, -20, -20)), Math.sqrt(300));
+        });
+    });
 });

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2502,6 +2502,9 @@ export class MapView extends THREE.EventDispatcher {
                 }
                 object.position.x += worldOffsetX;
                 object.position.sub(this.m_camera.position);
+                if (tile.localTangentSpace) {
+                    object.setRotationFromMatrix(tile.boundingBox.getRotationMatrix());
+                }
                 this.m_mapTilesRoot.add(object);
             }
         }

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -281,11 +281,6 @@ export class Tile implements CachedResource {
     readonly boundingBox = new OrientedBox3();
 
     /**
-     * The center of this `Tile` in world coordinates.
-     */
-    readonly center: THREE.Vector3 = new THREE.Vector3();
-
-    /**
      * A record of road data that cannot be intersected with THREE.JS, because the geometry is
      * created in the vertex shader.
      */
@@ -385,7 +380,6 @@ export class Tile implements CachedResource {
     ) {
         this.geoBox = this.dataSource.getTilingScheme().getGeoBox(this.tileKey);
         this.projection.projectBox(this.geoBox, this.boundingBox);
-        this.boundingBox.getCenter(this.center);
     }
 
     /**
@@ -433,6 +427,13 @@ export class Tile implements CachedResource {
             this.computeResourceInfo();
         }
         return this.m_resourceInfo!.heapSize;
+    }
+
+    /**
+     * The center of this `Tile` in world coordinates.
+     */
+    get center(): THREE.Vector3 {
+        return this.boundingBox.position;
     }
 
     /**
@@ -613,6 +614,11 @@ export class Tile implements CachedResource {
      */
     setDecodedTile(decodedTile: DecodedTile) {
         this.m_decodedTile = decodedTile;
+        if (this.m_decodedTile.boundingBox !== undefined) {
+            // If the decoder provides a more accurate bounding box than the one we computed from
+            // the flat geo box we take it instead.
+            this.boundingBox.copy(this.m_decodedTile.boundingBox);
+        }
         this.invalidateResourceInfo();
 
         const stats = PerformanceStatistics.instance;

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -331,6 +331,7 @@ export class Tile implements CachedResource {
     preparedTextPaths: TextPathGeometry[] | undefined;
 
     private m_disposed: boolean = false;
+    private m_localTangentSpace = false;
 
     private m_forceHasGeometry: boolean | undefined = undefined;
 
@@ -372,14 +373,17 @@ export class Tile implements CachedResource {
      * supported, because of the use of the upper bits for the offset.
      * @param offset The optional offset, this is an integer which represents what multiple of 360
      * degrees to shift, only useful for flat projections, hence optional.
+     * @param localTangentSpace Whether the tile geometry is in local tangent space or not.
      */
     constructor(
         readonly dataSource: DataSource,
         readonly tileKey: TileKey,
-        public offset: number = 0
+        public offset: number = 0,
+        localTangentSpace?: boolean
     ) {
         this.geoBox = this.dataSource.getTilingScheme().getGeoBox(this.tileKey);
         this.projection.projectBox(this.geoBox, this.boundingBox);
+        this.m_localTangentSpace = localTangentSpace !== undefined ? localTangentSpace : false;
     }
 
     /**
@@ -409,6 +413,16 @@ export class Tile implements CachedResource {
      */
     get mapView(): MapView {
         return this.dataSource.mapView;
+    }
+
+    /**
+     * Whether the data of this tile is in local tangent space or not.
+     * If the data is in local tangent space (i.e. up vector is (0,0,1) for high zoomlevels) then
+     * [[MapView]] will rotate the objects before rendering using the rotation matrix of the
+     * oriented [[boundingBox]].
+     */
+    get localTangentSpace(): boolean {
+        return this.m_localTangentSpace;
     }
 
     /**

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -13,6 +13,7 @@ import { GeoBox, Projection, TileKey } from "@here/harp-geoutils";
 import { CachedResource, GroupedPriorityList } from "@here/harp-utils";
 import * as THREE from "three";
 
+import { OrientedBox3 } from "@here/harp-geometry";
 import { AnimatedExtrusionTileHandler } from "./AnimatedExtrusionHandler";
 import { CopyrightInfo } from "./CopyrightInfo";
 import { DataSource } from "./DataSource";
@@ -277,7 +278,7 @@ export class Tile implements CachedResource {
     /**
      * The bounding box of this `Tile` in world coordinates.
      */
-    readonly boundingBox: THREE.Box3 = new THREE.Box3();
+    readonly boundingBox = new OrientedBox3();
 
     /**
      * The center of this `Tile` in world coordinates.

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -14,6 +14,7 @@ import {
     TileInfo
 } from "@here/harp-datasource-protocol";
 import { Env, MapEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+import { OrientedBox3 } from "@here/harp-geometry";
 import {
     GeoBox,
     Projection,
@@ -438,6 +439,8 @@ export namespace OmvDecoder {
          */
         readonly geoBox: GeoBox;
 
+        readonly projectedBoundingBox = new OrientedBox3();
+
         /**
          * The tile bounds in the OMV tile space [[webMercatorTilingScheme]].
          */
@@ -478,7 +481,9 @@ export namespace OmvDecoder {
             this.geoBox = this.tilingScheme.getGeoBox(tileKey);
 
             this.targetProjection.projectBox(this.geoBox, this.projectedTileBounds);
-            this.projectedTileBounds.getCenter(this.center);
+
+            this.targetProjection.projectBox(this.geoBox, this.projectedBoundingBox);
+            this.projectedBoundingBox.getCenter(this.center);
 
             this.tilingScheme.getWorldBox(tileKey, this.tileBounds);
             this.tileBounds.getSize(this.tileSize);


### PR DESCRIPTION
Change the semantics of `Tile.boundingBox` to use oriented bounding
boxes to represent tile world bounds. This change should improve
the precision of tile geometries projected on spherical globe,
because the center of the tile will be closer to the surface.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>