### PR TITLE
HARP-5755: Fix normalization bug & use normalized coord in geoCenter

### DIFF
--- a/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
@@ -112,7 +112,8 @@ export class GeoCoordinates implements GeoCoordinatesLike {
         }
 
         if (longitude < -180 || longitude > 180) {
-            longitude = ((longitude + 180) % 360) - 180;
+            const sign = Math.sign(longitude);
+            longitude = (((longitude % 360) + 180 * sign) % 360) - 180 * sign;
         }
 
         if (latitude === this.latitude && longitude === this.longitude) {

--- a/@here/harp-geoutils/test/GeoCoordinatesTest.ts
+++ b/@here/harp-geoutils/test/GeoCoordinatesTest.ts
@@ -26,7 +26,11 @@ describe("GeoCoordinates", function() {
         { args: [-360, 123], expected: [0, 123] },
         { args: [361, 123], expected: [1, 123] },
         { args: [-360, 123, 0], expected: [0, 123, 0] },
-        { args: [361, 123, 50], expected: [1, 123, 50] }
+        { args: [361, 123, 50], expected: [1, 123, 50] },
+        { args: [361, -720, 50], expected: [1, 0, 50] },
+        { args: [361, -711, 50], expected: [1, 9, 50] },
+        { args: [361, -4534, 50], expected: [1, 146, 50] },
+        { args: [361, 4534, 50], expected: [1, -146, 50] }
     ];
 
     tests.forEach(function(test) {

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1245,7 +1245,7 @@ export class MapView extends THREE.EventDispatcher {
      * The position in geo coordinates of the center of the scene.
      */
     get geoCenter(): GeoCoordinates {
-        return this.projection.unprojectPoint(this.m_camera.position);
+        return this.projection.unprojectPoint(this.m_camera.position).normalized();
     }
 
     /**


### PR DESCRIPTION
One more problem was encountered while debugging this task:
 - `GeoCoordinates#normalized()` method was not supporting negative values (like -711, -400, ...). **Problem was solved**.

Introduced normalized value for `MapView#geoCenter` accessor.