### PR TITLE
HARP-6811: Improve map view fog calculation.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2440,7 +2440,7 @@ export class MapView extends THREE.EventDispatcher {
         }
 
         this.updateCameras();
-        this.m_fog.update(this.m_camera);
+        this.m_fog.update(this.m_camera, this.projection);
         this.m_renderer.clear();
 
         // clear the scene

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2266,6 +2266,7 @@ export class MapView extends THREE.EventDispatcher {
         const zoomLevelDistance = cameraPosZ / Math.cos(Math.min(cameraPitch, Math.PI / 3));
 
         this.m_zoomLevel = MapViewUtils.calculateZoomLevelFromDistance(zoomLevelDistance, this);
+        this.m_fog.update(this.m_camera, this.projection, clipPlanes.maximum);
     }
 
     /**
@@ -2440,7 +2441,6 @@ export class MapView extends THREE.EventDispatcher {
         }
 
         this.updateCameras();
-        this.m_fog.update(this.m_camera, this.projection);
         this.m_renderer.clear();
 
         // clear the scene

--- a/@here/harp-mapview/lib/poi/PixelPicker.ts
+++ b/@here/harp-mapview/lib/poi/PixelPicker.ts
@@ -58,8 +58,8 @@ export function screenToUvCoordinates(
     const maxX = box.x + box.w;
     const minY = box.y;
     const maxY = box.y + box.h;
-    const u = MathUtils.lerp(screenX, minX, maxX, uvBox.s0, uvBox.s1);
-    const v = MathUtils.lerp(screenY, minY, maxY, uvBox.t0, uvBox.t1);
+    const u = MathUtils.map(screenX, minX, maxX, uvBox.s0, uvBox.s1);
+    const v = MathUtils.map(screenY, minY, maxY, uvBox.t0, uvBox.t1);
 
     return { u, v };
 }

--- a/@here/harp-utils/lib/MathUtils.ts
+++ b/@here/harp-utils/lib/MathUtils.ts
@@ -19,6 +19,22 @@ export namespace MathUtils {
     }
 
     /**
+     * Returns a linear interpolation between the values of edge0 and edge1 based on the factor.
+     *
+     * Given two known points the linear interpolant between these points may be presented as
+     * straight line. This means that for given factor change the resulting change of return
+     * value is always const.
+     * @see https://en.wikipedia.org/wiki/Linear_interpolation
+     *
+     * @param edge0
+     * @param edge1
+     * @param factor Interpolation factor that ranges between: 0 <= x <= 1.
+     */
+    export function lerp(edge0: number, edge1: number, factor: number): number {
+        return edge0 * (1 - factor) + edge1 * factor;
+    }
+
+    /**
      * Returns a smooth interpolation between the values edge0 and edge1 based on the interpolation
      * factor x. `0 <= x <= 1`.
      * @see https://en.wikipedia.org/wiki/Smoothstep
@@ -63,13 +79,7 @@ export namespace MathUtils {
      * @param outMin Lower bound of the value's target range.
      * @param outMax Upper bound of the value's target range.
      */
-    export function lerp(
-        val: number,
-        inMin: number,
-        inMax: number,
-        outMin: number,
-        outMax: number
-    ) {
+    export function map(val: number, inMin: number, inMax: number, outMin: number, outMax: number) {
         return ((val - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin;
     }
 


### PR DESCRIPTION
MapViewFog is now tilt angle dependent and should work with any kind of
projection type. Moreover it allows to define both vertical (looking top-
down) and horizontal density. This values may be moved in future to the
Theme fog definition.
This change is required in order to support dynamic frustum (near/far
planes) changes, because old implementation is only far plane related
and does not support precise far plane setup just below the ground level.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
