### PR TITLE
HARP-6763: SubTiles generate bad tile keys on custom subdivision schemes

### DIFF
--- a/@here/harp-geoutils/lib/tiling/SubTiles.ts
+++ b/@here/harp-geoutils/lib/tiling/SubTiles.ts
@@ -7,78 +7,41 @@
 import { TileKey } from "./TileKey";
 
 export class SubTiles implements Iterable<TileKey> {
-    private m_tileKey: TileKey;
-    private m_level: number;
-    private m_count: number;
-    private m_mask: number;
-    private m_shift: number;
+    constructor(public tileKey: TileKey, public sizeX: number, public sizeY: number) {}
 
-    constructor(tileKey: TileKey, level: number, mask: number) {
-        this.m_tileKey = tileKey;
-        this.m_level = level;
-        // tslint:disable:no-bitwise
-        this.m_count = 1 << (level << 1);
-        this.m_mask = mask;
-        this.m_shift = level > 2 ? (level - 2) << 1 : 0;
-        // tslint:enable:no-bitwise
-    }
-
-    get level(): number {
-        return this.m_level;
-    }
-    get tileKey(): TileKey {
-        return this.m_tileKey;
-    }
-
-    [Symbol.iterator](): SubTiles.SubTileIterator {
-        return new SubTiles.SubTileIterator(this, this.m_count);
-    }
-
-    iterator() {
-        return this[Symbol.iterator]();
-    }
-
-    skip(index: number): number {
-        // tslint:disable:no-bitwise
-        if (this.m_mask !== ~0) {
-            while (index < this.m_count && (this.m_mask & (1 << (index >> this.m_shift))) === 0) {
-                ++index;
-            }
-        }
-        // tslint:enable:no-bitwise
-        return index;
+    [Symbol.iterator](): Iterator<TileKey> {
+        return this.sizeX === 2 && this.sizeY === 2
+            ? SubTiles.ZCurveIterator(this.tileKey)
+            : SubTiles.RowColumnIterator(this.tileKey, this.sizeX, this.sizeY);
     }
 }
 
 export namespace SubTiles {
-    export class SubTileIterator implements Iterator<TileKey> {
-        private m_parent: SubTiles;
-        private m_index: number;
-        private m_totalSubTileCount: number;
-
-        constructor(parent: SubTiles, totalSubTileCount: number, index: number = 0) {
-            this.m_parent = parent;
-            this.m_index = parent.skip(index);
-            this.m_totalSubTileCount = totalSubTileCount;
+    export function* RowColumnIterator(
+        parentKey: TileKey,
+        sizeX: number,
+        sizeY: number
+    ): Iterator<TileKey> {
+        for (let y = 0; y < sizeY; y++) {
+            for (let x = 0; x < sizeX; x++) {
+                yield TileKey.fromRowColumnLevel(
+                    parentKey.row * sizeY + y,
+                    parentKey.column * sizeX + x,
+                    parentKey.level + 1
+                );
+            }
         }
+    }
 
-        get value() {
-            const parentKey = this.m_parent.tileKey;
-            const subLevel = this.m_parent.level;
-
-            return TileKey.fromRowColumnLevel(
-                // tslint:disable:no-bitwise
-                (parentKey.row << subLevel) | (this.m_index >> subLevel),
-                (parentKey.column << subLevel) | (this.m_index & ((1 << subLevel) - 1)),
-                parentKey.level + subLevel
-                // tslint:enableno-bitwise
+    export function* ZCurveIterator(parentKey: TileKey): Iterator<TileKey> {
+        // tslint:disable:no-bitwise
+        for (let i = 0; i < 4; i++) {
+            yield TileKey.fromRowColumnLevel(
+                (parentKey.row << 1) | (i >> 1),
+                (parentKey.column << 1) | (i & 1),
+                parentKey.level + 1
             );
         }
-
-        next() {
-            const current = { value: this.value, done: this.m_index >= this.m_totalSubTileCount };
-            this.m_index = this.m_parent.skip(++this.m_index);
-            return current;
-        }
+        // tslint:enableno-bitwise
     }
 }

--- a/@here/harp-geoutils/lib/tiling/TileTreeTraverse.ts
+++ b/@here/harp-geoutils/lib/tiling/TileTreeTraverse.ts
@@ -15,21 +15,10 @@ export class TileTreeTraverse {
         this.m_subdivisionScheme = subdivisionScheme;
     }
 
-    subTiles(tileKey: TileKey): TileKey[] {
-        const subTileCount =
-            this.m_subdivisionScheme.getSubdivisionX(tileKey.level) *
-            this.m_subdivisionScheme.getSubdivisionY(tileKey.level);
+    subTiles(tileKey: TileKey): Iterable<TileKey> {
+        const divX = this.m_subdivisionScheme.getSubdivisionX(tileKey.level);
+        const divY = this.m_subdivisionScheme.getSubdivisionY(tileKey.level);
 
-        // tslint:disable-next-line:no-bitwise
-        const subTileMask = ~(~0 << subTileCount);
-
-        const subTiles = new SubTiles(tileKey, 1, subTileMask);
-        const result = new Array<TileKey>();
-
-        for (const subTile of subTiles) {
-            result.push(subTile);
-        }
-
-        return result;
+        return new SubTiles(tileKey, divX, divY);
     }
 }

--- a/@here/harp-geoutils/lib/tiling/TilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/TilingScheme.ts
@@ -38,7 +38,7 @@ export class TilingScheme {
      * @param tileKey The [[TileKey]].
      * @returns The list of the sub tile keys.
      */
-    getSubTileKeys(tileKey: TileKey): TileKey[] {
+    getSubTileKeys(tileKey: TileKey): Iterable<TileKey> {
         return this.tileTreeTraverse.subTiles(tileKey);
     }
 

--- a/@here/harp-geoutils/package.json
+++ b/@here/harp-geoutils/package.json
@@ -22,9 +22,11 @@
     "devDependencies": {
         "@types/chai": "^4.1.2",
         "@types/mocha": "^5.2.7",
+        "@types/sinon": "^7.0.13",
         "chai": "^4.0.2",
         "cross-env": "^5.2.0",
         "mocha": "^6.1.4",
+        "sinon": "^7.1.1",
         "source-map-support": "^0.5.2",
         "typescript": "^3.5.2"
     },

--- a/@here/harp-geoutils/test/SubTilesTest.ts
+++ b/@here/harp-geoutils/test/SubTilesTest.ts
@@ -12,8 +12,8 @@ import { SubTiles } from "../lib/tiling/SubTiles";
 import { TileKey } from "../lib/tiling/TileKey";
 
 describe("SubTiles", function() {
-    it("iterates through all masked subtiles", function() {
-        const subTiles = new SubTiles(TileKey.fromRowColumnLevel(0, 0, 0), 1, 0x3);
+    it("iterates through all subtiles", function() {
+        const subTiles = new SubTiles(TileKey.fromRowColumnLevel(0, 0, 0), 1, 2);
         const actualSubtiles: TileKey[] = [];
 
         for (const subTile of subTiles) {

--- a/@here/harp-geoutils/test/TileTreeTraverseTest.ts
+++ b/@here/harp-geoutils/test/TileTreeTraverseTest.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { assert } from "chai";
+import * as sinon from "sinon";
+
+import { SubdivisionScheme } from "../lib/tiling/SubdivisionScheme";
+import { TileKey } from "../lib/tiling/TileKey";
+import { TileTreeTraverse } from "../lib/tiling/TileTreeTraverse";
+
+/**
+ * A stub scheme definition, all member functions will be overriden for each test case
+ */
+class TestSubdivisionScheme implements SubdivisionScheme {
+    getSubdivisionX(level: number): number {
+        return 0;
+    }
+    getSubdivisionY(level: number): number {
+        return 0;
+    }
+    getLevelDimensionX(level: number): number {
+        return 0;
+    }
+    getLevelDimensionY(level: number): number {
+        return 0;
+    }
+}
+
+describe("TileTreeTraverse", function() {
+    let subdivisionScheme: sinon.SinonStubbedInstance<TestSubdivisionScheme>;
+    let ttt: TileTreeTraverse;
+
+    beforeEach(function() {
+        subdivisionScheme = sinon.createStubInstance(TestSubdivisionScheme);
+
+        ttt = new TileTreeTraverse(subdivisionScheme);
+    });
+
+    function getSubTileArray(row: number, column: number, level: number): TileKey[] {
+        return [...ttt.subTiles(TileKey.fromRowColumnLevel(row, column, level))];
+    }
+
+    it("get tiles of 1x1 subdivison", function() {
+        subdivisionScheme.getSubdivisionX.returns(1);
+        subdivisionScheme.getSubdivisionY.returns(1);
+        subdivisionScheme.getLevelDimensionX.returns(1);
+        subdivisionScheme.getLevelDimensionY.returns(1);
+
+        const result1 = getSubTileArray(0, 0, 0);
+        assert.equal(result1.length, 1);
+        assert.deepInclude(result1, { row: 0, column: 0, level: 1 });
+
+        const result2 = getSubTileArray(0, 0, 1);
+        assert.equal(result2.length, 1);
+        assert.deepInclude(result2, { row: 0, column: 0, level: 2 });
+
+        const result3 = getSubTileArray(0, 0, 2);
+        assert.equal(result3.length, 1);
+        assert.deepInclude(result3, { row: 0, column: 0, level: 3 });
+
+        const result4 = getSubTileArray(0, 0, 19);
+        assert.equal(result4.length, 1);
+        assert.deepInclude(result4, { row: 0, column: 0, level: 20 });
+    });
+
+    it("get tiles of 2x1 subdivison", function() {
+        // tslint:disable:no-bitwise
+        subdivisionScheme.getSubdivisionX.returns(2);
+        subdivisionScheme.getSubdivisionY.returns(1);
+        subdivisionScheme.getLevelDimensionX.callsFake((level: number) => 1 << level);
+        subdivisionScheme.getLevelDimensionY.returns(1);
+        // tslint:enable:no-bitwise
+
+        const result1 = getSubTileArray(0, 0, 0);
+        assert.equal(result1.length, 2);
+        assert.deepInclude(result1, { row: 0, column: 0, level: 1 });
+        assert.deepInclude(result1, { row: 0, column: 1, level: 1 });
+
+        const result2 = getSubTileArray(0, 1, 1);
+        assert.equal(result2.length, 2);
+        assert.deepInclude(result2, { row: 0, column: 2, level: 2 });
+        assert.deepInclude(result2, { row: 0, column: 3, level: 2 });
+
+        const result3 = getSubTileArray(0, 2, 2);
+        assert.equal(result3.length, 2);
+        assert.deepInclude(result3, { row: 0, column: 4, level: 3 });
+        assert.deepInclude(result3, { row: 0, column: 5, level: 3 });
+
+        const result4 = getSubTileArray(0, 9, 14);
+        assert.equal(result4.length, 2);
+        assert.deepInclude(result4, { row: 0, column: 18, level: 15 });
+        assert.deepInclude(result4, { row: 0, column: 19, level: 15 });
+    });
+
+    it("get tiles of 1x2 subdivison", function() {
+        // tslint:disable:no-bitwise
+        subdivisionScheme.getSubdivisionX.returns(1);
+        subdivisionScheme.getSubdivisionY.returns(2);
+        subdivisionScheme.getLevelDimensionX.returns(1);
+        subdivisionScheme.getLevelDimensionY.callsFake((level: number) => 1 << level);
+        // tslint:enable:no-bitwise
+
+        const result1 = getSubTileArray(0, 0, 0);
+        assert.equal(result1.length, 2);
+        assert.deepInclude(result1, { row: 0, column: 0, level: 1 });
+        assert.deepInclude(result1, { row: 1, column: 0, level: 1 });
+
+        const result2 = getSubTileArray(1, 0, 1);
+        assert.equal(result2.length, 2);
+        assert.deepInclude(result2, { row: 2, column: 0, level: 2 });
+        assert.deepInclude(result2, { row: 3, column: 0, level: 2 });
+
+        const result3 = getSubTileArray(2, 0, 2);
+        assert.equal(result3.length, 2);
+        assert.deepInclude(result3, { row: 4, column: 0, level: 3 });
+        assert.deepInclude(result3, { row: 5, column: 0, level: 3 });
+
+        const result4 = getSubTileArray(9, 0, 14);
+        assert.equal(result4.length, 2);
+        assert.deepInclude(result4, { row: 18, column: 0, level: 15 });
+        assert.deepInclude(result4, { row: 19, column: 0, level: 15 });
+    });
+
+    it("get tiles of 2x2 subdivison", function() {
+        // tslint:disable:no-bitwise
+        subdivisionScheme.getSubdivisionX.returns(2);
+        subdivisionScheme.getSubdivisionY.returns(2);
+        subdivisionScheme.getLevelDimensionX.callsFake((level: number) => 1 << level);
+        subdivisionScheme.getLevelDimensionY.callsFake((level: number) => 1 << level);
+        // tslint:enable:no-bitwise
+
+        const result1 = getSubTileArray(0, 0, 0);
+        assert.equal(result1.length, 4);
+        assert.deepInclude(result1, { row: 0, column: 0, level: 1 });
+        assert.deepInclude(result1, { row: 0, column: 1, level: 1 });
+        assert.deepInclude(result1, { row: 1, column: 0, level: 1 });
+        assert.deepInclude(result1, { row: 1, column: 1, level: 1 });
+
+        const result2 = getSubTileArray(11, 7, 4);
+        assert.equal(result2.length, 4);
+        assert.deepInclude(result2, { row: 22, column: 14, level: 5 });
+        assert.deepInclude(result2, { row: 22, column: 15, level: 5 });
+        assert.deepInclude(result2, { row: 23, column: 14, level: 5 });
+        assert.deepInclude(result2, { row: 23, column: 15, level: 5 });
+    });
+
+    it("get tiles of double umbrella subdivison", function() {
+        // tslint:disable:no-bitwise
+        subdivisionScheme.getSubdivisionX.returns(2);
+        subdivisionScheme.getSubdivisionY.callsFake((level: number) => (level === 0 ? 2 : 1));
+        subdivisionScheme.getLevelDimensionX.callsFake((level: number) => 1 << level);
+        subdivisionScheme.getLevelDimensionY.callsFake((level: number) => (level === 0 ? 1 : 2));
+        // tslint:enable:no-bitwise
+
+        const result1 = getSubTileArray(0, 0, 0);
+        assert.equal(result1.length, 4);
+        assert.deepInclude(result1, { row: 0, column: 0, level: 1 });
+        assert.deepInclude(result1, { row: 0, column: 1, level: 1 });
+        assert.deepInclude(result1, { row: 1, column: 0, level: 1 });
+        assert.deepInclude(result1, { row: 1, column: 1, level: 1 });
+
+        const result2 = getSubTileArray(1, 61, 7);
+        assert.equal(result2.length, 2);
+        assert.deepInclude(result2, { row: 1, column: 122, level: 8 });
+        assert.deepInclude(result2, { row: 1, column: 123, level: 8 });
+
+        const result3 = getSubTileArray(0, 44, 15);
+        assert.equal(result3.length, 2);
+        assert.deepInclude(result3, { row: 0, column: 88, level: 16 });
+        assert.deepInclude(result3, { row: 0, column: 89, level: 16 });
+    });
+});

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -244,13 +244,14 @@ export class AnimatedExtrusionTileHandler {
     }
 
     private getChildTiles(tileKeys: TileKey[]) {
-        let result: TileKey[] = [];
+        const result: TileKey[] = [];
 
         tileKeys.forEach(tileKey => {
-            const dataSource = this.tile.dataSource;
-            const childTileKeys = dataSource.getTilingScheme().getSubTileKeys(tileKey);
+            const childTileKeys = this.tile.dataSource.getTilingScheme().getSubTileKeys(tileKey);
 
-            result = result.concat(childTileKeys);
+            for (const childTileKey of childTileKeys) {
+                result.push(childTileKey);
+            }
         });
         return result;
     }

--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -130,7 +130,7 @@ export class FrustumIntersection {
                 continue;
             }
 
-            tilingScheme.getSubTileKeys(tileKey).forEach(childTileKey => {
+            for (const childTileKey of tilingScheme.getSubTileKeys(tileKey)) {
                 const offset = tileEntry.offset;
                 const tileKeyAndOffset = TileOffsetUtils.getKeyForTileKeyAndOffset(
                     childTileKey,
@@ -169,7 +169,7 @@ export class FrustumIntersection {
                     this.m_tileKeyEntries.set(tileKeyAndOffset, subTileEntry);
                     workList.push(subTileEntry);
                 }
-            });
+            }
         }
         return { tileKeyEntries: this.m_tileKeyEntries, calculationFinal };
     }

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -609,7 +609,8 @@ export class VisibleTileSet {
                             mortonCode
                         } = TileOffsetUtils.extractOffsetAndMortonKeyFromKey(tileKeyCode);
                         const tileKey = TileKey.fromMortonCode(mortonCode);
-                        tilingScheme.getSubTileKeys(tileKey).forEach(childTileKey => {
+
+                        for (const childTileKey of tilingScheme.getSubTileKeys(tileKey)) {
                             const childTileCode = TileOffsetUtils.getKeyForTileKeyAndOffset(
                                 childTileKey,
                                 offset
@@ -627,7 +628,7 @@ export class VisibleTileSet {
                             if (nextLevelDiff < this.options.quadTreeSearchDistanceDown) {
                                 nextLevelCandidates.set(childTileCode, SearchDirection.DOWN);
                             }
-                        });
+                        }
                     }
                 });
                 incompleteTiles = nextLevelCandidates;


### PR DESCRIPTION
Signed-off-by: Oleksii Kanishchev <49714978+okanishchev@users.noreply.github.com>

Fixed SubTiles to support custom subdivision schemes;
Force SubTiles to return an iterator and as result avoid using IIFE while iterating over SubTiles.