### PR TITLE
HARP-6556: Support for Expression language in technique & feature attributes.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -23,6 +23,12 @@ export interface ExprVisitor<Result, Context> {
     visitCaseExpr(expr: CaseExpr, context: Context): Result;
 }
 
+export type JsonExpr = unknown[];
+
+export function isJsonExpr(v: any): v is JsonExpr {
+    return Array.isArray(v) && v.length > 0 && typeof v[0] === "string";
+}
+
 /**
  * Abstract class defining a shape of a [[Theme]]'s expression
  */

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -22,6 +22,7 @@ import {
 } from "./Expr";
 
 import { CastOperators } from "./operators/CastOperators";
+import { ColorOperators } from "./operators/ColorOperators";
 import { ComparisonOperators } from "./operators/ComparisonOperators";
 import { FlowOperators } from "./operators/FlowOperators";
 import { MathOperators } from "./operators/MathOperators";
@@ -189,6 +190,7 @@ ExprEvaluator.defineOperators(CastOperators);
 ExprEvaluator.defineOperators(ComparisonOperators);
 ExprEvaluator.defineOperators(MathOperators);
 ExprEvaluator.defineOperators(StringOperators);
+ExprEvaluator.defineOperators(ColorOperators);
 ExprEvaluator.defineOperators(TypeOperators);
 ExprEvaluator.defineOperators(MiscOperators);
 ExprEvaluator.defineOperators(FlowOperators);

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -8,11 +8,11 @@ import { Color, CubicInterpolant, DiscreteInterpolant, LinearInterpolant } from 
 
 import { LoggerManager } from "@here/harp-utils";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
