### PR TITLE
Harp 5722 background data source

### DIFF
--- a/@here/harp-features-datasource/lib/FeaturesDataSource.ts
+++ b/@here/harp-features-datasource/lib/FeaturesDataSource.ts
@@ -36,7 +36,6 @@ export class FeaturesDataSource extends OmvDataSource {
         super({
             dataProvider: new GeoJsonDataProvider(NAME, DEFAULT_GEOJSON, { workerTilerUrl })
         });
-        this.addTileBackground = false;
     }
 
     /**

--- a/@here/harp-geoutils/lib/tiling/SubTiles.ts
+++ b/@here/harp-geoutils/lib/tiling/SubTiles.ts
@@ -6,7 +6,7 @@
 
 import { TileKey } from "./TileKey";
 
-export class SubTiles {
+export class SubTiles implements Iterable<TileKey> {
     private m_tileKey: TileKey;
     private m_level: number;
     private m_count: number;
@@ -23,9 +23,6 @@ export class SubTiles {
         // tslint:enable:no-bitwise
     }
 
-    get length(): number {
-        return this.m_count;
-    }
     get level(): number {
         return this.m_level;
     }
@@ -33,8 +30,12 @@ export class SubTiles {
         return this.m_tileKey;
     }
 
+    [Symbol.iterator](): SubTiles.SubTileIterator {
+        return new SubTiles.SubTileIterator(this, this.m_count);
+    }
+
     iterator() {
-        return new SubTiles.Iterator(this);
+        return this[Symbol.iterator]();
     }
 
     skip(index: number): number {
@@ -50,13 +51,15 @@ export class SubTiles {
 }
 
 export namespace SubTiles {
-    export class Iterator {
+    export class SubTileIterator implements Iterator<TileKey> {
         private m_parent: SubTiles;
         private m_index: number;
+        private m_totalSubTileCount: number;
 
-        constructor(parent: SubTiles, index: number = 0) {
+        constructor(parent: SubTiles, totalSubTileCount: number, index: number = 0) {
             this.m_parent = parent;
             this.m_index = parent.skip(index);
+            this.m_totalSubTileCount = totalSubTileCount;
         }
 
         get value() {
@@ -73,7 +76,9 @@ export namespace SubTiles {
         }
 
         next() {
+            const current = { value: this.value, done: this.m_index >= this.m_totalSubTileCount };
             this.m_index = this.m_parent.skip(++this.m_index);
+            return current;
         }
     }
 }

--- a/@here/harp-geoutils/lib/tiling/TileTreeTraverse.ts
+++ b/@here/harp-geoutils/lib/tiling/TileTreeTraverse.ts
@@ -24,13 +24,10 @@ export class TileTreeTraverse {
         const subTileMask = ~(~0 << subTileCount);
 
         const subTiles = new SubTiles(tileKey, 1, subTileMask);
-        const it = subTiles.iterator();
         const result = new Array<TileKey>();
 
-        // tslint:disable-next-line:prefer-for-of
-        for (let i = 0; i < subTiles.length; ++i) {
-            result.push(it.value);
-            it.next();
+        for (const subTile of subTiles) {
+            result.push(subTile);
         }
 
         return result;

--- a/@here/harp-geoutils/test/SubTilesTest.ts
+++ b/@here/harp-geoutils/test/SubTilesTest.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { assert } from "chai";
+import { SubTiles } from "../lib/tiling/SubTiles";
+import { TileKey } from "../lib/tiling/TileKey";
+
+describe("SubTiles", function() {
+    it("iterates through all masked subtiles", function() {
+        const subTiles = new SubTiles(TileKey.fromRowColumnLevel(0, 0, 0), 1, 0x3);
+        const actualSubtiles: TileKey[] = [];
+
+        for (const subTile of subTiles) {
+            actualSubtiles.push(subTile);
+        }
+
+        assert.equal(actualSubtiles.length, 2);
+    });
+});

--- a/@here/harp-mapview/lib/BackgroundDataSource.ts
+++ b/@here/harp-mapview/lib/BackgroundDataSource.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TileKey, TilingScheme, webMercatorTilingScheme } from "@here/harp-geoutils";
+import { DataSource } from "./DataSource";
+import { TileGeometryCreator } from "./geometry/TileGeometryCreator";
+import { Tile } from "./Tile";
+
+/**
+ * Provides background geometry for all tiles.
+ */
+export class BackgroundDataSource extends DataSource {
+    private static readonly DEFAULT_TILING_SCHEME = webMercatorTilingScheme;
+    private m_referenceDataSource: DataSource | undefined;
+    private m_tilingScheme: TilingScheme;
+
+    constructor() {
+        super("background", undefined, 1, 20);
+        this.cacheable = true;
+        this.m_referenceDataSource = undefined;
+        this.m_tilingScheme = BackgroundDataSource.DEFAULT_TILING_SCHEME;
+    }
+
+    updateTilingScheme() {
+        if (
+            this.m_referenceDataSource &&
+            this.mapView.isDataSourceEnabled(this.m_referenceDataSource)
+        ) {
+            return;
+        }
+
+        const newReferenceDataSource = this.mapView.dataSources.find(
+            ds => ds !== this && this.mapView.isDataSourceEnabled(ds)
+        );
+
+        const tilingSchemeChanged = this.setReferenceDataSource(newReferenceDataSource);
+
+        if (tilingSchemeChanged) {
+            this.mapView.clearTileCache(this.name);
+        }
+    }
+    getTilingScheme(): TilingScheme {
+        return this.m_tilingScheme;
+    }
+
+    getTile(tileKey: TileKey): Tile | undefined {
+        const tile = new Tile(this, tileKey);
+        tile.forceHasGeometry(true);
+        tile.removeDecodedTile(); // Skip geometry loading.
+        TileGeometryCreator.instance.addGroundPlane(tile);
+
+        return tile;
+    }
+
+    // Returns true if the tiling scheme changed, false otherwise.
+    private setReferenceDataSource(referenceDataSource: DataSource | undefined): boolean {
+        this.m_referenceDataSource = referenceDataSource;
+        let newTilingScheme = BackgroundDataSource.DEFAULT_TILING_SCHEME;
+
+        if (this.m_referenceDataSource !== undefined) {
+            newTilingScheme = this.m_referenceDataSource.getTilingScheme();
+            this.storageLevelOffset = this.m_referenceDataSource.storageLevelOffset;
+        }
+        const tilingSchemeChanged = this.m_tilingScheme !== newTilingScheme;
+
+        this.m_tilingScheme = newTilingScheme;
+
+        return tilingSchemeChanged;
+    }
+}

