### PR TITLE
HARP-5574: StringEncodedNumeral support.

### DIFF
--- a/@here/harp-datasource-protocol/index.ts
+++ b/@here/harp-datasource-protocol/index.ts
@@ -19,3 +19,4 @@ export * from "./lib/DecodedTile";
 export * from "./lib/TileInfo";
 export * from "./lib/GeoJsonDataType";
 export * from "./lib/ThemeVisitor";
+export * from "./lib/StringEncodedNumeral";

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -3,10 +3,10 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
+import { Color, CubicInterpolant, DiscreteInterpolant, LinearInterpolant } from "three";
 
-import { MathUtils } from "@here/harp-geoutils";
-import { CubicInterpolant, DiscreteInterpolant, LinearInterpolant } from "three";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
+import { StringEncodedNumeralFormats, StringEncodedNumeralType } from "./StringEncodedNumeral";
 
 import {
     InterpolatedProperty,
@@ -15,6 +15,8 @@ import {
     MaybeInterpolatedProperty
 } from "./InterpolatedPropertyDefs";
 
+import { StyleColor, StyleLength } from "./TechniqueParams";
+
 const interpolants = [
     DiscreteInterpolant,
     LinearInterpolant,
@@ -22,48 +24,7 @@ const interpolants = [
     ExponentialInterpolant
 ];
 
-/**
- * Get the value of the specified property at the given zoom level. Handles [[InterpolatedProperty]]
- * instances as well as future interpolated values.
- *
- * @param property Property of a technique.
- * @param level Display level the property should be rendered at.
- */
-export function getPropertyValue<T>(
-    property: InterpolatedProperty<T> | MaybeInterpolatedProperty<T> | undefined,
-    level: number
-): T | undefined {
-    if (!isInterpolatedProperty(property)) {
-        if (isInterpolatedPropertyDefinition(property)) {
-            throw new Error("Invalid property definition");
-        }
-        return property;
-    } else {
-        const nChannels = property.values.length / property.zoomLevels.length;
-        const isMultiChannel = nChannels > 1;
-        const interpolant = new interpolants[property.interpolationMode](
-            property.zoomLevels,
-            property.values,
-            nChannels
-        );
-        if (
-            property.interpolationMode === InterpolationMode.Exponential &&
-            property.exponent !== undefined
-        ) {
-            (interpolant as ExponentialInterpolant).exponent = property.exponent;
-        }
-        interpolant.evaluate(level);
-        let result = isMultiChannel ? "#" : 0;
-        for (const value of interpolant.resultBuffer) {
-            // tslint:disable:no-bitwise
-            const val = isMultiChannel
-                ? ("0" + ((MathUtils.clamp(value, 0, 1) * 255) | 0).toString(16)).slice(-2)
-                : value;
-            result += val;
-        }
-        return (result as unknown) as T;
-    }
-}
+const tmpColor = new Color();
 
 /**
  * Checks if a property is interpolated.
@@ -102,4 +63,124 @@ export function isInterpolatedProperty<T>(p: any): p is InterpolatedProperty<T> 
         return true;
     }
     return false;
+}
+
+/**
+ * Get the value of the specified property at the given zoom level, represented as a `number` value.
+ *
+ * @param property Property of a technique.
+ * @param level Display level the property should be rendered at.
+ * @param pixelToMeters Optional pixels to meters conversion factor (needed for proper
+ * interpolation of `length` values).
+ *
+ */
+export function getPropertyValue<T>(
+    property: InterpolatedProperty<T> | MaybeInterpolatedProperty<T>,
+    level: number,
+    pixelToMeters: number = 1.0
+): number {
+    if (isInterpolatedPropertyDefinition<T>(property)) {
+        throw new Error("Cannot interpolate a InterpolatedPropertyDefinition.");
+    } else if (!isInterpolatedProperty(property)) {
+        if (typeof property !== "string") {
+            return (property as unknown) as number;
+        } else {
+            const matchedFormat = StringEncodedNumeralFormats.find(format =>
+                format.regExp.test(property)
+            );
+            if (matchedFormat === undefined) {
+                throw new Error(`No StringEncodedNumeralFormat matched ${property}.`);
+            }
+            switch (matchedFormat.type) {
+                case StringEncodedNumeralType.Meters:
+                    return matchedFormat.decoder(property)[0];
+                case StringEncodedNumeralType.Pixels:
+                    return matchedFormat.decoder(property)[0] * pixelToMeters;
+                case StringEncodedNumeralType.Hex:
+                case StringEncodedNumeralType.RGB:
+                case StringEncodedNumeralType.HSL:
+                    const hslValues = matchedFormat.decoder(property);
+                    return tmpColor.setHSL(hslValues[0], hslValues[1], hslValues[2]).getHex();
+                default:
+                    return matchedFormat.decoder(property)[0];
+            }
+        }
+    } else if (property._stringEncodedNumeralType !== undefined) {
+        switch (property._stringEncodedNumeralType) {
+            case StringEncodedNumeralType.Meters:
+            case StringEncodedNumeralType.Pixels:
+                return getInterpolatedLength(property, level, pixelToMeters);
+            case StringEncodedNumeralType.Hex:
+            case StringEncodedNumeralType.RGB:
+            case StringEncodedNumeralType.HSL:
+                return getInterpolatedColor(property, level);
+        }
+    }
+    return getInterpolatedLength(property, level, pixelToMeters);
+}
+
+function getInterpolatedLength(
+    property: InterpolatedProperty<StyleLength>,
+    level: number,
+    pixelToMeters: number
+): number {
+    const nChannels = property.values.length / property.zoomLevels.length;
+    const interpolant = new interpolants[property.interpolationMode](
+        property.zoomLevels,
+        property.values,
+        nChannels
+    );
+    if (
+        property.interpolationMode === InterpolationMode.Exponential &&
+        property.exponent !== undefined
+    ) {
+        (interpolant as ExponentialInterpolant).exponent = property.exponent;
+    }
+    interpolant.evaluate(level);
+
+    if (property._stringEncodedNumeralDynamicMask === undefined) {
+        return interpolant.resultBuffer[0];
+    } else {
+        const maskInterpolant = new interpolants[property.interpolationMode](
+            property.zoomLevels,
+            property._stringEncodedNumeralDynamicMask,
+            1
+        );
+        if (
+            property.interpolationMode === InterpolationMode.Exponential &&
+            property.exponent !== undefined
+        ) {
+            (maskInterpolant as ExponentialInterpolant).exponent = property.exponent;
+        }
+        maskInterpolant.evaluate(level);
+
+        return (
+            interpolant.resultBuffer[0] *
+            (1 + maskInterpolant.resultBuffer[0] * (pixelToMeters - 1))
+        );
+    }
+}
+
+function getInterpolatedColor(property: InterpolatedProperty<StyleColor>, level: number): number {
+    const nChannels = property.values.length / property.zoomLevels.length;
+    const interpolant = new interpolants[property.interpolationMode](
+        property.zoomLevels,
+        property.values,
+        nChannels
+    );
+    if (
+        property.interpolationMode === InterpolationMode.Exponential &&
+        property.exponent !== undefined
+    ) {
+        (interpolant as ExponentialInterpolant).exponent = property.exponent;
+    }
+    interpolant.evaluate(level);
+
+    return tmpColor
+        .setHSL(
+            interpolant.resultBuffer[0],
+            interpolant.resultBuffer[1],
+            interpolant.resultBuffer[2]
+        )
+        .getHex();
 }

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { StringEncodedNumeralType } from "./StringEncodedNumeral";
+
 /**
  * Interpolation mode used when computing a [[InterpolatedProperty]] value for a given zoom level.
  */
@@ -57,4 +59,17 @@ export interface InterpolatedProperty<T> {
      * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
      */
     exponent?: number;
+
+    /**
+     * @hidden
+     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
+     */
+    _stringEncodedNumeralType?: StringEncodedNumeralType;
+
+    /**
+     * @hidden
+     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
+     * [[StringEncodedNumeral]]s.
+     */
+    _stringEncodedNumeralDynamicMask?: Float32Array;
 }

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Color } from "three";
+
+const tmpColor = new Color();
+const tmpHSL = { h: 0, s: 0, l: 0 };
+
+/**
+ * Enumeration of supported string encoded numerals.
+ */
+export enum StringEncodedNumeralType {
+    Meters,
+    Pixels,
+    Hex,
+    RGB,
+    HSL
+}
+
+/**
+ * Interface containing information about a [[StringEncodedNumeral]] format, component size and
+ * evaluation.
+ */
+export interface StringEncodedNumeralFormat {
+    type: StringEncodedNumeralType;
+    size: number;
+    regExp: RegExp;
+    mask?: number;
+    decoder: (encodedValue: string) => number[];
+}
+export const StringEncodedMeters: StringEncodedNumeralFormat = {
+    type: StringEncodedNumeralType.Meters,
+    size: 1,
+    regExp: /((?=\.\d|\d)(?:\d+)?(?:\.?\d*))m/,
+    decoder: (encodedValue: string) => {
+        return [Number(StringEncodedMeters.regExp.exec(encodedValue)![1])];
+    }
+};
+export const StringEncodedPixels: StringEncodedNumeralFormat = {
+    type: StringEncodedNumeralType.Pixels,
+    size: 1,
+    mask: 1.0,
+    regExp: /((?=\.\d|\d)(?:\d+)?(?:\.?\d*))px/,
+    decoder: (encodedValue: string) => {
+        return [Number(StringEncodedPixels.regExp.exec(encodedValue)![1])];
+    }
+};
+export const StringEncodedHex: StringEncodedNumeralFormat = {
+    type: StringEncodedNumeralType.Hex,
+    size: 3,
+    regExp: /#([0-9A-Fa-f]{1,2})([0-9A-Fa-f]{1,2})([0-9A-Fa-f]{1,2})/,
+    decoder: (encodedValue: string) => {
+        tmpColor.set(encodedValue).getHSL(tmpHSL);
+        return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
+    }
+};
+export const StringEncodedRGB: StringEncodedNumeralFormat = {
+    type: StringEncodedNumeralType.RGB,
+    size: 3,
+    // tslint:disable-next-line:max-line-length
+    regExp: /rgb\((?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]))\)/,
+    decoder: (encodedValue: string) => {
+        const channels = StringEncodedRGB.regExp.exec(encodedValue)!;
+        tmpColor
+            .setRGB(
+                parseInt(channels[1], 16) / 255,
+                parseInt(channels[2], 16) / 255,
+                parseInt(channels[3], 16) / 255
+            )
+            .getHSL(tmpHSL);
+        return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
+    }
+};
+export const StringEncodedHSL: StringEncodedNumeralFormat = {
+    type: StringEncodedNumeralType.HSL,
+    size: 3,
+    // tslint:disable-next-line:max-line-length
+    regExp: /hsl\(((?:[0-9]|[1-9][0-9]|1[0-9]{1,2}|2[0-9]{1,2}|3[0-5][0-9]|360)), ?(?:([0-9]|[1-9][0-9]|100)%), ?(?:([0-9]|[1-9][0-9]|100)%)\)/,
+    decoder: (encodedValue: string) => {
+        const channels = StringEncodedHSL.regExp.exec(encodedValue)!;
+        return [
+            parseInt(channels[1], 10) / 360,
+            parseInt(channels[2], 10) / 100,
+            parseInt(channels[3], 10) / 100
+        ];
+    }
+};
+
+/**
+ * Array of supported [[StringEncodedNumeralFormat]]s (inteded to be indexed with
+ * [[StringEncodedNumeralType]] enum).
+ */
+export const StringEncodedNumeralFormats: StringEncodedNumeralFormat[] = [
+    StringEncodedMeters,
+    StringEncodedPixels,
+    StringEncodedHex,
+    StringEncodedRGB,
+    StringEncodedHSL
+];

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -84,6 +84,18 @@ export enum GeometryKind {
     Detail = "detail"
 }
 