+import { Expr, Value } from "./Expr";
 import {
     InterpolatedProperty,
     InterpolatedPropertyDefinition,
-    InterpolationMode,
-    MaybeInterpolatedProperty
+    InterpolationMode
 } from "./InterpolatedPropertyDefs";
 import {
     StringEncodedHex,
@@ -86,7 +86,7 @@ export function isInterpolatedProperty<T>(p: any): p is InterpolatedProperty<T> 
  *
  */
 export function getPropertyValue<T>(
-    property: InterpolatedProperty<T> | MaybeInterpolatedProperty<T>,
+    property: Value | Expr | InterpolatedProperty<T> | undefined,
     level: number,
     pixelToMeters: number = 1.0
 ): number {

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -34,8 +34,6 @@ export interface InterpolatedPropertyDefinition<T> {
     exponent?: number;
 }
 
-export type MaybeInterpolatedProperty<T> = T | InterpolatedPropertyDefinition<T>;
-
 /**
  * Property which value is interpolated across different zoom levels.
  */

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -11,10 +11,12 @@ import {
     CallExpr,
     CaseExpr,
     ContainsExpr,
+    Env,
     Expr,
     ExprVisitor,
     HasAttributeExpr,
-    MapEnv,
+    isJsonExpr,
+    JsonExpr,
     MatchExpr,
     NullLiteralExpr,
     NumberLiteralExpr,
@@ -27,10 +29,14 @@ import {
     createInterpolatedProperty,
     isInterpolatedPropertyDefinition
 } from "./InterpolatedProperty";
-import { IndexedTechnique, Technique } from "./Techniques";
-import { isReference, Style, StyleDeclaration, StyleSelector, StyleSet } from "./Theme";
+import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
+import { AttrScope, mergeTechniqueDescriptor, TechniquePropNames } from "./TechniqueDescriptor";
+import { IndexedTechnique, Technique, techniqueDescriptors } from "./Techniques";
+import { LineStyle, Style, StyleDeclaration, StyleSelector, StyleSet } from "./Theme";
 
 const logger = LoggerManager.instance.create("StyleSetEvaluator");
+
+const emptyTechniqueDescriptor = mergeTechniqueDescriptor<Technique>({});
 
 interface StyleInternalParams {
     /**
@@ -38,11 +44,40 @@ interface StyleInternalParams {
      */
     _whenExpr?: Expr;
 
+    _staticAttributes?: Array<[string, Value | InterpolatedProperty<unknown>]>;
+
+    /**
+     * These attributes are used to instantiate Technique variants.
+     *
+     * @see [[TechiqueDescriptor.techniquePropNames]]
+     */
+    _dynamicTechniqueAttributes?: Array<[string, Expr]>;
+
+    /**
+     * These attributes must be evaluated basing with feature env.
+     *
+     * They are not propagated to rendering scope.
+     *
+     * @see [[TechniqueAttrScope.Feature]]
+     */
+    _dynamicFeatureAttributes?: Array<[string, Expr | InterpolatedProperty<unknown>]>;
+
+    /**
+     * These attributes are forwarded as serialized by decoder to main thread, so they are resolved
+     * directly in render loop.
+     *
+     * Will contain attributes from these lists
+     *  - interpolants from [[TechiqueDescriptor.techniquePropNames]]
+     *  - expressions [[TechniqueDescriptor.dynamicPropNames]] (Future)
+     */
+    _dynamicForwaredAttributes?: Array<[string, Expr | InterpolatedProperty<unknown>]>;
+    _dynamicTechniques?: Map<string, IndexedTechnique>;
+
     /**
      * Optimization: Index into table in StyleSetEvaluator.
      * @hidden
      */
-    _index?: number;
+    _staticTechnique?: IndexedTechnique;
 
     /**
      * Optimization: StyleSet index.
@@ -57,7 +92,7 @@ interface StyleInternalParams {
     _layer?: string;
 }
 
-type InternalStyle = Style & StyleSelector & Partial<StyleInternalParams>;
+type InternalStyle = Style & StyleSelector & StyleInternalParams;
 
 /**
  * [[ExprClassifier]] searches for usages of `$layer` in `when` conditions
@@ -194,8 +229,8 @@ export class StyleSetEvaluator {
         let techniqueRenderOrder = 0;
         let styleSetIndex = 0;
 
-        const cloneStyle = (style: StyleDeclaration): InternalStyle | undefined => {
-            if (isReference(style)) {
+        const cloneStyle = (style: StyleDeclaration): StyleDeclaration | undefined => {
+            if (isJsonExpr(style)) {
                 return undefined;
             }
             return {
@@ -208,10 +243,7 @@ export class StyleSetEvaluator {
                         : undefined
             };
         };
-        this.styleSet = styleSet
-            .map(style => cloneStyle(style))
-            .filter(subStyle => subStyle !== undefined) as InternalStyle[];
-
+        styleSet = styleSet.map(style => cloneStyle(style) as StyleDeclaration);
         const computeDefaultRenderOrder = (style: InternalStyle): void => {
             if (style.renderOrderBiasGroup !== undefined) {
                 const renderOrderBiasGroupOrder = style.renderOrderBiasGroup
@@ -258,17 +290,18 @@ export class StyleSetEvaluator {
                     computeDefaultRenderOrder(currStyle as InternalStyle);
                 }
             } else {
-                style._styleSetIndex = styleSetIndex++;
+                (style as InternalStyle)._styleSetIndex = styleSetIndex++;
                 if (style.technique !== undefined && style.renderOrder === undefined) {
                     style.renderOrder = techniqueRenderOrder++;
                 }
             }
         };
 
-        for (const style of this.styleSet) {
-            computeDefaultRenderOrder(style);
+        for (const style of styleSet) {
+            computeDefaultRenderOrder(style as InternalStyle);
         }
 
+        this.styleSet = styleSet as InternalStyle[];
         this.compileStyleSet();
     }
 
@@ -280,7 +313,7 @@ export class StyleSetEvaluator {
      * @param env The objects environment, i.e. the attributes that are relevant for its
      * representation.
      */
-    getMatchingTechniques(env: MapEnv): IndexedTechnique[] {
+    getMatchingTechniques(env: Env): IndexedTechnique[] {
         const result: IndexedTechnique[] = [];
         const styleStack = new Array<InternalStyle>();
         this.m_cachedResults.clear();
@@ -307,6 +340,16 @@ export class StyleSetEvaluator {
 
         return result;
     }
+
+    /**
+     * Get the expression evaluation cache, for further feature processing.
+     *
+     * This object is valid until next `getMatchingTechniques` call.
+     */
+    get expressionEvaluatorCache() {
+        return this.m_cachedResults;
+    }
+
     /**
      * Get the (current) array of techniques that have been created during decoding.
      */
@@ -314,28 +357,17 @@ export class StyleSetEvaluator {
         return this.m_techniques;
     }
 
+    /**
+     * Get the (current) array of techniques that have been created during decoding.
+     */
+    get decodedTechniques(): IndexedTechnique[] {
+        return this.m_techniques.map(makeDecodedTechnique);
+    }
+
     private changeLayer(layer: string | undefined) {
         const savedLayer = this.m_layer;
         this.m_layer = layer;
         return savedLayer;
-    }
-
-    /**
-     * Shorten the style object for debug log. Remove special strings (starting with "_") as well
-     * as the sub-styles of style groups.
-     *
-     * @param key Key in object
-     * @param value value in object
-     */
-    private cleanupStyle(key: string, value: any): any {
-        // Filtering out properties
-        if (key === "styles") {
-            return "[...]";
-        }
-        if (key.startsWith("_")) {
-            return undefined;
-        }
-        return value;
     }
 
     /**
@@ -395,7 +427,7 @@ export class StyleSetEvaluator {
      *          more than one technique should be applied.
      */
     private processStyle(
-        env: MapEnv,
+        env: Env,
         styleStack: InternalStyle[],
         style: InternalStyle,
         result: Technique[]
@@ -420,14 +452,6 @@ export class StyleSetEvaluator {
         }
 
         if (style.styles !== undefined) {
-            if (style.debug) {
-                logger.log(
-                    "\n======== style group =========\nenv:",
-                    JSON.stringify(env.unmap(), undefined, 2),
-                    "\nstyle group:",
-                    JSON.stringify(style, this.cleanupStyle, 2)
-                );
-            }
             styleStack.push(style);
             for (const currStyle of style.styles) {
                 if (this.processStyle(env, styleStack, currStyle as InternalStyle, result)) {
@@ -436,87 +460,210 @@ export class StyleSetEvaluator {
                 }
             }
             styleStack.pop();
-        } else {
-            // we found a technique!
-            if (style.technique !== undefined) {
-                if (style.technique !== "none") {
-                    // Check if we already assembled the technique for exactly this style. If we
-                    // have, we return the preassembled technique object. Otherwise we assemble the
-                    // technique from all parent styles' attributes and the current stales'
-                    // attributes, and add it to the cached techniques.
-                    if (style._index === undefined) {
-                        const technique = this.createTechnique(style, styleStack);
-                        result.push(technique);
-                        if (style.debug) {
-                            logger.log(
-                                "\n======== style w/ technique =========\nenv:",
-                                JSON.stringify(env.unmap(), undefined, 2),
-                                "\nstyle:",
-                                JSON.stringify(style, this.cleanupStyle, 2),
-                                "\ntechnique:",
-                                JSON.stringify(technique, this.cleanupStyle, 2)
-                            );
+            return false;
+        }
+
+        if (style.technique === undefined) {
+            return false;
+        }
+        // we found a technique!
+        if (style.technique !== "none") {
+            this.checkStyleDynamicAttributes(style, styleStack);
+
+            if (style._dynamicTechniques !== undefined) {
+                const dynamicAttributes = this.evaluateTechniqueProperties(style, env);
+                const dynamicAttrKey = dynamicAttributes
+                    .map(([attrName, attrValue]) => {
+                        if (attrValue === undefined) {
+                            return "U";
+                        } else {
+                            return JSON.stringify(attrValue);
                         }
-                    } else {
-                        result.push(this.m_techniques[style._index]);
-                    }
+                    })
+                    .join(":");
+                const key = `${style._styleSetIndex!}:${dynamicAttrKey}`;
+                let technique = style._dynamicTechniques!.get(key);
+                if (technique === undefined) {
+                    technique = this.createTechnique(style, key, dynamicAttributes);
+                    style._dynamicTechniques!.set(key, technique);
                 }
-                // stop processing if "final" is set
-                return style.final === true;
+                result.push(technique);
+            } else {
+                let technique = style._staticTechnique;
+                if (technique === undefined) {
+                    style._staticTechnique = technique = this.createTechnique(
+                        style,
+                        `${style._styleSetIndex}`,
+                        []
+                    ) as IndexedTechnique;
+                }
+                result.push(technique as IndexedTechnique);
             }
         }
-        return false;
+        // stop processing if "final" is set
+        return style.final === true;
     }
 
-    private createTechnique(style: InternalStyle, styleStack: InternalStyle[]) {
-        const technique = {} as any;
-        technique.name = style.technique;
-        const addAttributes = (currStyle: InternalStyle) => {
-            if (currStyle.renderOrder !== undefined) {
-                technique.renderOrder = currStyle.renderOrder;
+    private checkStyleDynamicAttributes(style: InternalStyle, styleStack: InternalStyle[]) {
+        if (style._dynamicTechniqueAttributes !== undefined || style.technique === "none") {
+            return;
+        }
+
+        style._dynamicTechniqueAttributes = [];
+        style._dynamicFeatureAttributes = [];
+        style._dynamicForwaredAttributes = [];
+        style._staticAttributes = [];
+
+        const dynamicFeatureAttributes = style._dynamicFeatureAttributes;
+        const dynamicTechniqueAttributes = style._dynamicTechniqueAttributes;
+        const dynamicForwardedAttributes = style._dynamicForwaredAttributes;
+        const targetStaticAttributes = style._staticAttributes;
+
+        const techniqueDescriptor =
+            techniqueDescriptors[style.technique] || emptyTechniqueDescriptor;
+
+        const processAttribute = (
+            attrName: TechniquePropNames<Technique>,
+            attrValue: Value | JsonExpr | undefined
+        ) => {
+            if (attrValue === undefined) {
+                return;
             }
-            if (currStyle.transient !== undefined) {
-                technique.transient = currStyle.transient;
-            }
-            if (currStyle.renderOrderBiasProperty !== undefined) {
-                technique.renderOrderBiasProperty = currStyle.renderOrderBiasProperty;
-            }
-            if (currStyle.labelProperty !== undefined) {
-                technique.label = currStyle.labelProperty;
-            }
-            if (currStyle.renderOrderBiasRange !== undefined) {
-                technique.renderOrderBiasRange = currStyle.renderOrderBiasRange;
-            }
-            if (currStyle.renderOrderBiasGroup !== undefined) {
-                technique.renderOrderBiasGroup = currStyle.renderOrderBiasGroup;
-            }
-            if ((currStyle as any).secondaryRenderOrder !== undefined) {
-                technique.secondaryRenderOrder = (currStyle as any).secondaryRenderOrder;
-            }
-            if (currStyle.attr !== undefined) {
-                Object.getOwnPropertyNames(currStyle.attr).forEach(property => {
-                    const prop = (currStyle.attr as any)[property];
-                    if (isInterpolatedPropertyDefinition(prop)) {
-                        const interpolatedProperty = createInterpolatedProperty(prop);
-                        if (interpolatedProperty !== undefined) {
-                            technique[property] = interpolatedProperty;
-                        }
-                    } else if (prop !== undefined) {
-                        technique[property] = prop;
-                    }
-                });
+
+            const attrScope: AttrScope | undefined = (techniqueDescriptor.attrScopes as any)[
+                attrName as any
+            ];
+
+            if (isJsonExpr(attrValue)) {
+                const expr = Expr.fromJSON(attrValue).intern(this.m_exprPool);
+                switch (attrScope) {
+                    case AttrScope.FeatureGeometry:
+                        dynamicFeatureAttributes.push([attrName, expr]);
+                        break;
+                    case AttrScope.TechniqueGeometry:
+                    case AttrScope.TechniqueRendering:
+                        dynamicTechniqueAttributes.push([attrName, expr]);
+                        break;
+                }
+            } else if (isInterpolatedPropertyDefinition(attrValue)) {
+                const interpolatedProperty = createInterpolatedProperty(attrValue);
+                if (!interpolatedProperty) {
+                    return;
+                }
+                switch (attrScope) {
+                    case AttrScope.FeatureGeometry:
+                        dynamicFeatureAttributes.push([attrName, interpolatedProperty]);
+                        break;
+                    case AttrScope.TechniqueRendering:
+                    case AttrScope.TechniqueGeometry:
+                        dynamicForwardedAttributes.push([attrName, interpolatedProperty]);
+                        break;
+                }
+            } else {
+                targetStaticAttributes.push([attrName, attrValue]);
             }
         };
-        for (const currStyle of styleStack) {
-            addAttributes(currStyle);
+
+        function processAttributes(style2: Style) {
+            processAttribute("renderOrder", style2.renderOrder);
+            processAttribute("renderOrderOffset", style2.renderOrderOffset);
+
+            // TODO: What the heck is that !?
+            processAttribute("label", style2.labelProperty);
+
+            // line & solid-line secondaryRenderOrder should be generic attr
+            // TODO: maybe just warn and force move it to `attr` ?
+            processAttribute("secondaryRenderOrder", (style2 as LineStyle).secondaryRenderOrder);
+
+            if (style2.attr !== undefined) {
+                for (const attrName in style2.attr) {
+                    if (!style2.attr.hasOwnProperty(attrName)) {
+                        continue;
+                    }
+                    processAttribute(
+                        attrName as TechniquePropNames<Technique>,
+                        (style2.attr as any)[attrName]
+                    );
+                }
+            }
         }
-        addAttributes(style);
 
-        style._index = this.m_techniques.length;
-        (technique as IndexedTechnique)._index = style._index;
-        (technique as IndexedTechnique)._styleSetIndex = style._styleSetIndex!;
-        this.m_techniques.push(technique as IndexedTechnique);
+        for (const parentStyle of styleStack) {
+            processAttributes(parentStyle);
+        }
+        processAttributes(style);
 
-        return technique as Technique;
+        if (dynamicTechniqueAttributes.length > 0) {
+            style._dynamicTechniques = new Map();
+        }
     }
+
+    private evaluateTechniqueProperties(style: InternalStyle, env: Env): Array<[string, Value]> {
+        if (style._dynamicTechniqueAttributes === undefined) {
+            return [];
+        }
+        return style._dynamicTechniqueAttributes.map(([attrName, attrExpr]) => {
+            const evaluatedValue = attrExpr.evaluate(env, this.m_cachedResults);
+            return [attrName, evaluatedValue];
+        });
+    }
+
+    private createTechnique(
+        style: InternalStyle,
+        key: string,
+        dynamicAttrs: Array<[string, Value]>
+    ) {
+        const technique: any = {};
+        technique.name = style.technique;
+        if (style._staticAttributes !== undefined) {
+            for (const [attrName, attrValue] of style._staticAttributes) {
+                technique[attrName] = attrValue;
+            }
+        }
+        for (const [attrName, attrValue] of dynamicAttrs) {
+            technique[attrName] = attrValue;
+        }
+
+        if (style._dynamicFeatureAttributes !== undefined) {
+            for (const [attrName, attrValue] of style._dynamicFeatureAttributes) {
+                technique[attrName] = attrValue;
+            }
+        }
+
+        if (style._dynamicForwaredAttributes !== undefined) {
+            for (const [attrName, attrValue] of style._dynamicForwaredAttributes) {
+                if (attrValue instanceof Expr) {
+                    // TODO: We don't support `Expr` instances in main thread yet.
+                    continue;
+                }
+                technique[attrName] = attrValue;
+            }
+        }
+
+        technique._index = this.m_techniques.length;
+        technique._styleSetIndex = style._styleSetIndex!;
+        technique._key = key;
+        this.m_techniques.push(technique as IndexedTechnique);
+        return technique as IndexedTechnique;
+    }
+}
+
+/**
+ * Create transferable representation of dynamic technique.
+ *
+ * As for now, we remove all `Expr` as they are not supported on other side.
+ */
+export function makeDecodedTechnique(technique: IndexedTechnique): IndexedTechnique {
+    const result: Partial<IndexedTechnique> = {};
+    for (const attrName in technique) {
+        if (!technique.hasOwnProperty(attrName)) {
+            continue;
+        }
+        const attrValue: any = (technique as any)[attrName];
+        if (attrValue instanceof Expr) {
+            continue;
+        }
+        (result as any)[attrName] = attrValue;
+    }
+    return (result as any) as IndexedTechnique;
 }

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Env, Expr, MapEnv, Value } from "./Expr";
+import { getPropertyValue, isInterpolatedProperty } from "./InterpolatedProperty";
+import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
+
+export interface AttrEvaluationContext {
+    /**
+     * Expression evaluation environment containing variable bindings.
+     */
+    env: MapEnv;
+
+    /**
+     * Storage level of tile containing this feature.
+     *
+     * To be removed, when interpolators will be based on [[Expr]].
+     */
+    storageLevel: number;
+
+    /**
+     * Optional, cache of expression results.
+     *
+     * @see [[Expr.evaluate]]
+     */
+    cachedExprResults?: Map<Expr, Value>;
+}
+
+/**
+ * Evaluate feature attr _without_ default value.
+ *
+ * @returns actual value or `undefined`
+ */
+export function evaluateTechniqueAttr<T = Value>(
+    context: Env | AttrEvaluationContext,
+    attrValue: T | Expr | InterpolatedProperty<T> | undefined
+): T | undefined;
+
+/**
+ * Evaluate feature attr _with_ default value.
+ *
+ * @returns actual value or `defaultValue`
+ */
+export function evaluateTechniqueAttr<T = Value>(
+    context: Env | AttrEvaluationContext,
+    attrValue: T | Expr | InterpolatedProperty<T> | undefined,
+    defaultValue: T
+): T;
+
+export function evaluateTechniqueAttr<T = Value>(
+    context: Env | AttrEvaluationContext,
+    attrValue: T | Expr | InterpolatedProperty<T> | undefined,
+    defaultValue?: T
+): T | undefined {
+    const env = context instanceof Env ? context : context.env;
+
+    let evaluated: Value | undefined;
+    if (attrValue instanceof Expr) {
+        evaluated = attrValue.evaluate(
+            env,
+            !(context instanceof Env) ? context.cachedExprResults : undefined
+        );
+    } else if (isInterpolatedProperty(attrValue)) {
+        const storageLevel =
+            context instanceof Env ? (context.lookup("$level") as number) : context.storageLevel;
+        evaluated = getPropertyValue(attrValue, storageLevel);
+    } else {
+        evaluated = (attrValue as unknown) as Value;
+    }
+    if (evaluated === undefined) {
+        return defaultValue;
+    } else {
+        return (evaluated as unknown) as T;
+    }
+}

--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Technique } from "./Techniques";
+
+export enum AttrScope {
+    /**
+     * Attributes that affect generation of feature geometry and thus must be resolved at decoding
+     * time.
+     *
+     * They may have huge variancy as they are implemented as vertex attributes or embedded in
+     * generated meshes.
+     *
+     * These attributes are available only in decoding scope.
+     */
+    FeatureGeometry,
+
+    /**
+     * Attributes that are common to whole group of features drawn with this technique.
+     * These attributes affect generated geometry and  thus must be resolved at decoding time.
+     *
+     * They shouldn't have big variancy and evaluate to at least dozens of values as each
+     * combination of these attributes consitute new technique and material.
+     *
+     * These attributes are available in decoding and rendering scope.
+     */
+    TechniqueGeometry,
+
+    /**
+     * Attributes that are common to whole group of features drawn with this technique.
+     * Attributes that can be changed in resulting object/material from frame to frame. They are
+     * usually implemented as uniforms.
+     *
+     * These attributes may be available only at rendering scope.
+     */
+    TechniqueRendering
+}
+
+/**
+ * Extract  property names from [[Technique]]-like interface (excluding `name`) as union of string
+ * literals.
+ *
+ * TechniquePropName<Base
+ *
+ */
+export type TechniquePropNames<T> = T extends { name: any } ? keyof Omit<T, "name"> : keyof T;
+
+export type TechniquePropScopes<T> = {
+    [P in TechniquePropNames<T>]?: AttrScope;
+};
+
+export interface TechniqueDescriptor<T> {
+    attrScopes: TechniquePropScopes<T>;
+}
+
+type OneThatMatches<T, P> = T extends P ? T : never;
+type TechniqueByName<K extends Technique["name"]> = OneThatMatches<Technique, { name: K }>;
+
+export type TechniqueDescriptorRegistry = {
+    [P in Technique["name"]]?: TechniqueDescriptor<TechniqueByName<P>>;
+};
+
+export function mergeTechniqueDescriptor<T>(
+    ...descriptors: Array<Partial<TechniqueDescriptor<T>>>
+): TechniqueDescriptor<T> {
+    const result: TechniqueDescriptor<T> = {
+        attrScopes: {}
+    };
+    for (const descriptor of descriptors) {
+        if (descriptor.attrScopes !== undefined) {
+            result.attrScopes = { ...result.attrScopes, ...descriptor.attrScopes };
+        }
+    }
+    return result;
+}

--- a/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
+++ b/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isReference, StyleDeclaration, Theme } from "./Theme";
+import { isJsonExpr } from "./Expr";
+import { StyleDeclaration, Theme } from "./Theme";
 
 /**
  * The ThemeVisitor visits every style in the theme in a depth-first fashion.
@@ -20,7 +21,7 @@ export class ThemeVisitor {
      */
     visitStyles(visitFunc: (style: StyleDeclaration) => boolean): boolean {
         const visit = (style: StyleDeclaration): boolean => {
-            if (isReference(style)) {
+            if (isJsonExpr(style)) {
                 return false;
             }
             if (visitFunc(style)) {

--- a/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import { Expr } from "../Expr";
+
+import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
+
+const tmpColor = new THREE.Color();
+const operators = {
+    rgb: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            const r = Number(context.evaluate(args[0]));
+            const g = Number(context.evaluate(args[1]));
+            const b = Number(context.evaluate(args[2]));
+            tmpColor.setRGB(r, g, b);
+            return "#" + tmpColor.getHexString();
+        }
+    }
+};
+
+export const ColorOperators: OperatorDescriptorMap = operators;
+export type ColorOperatorNames = keyof typeof operators;

--- a/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MathUtils } from "@here/harp-geoutils";
 import { Expr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
@@ -191,6 +192,27 @@ const operators = {
     min: {
         call: (context: ExprEvaluatorContext, args: Expr[]) => {
             return Math.min(...args.map(v => Number(context.evaluate(v))));
+        }
+    },
+
+    /**
+     * Clamp numeric value to given range, inclusive.
+     *
+     * Synopsis:
+     * ```
+     * ["clamp", v: number, min: number, max: number]`
+     * ```
+     */
+    clamp: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            const v = context.evaluate(args[0]);
+            const min = context.evaluate(args[1]);
+            const max = context.evaluate(args[2]);
+
+            if (typeof v !== "number" || typeof min !== "number" || typeof max !== "number") {
+                throw new Error(`invalid operands '${v}', ${min}, ${max} for operator 'clamp'`);
+            }
+            return MathUtils.clamp(v, min, max);
         }
     },
 

--- a/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
@@ -16,6 +16,17 @@ const operators = {
             }
             throw new Error(`invalid operand '${value}' for operator 'length'`);
         }
+    },
+    coalesce: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            for (const childExpr of args) {
+                const value = context.evaluate(childExpr);
+                if (value !== null) {
+                    return value;
+                }
+            }
+            return null;
+        }
     }
 };
 

--- a/@here/harp-datasource-protocol/test/TileInfoTest.ts
+++ b/@here/harp-datasource-protocol/test/TileInfoTest.ts
@@ -210,14 +210,19 @@ describe("ExtendedTileInfo", function() {
 
     function createPointInfo(
         index: number
-    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: MapEnv } {
+    ): {
+        technique: IndexedTechnique;
+        storedTechnique: IndexedTechnique;
+        env: MapEnv;
+    } {
         const technique: IndexedTechnique = {
             name: "squares",
             color: "#F00",
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const storedTechnique: IndexedTechnique = {
             name: "squares",
@@ -225,7 +230,8 @@ describe("ExtendedTileInfo", function() {
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const env = new MapEnv({
             $layer: "point_layer-" + index,
@@ -243,14 +249,19 @@ describe("ExtendedTileInfo", function() {
 
     function createLineInfo(
         index: number
-    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: MapEnv } {
+    ): {
+        technique: IndexedTechnique;
+        storedTechnique: IndexedTechnique;
+        env: MapEnv;
+    } {
         const technique: IndexedTechnique = {
             name: "line",
             color: "#0F0",
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const storedTechnique: IndexedTechnique = {
             name: "line",
@@ -258,7 +269,8 @@ describe("ExtendedTileInfo", function() {
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const env = new MapEnv({
             $layer: "line_layer-" + index,
@@ -276,20 +288,26 @@ describe("ExtendedTileInfo", function() {
 
     function createPolygonInfo(
         index: number
-    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: MapEnv } {
+    ): {
+        technique: IndexedTechnique;
+        storedTechnique: IndexedTechnique;
+        env: MapEnv;
+    } {
         const technique: IndexedTechnique = {
             name: "fill",
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const storedTechnique: IndexedTechnique = {
             name: "fill",
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const env = new MapEnv({
             $layer: "fill_layer-" + index,
@@ -355,9 +373,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.pointGroup,
-            technique,
             env,
             1234,
+            "name",
             techniqueIndex,
             FeatureGroupType.Point
         );
@@ -385,9 +403,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.pointGroup,
-            technique,
             env,
             3456,
+            "point_label-3456",
             techniqueIndex,
             FeatureGroupType.Point
         );
@@ -447,9 +465,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.pointGroup,
-            technique,
             env,
             3456,
+            "point_label-3456",
             techniqueIndex,
             FeatureGroupType.Point
         );
@@ -460,9 +478,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.pointGroup,
-            pointInfo2.technique,
             pointInfo2.env,
             7890,
+            "point_label-7890",
             techniqueIndex2,
             FeatureGroupType.Point
         );
@@ -545,9 +563,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.lineGroup,
-            technique,
             env,
             678,
+            "lineLabel-123",
             techniqueIndex,
             FeatureGroupType.Line
         );
@@ -602,9 +620,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.lineGroup,
-            technique,
             env,
             678,
+            "lineLabel-123",
             techniqueIndex,
             FeatureGroupType.Line
         );
@@ -615,9 +633,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.lineGroup,
-            lineInfo2.technique,
             lineInfo2.env,
             7890,
+            "lineLabel-456",
             techniqueIndex2,
             FeatureGroupType.Line
         );
@@ -690,9 +708,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            technique,
             env,
             678,
+            "fillLabel-123",
             techniqueIndex,
             FeatureGroupType.Polygon
         );
@@ -754,9 +772,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            technique,
             env,
             678,
+            "fillLabel-123",
             techniqueIndex,
             FeatureGroupType.Polygon
         );
@@ -767,9 +785,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            polygonInfo2.technique,
             polygonInfo2.env,
             999,
+            "fillLabel-999",
             techniqueIndex2,
             FeatureGroupType.Polygon
         );
@@ -851,9 +869,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            technique,
             env,
             678,
+            "fillLabel-123",
             techniqueIndex,
             FeatureGroupType.Polygon
         );
@@ -865,9 +883,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            polygonInfo2.technique,
             polygonInfo2.env,
             999,
+            "fillLabel-999",
             techniqueIndex2,
             FeatureGroupType.Polygon
         );
@@ -951,9 +969,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            technique,
             env,
             678,
+            "fillLabel-123",
             techniqueIndex,
             FeatureGroupType.Polygon
         );
@@ -966,9 +984,9 @@ describe("ExtendedTileInfo", function() {
 
         writer.addFeature(
             tileInfo.polygonGroup,
-            polygonInfo2.technique,
             polygonInfo2.env,
             999,
+            "fillLabel-999",
             techniqueIndex2,
             FeatureGroupType.Polygon
         );

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -24,7 +24,7 @@ export namespace TiledGeoJsonTechniquesExample {
         </style>
     `;
 
-    const theme: Theme = ({
+    const theme: Theme = {
         clearColor: "#234152",
         styles: {
             tilezen: [
@@ -409,8 +409,7 @@ export namespace TiledGeoJsonTechniquesExample {
                 }
             ]
         }
-        // TODO: as Theme is needed to satisfy `typedoc`
-    } as any) as Theme;
+    };
 
     /**
      * Creates a new MapView for the HTMLCanvasElement of the given id.

--- a/@here/harp-examples/src/styling_textured-areas.ts
+++ b/@here/harp-examples/src/styling_textured-areas.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isReference, TextureCoordinateType, Theme } from "@here/harp-datasource-protocol";
+import { TextureCoordinateType, Theme } from "@here/harp-datasource-protocol";
+import { isJsonExpr } from "@here/harp-datasource-protocol/lib/Expr";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, CopyrightInfo, MapView, ThemeLoader } from "@here/harp-mapview";
@@ -73,7 +74,7 @@ West</a>.</p>`;
                 }
                 const styleSet = theme.styles[styleSetName];
                 styleSet.forEach(style => {
-                    if (isReference(style)) {
+                    if (isJsonExpr(style)) {
                         return;
                     }
                     if (style.description === "urban area") {

--- a/@here/harp-examples/src/theme_data-driven.ts
+++ b/@here/harp-examples/src/theme_data-driven.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GeoCoordinates } from "@here/harp-geoutils";
+import { MapControls, MapControlsUI } from "@here/harp-map-controls";
+import { CopyrightElementHandler, CopyrightInfo, MapView } from "@here/harp-mapview";
+import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { accessToken } from "../config";
+
+export namespace DataDrivenThemeExample {
+    function initializeMapView(id: string): MapView {
+        const canvas = document.getElementById(id) as HTMLCanvasElement;
+
+        const mapView = new MapView({
+            canvas,
+            theme: {
+                extends: "resources/berlin_tilezen_base.json",
+                definitions: {
+                    countryPopulationLevel: {
+                        type: "number",
+                        value: ["-", ["log10", ["number", ["get", "population"], 1000]], 3]
+                    }
+                },
+                styles: {
+                    tilezen: [
+                        ["ref", "countryBorderOutline"],
+                        ["ref", "waterPolygons"],
+                        {
+                            when: [
+                                "all",
+                                ["==", ["get", "$layer"], "places"],
+                                ["in", ["get", "kind"], ["country"]]
+                            ],
+                            technique: "text",
+                            attr: {
+                                priority: ["+", 100, ["^", 2, ["ref", "countryPopulationLevel"]]],
+                                size: ["+", 8, ["^", 1.7, ["ref", "countryPopulationLevel"]]],
+                                text: [
+                                    "concat",
+                                    ["coalesce", ["get", "name:en"], ["get", "name"]],
+                                    "\n",
+                                    ["coalesce", ["get", "population"], "n/a"]
+                                ],
+                                color: "#3F1821",
+                                backgroundColor: "#FFFFFF",
+                                backgroundOpacity: 0.7,
+                                fontVariant: "SmallCaps",
+                                opacity: 0.9
+                            }
+                        }
+                    ]
+                }
+            },
+            disableFading: true
+        });
+
+        CopyrightElementHandler.install("copyrightNotice", mapView);
+
+        mapView.resize(window.innerWidth, window.innerHeight);
+
+        window.addEventListener("resize", () => {
+            mapView.resize(window.innerWidth, window.innerHeight);
+        });
+
+        return mapView;
+    }
+
+    function main() {
+        const map = initializeMapView("mapCanvas");
+
+        const hereCopyrightInfo: CopyrightInfo = {
+            id: "here.com",
+            year: new Date().getFullYear(),
+            label: "HERE",
+            link: "https://legal.here.com/terms"
+        };
+
+        const copyrights: CopyrightInfo[] = [hereCopyrightInfo];
+
+        const omvDataSource = new OmvDataSource({
+            baseUrl: "https://xyz.api.here.com/tiles/osmbase/512/all",
+            apiFormat: APIFormat.XYZMVT,
+            styleSetName: "tilezen",
+            maxZoomLevel: 17,
+            authenticationCode: accessToken,
+            copyrightInfo: copyrights
+        });
+
+        const mapControls = MapControls.create(map);
+
+        const ui = new MapControlsUI(mapControls);
+        map.canvas.parentElement!.appendChild(ui.domElement);
+
+        map.setCameraGeolocationAndZoom(new GeoCoordinates(50.443041, 11.4229649), 5);
+        map.addDataSource(omvDataSource);
+    }
+
+    main();
+}

--- a/@here/harp-geojson-datasource/lib/GeoJsonParser.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonParser.ts
@@ -465,8 +465,8 @@ export class GeoJsonParser {
         if (featureId !== undefined) {
             featureDetails.featureId = featureId;
         }
-
         const env = new MapEnv({ type: "line", ...(featureDetails as ValueMap) });
+
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
         const featureIdNumber = 0; //geojsonTile do not have an integer for the featureId. Use 0.
         if (buffer.lines.vertices.length !== buffer.lines.geojsonProperties.length) {
@@ -750,6 +750,7 @@ export class GeoJsonParser {
             return;
         }
         const tileInfoWriter = extendedTile.writer;
+
         for (const technique of techniques) {
             if (technique === undefined) {
                 continue;
@@ -769,11 +770,12 @@ export class GeoJsonParser {
 
                 currentGeoJsonIndex++;
 
+                const featureText = ExtendedTileInfo.getFeatureText(env, technique);
                 tileInfoWriter.addFeature(
                     extendedTile.info.lineGroup,
-                    technique,
                     env,
                     featureId,
+                    featureText,
                     infoTileTechniqueIndex,
                     FeatureGroupType.Line
                 );

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -17,41 +17,30 @@
             "type": "color",
             "value": "#EDE7E1"
         },
-        "extrudedBuildings": {
-            "description": "buildings with pre-defined color",
-            "technique": "extruded-polygon",
-            "when": ["all", ["ref", "extrudedBuildingsCondition"], ["!", ["has", "color"]]],
-            "attr": {
-                "color": ["ref", "defaultBuildingColor"],
-                "opacity": 0.9,
-                "roughness": 1,
-                "metalness": 0.8,
-                "emissive": "#78858C",
-                "emissiveIntensity": 0.85,
-                "footprint": true,
-                "maxSlope": 0.8799999999999999,
-                "lineWidth": 1,
-                "lineColor": "#172023",
-                "lineColorMix": 0.6,
-                "fadeNear": 0.9,
-                "fadeFar": 1,
-                "lineFadeNear": -0.75,
-                "lineFadeFar": 1,
-                "animateExtrusion": {
-                    "interpolation": "Discrete",
-                    "zoomLevels": [14, 15],
-                    "values": [false, true]
-                }
-            },
-            "renderOrder": 2000
+        "waterColor": {
+            "type": "color",
+            "value": "#436981"
         },
-        "coloredExtrudedBuildings": {
-            "description": "buildings with varying colors",
-            "technique": "extruded-polygon",
-            "when": ["all", ["ref", "extrudedBuildingsCondition"], ["has", "color"]],
+        "waterPolygons": {
+            "description": "water",
+            "when": [
+                "all",
+                ["==", ["get", "$layer"], "water"],
+                ["==", ["get", "$geometryType"], "polygon"]
+            ],
+            "technique": "fill",
             "attr": {
-                "vertexColors": true,
-                "defaultColor": ["ref", "defaultBuildingColor"],
+                "color": ["ref", "waterColor"]
+            },
+            "renderOrder": 5
+        },
+        "extrudedBuildings": {
+            "description": "extruded buildings",
+            "technique": "extruded-polygon",
+            "when": ["ref", "extrudedBuildingsCondition"],
+            "attr": {
+                "height": ["get", "height"],
+                "color": ["ref", "defaultBuildingColor"],
                 "opacity": 0.9,
                 "roughness": 1,
                 "metalness": 0.8,
@@ -92,6 +81,45 @@
         "roadsFadeFar": {
             "type": "number",
             "value": 0.95
+        },
+
+        "countryBorderOutlineWidth": {
+            "type": "number",
+            "value": {
+                "interpolation": "Linear",
+                "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+                "values": [10000, 8000, 7000, 5000, 3000, 2000, 1000, 500, 250, 120, 80, 40, 20, 10]
+            }
+        },
+        "countryBorderLine": {
+            "description": "country border",
+            "when": [
+                "all",
+                ["==", ["get", "$layer"], "boundaries"],
+                ["==", ["get", "$geometryType"], "line"],
+                ["==", ["get", "kind"], "country"]
+            ],
+            "technique": "solid-line",
+            "attr": {
+                "color": "#2F444B",
+                "lineWidth": ["ref", "countryBorderLineWidth"]
+            },
+            "renderOrder": 4.1
+        },
+        "countryBorderOutline": {
+            "description": "country border - outline",
+            "when": [
+                "all",
+                ["==", ["get", "$layer"], "boundaries"],
+                ["==", ["get", "$geometryType"], "line"],
+                ["==", ["get", "kind"], "country"]
+            ],
+            "technique": "solid-line",
+            "attr": {
+                "color": "#52676E",
+                "lineWidth": ["ref", "countryBorderOutlineWidth"]
+            },
+            "renderOrder": 4
         }
     },
     "sky": {
@@ -186,46 +214,13 @@
     "styles": {
         "tilezen": [
             {
-                "description": "highway-roadshield-2",
+                "description": "highway-roadshield",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "highway"],
                     ["==", ["get", "kind_detail"], "motorway"],
                     ["has", "ref"],
-                    ["<=", ["length", ["get", "ref"]], 2]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-2",
-                    "iconScale": 1.28,
-                    "priority": 35,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-3, level > 7",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
                     [">", ["get", "$level"], 7]
                 ],
                 "technique": "line-marker",
@@ -233,108 +228,13 @@
                     "style": "smallSign",
                     "label": "ref",
                     "size": 12.8,
-                    "imageTexture": "default-3",
+                    "imageTexture": [
+                        "concat",
+                        "default-",
+                        ["clamp", ["length", ["get", "ref"]], 2, 6]
+                    ],
                     "iconScale": 1.28,
-                    "priority": 34,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-4, level > 8",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["get", "$level"], 8]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-4",
-                    "iconScale": 1.28,
-                    "priority": 33,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-5, level > 8",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 8]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-5",
-                    "iconScale": 1.28,
-                    "priority": 32,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-5+, invisible",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 8]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-6",
-                    "iconScale": 1.28,
-                    "priority": 31,
+                    "priority": ["-", 37, ["length", ["get", "ref"]]],
                     "minDistance": 200,
                     "vAlignment": "Center",
                     "hAlignment": "Center",
@@ -685,14 +585,13 @@
                 "final": true
             },
             {
-                "description": "secondary-road-shield-2, level > 11",
+                "description": "secondary-road-shield, level > 11",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "secondary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 2],
                     [">", ["get", "$level"], 11]
                 ],
                 "technique": "line-marker",
@@ -702,151 +601,19 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "size": 12.8,
-                    "imageTexture": "default-2",
+                    "imageTexture": [
+                        "concat",
+                        "default-",
+                        ["clamp", ["length", ["get", "ref"]], 2, 6]
+                    ],
                     "iconScale": 1.28,
-                    "priority": 25,
+                    "priority": ["-", 26, ["length", ["get", "ref"]]],
                     "fadeNear": 0.8,
                     "fadeFar": 0.9,
                     "minDistance": 300,
                     "textIsOptional": false,
                     "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-3, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-3",
-                    "iconScale": 1.28,
-                    "priority": 24,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-4, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-4",
-                    "iconScale": 1.28,
-                    "priority": 23,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-5, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-5",
-                    "iconScale": 1.28,
-                    "priority": 22,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-5+, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-6",
-                    "iconScale": 1.28,
-                    "priority": 21,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
+                    "textMayOverlap": true,
                     "textReserveSpace": true,
                     "iconMayOverlap": true,
                     "iconReserveSpace": false,
@@ -885,14 +652,13 @@
                 "final": true
             },
             {
-                "description": "tertiary-road-shield-2, level > 13",
+                "description": "tertiary-road-shield, level > 13",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "tertiary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 2],
                     [">", ["get", "$level"], 13]
                 ],
                 "technique": "line-marker",
@@ -902,145 +668,13 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "size": 12.8,
-                    "imageTexture": "default-2",
+                    "imageTexture": [
+                        "concat",
+                        "default-",
+                        ["clamp", ["length", ["get", "ref"]], 2, 6]
+                    ],
                     "iconScale": 1.28,
-                    "priority": 20,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-3, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-3",
-                    "iconScale": 1.28,
-                    "priority": 19,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-4, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-4",
-                    "iconScale": 1.28,
-                    "priority": 18,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-5, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-5",
-                    "iconScale": 1.28,
-                    "priority": 17,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-5+, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-6",
-                    "iconScale": 1.28,
-                    "priority": 16,
+                    "priority": ["-", 22, ["length", ["get", "ref"]]],
                     "fadeNear": 0.8,
                     "fadeFar": 0.9,
                     "minDistance": 200,
@@ -1463,19 +1097,7 @@
                 "renderOrder": 5.15,
                 "final": true
             },
-            {
-                "description": "water",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "water"],
-                    ["==", ["get", "$geometryType"], "polygon"]
-                ],
-                "technique": "fill",
-                "attr": {
-                    "color": "#436981"
-                },
-                "renderOrder": 5
-            },
+            ["ref", "waterPolygons"],
             {
                 "description": "water",
                 "when": ["==", ["get", "$layer"], "water"],
@@ -1488,57 +1110,10 @@
                     "size": 12.8
                 }
             },
+            ["ref", "countryBorderOutline"],
+            ["ref", "countryBorderLine"],
             {
-                "description": "country border",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
-                    ["==", ["get", "kind"], "country"]
-                ],
-                "technique": "solid-line",
-                "attr": {
-                    "color": "#52676E",
-                    "lineWidth": {
-                        "interpolation": "Linear",
-                        "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-                        "values": [
-                            10000,
-                            8000,
-                            7000,
-                            5000,
-                            3000,
-                            2000,
-                            1000,
-                            500,
-                            250,
-                            120,
-                            80,
-                            40,
-                            20,
-                            10
-                        ]
-                    }
-                },
-                "renderOrder": 4
-            },
-            {
-                "description": "country border",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
-                    ["==", ["get", "kind"], "country"]
-                ],
-                "technique": "solid-line",
-                "attr": {
-                    "color": "#2F444B",
-                    "lineWidth": ["ref", "countryBorderLineWidth"]
-                },
-                "renderOrder": 4.1
-            },
-            {
-                "description": "country border",
+                "description": "country border - labels",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
@@ -2336,7 +1911,6 @@
                 "final": true
             },
             ["ref", "extrudedBuildings"],
-            ["ref", "coloredExtrudedBuildings"],
             {
                 "description": "building_address",
                 "when": [

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExtrudedPolygonTechniqueParams } from "@here/harp-datasource-protocol";
-import { MapMeshStandardMaterial } from "@here/harp-materials";
 import * as THREE from "three";
+
+import { ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
+import { MapMeshStandardMaterial } from "@here/harp-materials";
 
 /**
  * Bitmask used for the depth pre-pass to prevent multiple fragments in the same screen position
@@ -22,7 +23,7 @@ export const DEPTH_PRE_PASS_STENCIL_MASK = 0x01;
  *
  * @param technique [[BaseStandardTechnique]] instance to be checked
  */
-export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechniqueParams) {
+export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique) {
     return (
         technique.enableDepthPrePass !== false &&
         technique.opacity !== undefined &&

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -7,7 +7,7 @@
 import {
     Definitions,
     isActualSelectorDefinition,
-    isReference,
+    isJsonExprReference,
     isValueDefinition,
     ResolvedStyleDeclaration,
     ResolvedStyleSet,
@@ -121,7 +121,6 @@ export class ThemeLoader {
             );
             ThemeLoader.resolveThemeReferences(theme, contextLoader);
         }
-
         return theme;
     }
 
@@ -328,7 +327,7 @@ export class ThemeLoader {
         definitions: Definitions | undefined,
         contextLogger: IContextLogger
     ): ResolvedStyleDeclaration | undefined {
-        if (isReference(style)) {
+        if (isJsonExprReference(style)) {
             // expand and instantiate references to style definitions.
 
             const def = definitions && definitions[style[1]];
@@ -407,7 +406,7 @@ export class ThemeLoader {
     ): T | undefined {
         let failed = false;
         function resolveInternal(node: any) {
-            if (isReference(node)) {
+            if (isJsonExprReference(node)) {
                 const defName = node[1];
                 const def = definitions && definitions[defName];
                 if (def === undefined) {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -29,6 +29,7 @@ import {
     isTerrainTechnique,
     isTextTechnique,
     LineMarkerTechnique,
+    MakeTechniqueAttrs,
     needsVertexNormals,
     PoiTechnique,
     SolidLineTechnique,
@@ -710,7 +711,7 @@ export class TileGeometryCreator {
 
                 object.frustumCulled = false;
 
-                object.renderOrder = technique.renderOrder;
+                object.renderOrder = technique.renderOrder!;
 
                 if (group.renderOrderOffset !== undefined) {
                     object.renderOrder += group.renderOrderOffset;
@@ -1569,7 +1570,7 @@ export class TileGeometryCreator {
      */
     private getFadingParams(
         displayZoomLevel: number,
-        technique: BaseTechniqueParams
+        technique: MakeTechniqueAttrs<BaseTechniqueParams>
     ): FadingParameters {
         const fadeNear =
             technique.fadeNear !== undefined

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -35,7 +35,7 @@ export function computeStyleCacheId(
     technique: Technique & Partial<IndexedTechniqueParams>,
     zoomLevel: number
 ): string {
-    return `${datasourceName}_${technique._styleSetIndex}_${zoomLevel}`;
+    return `${datasourceName}_${technique._key}_${zoomLevel}`;
 }
 
 /**

--- a/@here/harp-omv-datasource/lib/VTJsonDataAdapter.ts
+++ b/@here/harp-omv-datasource/lib/VTJsonDataAdapter.ts
@@ -162,6 +162,7 @@ export class VTJsonDataAdapter implements OmvDataAdapter {
                         env,
                         tileKey.level
                     );
+
                     break;
                 }
                 case VTJsonGeometryType.Unknown: {

--- a/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -120,13 +120,18 @@ describe("OmvDecodedTileEmitter", function() {
 
         const { tileEmitter, styleSetEvaluator } = createTileEmitter();
 
-        const mockEnv = new MapEnv({ layer: "mock-layer" });
-        const matchedTechniques = styleSetEvaluator.getMatchingTechniques(mockEnv);
+        const storageLevel = 10;
+        const mockContext = {
+            env: new MapEnv({ layer: "mock-layer" }),
+            storageLevel
+        };
+
+        const matchedTechniques = styleSetEvaluator.getMatchingTechniques(mockContext.env);
         tileEmitter.processPolygonFeature(
             "mock-layer",
             4096,
             polygons,
-            mockEnv,
+            mockContext,
             matchedTechniques,
             undefined
         );


### PR DESCRIPTION
Support for static expression based Technique attributes resolved in decoding phase.

Expression support in style
 * introduce "static"expressions in all technique/style attrs in Theme - by static, it means that these expressions depend only on feature attributes and must be resolved at decoding time
 * `text`-based techniques:
      * introduces `text` property which should ultimately replace `label`, `useAbbreviation` and custom resolution methods

 * `extruded-polygon` technique
     * adds `height` and `floorHeight` properties
 * introduces `coalesce`, `clamp` and `rgb` expressions as they were needed by examples
 * for example,
   *  see `berlin_tilezen_base.json` patch
   * and `theme_data-driven.ts` example

Technical overview:
 * introduces technique attr resolution scopes: `FeatureGeometry`, `TechniqueGeometry` & `TechniqueRendering`, see TechniqueDescriptor.ts
 * defines attr scopes for all attributes (Techniques.ts)
 * `StyleSetEvaluator` as for now implements most of features
    * creates unique Technique for each unique set of `TechniqueGeometry` attributes
    * *NOTE* as for now, one rule can emit several techniques, which cannot be identified by old `_index` and `_styleSetIndex`, so new `_key` property which is stable even if some tiles don't generate all technique instances!
    * passes `FeatureGeometry` attributes to decoder as expressions, so decoder can emit different values for "feautre-varying" attributes like text, width
   * (not yet, #697) passes `TechniqueRendering` scoped expressions to be evaluated dynamically before each render

Other non-core changes
* depends on #771
* depends on #772

Followup for full support including render-time dynamic attributes in #697 