### PR TITLE
Fix GeoJsonDataProvider caused by improper async usage in TilerService.

### DIFF
--- a/@here/harp-mapview-decoder/lib/TilerService.ts
+++ b/@here/harp-mapview-decoder/lib/TilerService.ts
@@ -61,7 +61,7 @@ export class TilerService extends WorkerService {
         request: WorkerTilerProtocol.TileRequest
     ): Promise<WorkerServiceResponse> {
         const tileKey = TileKey.fromMortonCode(request.tileKey);
-        const tile = this.tiler.getTile(request.index, tileKey);
+        const tile = await this.tiler.getTile(request.index, tileKey);
 
         return { response: tile || {} };
     }


### PR DESCRIPTION
Fixes
```
   Error: DataCloneError: Failed to execute 'postMessage' on
      'DedicatedWorkerGlobalScope': #<Promise> could not be cloned
```
error caused introduced in #526.

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>