### PR TITLE
HARP-5197: Fix inertia durations of 0.

### DIFF
--- a/@here/harp-map-controls/lib/MapControls.ts
+++ b/@here/harp-map-controls/lib/MapControls.ts
@@ -689,7 +689,7 @@ export class MapControls extends THREE.EventDispatcher {
             );
             this.m_zoomDeltaRequested = 0;
         }
-        if (this.inertiaEnabled) {
+        if (this.inertiaEnabled && this.zoomInertiaDampingDuration > 0) {
             if (!this.m_zoomIsAnimated) {
                 this.m_zoomIsAnimated = true;
                 this.mapView.addEventListener(MapViewEventNames.AfterRender, this.handleZoom);
@@ -744,6 +744,7 @@ export class MapControls extends THREE.EventDispatcher {
 
         const applyInertia =
             this.inertiaEnabled &&
+            this.panInertiaDampingDuration > 0 &&
             this.m_state === State.NONE &&
             this.m_lastAveragedPanDistance > 0;
 


### PR DESCRIPTION
Setting `panInertiaDampingDuration` or `zoomInertiaDampingDuration` to `0` was breaking the controls.