### PR TITLE
HARP-6776: Allow worker count to be set independently per decoder bundle

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -61,6 +61,11 @@ export interface TileDataSourceOptions {
     concurrentDecoderScriptUrl?: string;
 
     /**
+     * Optional count of web workers to use with the decoder bundle.
+     */
+    concurrentDecoderWorkerCount?: number;
+
+    /**
      * Optional, default copyright information of tiles provided by this data source.
      *
      * Implementation should provide this information from the source data if possible.
@@ -143,7 +148,8 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
         } else if (m_options.concurrentDecoderServiceName) {
             this.m_decoder = ConcurrentDecoderFacade.getTileDecoder(
                 m_options.concurrentDecoderServiceName,
-                m_options.concurrentDecoderScriptUrl
+                m_options.concurrentDecoderScriptUrl,
+                m_options.concurrentDecoderWorkerCount
             );
         } else {
             throw new Error(

--- a/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
@@ -31,9 +31,14 @@ export class ConcurrentDecoderFacade {
      *
      * @param decoderServiceType The name of the decoder service type.
      * @param scriptUrl The optional URL with the workers' script.
+     * @param workerCount The number of web workers to use.
      */
-    static getTileDecoder(decoderServiceType: string, scriptUrl?: string): ITileDecoder {
-        const workerSet = this.getWorkerSet(scriptUrl);
+    static getTileDecoder(
+        decoderServiceType: string,
+        scriptUrl?: string,
+        workerCount?: number
+    ): ITileDecoder {
+        const workerSet = this.getWorkerSet(scriptUrl, workerCount);
 
         return new WorkerBasedDecoder(workerSet, decoderServiceType);
     }
@@ -43,8 +48,9 @@ export class ConcurrentDecoderFacade {
      *
      * @param scriptUrl The optional URL with the workers' script. If not specified,
      * the function uses [[defaultScriptUrl]] instead.
+     * @param workerCount The number of web workers to use.
      */
-    static getWorkerSet(scriptUrl?: string): ConcurrentWorkerSet {
+    static getWorkerSet(scriptUrl?: string, workerCount?: number): ConcurrentWorkerSet {
         if (scriptUrl === undefined) {
             scriptUrl = this.defaultScriptUrl;
         }
@@ -53,7 +59,7 @@ export class ConcurrentDecoderFacade {
         if (workerSet === undefined) {
             workerSet = new ConcurrentWorkerSet({
                 scriptUrl,
-                workerCount: this.defaultWorkerCount
+                workerCount: workerCount === undefined ? this.defaultWorkerCount : workerCount
             });
             this.workerSets[scriptUrl] = workerSet;
         }

--- a/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
@@ -31,9 +31,10 @@ export class ConcurrentTilerFacade {
      *
      * @param tilerServiceType The name of the tiler service type.
      * @param scriptUrl The optional URL with the workers' script.
+     * @param workerCount The number of web workers to use.
      */
-    static getTiler(tilerServiceType: string, scriptUrl?: string): ITiler {
-        const workerSet = this.getWorkerSet(scriptUrl);
+    static getTiler(tilerServiceType: string, scriptUrl?: string, workerCount?: number): ITiler {
+        const workerSet = this.getWorkerSet(scriptUrl, workerCount);
 
         return new WorkerBasedTiler(workerSet, tilerServiceType);
     }
@@ -43,8 +44,9 @@ export class ConcurrentTilerFacade {
      *
      * @param scriptUrl The optional URL with the workers' script. If not specified,
      * the function uses [[defaultScriptUrl]] instead.
+     * @param workerCount The number of web workers to use.
      */
-    static getWorkerSet(scriptUrl?: string): ConcurrentWorkerSet {
+    static getWorkerSet(scriptUrl?: string, workerCount?: number): ConcurrentWorkerSet {
         if (scriptUrl === undefined) {
             scriptUrl = this.defaultScriptUrl;
         }
@@ -53,7 +55,7 @@ export class ConcurrentTilerFacade {
         if (workerSet === undefined) {
             workerSet = new ConcurrentWorkerSet({
                 scriptUrl,
-                workerCount: this.defaultWorkerCount
+                workerCount: workerCount === undefined ? this.defaultWorkerCount : workerCount
             });
             this.workerSets[scriptUrl] = workerSet;
         }


### PR DESCRIPTION
- Users may now also override the MapView default worker count when
  instantiating a TileDataSource