### PR TITLE
HARP-6407: Temporarily disable extrusion animation in 'effect_theme'

### DIFF
--- a/@here/harp-examples/src/effects_themes.ts
+++ b/@here/harp-examples/src/effects_themes.ts
@@ -24,6 +24,8 @@ export namespace EffectsExample {
             theme: "resources/berlin_tilezen_base.json"
         });
 
+        mapView.animatedExtrusionHandler.enabled = false;
+
         CopyrightElementHandler.install("copyrightNotice", mapView);
 
         const mapControls = new MapControls(mapView);


### PR DESCRIPTION
Temporarily disable extrusion animation for effect/theme example.
Will be enabled back when outline post effect starts working with animation extrusion.

Signed-off-by: Sergii Kulakovskyi <ext-sergii.kulakovskyi@here.com>