### PR TITLE
HARP-6781: Restrict the values manipilated by style expressions.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -140,7 +140,7 @@ export type BinaryOp = RelationalOp | EqualityOp;
 /**
  * @hidden
  */
-export type Value = undefined | null | boolean | number | string;
+export type Value = null | boolean | number | string;
 
 /**
  * @hidden
@@ -151,14 +151,14 @@ export class Env {
      *
      * @param name Name of property.
      */
-    lookup(_name: string): Value {
+    lookup(_name: string): Value | undefined {
         return undefined;
     }
 
     /**
      * Return an object containing all properties of this environment. (Here: empty object).
      */
-    unmap(): any {
+    unmap(): ValueMap {
         return {};
     }
 }
@@ -183,7 +183,7 @@ export class MapEnv extends Env {
      *
      * @param name Name of property.
      */
-    lookup(name: string): Value {
+    lookup(name: string): Value | undefined {
         if (this.entries.hasOwnProperty(name)) {
             const value = this.entries[name];
 
@@ -199,7 +199,7 @@ export class MapEnv extends Env {
      * Return an object containing all properties of this environment, takes care of the parent
      * object.
      */
-    unmap(): any {
+    unmap(): ValueMap {
         const obj: any = this.parent ? this.parent.unmap() : {};
 
         for (const key in this.entries) {

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -48,7 +48,10 @@ export class ExprEvaluatorContext {
     ) {}
 
     evaluate(expr: Expr | undefined) {
-        return expr === undefined ? undefined : expr.accept(this.evaluator, this);
+        if (expr !== undefined) {
+            return expr.accept(this.evaluator, this);
+        }
+        throw new Error("Failed to evaluate expression");
     }
 }
 

--- a/@here/harp-datasource-protocol/lib/TileInfo.ts
+++ b/@here/harp-datasource-protocol/lib/TileInfo.ts
@@ -544,7 +544,7 @@ export class ExtendedTileInfoWriter {
         const textLabel = textTechnique.label;
         const useAbbreviation = textTechnique.useAbbreviation as boolean;
         const useIsoCode = textTechnique.useIsoCode as boolean;
-        const name: Value =
+        const name =
             typeof textLabel === "string"
                 ? env.lookup(textLabel)
                 : ExtendedTileInfo.getFeatureName(env, useAbbreviation, useIsoCode, this.languages);
@@ -673,24 +673,28 @@ export class ExtendedTileInfoWriter {
         ExtendedTileInfo.finish(this.tileInfo);
     }
 
-    private addText(name: Value): number {
+    private addText(name: Value | undefined): number {
         return this.addStringValue(name, this.tileInfo.textCatalog, this.stringMap);
     }
 
-    private addLayer(name: Value): number {
+    private addLayer(name: Value | undefined): number {
         return this.addStringValue(name, this.tileInfo.layerCatalog!, this.layerMap);
     }
 
-    private addClass(name: Value): number {
+    private addClass(name: Value | undefined): number {
         return this.addStringValue(name, this.tileInfo.classCatalog!, this.classMap);
     }
 
-    private addType(name: Value): number {
+    private addType(name: Value | undefined): number {
         return this.addStringValue(name, this.tileInfo.typeCatalog!, this.typeMap);
     }
 
     // Add a string to the strings catalog. Returns index into the catalog.
-    private addStringValue(str: Value, catalog: string[], map: Map<string, number>): number {
+    private addStringValue(
+        str: Value | undefined,
+        catalog: string[],
+        map: Map<string, number>
+    ): number {
         if (str === undefined || str === null) {
             return -1;
         }

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -53,8 +53,7 @@ describe("MapEnv", function() {
     before(function() {
         env = new MapEnv(
             {
-                foo: "foo",
-                bar: undefined
+                foo: "foo"
             },
             new MapEnv({
                 parentProperty: 123,

--- a/@here/harp-geojson-datasource/lib/GeoJsonParser.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonParser.ts
@@ -21,7 +21,12 @@ import {
     isTextTechnique,
     LineFeatureGroup
 } from "@here/harp-datasource-protocol";
-import { MapEnv, StyleSetEvaluator, Value } from "@here/harp-datasource-protocol/index-decoder";
+import {
+    MapEnv,
+    StyleSetEvaluator,
+    Value,
+    ValueMap
+} from "@here/harp-datasource-protocol/index-decoder";
 
 import { GeoCoordinates, Projection } from "@here/harp-geoutils";
 import { LoggerManager } from "@here/harp-utils";
@@ -461,7 +466,7 @@ export class GeoJsonParser {
             featureDetails.featureId = featureId;
         }
 
-        const env = new MapEnv({ type: "line", ...featureDetails });
+        const env = new MapEnv({ type: "line", ...(featureDetails as ValueMap) });
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
         const featureIdNumber = 0; //geojsonTile do not have an integer for the featureId. Use 0.
         if (buffer.lines.vertices.length !== buffer.lines.geojsonProperties.length) {
@@ -519,7 +524,7 @@ export class GeoJsonParser {
             featureDetails.featureId = featureId;
         }
 
-        const env = new MapEnv({ type: "line", ...featureDetails });
+        const env = new MapEnv({ type: "line", ...(featureDetails as ValueMap) });
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
         const featureIdNumber = 0; //geojsonTile do not have an integer for the featureId. Use 0.
         if (buffer.lines.vertices.length !== buffer.lines.geojsonProperties.length) {
@@ -725,7 +730,7 @@ export class GeoJsonParser {
     ): number[] {
         const featureDetails: FeatureDetails = Flattener.flatten(feature.properties, "properties");
         featureDetails.featureId = feature.id;
-        const env = new MapEnv({ type: envType, ...featureDetails });
+        const env = new MapEnv({ type: envType, ...(featureDetails as ValueMap) });
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
         return techniques.map(technique => {
             return technique._index;

--- a/@here/harp-omv-datasource/lib/OmvData.ts
+++ b/@here/harp-omv-datasource/lib/OmvData.ts
@@ -352,7 +352,10 @@ function createFeatureEnv(
 
     // Some sources serve `id` directly as `IFeature` property ...
     if (feature.id !== undefined) {
-        attributes.$id = decodeFeatureId(feature, logger);
+        const featureId = decodeFeatureId(feature, logger);
+        if (featureId !== undefined) {
+            attributes.$id = featureId;
+        }
     }
 
     readAttributes(layer, feature, attributes);

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -240,7 +240,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                     const textLabel = textTechnique.label;
                     const useAbbreviation = textTechnique.useAbbreviation as boolean;
                     const useIsoCode = textTechnique.useIsoCode as boolean;
-                    const name: Value =
+                    const name =
                         typeof textLabel === "string"
                             ? env.lookup(textLabel)
                             : OmvDecoder.getFeatureName(
@@ -359,7 +359,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 const textLabel = textTechnique.label;
                 const useAbbreviation = textTechnique.useAbbreviation as boolean;
                 const useIsoCode = textTechnique.useIsoCode as boolean;
-                let text: Value =
+                let text =
                     typeof textLabel === "string"
                         ? env.lookup(textLabel)
                         : OmvDecoder.getFeatureName(


### PR DESCRIPTION
This change removes 'undefined' from the possible types that
the evaluation of expression can generate. That is, 'undefined'
values when evaluating expressions should be treated as errors.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