--- a/@here/harp-mapview/lib/CameraMovementDetector.ts
+++ b/@here/harp-mapview/lib/CameraMovementDetector.ts
@@ -92,6 +92,9 @@ export class CameraMovementDetector {
     clear(mapView: MapView) {
         const newCameraPos = mapView.camera.getWorldPosition(this.m_newCameraPos);
         this.m_lastCameraPos.set(newCameraPos.x, newCameraPos.y, newCameraPos.z);
+
+        const newYawPitchRoll = MapViewUtils.extractYawPitchRoll(mapView.camera.quaternion);
+        this.m_lastYawPitchRoll = newYawPitchRoll;
     }
 
     /**

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -38,29 +38,6 @@ export abstract class DataSource extends THREE.EventDispatcher {
     name: string;
 
     /**
-     * If `true` or `undefined`, a geometry for every tile is generated. The background has the size
-     * of the covered tile area. It is required to clear the area of a tile. It is also used to
-     * identify the tile during picking operations. If no tile background is generated, a tile
-     * cannot be identified during picking if no geometry is defined at the picking location. To be
-     * able to pick the tile with the help of the tile background, tile background does not have to
-     * be visible (set `tileBackgroundIsVisible` to `false`).
-     */
-    addTileBackground: boolean = true;
-
-    /**
-     * If defined, this option defines the color of the tile background. If it is `undefined`, the
-     * [[MapView.clearColor]] defined in the [[Theme]] is used.
-     */
-    tileBackgroundColor: number | undefined = undefined;
-
-    /**
-     * If set to `true`, and if `addTileBackground` is true, the background is actually rendered. If
-     * set to `false` or `undefined`, the background is only used for picking, but is not rendered,
-     * but only used for picking.
-     */
-    tileBackgroundIsVisible: boolean = false;
-
-    /**
      * The [[MapView]] instance holding a reference to this `DataSource`.
      */
     private m_mapView?: MapView;

--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OrientedBox3 } from "@here/harp-geometry";
+import { MathUtils, Projection, ProjectionType, TileKey, TilingScheme } from "@here/harp-geoutils";
+import { assert } from "chai";
+import * as THREE from "three";
+import { CalculationStatus, ElevationRangeSource } from "./ElevationRangeSource";
+import { MapTileCuller } from "./MapTileCuller";
+import { MapViewUtils, TileOffsetUtils } from "./Utils";
+
+/**
+ * Represents a unique TileKey and the area it takes up on screen.
+ *
+ * Note, in certain tiling projections, it is possible to have an offset, which represents a tile
+ * which has fully wrapped around, hence this defaults to 0 to simplify usage for projections which
+ * don't require it.
+ */
+export class TileKeyEntry {
+    constructor(public tileKey: TileKey, public area: number, public offset: number = 0) {}
+}
+
+function getGeoBox(tilingScheme: TilingScheme, childTileKey: TileKey, offset: number) {
+    const geoBox = tilingScheme.getGeoBox(childTileKey);
+    const longitudeOffset = 360.0 * offset;
+    geoBox.northEast.longitude += longitudeOffset;
+    geoBox.southWest.longitude += longitudeOffset;
+    return geoBox;
+}
+
+namespace FrustumIntersection {
+    export interface Result {
+        /**
+         * Tiles intersected by the frustum. Keys are a combination of morton code and tile offset,
+         * see [[TileOffsetUtils.getKeyForTileKeyAndOffset]].
+         */
+        readonly tileKeyEntries: Map<number, TileKeyEntry>;
+        /**
+         * True if the intersection was calculated using precise elevation data, false if it's an
+         * approximation.
+         */
+        calculationFinal: boolean;
+    }
+}
+
+/**
+ * Computes the tiles intersected by the frustum defined by the current camera setup.
+ */
+export class FrustumIntersection {
+    private readonly m_frustum: THREE.Frustum = new THREE.Frustum();
+    // used to project global coordinates into camera local coordinates
+    private readonly m_viewProjectionMatrix = new THREE.Matrix4();
+    private readonly m_mapTileCuller: MapTileCuller;
+    private m_rootTileKeys: TileKeyEntry[] = [];
+    private readonly m_tileKeyEntries: Map<number, TileKeyEntry> = new Map();
+
+    constructor(
+        private readonly m_camera: THREE.PerspectiveCamera,
+        private readonly m_projection: Projection,
+        private readonly m_extendedFrustumCulling: boolean
+    ) {
+        this.m_mapTileCuller = new MapTileCuller(m_camera);
+    }
+
+    /**
+     * Updates the frustum to match the current camera setup.
+     */
+    updateFrustum() {
+        this.m_viewProjectionMatrix.multiplyMatrices(
+            this.m_camera.projectionMatrix,
+            this.m_camera.matrixWorldInverse
+        );
+
+        this.m_frustum.setFromMatrix(this.m_viewProjectionMatrix);
+
+        if (this.m_extendedFrustumCulling) {
+            this.m_mapTileCuller.setup();
+        }
+        this.computeRequiredInitialRootTileKeys(this.m_camera.position);
+    }
+
+    /**
+     * Computes the tiles intersected by the updated frustum, see [[updateFrustum]].
+     *
+     * @param tilingScheme The tiling scheme used to generate the tiles.
+     * @param maxTileLevel The maximum tile level that will be checked for intersections.
+     * @param elevationRangeSource Source of elevation range data if any.
+     * @returns The computation result, see [[FrustumIntersection.Result]].
+     */
+    compute(
+        tilingScheme: TilingScheme,
+        maxTileLevel: number,
+        elevationRangeSource: ElevationRangeSource | undefined
+    ): FrustumIntersection.Result {
+        this.m_tileKeyEntries.clear();
+        let calculationFinal = true;
+
+        for (const item of this.m_rootTileKeys) {
+            this.m_tileKeyEntries.set(
+                TileOffsetUtils.getKeyForTileKeyAndOffset(item.tileKey, item.offset),
+                new TileKeyEntry(item.tileKey, Infinity, item.offset)
+            );
+        }
+
+        const useElevationRangeSource: boolean =
+            elevationRangeSource !== undefined &&
+            elevationRangeSource.getTilingScheme() === tilingScheme;
+
+        const tileBounds = new THREE.Box3();
+        const workList = [...this.m_rootTileKeys];
+
+        while (workList.length > 0) {
+            const tileEntry = workList.pop();
+
+            if (tileEntry === undefined) {
+                continue;
+            }
+
+            const tileKey = tileEntry.tileKey;
+            const uniqueKey = TileOffsetUtils.getKeyForTileKeyAndOffset(tileKey, tileEntry.offset);
+            const cachedTileEntry = this.m_tileKeyEntries.get(uniqueKey);
+
+            assert(cachedTileEntry !== undefined);
+            assert(cachedTileEntry!.area > 0);
+
+            if (tileKey.level > maxTileLevel) {
+                continue;
+            }
+
+            tilingScheme.getSubTileKeys(tileKey).forEach(childTileKey => {
+                const offset = tileEntry.offset;
+                const tileKeyAndOffset = TileOffsetUtils.getKeyForTileKeyAndOffset(
+                    childTileKey,
+                    offset
+                );
+
+                assert(this.m_tileKeyEntries.get(tileKeyAndOffset) === undefined);
+
+                const geoBox = getGeoBox(tilingScheme, childTileKey, offset);
+
+                if (useElevationRangeSource) {
+                    const range = elevationRangeSource!.getElevationRange(childTileKey);
+                    geoBox.southWest.altitude = range.minElevation;
+                    geoBox.northEast.altitude = range.maxElevation;
+
+                    calculationFinal =
+                        calculationFinal &&
+                        range.calculationStatus === CalculationStatus.FinalPrecise;
+                }
+
+                let subTileArea = 0;
+
+                if (this.m_projection.type === ProjectionType.Spherical) {
+                    const obb = new OrientedBox3();
+                    this.m_projection.projectBox(geoBox, obb);
+                    if (obb.intersects(this.m_frustum)) {
+                        subTileArea = 1;
+                    }
+                } else {
+                    this.m_projection.projectBox(geoBox, tileBounds);
+                    subTileArea = this.computeSubTileArea(tileBounds);
+                }
+
+                if (subTileArea > 0) {
+                    const subTileEntry = new TileKeyEntry(childTileKey, subTileArea, offset);
+                    this.m_tileKeyEntries.set(tileKeyAndOffset, subTileEntry);
+                    workList.push(subTileEntry);
+                }
+            });
+        }
+        return { tileKeyEntries: this.m_tileKeyEntries, calculationFinal };
+    }
+
+    // Computes the rough screen area of the supplied box.
+    // TileBounds must be in world space.
+    private computeSubTileArea(tileBounds: THREE.Box3) {
+        if (
+            (!this.m_extendedFrustumCulling ||
+                this.m_mapTileCuller.frustumIntersectsTileBox(tileBounds)) &&
+            this.m_frustum.intersectsBox(tileBounds)
+        ) {
+            const contour = [
+                new THREE.Vector3(tileBounds.min.x, tileBounds.min.y, 0).applyMatrix4(
+                    this.m_viewProjectionMatrix
+                ),
+                new THREE.Vector3(tileBounds.max.x, tileBounds.min.y, 0).applyMatrix4(
+                    this.m_viewProjectionMatrix
+                ),
+                new THREE.Vector3(tileBounds.max.x, tileBounds.max.y, 0).applyMatrix4(
+                    this.m_viewProjectionMatrix
+                ),
+                new THREE.Vector3(tileBounds.min.x, tileBounds.max.y, 0).applyMatrix4(
+                    this.m_viewProjectionMatrix
+                )
+            ];
+
+            contour.push(contour[0]);
+
+            const n = contour.length;
+
+            let subTileArea = 0;
+            for (let p = n - 1, q = 0; q < n; p = q++) {
+                subTileArea += contour[p].x * contour[q].y - contour[q].x * contour[p].y;
+            }
+
+            return Math.abs(subTileArea * 0.5);
+        }
+        return 0;
+    }
+
+    /**
+     * Create a list of root nodes to test against the frustum. The root nodes each start at level 0
+     * and have an offset (see [[Tile]]) based on:
+     * - the current position [[worldCenter]].
+     * - the height of the camera above the world.
+     * - the field of view of the camera (the maximum value between the horizontal / vertical
+     *   values)
+     * - the tilt of the camera (because we see more tiles when tilted).
+     *
+     * @param worldCenter The center of the camera in world space.
+     */
+    private computeRequiredInitialRootTileKeys(worldCenter: THREE.Vector3) {
+        this.m_rootTileKeys = [];
+        const rootTileKey = TileKey.fromRowColumnLevel(0, 0, 0);
+        const tileWrappingEnabled = this.m_projection.type === ProjectionType.Planar;
+        if (!tileWrappingEnabled) {
+            this.m_rootTileKeys.push(new TileKeyEntry(rootTileKey, 0));
+            return;
+        }
+
+        const worldGeoPoint = this.m_projection.unprojectPoint(worldCenter);
+        const startOffset = Math.round(worldGeoPoint.longitude / 360.0);
+
+        // This algorithm computes the number of offsets we need to test. The following diagram may
+        // help explain the algorithm below.
+        //
+        //   |🎥
+        //   |.\ .
+        //   | . \  .
+        // z |  .  \   .c2
+        //   |  c1.  \b    .
+        //   |     .   \      .
+        //___|a___d1.____\e______.d2______f
+        //
+        // Where:
+        // - 🎥 is the camera
+        // - z is the height of the camera above the ground.
+        // - a is a right angle.
+        // - b is the look at vector of the camera.
+        // - c1 and c2 are the frustum planes of the camera.
+        // - c1 to c2 is the fov.
+        // - d1 and d2 are the intersection points of the frustum with the world plane.
+        // - e is the tilt/pitch of the camera.
+        // - f is the world
+        //
+        // The goal is to find the distance from e->d2. This is a longitude value, and we convert it
+        // to some offset range. Note e->d2 >= e->d1 (because we can't have a negative tilt).
+        // To find e->d2, we use the right triangle 🎥, a, d2 and subtract the distance a->d2 with
+        // a->e.
+        // a->d2 is found using the angle between a and d2 from the 🎥, this is simply e (because of
+        // similar triangles, angle between a, 🎥 and e equals the tilt) + half of the fov (because
+        // we need the angle between e, 🎥 and d2) and using trigonometry, result is therefore:
+        // (tan(a->d2) * z).
+        // a->e needs just the tilt and trigonometry to compute, result is: (tan(a->e) * z).
+
+        const camera = this.m_camera;
+        const cameraPitch = MapViewUtils.extractYawPitchRoll(camera.quaternion).pitch;
+        // Ensure that the aspect is >= 1.
+        const aspect = camera.aspect > 1 ? camera.aspect : 1 / camera.aspect;
+        // Angle between a->d2, note, the fov is vertical, hence we translate to horizontal.
+        const totalAngleRad = MathUtils.degToRad((camera.fov * aspect) / 2) + cameraPitch;
+        // Length a->d2
+        const worldLengthHorizontalFull = Math.tan(totalAngleRad) * camera.position.z;
+        // Length a->e
+        const worldLengthHorizontalSmallerHalf = Math.tan(cameraPitch) * camera.position.z;
+        // Length e -> d2
+        const worldLengthHorizontal = worldLengthHorizontalFull - worldLengthHorizontalSmallerHalf;
+        const worldLeftPoint = new THREE.Vector3(
+            worldCenter.x - worldLengthHorizontal,
+            worldCenter.y,
+            worldCenter.z
+        );
+        const worldLeftGeoPoint = this.m_projection.unprojectPoint(worldLeftPoint);
+        // We multiply by SQRT2 because we need to account for a rotated view (in which case there
+        // are more tiles that can be seen).
+        const offsetRange = MathUtils.clamp(
+            Math.ceil(
+                Math.abs((worldGeoPoint.longitude - worldLeftGeoPoint.longitude) / 360) * Math.SQRT2
+            ),
+            0,
+            // We can store currently up to 16 unique keys(2^4, where 4 is the default bit-shift
+            // value which is used currently in the [[VisibleTileSet]] methods) hence we can have a
+            // maximum range of 7 (because 2*7+1 = 15).
+            7
+        );
+        for (
+            let offset = -offsetRange + startOffset;
+            offset <= offsetRange + startOffset;
+            offset++
+        ) {
+            this.m_rootTileKeys.push(new TileKeyEntry(rootTileKey, 0, offset));
+        }
+    }
+}

