### PR TITLE
HARP-6453 Control zoom level for WebTileDataSource

### DIFF
--- a/@here/harp-examples/src/datasource_webtile.ts
+++ b/@here/harp-examples/src/datasource_webtile.ts
@@ -63,7 +63,7 @@ export namespace WebTileDataSourceExample {
     const webTileDataSource = new WebTileDataSource({
         appId,
         appCode,
-        ppi: 320
+        ppi: WebTileDataSource.ppiValue.ppi320
     });
     // end:harp_gl_datasource_webtile_1.ts
 

--- a/@here/harp-examples/src/datasource_webtile_globe.ts
+++ b/@here/harp-examples/src/datasource_webtile_globe.ts
@@ -61,7 +61,7 @@ export namespace WebTileDataSourceGlobeExample {
         const webTileDataSource = new WebTileDataSource({
             appId,
             appCode,
-            ppi: 320
+            ppi: WebTileDataSource.ppiValue.ppi320
         });
         // end:harp_gl_datasource_webtile_globe_1.ts
 

--- a/@here/harp-webtile-datasource/test/WebTileTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileTest.ts
@@ -8,9 +8,44 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+import { WebTileDataSource } from "../index";
 
-describe("WebBoxTile", function() {
+describe("WebTileDataSource", function() {
     it("ok", function() {
         assert.isTrue(true);
+    });
+
+    it("#createWebTileDataSource has default values", async function() {
+        const appId = "123";
+        const appCode = "456";
+        const webTileDataSource = new WebTileDataSource({
+            appId,
+            appCode
+        });
+        assert(webTileDataSource.maxZoomLevel === 19);
+    });
+    it("#createWebTileDataSource with 256px and ppi320", async function() {
+        const appId = "123";
+        const appCode = "456";
+        const webTileDataSource = new WebTileDataSource({
+            appId,
+            appCode,
+            resolution: WebTileDataSource.resolutionValue.resolution256,
+            ppi: WebTileDataSource.ppiValue.ppi320
+        });
+        assert(webTileDataSource.maxZoomLevel === 20);
+    });
+    it("#createWebTileDataSource with satellite.day and ppi320", async function() {
+        const appId = "123";
+        const appCode = "456";
+        assert.throw(
+            () =>
+                new WebTileDataSource({
+                    appId,
+                    appCode,
+                    tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE,
+                    ppi: WebTileDataSource.ppiValue.ppi320
+                })
+        );
     });
 });


### PR DESCRIPTION
Add enums for `ppi` and `resolution`.
Add checks for invalid combinations of `ppi`, `resolution` and `tileBaseAddress`.
Add test cases for all of the above.