### PR TITLE
HARP-6249: Caps for lines endings

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -8,6 +8,12 @@ import { JsonExpr } from "./Expr";
 import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 
 /**
+ * Available line caps types(`"None"`, `"Round"`, `"Square"`, `"TriangleOut"`, `"TriangleIn"`).
+ * Default is `"Round"`.
+ */
+export type LineCaps = "Square" | "Round" | "None" | "TriangleOut" | "TriangleIn";
+
+/**
  * The kind of geometry is used to
  *
  * a) Group objects together, allowing the group to be hidden or displayed.
@@ -916,6 +922,12 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      * The render order of the secondary line geometry object created using this technique.
      */
     secondaryRenderOrder?: number;
+
+    /**
+     * Describes line caps type (`"None"`, `"Round"`, `"Square"`, `"TriangleOut"`, `"TriangleIn"`).
+     * Default is `"Round"`.
+     */
+    caps?: LineCaps;
 }
 
 /**
@@ -975,6 +987,12 @@ export interface DashedLineTechniqueParams extends BaseTechniqueParams, Polygona
      * Clip the line outside the tile if `true`.
      */
     clipping?: boolean;
+
+    /**
+     * Describes line caps type (`"None"`, `"Round"`, `"Square"`, `"TriangleOut"`, `"TriangleIn"`).
+     * Default is `"Round"`.
+     */
+    caps?: LineCaps;
 }
 
 /**

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -26,7 +26,6 @@
     "dependencies": {
         "@here/harp-geometry": "^0.10.0",
         "@here/harp-geoutils": "^0.10.0",
-        "@here/harp-lines": "^0.10.0",
         "@here/harp-utils": "^0.10.0"
     },
     "devDependencies": {

--- a/@here/harp-lines/lib/Lines.ts
+++ b/@here/harp-lines/lib/Lines.ts
@@ -36,21 +36,23 @@ interface VertexDescriptor {
 /** Optional normal and uv coordinates. */
 const NORMAL_UV_VERTEX_ATTRIBUTES: VertexDescriptor = {
     attributes: [
-        { name: "uv", itemSize: 2, offset: 12 },
-        { name: "normal", itemSize: 3, offset: 14 }
+        { name: "uv", itemSize: 2, offset: 13 },
+        { name: "normal", itemSize: 3, offset: 15 }
     ],
     stride: 5
 };
 
 /** Base line vertex attributes. */
 const LINE_VERTEX_ATTRIBUTES: VertexDescriptor = {
+    // The "extrusionCoord" its a vec3. Represents UV coordinates + line length for the third
+    // component.
     attributes: [
-        { name: "extrusionCoord", itemSize: 2, offset: 0 },
-        { name: "position", itemSize: 3, offset: 2 },
-        { name: "tangent", itemSize: 3, offset: 5 },
-        { name: "bitangent", itemSize: 4, offset: 8 }
+        { name: "extrusionCoord", itemSize: 3, offset: 0 },
+        { name: "position", itemSize: 3, offset: 3 },
+        { name: "tangent", itemSize: 3, offset: 6 },
+        { name: "bitangent", itemSize: 4, offset: 9 }
     ],
-    stride: 12
+    stride: 13
 };
 
 /** Base line vertex attributes plus normals and uv coordinates. */
@@ -151,6 +153,7 @@ export function createLineGeometry(
         sum = sum + len;
         segments[i + 1] = sum;
     }
+    const lineLength = segments[segments.length - 1];
 
     // Check if we're working with a closed line.
     let isClosed = true;
@@ -167,7 +170,7 @@ export function createLineGeometry(
     ) => {
         for (let v = -1; v <= 1; v += 2) {
             // Store the segment and extrusionCoord attributes.
-            geometry.vertices.push(segment, extrusionCoord * v);
+            geometry.vertices.push(segment, extrusionCoord * v, lineLength);
 
             // Store the position attribute (component-dependant).
             for (let j = 0; j < 3; ++j) {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -47,6 +47,7 @@ import {
     EdgeMaterial,
     EdgeMaterialParameters,
     FadingFeature,
+    LineCapsDefinitions,
     MapMeshBasicMaterial,
     MapMeshStandardMaterial,
     SolidLineMaterial
@@ -689,6 +690,13 @@ export class TileGeometryCreator {
 
                     if (bufferGeometry.getAttribute("color")) {
                         lineMaterial.defines.USE_COLOR = 1;
+                    }
+
+                    if (
+                        technique.caps !== undefined &&
+                        LineCapsDefinitions.hasOwnProperty(technique.caps)
+                    ) {
+                        lineMaterial.defines[LineCapsDefinitions[technique.caps]] = 1;
                     }
                 }
 

--- a/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
@@ -34,6 +34,43 @@ float joinDist(vec2 segment, vec2 texcoord) {
     return d;
 }
 `,
+    round_edges_and_add_caps: `
+float roundEdgesAndAddCaps(in vec2 segment, in vec2 uv, in float lineEnds) {
+
+    float dist = 0.0;
+
+    #if defined(CAPS_NONE)
+        if (lineEnds > -0.1) {
+            dist = max((lineEnds + 0.1) / 0.1, abs(uv.y));
+        } else {
+            dist = joinDist(segment, uv);
+        }
+    #elif defined(CAPS_SQUARE)
+        if (lineEnds > 0.0) {
+            dist = max(abs(uv.y), lineEnds);
+        } else {
+            dist = joinDist(segment, uv);
+        }
+    #elif defined(CAPS_TRIANGLE_OUT)
+        if (lineEnds > 0.0) {
+            dist = (abs(uv.y)) + lineEnds;
+        } else {
+            dist = joinDist(segment, uv);
+        }
+    #elif defined(CAPS_TRIANGLE_IN)
+        if (lineEnds > 0.0) {
+            float y = abs(uv.y);
+            dist = max(y, (lineEnds-y) + lineEnds);
+        } else {
+            dist = joinDist(segment, uv);
+        }
+    #else
+        dist = joinDist(vSegment, vExtrusionCoord);
+    #endif
+
+    return dist;
+}
+`,
     tile_clip_func: `
 void tileClip(vec2 tilePos, vec2 tileSize) {
     if (tileSize.x > 0.0 && (tilePos.x < -tileSize.x / 2.0 || tilePos.x > tileSize.x / 2.0))

--- a/@here/harp-materials/package.json
+++ b/@here/harp-materials/package.json
@@ -20,6 +20,7 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
+        "@here/harp-datasource-protocol": "^0.10.0",
         "@here/harp-utils": "^0.10.0"
     },
     "devDependencies": {


### PR DESCRIPTION
   Added caps support for lines.
   The following types are supported now:
   "Square", "Round", "None", "TriangleOut", "TriangleIn"

Signed-off-by: Stepan Krovspei <11714928+pit-rpg@users.noreply.github.com>