### PR TITLE
HARP-6453 Fix webtile example

### DIFF
--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -276,7 +276,7 @@ export class WebTileDataSource extends DataSource {
         "traffic.maps.api.here.com/maptile/2.1/traffictile/newest/normal.day";
 
     private m_resolution: WebTileDataSource.resolutionValue;
-    private m_ppi: WebTileDataSource.ppiValue | null;
+    private m_ppi: WebTileDataSource.ppiValue;
     private m_tileBaseAddress: string;
     private m_languages?: string[];
     private m_cachedCopyrightResponse?: Promise<AreaCopyrightInfo[]>;
@@ -297,11 +297,11 @@ export class WebTileDataSource extends DataSource {
         if (this.m_resolution === WebTileDataSource.resolutionValue.resolution512) {
             this.maxZoomLevel = 19; // 512x512 tiles do not have z19
         }
-        this.m_ppi = getOptionValue(m_options.ppi, null);
+        this.m_ppi = getOptionValue(m_options.ppi, WebTileDataSource.ppiValue.ppi72);
         this.m_tileBaseAddress = m_options.tileBaseAddress || WebTileDataSource.TILE_BASE_NORMAL;
         if (
             this.m_tileBaseAddress === WebTileDataSource.TILE_AERIAL_SATELLITE &&
-            this.m_ppi !== null
+            this.m_ppi !== WebTileDataSource.ppiValue.ppi72
         ) {
             throw new Error("Requested combination of scheme satellite.day and ppi is not valid");
         }
@@ -337,7 +337,8 @@ export class WebTileDataSource extends DataSource {
             `?app_id=${appId}&app_code=${appCode}` +
             getOptionValue(this.m_options.additionalRequestParameters, "");
 
-        if (this.m_ppi !== null) {
+        if (this.m_ppi !== WebTileDataSource.ppiValue.ppi72) {
+            // because ppi=72 is default, we do not include it in the request
             url += `&ppi=${this.m_ppi.toString}`;
         }
         if (this.m_languages !== undefined && this.m_languages[0] !== undefined) {

--- a/@here/harp-webtile-datasource/test/WebTileTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileTest.ts
@@ -35,6 +35,27 @@ describe("WebTileDataSource", function() {
         });
         assert(webTileDataSource.maxZoomLevel === 20);
     });
+    it("#createWebTileDataSource with satellite.day", async function() {
+        const appId = "123";
+        const appCode = "456";
+        const webTileDataSource = new WebTileDataSource({
+            appId,
+            appCode,
+            tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE
+        });
+        assert(webTileDataSource.maxZoomLevel === 19);
+    });
+    it("#createWebTileDataSource with satellite.day and 256px", async function() {
+        const appId = "123";
+        const appCode = "456";
+        const webTileDataSource = new WebTileDataSource({
+            appId,
+            appCode,
+            tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE,
+            resolution: WebTileDataSource.resolutionValue.resolution256
+        });
+        assert(webTileDataSource.maxZoomLevel === 20);
+    });
     it("#createWebTileDataSource with satellite.day and ppi320", async function() {
         const appId = "123";
         const appCode = "456";


### PR DESCRIPTION
When creating a default `WebTileDataSource` with aerial tiles there is an error thrown because of wrong usage of `ppi`.

Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>