### PR TITLE
MINOR: New CSS for map controls button

### DIFF
--- a/@here/harp-map-controls/lib/MapControlsUI.ts
+++ b/@here/harp-map-controls/lib/MapControlsUI.ts
@@ -85,6 +85,7 @@ export class MapControlsUI {
 
         const tiltButton = document.createElement("button");
         tiltButton.innerText = "3D";
+        tiltButton.id = "tiltButtonUi";
 
         // Optional zoom level displaying
         if (options.zoomLevel === "show") {
@@ -181,7 +182,7 @@ export class MapControlsUI {
             document.createTextNode(`
             .harp-gl_controls-button {
                 display: block;
-                background-color: #fff;
+                background-color: #272d37;
                 width: 40px;
                 height: 40px;
                 font-size: 22px;
@@ -189,14 +190,16 @@ export class MapControlsUI {
                 outline: none;
                 margin: 5px;
                 border: none;
-                color: #555;
-                opacity: 0.87;
+                color: rgba(255, 255, 255, 0.8);
                 cursor: pointer;
                 border-radius: 4px;
-                box-shadow: 0px 0px 4px #aaa;
+                box-shadow: 0 1px 4px 0  rgba(15, 22, 33, 0.4);
                 transition: all 0.1s;
                 padding: 0 0 1px 1px;
                 user-select: none;
+            }
+            #tiltButtonUi {
+               font-size: 16px;
             }
             .harp-gl_controls-button:active {
                 background-color: #37afaa;


### PR DESCRIPTION
This is a proposal for new map controls button style.

The white button style had slightly too much contrast and was distracting from the map in my opinion. I ported the dark style from Arnaud's product to harp.gl. This not only reduces the contrast of the buttons in comparison to the base map, but also adds a *tiny* bit of unification between harp.gl and the other product.

Please discuss what you like better.

Previous button style:
![Screen Shot 2019-07-08 at 1 21 52 PM](https://user-images.githubusercontent.com/221746/60839998-5e83e280-a183-11e9-8c47-a38409a677df.png)

New button style:
![Screen Shot 2019-07-08 at 1 16 13 PM](https://user-images.githubusercontent.com/221746/60840028-6ba0d180-a183-11e9-80ce-a521d16909eb.png)
![Screen Shot 2019-07-08 at 1 16 46 PM](https://user-images.githubusercontent.com/221746/60840035-6e9bc200-a183-11e9-9fee-85d00139b139.png)
![Screen Shot 2019-07-08 at 1 16 27 PM](https://user-images.githubusercontent.com/221746/60840039-70658580-a183-11e9-90bf-47dc5d3ba2bf.png)