### PR TITLE
HARP-6669: BackgroundDataSource can pick wrong tiling scheme

### DIFF
--- a/@here/harp-mapview/lib/BackgroundDataSource.ts
+++ b/@here/harp-mapview/lib/BackgroundDataSource.ts
@@ -14,34 +14,50 @@ import { Tile } from "./Tile";
  */
 export class BackgroundDataSource extends DataSource {
     private static readonly DEFAULT_TILING_SCHEME = webMercatorTilingScheme;
-    private m_referenceDataSource: DataSource | undefined;
-    private m_tilingScheme: TilingScheme;
+    private m_tilingScheme: TilingScheme = BackgroundDataSource.DEFAULT_TILING_SCHEME;
 
     constructor() {
-        super("background", undefined, 1, 20);
+        super("background");
         this.cacheable = true;
-        this.m_referenceDataSource = undefined;
-        this.m_tilingScheme = BackgroundDataSource.DEFAULT_TILING_SCHEME;
     }
 
-    updateTilingScheme() {
-        if (
-            this.m_referenceDataSource &&
-            this.mapView.isDataSourceEnabled(this.m_referenceDataSource)
-        ) {
-            return;
+    updateStorageLevelOffset() {
+        let storageLevelOffset: number | undefined;
+
+        this.mapView.dataSources.forEach(ds => {
+            if (ds === this) {
+                return;
+            }
+            const tilingScheme = ds.getTilingScheme();
+            if (tilingScheme === this.m_tilingScheme) {
+                storageLevelOffset =
+                    storageLevelOffset === undefined
+                        ? ds.storageLevelOffset
+                        : Math.max(storageLevelOffset, ds.storageLevelOffset);
+            }
+        });
+
+        if (storageLevelOffset === undefined) {
+            storageLevelOffset = 0;
         }
 
-        const newReferenceDataSource = this.mapView.dataSources.find(
-            ds => ds !== this && this.mapView.isDataSourceEnabled(ds)
-        );
-
-        const tilingSchemeChanged = this.setReferenceDataSource(newReferenceDataSource);
-
-        if (tilingSchemeChanged) {
+        if (storageLevelOffset !== this.storageLevelOffset) {
+            this.storageLevelOffset = storageLevelOffset;
             this.mapView.clearTileCache(this.name);
         }
     }
+
+    setTilingScheme(tilingScheme?: TilingScheme) {
+        const newScheme = tilingScheme || BackgroundDataSource.DEFAULT_TILING_SCHEME;
+        if (newScheme === this.m_tilingScheme) {
+            return;
+        }
+
+        this.m_tilingScheme = newScheme;
+        this.updateStorageLevelOffset();
+        this.mapView.clearTileCache(this.name);
+    }
+
     getTilingScheme(): TilingScheme {
         return this.m_tilingScheme;
     }
@@ -53,21 +69,5 @@ export class BackgroundDataSource extends DataSource {
         TileGeometryCreator.instance.addGroundPlane(tile);
 
         return tile;
-    }
-
-    // Returns true if the tiling scheme changed, false otherwise.
-    private setReferenceDataSource(referenceDataSource: DataSource | undefined): boolean {
-        this.m_referenceDataSource = referenceDataSource;
-        let newTilingScheme = BackgroundDataSource.DEFAULT_TILING_SCHEME;
-
-        if (this.m_referenceDataSource !== undefined) {
-            newTilingScheme = this.m_referenceDataSource.getTilingScheme();
-            this.storageLevelOffset = this.m_referenceDataSource.storageLevelOffset;
-        }
-        const tilingSchemeChanged = this.m_tilingScheme !== newTilingScheme;
-
-        this.m_tilingScheme = newTilingScheme;
-
-        return tilingSchemeChanged;
     }
 }

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -17,7 +17,8 @@ import {
     MathUtils,
     mercatorProjection,
     Projection,
-    ProjectionType
+    ProjectionType,
+    TilingScheme
 } from "@here/harp-geoutils";
 import { assert, getOptionValue, LoggerManager, PerformanceTimer } from "@here/harp-utils";
 import * as THREE from "three";
@@ -507,6 +508,11 @@ export interface MapViewOptions {
     enablePhasedLoading?: boolean;
 
     /**
+     * Set tiling scheme for [[BackgroundDataSource]]
+     */
+    backgroundTilingScheme?: TilingScheme;
+
+    /**
      * @hidden
      * Disable all fading animations for debugging and performance measurement.
      */
@@ -626,7 +632,7 @@ export class MapView extends THREE.EventDispatcher {
     private readonly m_tileDataSources: DataSource[] = [];
     private readonly m_connectedDataSources = new Set<string>();
     private readonly m_failedDataSources = new Set<string>();
-    private m_backgroundDataSource: BackgroundDataSource | undefined = undefined;
+    private m_backgroundDataSource?: BackgroundDataSource;
 
     // gestures
     private readonly m_raycaster = new THREE.Raycaster();
@@ -842,6 +848,10 @@ export class MapView extends THREE.EventDispatcher {
 
         this.m_backgroundDataSource = new BackgroundDataSource();
         this.addDataSource(this.m_backgroundDataSource);
+
+        if (options.backgroundTilingScheme !== undefined) {
+            this.m_backgroundDataSource.setTilingScheme(options.backgroundTilingScheme);
+        }
 
         this.initTheme();
 
@@ -1504,6 +1514,10 @@ export class MapView extends THREE.EventDispatcher {
         dataSource.attach(this);
         this.m_tileDataSources.push(dataSource);
 
+        if (this.m_backgroundDataSource) {
+            this.m_backgroundDataSource.updateStorageLevelOffset();
+        }
+
         return dataSource
             .connect()
             .then(() => {
@@ -1570,6 +1584,10 @@ export class MapView extends THREE.EventDispatcher {
         this.m_tileDataSources.splice(dsIndex, 1);
         this.m_connectedDataSources.delete(dataSource.name);
         this.m_failedDataSources.delete(dataSource.name);
+
+        if (this.m_backgroundDataSource) {
+            this.m_backgroundDataSource.updateStorageLevelOffset();
+        }
 
         this.update();
     }
@@ -2340,10 +2358,6 @@ export class MapView extends THREE.EventDispatcher {
 
         if (gatherStatistics) {
             setupTime = PerformanceTimer.now();
-        }
-
-        if (this.m_backgroundDataSource) {
-            this.m_backgroundDataSource.updateTilingScheme();
         }
 
         // TBD: Update renderList only any of its params (camera, etc...) has changed.

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -283,7 +283,7 @@ describe("MapView", function() {
         }
     });
 
-    it("updates background tiling scheme", async function() {
+    it("updates background storage level offset", async function() {
         if (inNodeContext) {
             global.requestAnimationFrame = (callback: FrameRequestCallback) => {
                 setTimeout(() => {
@@ -306,11 +306,11 @@ describe("MapView", function() {
             "background"
         ) as BackgroundDataSource;
         assert.isDefined(backgroundDataSource);
-        const updateTilingSchemeSpy = sinon.spy(backgroundDataSource, "updateTilingScheme");
+        const updateStorageOffsetSpy = sinon.spy(backgroundDataSource, "updateStorageLevelOffset");
 
         mapView.update();
         await waitForEvent(mapView, MapViewEventNames.AfterRender);
 
-        expect(updateTilingSchemeSpy.called);
+        expect(updateStorageOffsetSpy.called);
     });
 });


### PR DESCRIPTION
So the tiling scheme is pre-defined or passed via mapview options. But background tiles still needs to be same size or smaller than the regular tiles to look good.