### PR TITLE
Use new www.harp.gl domain

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -3,7 +3,7 @@
     </head>
     <body>
       <script>
-         window.location.href = "http://harp.gl.s3-website-us-east-1.amazonaws.com/docs/master/doc/";
+         window.location.href = "https://www.harp.gl/docs/master/doc/";
       </script>
     </body>
 </html>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -3,7 +3,7 @@
     </head>
     <body>
       <script>
-         window.location.href = "http://harp.gl.s3-website-us-east-1.amazonaws.com/docs/master/examples/";
+         window.location.href = "https://www.harp.gl/docs/master/examples/";
       </script>
     </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,13 +14,13 @@
       <meta name="twitter:site" content="@here" />
       <meta name="twitter:title" content="harp.gl" />
       <meta name="twitter:description" content="3d web map rendering engine" />
-      <meta name="twitter:image" content="http://harp.gl/resources/background.png" />
+      <meta name="twitter:image" content="https://www.harp.gl/resources/background.png" />
 
-      <meta property="og:url" content="http://harp.gl" />
+      <meta property="og:url" content="https://www.harp.gl" />
       <meta property="og:type" content="website" />
       <meta property="og:title" content="harp.gl" />
       <meta property="og:description" content="3d web map rendering engine" />
-      <meta property="og:image" content="http://harp.gl/resources/background.png" />
+      <meta property="og:image" content="https://www.harp.gl/resources/background.png" />
    </head>
    <body>
       <header>
@@ -29,9 +29,9 @@
             <nav>
                <div class="logo"></div>
                <div>
-                  <a id="docs-nav-mobile" href="http://harp.gl/docs" class="nav-item">Docs</a>
-                  <a id="docs-nav" href="http://harp.gl/docs" class="nav-item">Documentation</a>
-                  <a href="http://harp.gl/examples" class="nav-item">Examples</a>
+                  <a id="docs-nav-mobile" href="https://www.harp.gl/docs" class="nav-item">Docs</a>
+                  <a id="docs-nav" href="https://www.harp.gl/docs" class="nav-item">Documentation</a>
+                  <a href="http://www.harp.gl/examples" class="nav-item">Examples</a>
                   <a href="https://github.com/heremaps/harp.gl" class="nav-item">GitHub</a>
                </div>
             </nav>
@@ -104,10 +104,10 @@
                <div>
                   <p>Select the target release:</p>
                   <select name="versions"></select>
-                  <p>Please note that master includes bleeding edge changes. For a more stable build, try the most recent build.</p>
+                  <p>Please note that latest includes bleeding edge changes. For a more stable build, try the most recent release.</p>
                </div>
             </div>
-         </div>  
+         </div>
       </div>
       <footer>
          <div class="container footer">
@@ -115,6 +115,9 @@
                <h1 class="footer-title">harp.gl</h2>
             </div>
             <div>
+                  <span>
+                     &copy; 2018-<span id="year"></span> <a target="_blank" href="https://here.com">HERE</a>
+                  </span>
             </div>
          </div>
       </footer>

--- a/docs/js/index.js
+++ b/docs/js/index.js
@@ -1,19 +1,19 @@
-const s3Base = 'http://harp.gl.s3-website-us-east-1.amazonaws.com/docs/';
+const s3Base = 'https://www.harp.gl/docs/';
 
 //Update initial links to s3 base
 document.querySelector('.examples-link').href = s3Base + 'master/examples/';
 document.querySelector('.docs-link').href = s3Base + 'master/doc/';
 
 const releases = [{
-   date: 'master',
+   date: 'latest',
    hash: 'master'
 }]
 const dropdown = document.querySelector('select[name=versions]');
 
-fetch('https://heremaps.github.io/harp.gl/releases.json')
+fetch('https://www.harp.gl/releases.json')
 .then(res => res.json())
 .then(res => {
-   
+
    releases.push(...res);
    releases.forEach(release => {
       const option = document.createElement('option');
@@ -27,15 +27,15 @@ fetch('https://heremaps.github.io/harp.gl/releases.json')
       const date = releases.filter(x => x.date === selected.innerText)[0].date;
 
       //Update examples button and link
-      document.querySelector('.examples-link').href = s3Base + hash + '/examples';
+      document.querySelector('.examples-link').href = s3Base + hash + '/examples/';
       document.querySelector('.examples-link').innerText = 'Examples' + (date !== 'master' ? ` (${date})` : '');
 
       //Update docs button and link
-      document.querySelector('.docs-link').href = s3Base + hash + '/doc';
+      document.querySelector('.docs-link').href = s3Base + hash + '/doc/';
       document.querySelector('.docs-link').innerText = 'Documentation' + (date !== 'master' ? ` (${date})` : '');
    }
 }).catch(() => {
-   
+
    //In case network request to build information fails, add master link
    const option = document.createElement('option');
    option.innerText = 'master';
@@ -52,7 +52,7 @@ const canvas = document.getElementById('map');
 const map = new harp.MapView({
    canvas,
    theme: "resources/theme.json",
-   maxVisibleDataSourceTiles: 40, 
+   maxVisibleDataSourceTiles: 40,
    tileCacheSize: 100
 });
 
@@ -67,7 +67,7 @@ const omvDataSource = new harp.OmvDataSource({
 });
 map.addDataSource(omvDataSource);
 
-const options = { tilt: 45, distance: 3000 };
+const options = { tilt: 45, distance: 1500 };
 const NY = new harp.GeoCoordinates(42.361145, -71.057083);
 let azimuth = 300;
 map.addEventListener(harp.MapViewEventNames.Render, () => map.lookAt(NY, options.distance, options.tilt, (azimuth += 0.1)));


### PR DESCRIPTION
* Use `www.harp.gl` domain for all documentation and examples so that we can have `https` and remove temporary s3 and gh-pages urls.
* Rename `master` as `latest` to make it more accessible for users on the main website.
* Reduce the visible distance to 1500m
* Add (c) to footer

Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>
