### PR TITLE
HARP-6638: Continuous redraws in MapView

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -156,6 +156,7 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
             storageLevelOffset: this.m_options.storageLevelOffset
         });
 
+        this.useGeometryLoader = true;
         this.cacheable = true;
         this.m_tileLoaderCache = new LRUCache<number, TileLoader>(this.getCacheCount());
     }

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -33,6 +33,11 @@ export abstract class DataSource extends THREE.EventDispatcher {
     cacheable: boolean = false;
 
     /**
+     * Set to `true` if the loader should be used to get the tile contents.
+     */
+    useGeometryLoader: boolean = false;
+
+    /**
      * The unique name of a `DataSource` instance.
      */
     name: string;

--- a/@here/harp-mapview/lib/geometry/PhasedTileGeometryManager.ts
+++ b/@here/harp-mapview/lib/geometry/PhasedTileGeometryManager.ts
@@ -42,11 +42,13 @@ export class PhasedTileGeometryManager extends TileGeometryManagerBase {
     }
 
     initTile(tile: Tile): void {
-        tile.tileGeometryLoader = new PhasedTileGeometryLoader(
-            tile,
-            this.m_loadPhaseDefinitions,
-            this.m_basicGeometryKinds
-        );
+        if (tile.dataSource.useGeometryLoader) {
+            tile.tileGeometryLoader = new PhasedTileGeometryLoader(
+                tile,
+                this.m_loadPhaseDefinitions,
+                this.m_basicGeometryKinds
+            );
+        }
     }
 
     updateTiles(tiles: Tile[]): void {


### PR DESCRIPTION
Phased loader can't load generated tiles, and reports they are not finished, producing continuous redraws.