### PR TITLE
HARP-6773: Extruded building overlay without sockets.

### DIFF
--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -95,6 +95,10 @@ export function createDepthPrePassMesh(mesh: THREE.Mesh): THREE.Mesh {
     if (uvAttribute) {
         depthPassGeometry.addAttribute("uv", uvAttribute);
     }
+    const normalAttribute = originalGeometry.getAttribute("normal");
+    if (normalAttribute) {
+        depthPassGeometry.addAttribute("normal", normalAttribute);
+    }
     const extrusionAxisAttribute = originalGeometry.getAttribute("extrusionAxis");
     if (extrusionAxisAttribute) {
         depthPassGeometry.addAttribute("extrusionAxis", extrusionAxisAttribute);

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -985,6 +985,9 @@ export class TileGeometryCreator {
 
                 if (renderDepthPrePass) {
                     const depthPassMesh = createDepthPrePassMesh(object as THREE.Mesh);
+                    // Set geometry kind for depth pass mesh so that it gets the displacement map
+                    // for elevation overlay.
+                    this.registerTileObject(tile, depthPassMesh, technique.kind);
                     objects.push(depthPassMesh);
 
                     if (extrusionAnimationEnabled) {
@@ -1013,6 +1016,16 @@ export class TileGeometryCreator {
                     const extrusionAttribute = bufferGeometry.getAttribute("extrusionAxis");
                     if (extrusionAttribute !== undefined) {
                         edgeGeometry.addAttribute("extrusionAxis", extrusionAttribute);
+                    }
+
+                    const normalAttribute = bufferGeometry.getAttribute("normal");
+                    if (normalAttribute !== undefined) {
+                        edgeGeometry.addAttribute("normal", normalAttribute);
+                    }
+
+                    const uvAttribute = bufferGeometry.getAttribute("uv");
+                    if (uvAttribute !== undefined) {
+                        edgeGeometry.addAttribute("uv", uvAttribute);
                     }
 
                     edgeGeometry.setIndex(

--- a/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
+++ b/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
@@ -9,20 +9,14 @@ import * as THREE from "three";
 import { Tile, TileObject } from "../Tile";
 
 function overlayObject(object: TileObject, displacementMap: THREE.DataTexture): void {
-    if (!object.userData || !object.userData.kind) {
+    if (!("material" in object)) {
         return;
     }
 
-    if (
-        !object.userData.kind.find((kind: GeometryKind) => {
-            return kind !== GeometryKind.All && kind !== GeometryKind.Terrain;
-        })
-    ) {
-        return;
-    }
+    const material = (object as any).material;
 
-    if (object instanceof THREE.Mesh && "displacementMap" in object.material) {
-        (object.material as any).displacementMap = displacementMap;
+    if ("displacementMap" in material) {
+        (material as any).displacementMap = displacementMap;
     }
 }
 
@@ -38,7 +32,18 @@ export function overlayOnElevation(tile: Tile): void {
         return;
     }
     const displacementMap = elevationProvider.getDisplacementMap(tile.tileKey);
-    if (displacementMap === undefined) {
+    if (displacementMap === undefined || tile.objects.length === 0) {
+        return;
+    }
+
+    const firstObject = tile.objects[0];
+    if (
+        !firstObject.userData ||
+        !firstObject.userData.kind ||
+        !firstObject.userData.kind.find((kind: GeometryKind) => {
+            return kind !== GeometryKind.All && kind !== GeometryKind.Terrain;
+        })
+    ) {
         return;
     }
 

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -27,7 +27,10 @@ attribute vec3 normal;
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
 uniform float lineWidth;
+
+#ifdef USE_DISPLACEMENTMAP
 uniform sampler2D displacementMap;
+#endif
 
 varying vec2 vExtrusionCoord;
 varying vec2 vSegment;


### PR DESCRIPTION
Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

First implementation of extruded building overlay without creating sockets. All building vertices are displaced using the elevation map texture.

Tested on fake terrain since ElevationProvider does not provide yet elevation maps for zoom levels where extruded buildings are visible.