+/*
+ * Description of length units inside a style. Supports literal values (interpreted as `m`), `m` and
+ * `px`(i.e. `80`, `14px`, `0.6m`, etc.).
+ */
+export type StyleLength = string | number;
+
+/**
+ * Description of colors inside a style. Supports hex values as well as CSS hex, rgb and hsl values
+ * (i.e. `0xffffff`, `#f00fab`, `#aaa`, `rgb(255, 0 120)`, `hsl(360, 100%, 100%)`, etc.).
+ */
+export type StyleColor = string | number;
+
 /**
  * A set of [[GeometryKind]]s.
  */
@@ -222,7 +234,7 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.color.
      * @format color-hex
      */
-    color?: MaybeInterpolatedProperty<string>;
+    color?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * A value of `true` creates a wireframe geometry. (May not be supported with all techniques).
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.wireframe.
@@ -276,7 +288,7 @@ export interface StandardTechniqueParams extends BaseTechniqueParams {
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissive.
      * @format color-hex
      */
-    emissive?: MaybeInterpolatedProperty<string>;
+    emissive?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Intensity of the emissive light. Modulates the emissive color. Default is `1`.
      * See https://threejs.org/docs/#api/en/materials/MeshStandardMaterial.emissiveIntensity.
@@ -365,7 +377,7 @@ export interface PointTechniqueParams extends BaseTechniqueParams {
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color?: MaybeInterpolatedProperty<string>;
+    color?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * URL of a texture image to be loaded.
      */
@@ -602,13 +614,13 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color?: MaybeInterpolatedProperty<string>;
+    color?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Text background color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
      * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    backgroundColor?: MaybeInterpolatedProperty<string>;
+    backgroundColor?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * For transparent text, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.
@@ -662,7 +674,7 @@ export interface LineTechniqueParams extends BaseTechniqueParams {
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color: MaybeInterpolatedProperty<string>;
+    color: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Set to true if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -688,7 +700,7 @@ export interface SegmentsTechniqueParams extends BaseTechniqueParams {
      * Color of segments in a hexadecimal notation, for example: `"#e4e9ec"` or `"#fff"`.
      * @format color-hex
      */
-    color: MaybeInterpolatedProperty<string>;
+    color: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -744,7 +756,7 @@ export interface PolygonalTechniqueParams {
      * Sets the polygon outline color.
      * @format color-hex
      */
-    lineColor?: MaybeInterpolatedProperty<string>;
+    lineColor?: MaybeInterpolatedProperty<StyleColor>;
 
     /**
      * Distance to the camera (0.0 = nearPlane, 1.0 = farPlane) at which the object edges start
@@ -780,7 +792,7 @@ export interface BasicExtrudedLineTechniqueParams
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color: MaybeInterpolatedProperty<string>;
+    color: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -840,7 +852,7 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color: MaybeInterpolatedProperty<string>;
+    color: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -853,13 +865,14 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
     opacity?: MaybeInterpolatedProperty<number>;
     // TODO: Make pixel units default.
     /**
+     * @deprecated Specify metrics units as part of the value instead.
      * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
      */
     metricUnit?: string;
     /**
-     * Width of a line in `metricUnit`s for different zoom levels.
+     * Width of a line in `metricUnit` for different zoom levels.
      */
-    lineWidth: MaybeInterpolatedProperty<number>;
+    lineWidth: MaybeInterpolatedProperty<StyleLength>;
     /**
      * Clip the line outside the tile if `true`.
      */
@@ -869,11 +882,11 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      * `"#e4e9ec"`, `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    secondaryColor?: MaybeInterpolatedProperty<string>;
+    secondaryColor?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Width of secondary line geometry in `metricUnit`s for different zoom levels.
      */
-    secondaryWidth?: MaybeInterpolatedProperty<number>;
+    secondaryWidth?: MaybeInterpolatedProperty<StyleLength>;
     /**
      * The render order of the secondary line geometry object created using this technique.
      */
@@ -889,7 +902,7 @@ export interface DashedLineTechniqueParams extends BaseTechniqueParams, Polygona
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color: MaybeInterpolatedProperty<string>;
+    color: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -908,15 +921,15 @@ export interface DashedLineTechniqueParams extends BaseTechniqueParams, Polygona
     /**
      * Width of a line in `metricUnit`s for different zoom levels.
      */
-    lineWidth: MaybeInterpolatedProperty<number>;
+    lineWidth: MaybeInterpolatedProperty<StyleLength>;
     /**
      * Length of a line in meters for different zoom levels.
      */
-    dashSize?: MaybeInterpolatedProperty<number>;
+    dashSize?: MaybeInterpolatedProperty<StyleLength>;
     /**
      * Size of a gap between lines in meters for different zoom levels.
      */
-    gapSize?: MaybeInterpolatedProperty<number>;
+    gapSize?: MaybeInterpolatedProperty<StyleLength>;
     /**
      * Clip the line outside the tile if `true`.
      */
@@ -932,7 +945,7 @@ export interface FillTechniqueParams extends BaseTechniqueParams, PolygonalTechn
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color?: MaybeInterpolatedProperty<string>;
+    color?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
      * slight performance impact.
@@ -975,7 +988,7 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    lineColor?: MaybeInterpolatedProperty<string>;
+    lineColor?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Mix value between the lineColor(0.0) and the geometry's vertex colors(1.0).
      */
@@ -1004,7 +1017,7 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
      * and [[MapEnv]] did not return it too.
      * @format color-hex
      */
-    defaultColor?: MaybeInterpolatedProperty<string>;
+    defaultColor?: MaybeInterpolatedProperty<StyleColor>;
 
     /**
      * If `true`, the height of the extruded buildings will not be modified by the mercator
@@ -1180,13 +1193,13 @@ export interface TextTechniqueParams extends BaseTechniqueParams {
      * `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    color?: MaybeInterpolatedProperty<string>;
+    color?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * Text background color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`,
      * `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
      * @format color-hex
      */
-    backgroundColor?: MaybeInterpolatedProperty<string>;
+    backgroundColor?: MaybeInterpolatedProperty<StyleColor>;
     /**
      * For transparent text, set a value between 0.0 for totally transparent, to 1.0 for totally
      * opaque.

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -10,6 +10,7 @@
 import { assert } from "chai";
 import { getPropertyValue } from "../lib/InterpolatedProperty";
 import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
+import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
 const levels = new Float32Array([0, 5, 10]);
 const numberProperty: InterpolatedProperty<number> = {
@@ -25,7 +26,8 @@ const booleanProperty: InterpolatedProperty<boolean> = {
 const colorProperty: InterpolatedProperty<string> = {
     interpolationMode: InterpolationMode.Discrete,
     zoomLevels: levels,
-    values: new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1])
+    values: new Float32Array([0, 1, 0.5, 120 / 360, 1, 0.5, 240 / 360, 1, 0.5]),
+    _stringEncodedNumeralType: StringEncodedNumeralType.Hex
 };
 
 describe("Interpolation", function() {
@@ -38,21 +40,21 @@ describe("Interpolation", function() {
         assert.equal(getPropertyValue(numberProperty, 10), 500);
         assert.equal(getPropertyValue(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(booleanProperty, -Infinity), true);
-        assert.equal(getPropertyValue(booleanProperty, 0), true);
-        assert.equal(getPropertyValue(booleanProperty, 2.5), true);
-        assert.equal(getPropertyValue(booleanProperty, 5), false);
-        assert.equal(getPropertyValue(booleanProperty, 7.5), false);
-        assert.equal(getPropertyValue(booleanProperty, 10), true);
-        assert.equal(getPropertyValue(booleanProperty, Infinity), true);
+        assert.equal(getPropertyValue(booleanProperty, -Infinity), 1);
+        assert.equal(getPropertyValue(booleanProperty, 0), 1);
+        assert.equal(getPropertyValue(booleanProperty, 2.5), 1);
+        assert.equal(getPropertyValue(booleanProperty, 5), 0);
+        assert.equal(getPropertyValue(booleanProperty, 7.5), 0);
+        assert.equal(getPropertyValue(booleanProperty, 10), 1);
+        assert.equal(getPropertyValue(booleanProperty, Infinity), 1);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 0), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 2.5), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 5), "#00ff00");
-        assert.equal(getPropertyValue(colorProperty, 7.5), "#00ff00");
-        assert.equal(getPropertyValue(colorProperty, 10), "#0000ff");
-        assert.equal(getPropertyValue(colorProperty, Infinity), "#0000ff");
+        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00ff00);
+        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });
     it("Linear", () => {
         numberProperty.interpolationMode = InterpolationMode.Linear;
@@ -66,13 +68,13 @@ describe("Interpolation", function() {
         assert.equal(getPropertyValue(numberProperty, 10), 500);
         assert.equal(getPropertyValue(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 0), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 2.5), "#7f7f00");
-        assert.equal(getPropertyValue(colorProperty, 5), "#00ff00");
-        assert.equal(getPropertyValue(colorProperty, 7.5), "#007f7f");
-        assert.equal(getPropertyValue(colorProperty, 10), "#0000ff");
-        assert.equal(getPropertyValue(colorProperty, Infinity), "#0000ff");
+        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0xfeff00);
+        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00feff);
+        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });
     it("Cubic", () => {
         numberProperty.interpolationMode = InterpolationMode.Cubic;
@@ -86,13 +88,13 @@ describe("Interpolation", function() {
         assert.equal(getPropertyValue(numberProperty, 10), 500);
         assert.equal(getPropertyValue(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 0), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 2.5), "#6f9f00");
-        assert.equal(getPropertyValue(colorProperty, 5), "#00ff00");
-        assert.equal(getPropertyValue(colorProperty, 7.5), "#009f6f");
-        assert.equal(getPropertyValue(colorProperty, 10), "#0000ff");
-        assert.equal(getPropertyValue(colorProperty, Infinity), "#0000ff");
+        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0xfeff00);
+        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00feff);
+        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });
     it("Exponential", () => {
         numberProperty.interpolationMode = InterpolationMode.Exponential;
@@ -106,12 +108,12 @@ describe("Interpolation", function() {
         assert.equal(getPropertyValue(numberProperty, 10), 500);
         assert.equal(getPropertyValue(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 0), "#ff0000");
-        assert.equal(getPropertyValue(colorProperty, 2.5), "#bf3f00");
-        assert.equal(getPropertyValue(colorProperty, 5), "#00ff00");
-        assert.equal(getPropertyValue(colorProperty, 7.5), "#00bf3f");
-        assert.equal(getPropertyValue(colorProperty, 10), "#0000ff");
-        assert.equal(getPropertyValue(colorProperty, Infinity), "#0000ff");
+        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0xff7f00);
+        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00ff7f);
+        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });
 });

--- a/@here/harp-examples/src/techniques_interpolation.ts
+++ b/@here/harp-examples/src/techniques_interpolation.ts
@@ -349,21 +349,19 @@ export namespace TiledGeoJsonTechniquesExample {
                     attr: {
                         color: {
                             interpolation: "Linear",
-                            zoomLevels: [14, 15, 16, 17, 18, 19, 20],
+                            zoomLevels: [14, 15, 16, 18, 20],
                             values: [
                                 "#163d47",
-                                "#5b0876",
-                                "#7c069d",
-                                "#820042",
-                                "#900404",
-                                "#a99d0d",
-                                "#50a304"
+                                "#3fa6ff",
+                                "hsl(180, 100%, 50%)",
+                                "hsl(360, 100%, 50%)",
+                                "#fff250"
                             ]
                         },
                         lineWidth: {
                             interpolation: "Linear",
-                            zoomLevels: [14, 17, 20],
-                            values: [14, 4, 1]
+                            zoomLevels: [16.9, 17, 20],
+                            values: ["10px", "4m", "1m"]
                         }
                     },
                     renderOrder: 1998
@@ -379,14 +377,12 @@ export namespace TiledGeoJsonTechniquesExample {
                         emissiveIntensity: 1,
                         emissive: {
                             interpolation: "Linear",
-                            zoomLevels: [14, 15, 16, 17, 18, 19, 20],
+                            zoomLevels: [14, 15, 16, 18, 20],
                             values: [
                                 "#163d47",
                                 "#1a3b58",
-                                "#210c63",
-                                "#4e126d",
-                                "#5f0e0e",
-                                "#674800",
+                                "hsl(180, 60%, 50%)",
+                                "hsl(360, 60%, 50%)",
                                 "#2d5b03"
                             ]
                         },
@@ -395,14 +391,12 @@ export namespace TiledGeoJsonTechniquesExample {
                         lineColorMix: 0,
                         lineColor: {
                             interpolation: "Linear",
-                            zoomLevels: [14, 15, 16, 17, 18, 19, 20],
+                            zoomLevels: [14, 15, 16, 18, 20],
                             values: [
                                 "#163d47",
                                 "#3fa6ff",
-                                "#e13ca6",
-                                "#cd2afb",
-                                "#ff792a",
-                                "#fd4141",
+                                "hsl(180, 100%, 50%)",
+                                "hsl(360, 100%, 50%)",
                                 "#fff250"
                             ]
                         },

--- a/@here/harp-mapview/lib/ColorCache.ts
+++ b/@here/harp-mapview/lib/ColorCache.ts
@@ -30,7 +30,11 @@ export class ColorCache {
      * @param colorCode ThreeJS color code or name. You must provide a valid color code or name,
      * as this function does not do any validation.
      */
-    getColor(colorCode: string): THREE.Color {
+    getColor(colorCode: string | number): THREE.Color {
+        if (typeof colorCode === "number") {
+            colorCode = "#" + colorCode.toString(16).padStart(6, "0");
+        }
+
         let color = this.m_map.get(colorCode);
         if (color !== undefined) {
             return color;

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -457,8 +457,8 @@ export function applyTechniqueToMaterial(
         if (typeof m[prop] === "undefined") {
             return;
         }
-        if (level !== undefined && isInterpolatedProperty<any>(value)) {
-            value = getPropertyValue<any>(value, level);
+        if (level !== undefined && isInterpolatedProperty<number>(value)) {
+            value = getPropertyValue(value, level);
         }
         if (m[prop] instanceof THREE.Color) {
             m[prop].set(value);

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -195,17 +195,14 @@ export class RoadPicker {
 
     private getLineWidthInWorldUnit(technique: Technique, level: number): number | undefined {
         const solidLineTech = technique as SolidLineTechnique;
-        const metricUnit = getPropertyValue(solidLineTech.metricUnit, level);
 
-        if (metricUnit === "Pixel") {
-            const pixelToWorld =
-                this.m_mapView.renderer.getPixelRatio() * this.m_mapView.pixelToWorld * 0.5;
-            const lineWidth = getPropertyValue(solidLineTech.lineWidth, level);
-            return (
-                (lineWidth !== undefined
-                    ? (lineWidth as number)
-                    : SolidLineMaterial.DEFAULT_WIDTH) * pixelToWorld
-            );
+        if (solidLineTech.metricUnit === "Pixel") {
+            const lineWidth =
+                getPropertyValue(solidLineTech.lineWidth, level, this.m_mapView.pixelToWorld) * 0.5;
+
+            return lineWidth !== undefined
+                ? (lineWidth as number)
+                : SolidLineMaterial.DEFAULT_WIDTH;
         } else {
             const lineTechnique = technique as LineTechnique;
             return getPropertyValue(lineTechnique.lineWidth, level);

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -485,12 +485,21 @@ export class PoiManager {
             text = "";
         }
         if (text !== undefined) {
+            const displayZoomLevel = this.mapView.zoomLevel;
+
             const priority = technique.priority !== undefined ? technique.priority : 0;
+            const fadeNear =
+                technique.fadeNear !== undefined
+                    ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                    : 0;
+            const fadeFar =
+                technique.fadeFar !== undefined
+                    ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                    : 0;
 
             const positions = Array.isArray(x)
                 ? (x as THREE.Vector3[])
                 : new THREE.Vector3(x, y, z);
-            const displayZoomLevel = this.mapView.zoomLevel;
 
             textElement = new TextElement(
                 ContextualArabicConverter.instance.convert(text),
@@ -502,8 +511,8 @@ export class PoiManager {
                 technique.yOffset !== undefined ? technique.yOffset : 0.0,
                 featureId,
                 technique.style,
-                getPropertyValue(technique.fadeNear, displayZoomLevel),
-                getPropertyValue(technique.fadeFar, displayZoomLevel)
+                fadeNear,
+                fadeFar
             );
 
             textElement.mayOverlap = technique.textMayOverlap === true;
@@ -587,15 +596,18 @@ export class PoiManager {
             const defaultRenderParams = this.mapView.textElementsRenderer!.defaultStyle
                 .renderParams;
 
-            const hexColor = getPropertyValue(technique.color, Math.floor(this.mapView.zoomLevel));
-            if (hexColor !== undefined) {
+            if (technique.color !== undefined) {
+                const hexColor = getPropertyValue(
+                    technique.color,
+                    Math.floor(this.mapView.zoomLevel)
+                );
                 this.m_colorMap.set(cacheId, ColorCache.instance.getColor(hexColor));
             }
-            const hexBgColor = getPropertyValue(
-                technique.backgroundColor,
-                Math.floor(this.mapView.zoomLevel)
-            );
-            if (hexBgColor !== undefined) {
+            if (technique.backgroundColor !== undefined) {
+                const hexBgColor = getPropertyValue(
+                    technique.backgroundColor,
+                    Math.floor(this.mapView.zoomLevel)
+                );
                 this.m_colorMap.set(cacheId + "_bg", ColorCache.instance.getColor(hexBgColor));
             }
 
@@ -603,17 +615,17 @@ export class PoiManager {
                 fontName: getOptionValue(technique.fontName, defaultRenderParams.fontName),
                 fontSize: {
                     unit: FontUnit.Pixel,
-                    size: getOptionValue(
-                        getPropertyValue(technique.size, Math.floor(this.mapView.zoomLevel)),
-                        defaultRenderParams.fontSize!.size
-                    ),
-                    backgroundSize: getOptionValue(
-                        getPropertyValue(
-                            technique.backgroundSize,
-                            Math.floor(this.mapView.zoomLevel)
-                        ),
-                        defaultRenderParams.fontSize!.backgroundSize
-                    )
+                    size:
+                        technique.size !== undefined
+                            ? getPropertyValue(technique.size, Math.floor(this.mapView.zoomLevel))
+                            : defaultRenderParams.fontSize!.size,
+                    backgroundSize:
+                        technique.backgroundSize !== undefined
+                            ? getPropertyValue(
+                                  technique.backgroundSize,
+                                  Math.floor(this.mapView.zoomLevel)
+                              )
+                            : defaultRenderParams.fontSize!.backgroundSize
                 },
                 fontStyle:
                     technique.fontStyle === "Regular" ||
@@ -634,17 +646,17 @@ export class PoiManager {
                     this.m_colorMap.get(cacheId + "_bg"),
                     defaultRenderParams.backgroundColor
                 ),
-                opacity: getOptionValue(
-                    getPropertyValue(technique.opacity, Math.floor(this.mapView.zoomLevel)),
-                    defaultRenderParams.opacity
-                ),
-                backgroundOpacity: getOptionValue(
-                    getPropertyValue(
-                        technique.backgroundOpacity,
-                        Math.floor(this.mapView.zoomLevel)
-                    ),
-                    defaultRenderParams.backgroundOpacity
-                )
+                opacity:
+                    technique.opacity !== undefined
+                        ? getPropertyValue(technique.opacity, Math.floor(this.mapView.zoomLevel))
+                        : defaultRenderParams.opacity,
+                backgroundOpacity:
+                    technique.backgroundOpacity !== undefined
+                        ? getPropertyValue(
+                              technique.backgroundOpacity,
+                              Math.floor(this.mapView.zoomLevel)
+                          )
+                        : defaultRenderParams.backgroundOpacity
             };
 
             const themeRenderParams =

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -19,7 +19,6 @@ import {
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
     isFillTechnique,
-    isInterpolatedPropertyDefinition,
     isLineMarkerTechnique,
     isLineTechnique,
     isPoiTechnique,
@@ -1029,13 +1028,13 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
             if (isExtrudedPolygonTechnique(technique) && technique.vertexColors === true) {
                 const positionCount = (positions.length - basePosition) / 3;
                 const color = new THREE.Color(
-                    isInterpolatedPropertyDefinition(technique.color)
+                    technique.color !== undefined
                         ? getPropertyValue(technique.color, this.m_decodeInfo.tileKey.level)
-                        : this.isColorStringValid(technique.color)
-                        ? technique.color
                         : this.isColorStringValid(env.lookup("color") as string)
                         ? (env.lookup("color") as string)
-                        : getPropertyValue(technique.defaultColor, this.m_decodeInfo.tileKey.level)
+                        : technique.defaultColor !== undefined
+                        ? getPropertyValue(technique.defaultColor, this.m_decodeInfo.tileKey.level)
+                        : 0x000000
                 );
 
                 for (let i = 0; i < positionCount; ++i) {


### PR DESCRIPTION
* Added support for ``StringEncodedNumeral``, which are number values which can be specifed as strings (i.e. colors, distances in pixel, etc.).
* Improved the ``TechniqueParams`` typings to be more strict with the new ``color`` and ``length`` types.
* Implemented mix interpolation between:
    - Pixels and meter values (``metricUnit`` is now deprecated).
    - Hex, rgb and hsl colors (interpolation is performed internally in HSL space for better results).
* Refactored the ``getPropertyValue`` API to always return ``number`` (and also handle ``length`` and ``color`` interpolation properly).