### PR TITLE
Change repository url from SSH to HTTPS

### DIFF
--- a/@here/generator-harp.gl/package.json
+++ b/@here/generator-harp.gl/package.json
@@ -10,7 +10,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/generator-harp.gl"
     },
     "author": {

--- a/@here/harp-atlas-tools/package.json
+++ b/@here/harp-atlas-tools/package.json
@@ -16,7 +16,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-atlas-tools"
     },
     "author": {

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-datasource-protocol"
     },
     "author": {

--- a/@here/harp-debug-datasource/package.json
+++ b/@here/harp-debug-datasource/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-debug-datasource"
     },
     "author": {

--- a/@here/harp-examples/package.json
+++ b/@here/harp-examples/package.json
@@ -62,7 +62,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-examples"
     },
     "publishConfig": {

--- a/@here/harp-features-datasource/package.json
+++ b/@here/harp-features-datasource/package.json
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git"
+        "url": "https://github.com/heremaps/harp.gl.git"
     },
     "author": {
         "name": "HERE Europe B.V.",

--- a/@here/harp-fetch/package.json
+++ b/@here/harp-fetch/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-fetch"
     },
     "author": {

--- a/@here/harp-geojson-datasource/package.json
+++ b/@here/harp-geojson-datasource/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-geojson-datasource"
     },
     "author": {

--- a/@here/harp-geometry/package.json
+++ b/@here/harp-geometry/package.json
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-geometry"
     },
     "author": {

--- a/@here/harp-geoutils/package.json
+++ b/@here/harp-geoutils/package.json
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-geoutils"
     },
     "author": {

--- a/@here/harp-lines/package.json
+++ b/@here/harp-lines/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-lines"
     },
     "author": {

--- a/@here/harp-lrucache/package.json
+++ b/@here/harp-lrucache/package.json
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-lrucache"
     },
     "author": {

--- a/@here/harp-map-controls/package.json
+++ b/@here/harp-map-controls/package.json
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-map-controls"
     },
     "author": {

--- a/@here/harp-map-theme/package.json
+++ b/@here/harp-map-theme/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-map-theme"
     },
     "author": {

--- a/@here/harp-mapview-decoder/package.json
+++ b/@here/harp-mapview-decoder/package.json
@@ -18,7 +18,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git"
+        "url": "https://github.com/heremaps/harp.gl.git"
     },
     "author": {
         "name": "HERE Europe B.V.",

--- a/@here/harp-mapview/package.json
+++ b/@here/harp-mapview/package.json
@@ -23,7 +23,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-mapview"
     },
     "author": {

--- a/@here/harp-materials/package.json
+++ b/@here/harp-materials/package.json
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-materials"
     },
     "author": {

--- a/@here/harp-omv-datasource/package.json
+++ b/@here/harp-omv-datasource/package.json
@@ -19,7 +19,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-omv-datasource"
     },
     "author": {

--- a/@here/harp-test-utils/package.json
+++ b/@here/harp-test-utils/package.json
@@ -12,7 +12,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-test-utils"
     },
     "author": {

--- a/@here/harp-text-canvas/package.json
+++ b/@here/harp-text-canvas/package.json
@@ -11,7 +11,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-text-canvas"
     },
     "author": {

--- a/@here/harp-transfer-manager/package.json
+++ b/@here/harp-transfer-manager/package.json
@@ -15,7 +15,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-transfer-manager"
     },
     "author": {

--- a/@here/harp-utils/package.json
+++ b/@here/harp-utils/package.json
@@ -10,7 +10,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-utils"
     },
     "author": {

--- a/@here/harp-webtile-datasource/package.json
+++ b/@here/harp-webtile-datasource/package.json
@@ -14,7 +14,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git",
+        "url": "https://github.com/heremaps/harp.gl.git",
         "directory": "@here/harp-webtile-datasource"
     },
     "author": {

--- a/@here/harp.gl/package.json
+++ b/@here/harp.gl/package.json
@@ -20,7 +20,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git"
+        "url": "https://github.com/heremaps/harp.gl.git"
     },
     "author": {
         "name": "HERE Europe B.V.",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com:heremaps/harp.gl.git"
+        "url": "https://github.com/heremaps/harp.gl.git"
     },
     "private": true,
     "author": {


### PR DESCRIPTION
Using HTTPS allows users to clone the repository using tools like OSS Review Toolkit without authentication.