--- a/@here/harp-mapview/lib/geometry/PhasedTileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/PhasedTileGeometryLoader.ts
@@ -308,10 +308,6 @@ export class PhasedTileGeometryLoader implements TileGeometryLoader {
         const decodedTile = this.m_decodedTile;
 
         if (decodedTile !== undefined) {
-            if (!tile.hasGeometry && tile.dataSource.addTileBackground) {
-                geometryCreator.addGroundPlane(tile);
-            }
-
             const filter = (technique: Technique): boolean => {
                 if (technique.enabled === false) {
                     return false;

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -530,10 +530,6 @@ export class TileGeometryCreator {
         const displayZoomLevel = Math.floor(mapView.zoomLevel);
         const objects = tile.objects;
 
-        if (!tile.hasGeometry && dataSource.addTileBackground) {
-            this.addGroundPlane(tile);
-        }
-
         for (const srcGeometry of decodedTile.geometries) {
             const groups = srcGeometry.groups;
             const groupCount = groups.length;
@@ -1365,10 +1361,7 @@ export class TileGeometryCreator {
         const dataSource = tile.dataSource;
         const projection = tile.projection;
 
-        const color =
-            dataSource.tileBackgroundColor === undefined
-                ? mapView.clearColor
-                : dataSource.tileBackgroundColor;
+        const color = mapView.clearColor;
 
         if (tile.projection.type === ProjectionType.Spherical) {
             const { east, west, north, south } = tile.geoBox;
@@ -1392,7 +1385,7 @@ export class TileGeometryCreator {
             });
             const material = new MapMeshBasicMaterial({
                 color,
-                visible: dataSource.tileBackgroundIsVisible
+                visible: true
             });
             const bufferGeometry = new THREE.BufferGeometry();
             bufferGeometry.fromGeometry(g);
@@ -1409,7 +1402,7 @@ export class TileGeometryCreator {
                 planeSize.y,
                 tile.center,
                 color,
-                dataSource.tileBackgroundIsVisible
+                true
             );
 
             this.registerTileObject(tile, groundPlane, GeometryKind.Background);

--- a/@here/harp-mapview/test/BackgroundDataSourceTest.ts
+++ b/@here/harp-mapview/test/BackgroundDataSourceTest.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import {
+    hereTilingScheme,
+    mercatorTilingScheme,
+    webMercatorTilingScheme
+} from "@here/harp-geoutils";
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { BackgroundDataSource } from "../lib/BackgroundDataSource";
+import { MapView } from "../lib/MapView";
+import { FakeOmvDataSource } from "./FakeOmvDataSource";
+
+describe("BackgroundDataSource", function() {
+    describe("#getTilingScheme()", function() {
+        let fakeDataSource1: FakeOmvDataSource;
+        let fakeDataSource2: FakeOmvDataSource;
+        let backgroundDataSource: BackgroundDataSource;
+        let mapViewStub: sinon.SinonStubbedInstance<MapView>;
+        const defaultTilingScheme = webMercatorTilingScheme;
+        beforeEach(function() {
+            fakeDataSource1 = new FakeOmvDataSource();
+            fakeDataSource2 = new FakeOmvDataSource();
+            sinon.replace(fakeDataSource1, "getTilingScheme", sinon.fake.returns(hereTilingScheme));
+            sinon.replace(
+                fakeDataSource2,
+                "getTilingScheme",
+                sinon.fake.returns(mercatorTilingScheme)
+            );
+            fakeDataSource2.storageLevelOffset = -3;
+            backgroundDataSource = new BackgroundDataSource();
+            mapViewStub = sinon.createStubInstance(MapView);
+            sinon.stub(mapViewStub, "dataSources").get(function getterFn() {
+                return [fakeDataSource1, fakeDataSource2, backgroundDataSource];
+            });
+            mapViewStub.removeDataSource.restore();
+            backgroundDataSource.attach((mapViewStub as unknown) as MapView);
+        });
+
+        it("Returns default tiling scheme after construction", function() {
+            expect(backgroundDataSource.getTilingScheme()).to.be.equal(defaultTilingScheme);
+        });
+
+        it("Returns default tiling scheme if no data source is enabled on update", function() {
+            mapViewStub.isDataSourceEnabled.returns(false);
+            backgroundDataSource.updateTilingScheme();
+            expect(mapViewStub.clearTileCache.called);
+            expect(backgroundDataSource.getTilingScheme()).to.be.equal(defaultTilingScheme);
+        });
+
+        // tslint:disable-next-line: max-line-length
+        it("Returns tiling scheme of first enabled data source on update", function() {
+            mapViewStub.isDataSourceEnabled.returns(true);
+            mapViewStub.isDataSourceEnabled.withArgs(fakeDataSource1).returns(false);
+            backgroundDataSource.updateTilingScheme();
+            expect(mapViewStub.clearTileCache.called);
+            expect(backgroundDataSource.getTilingScheme()).to.be.equal(
+                fakeDataSource2.getTilingScheme()
+            );
+            expect(backgroundDataSource.storageLevelOffset).to.be.equal(
+                fakeDataSource2.storageLevelOffset
+            );
+        });
+    });
+});

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -284,8 +284,6 @@ describe("MapView", function() {
     });
 
     it("updates background tiling scheme", async function() {
-        this.timeout(500);
-
         if (inNodeContext) {
             global.requestAnimationFrame = (callback: FrameRequestCallback) => {
                 setTimeout(() => {
@@ -298,6 +296,7 @@ describe("MapView", function() {
             global.cancelAnimationFrame = () => {};
         }
         mapView = new MapView({ canvas });
+        mapView.theme = {};
 
         const dataSource = new FakeOmvDataSource();
 

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -207,8 +207,6 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
             skipShortLabels: this.m_params.skipShortLabels,
             storageLevelOffset: getOptionValue(m_params.storageLevelOffset, -1)
         };
-
-        this.tileBackgroundIsVisible = true;
     }
 
     /**


### PR DESCRIPTION
There are 3 commits in this PR:

1. Move creation of background area geometry to a separate data source: BackgroundDataSource.
2. Fix a bug found in TileTreeTraverse.subTiles() where it returns invalid tiles for halfquad tile subdivision scheme.
3. Add tile intersection caching so that intersection tiles are reused for data sources with same tiling scheme. Otherwise, with the addition of BackgroundDataSource we would be calculating the same tile intersections at least twice.