### PR TITLE
HARP-7009: Improve error handling when connecting to datasource

### DIFF
--- a/@here/harp-datasource-protocol/lib/WorkerServiceProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerServiceProtocol.ts
@@ -70,6 +70,9 @@ export namespace WorkerServiceProtocol {
     /**
      * This message is sent by the main thread to [[WorkerServiceManager]] to dynamically create a
      * new service.
+     *
+     * May throw `UnknownServiceError` if service of given type is not registered in
+     * [[WorkerServiceManager]], see [[isUnknownServiceError]].
      */
     export interface CreateServiceRequest extends ServiceRequest {
         type: Requests.CreateService;
@@ -85,6 +88,13 @@ export namespace WorkerServiceProtocol {
          * The newly created service instance will be available under this id.
          */
         targetServiceId: string;
+    }
+
+    /**
+     * Test if `error` thrown by [[CreateServiceRequest]] was caused by unknown type of service.
+     */
+    export function isUnknownServiceError(error: Error): boolean {
+        return /unknown targetServiceType requested: /.test(error.message);
     }
 
     /**

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -185,7 +185,6 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
 
     async connect() {
         await Promise.all([this.m_options.dataProvider.connect(), this.m_decoder.connect()]);
-
         this.m_isReady = true;
     }
 

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1693,6 +1693,10 @@ export class MapView extends THREE.EventDispatcher {
                 this.update();
             })
             .catch(error => {
+                logger.error(
+                    `Failed to connect to datasource ${dataSource.name}: ${error.message}`
+                );
+
                 this.m_failedDataSources.add(dataSource.name);
                 this.dispatchEvent({
                     type: MapViewEventNames.DataSourceConnect,

--- a/@here/harp-mapview/lib/WorkerBasedDecoder.ts
+++ b/@here/harp-mapview/lib/WorkerBasedDecoder.ts
@@ -15,11 +15,8 @@ import {
     WorkerServiceProtocol
 } from "@here/harp-datasource-protocol";
 import { Projection, TileKey } from "@here/harp-geoutils";
-import { LoggerManager } from "@here/harp-utils";
 
 import { ConcurrentWorkerSet } from "./ConcurrentWorkerSet";
-
-const logger = LoggerManager.instance.create("WorkerBasedDecoder");
 
 /**
  * Identifier of next decoder worker-service. Used to ensure uniqueness of service ids of decoders
@@ -79,19 +76,15 @@ export class WorkerBasedDecoder implements ITileDecoder {
     async connect(): Promise<void> {
         await this.workerSet.connect(WorkerServiceProtocol.WORKER_SERVICE_MANAGER_SERVICE_ID);
         if (!this.m_serviceCreated) {
-            try {
-                await this.workerSet.broadcastRequest(
-                    WorkerServiceProtocol.WORKER_SERVICE_MANAGER_SERVICE_ID,
-                    {
-                        type: WorkerServiceProtocol.Requests.CreateService,
-                        targetServiceType: this.decoderServiceType,
-                        targetServiceId: this.serviceId
-                    }
-                );
-                this.m_serviceCreated = true;
-            } catch (e) {
-                logger.error(e);
-            }
+            await this.workerSet.broadcastRequest(
+                WorkerServiceProtocol.WORKER_SERVICE_MANAGER_SERVICE_ID,
+                {
+                    type: WorkerServiceProtocol.Requests.CreateService,
+                    targetServiceType: this.decoderServiceType,
+                    targetServiceId: this.serviceId
+                }
+            );
+            this.m_serviceCreated = true;
         }
     }
 

--- a/@here/harp-mapview/lib/WorkerBasedTiler.ts
+++ b/@here/harp-mapview/lib/WorkerBasedTiler.ts
@@ -11,10 +11,7 @@ import {
     WorkerTilerProtocol
 } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils";
-import { LoggerManager } from "@here/harp-utils";
 import { ConcurrentWorkerSet } from "./ConcurrentWorkerSet";
-
-const logger = LoggerManager.instance.create("WorkerBasedTiler");
 
 /**
  * Identifier of next tiler worker-service. Used to ensure uniqueness of service ids of tilers
@@ -74,19 +71,16 @@ export class WorkerBasedTiler implements ITiler {
     async connect(): Promise<void> {
         await this.workerSet.connect(WorkerServiceProtocol.WORKER_SERVICE_MANAGER_SERVICE_ID);
         if (!this.m_serviceCreated) {
-            try {
-                await this.workerSet.broadcastRequest(
-                    WorkerServiceProtocol.WORKER_SERVICE_MANAGER_SERVICE_ID,
-                    {
-                        type: WorkerServiceProtocol.Requests.CreateService,
-                        targetServiceType: this.tilerServiceType,
-                        targetServiceId: this.serviceId
-                    }
-                );
-                this.m_serviceCreated = true;
-            } catch (e) {
-                logger.error(e);
-            }
+            await this.workerSet.broadcastRequest(
+                WorkerServiceProtocol.WORKER_SERVICE_MANAGER_SERVICE_ID,
+                {
+                    type: WorkerServiceProtocol.Requests.CreateService,
+                    targetServiceType: this.tilerServiceType,
+                    targetServiceId: this.serviceId
+                }
+            );
+
+            this.m_serviceCreated = true;
         }
     }
 

--- a/@here/harp-mapview/lib/workers/WorkerBootstrapDefs.ts
+++ b/@here/harp-mapview/lib/workers/WorkerBootstrapDefs.ts
@@ -8,7 +8,7 @@
  * Message sent by web worker that requests to resolve actual
  * URLs of it's dependencies.
  *
- * Main thread is expected
+ * Main thread is expected.
  */
 export interface WorkerBootstrapRequest {
     type: "worker-bootstrap-request";

--- a/@here/harp-mapview/test/FakeWebWorker.ts
+++ b/@here/harp-mapview/test/FakeWebWorker.ts
@@ -115,9 +115,9 @@ export interface LimitedWorkerScope {
  */
 export function willExecuteWorkerScript(
     workerConstructorStub: any,
-    workerScript: (self: LimitedWorkerScope) => void
+    workerScript: (self: LimitedWorkerScope, scriptUrl: string) => void
 ) {
-    workerConstructorStub.callsFake(function(this: FakeWorkerData) {
+    workerConstructorStub.callsFake(function(this: FakeWorkerData, scriptUrl: string) {
         const intListeners: ListenerMap = {
             message: new MessageQueue(),
             error: new MessageQueue()
@@ -144,7 +144,7 @@ export function willExecuteWorkerScript(
         const workerStartScript = () => {
             FakeWorkerSelf.fakeSelf(workerSelf);
             try {
-                workerScript(workerSelf);
+                workerScript(workerSelf, scriptUrl);
                 FakeWorkerSelf.restoreSelf();
             } catch (error) {
                 FakeWorkerSelf.restoreSelf();

--- a/@here/harp-mapview/test/WorkerLoaderTest.ts
+++ b/@here/harp-mapview/test/WorkerLoaderTest.ts
@@ -10,7 +10,7 @@
 import { assert } from "chai";
 import * as sinon from "sinon";
 
-import { getTestResourceUrl, stubGlobalConstructor } from "@here/harp-test-utils";
+import { assertRejected, getTestResourceUrl, stubGlobalConstructor } from "@here/harp-test-utils";
 
 import { WorkerLoader } from "../lib/workers/WorkerLoader";
 import { FakeWebWorker, willExecuteWorkerScript } from "./FakeWebWorker";
@@ -20,8 +20,49 @@ declare const global: any;
 const workerDefined = typeof Worker !== "undefined" && typeof Blob !== "undefined";
 const describeWithWorker = workerDefined ? describe : xdescribe;
 
+const testWorkerUrl = getTestResourceUrl("@here/harp-mapview", "test/resources/testWorker.js");
+
+describeWithWorker("Web Worker API", function() {
+    it("Worker is able to load worker from blob", done => {
+        // note, for this test to work, CSP (Content Security Policy)
+        // must allow for executing workers from blob:
+        // example:
+        //   child-src blob:   (legacy)
+        //   worker-src: blob: (new, but not yet recognized by browsers)
+        const script = `
+            self.postMessage({ hello: 'world' });
+        `;
+        assert.isDefined(Blob);
+
+        const blob = new Blob([script], { type: "application/javascript" });
+        assert.isTrue(blob.size > 0);
+        const worker = new Worker(URL.createObjectURL(blob));
+        worker.addEventListener("message", event => {
+            assert.isDefined(event.data);
+            assert.equal(event.data.hello, "world");
+            done();
+        });
+        worker.addEventListener("error", msg => {
+            done(new Error("received error event"));
+        });
+    });
+
+    it("Worker is able to load worker from URL", done => {
+        const worker = new Worker(testWorkerUrl);
+        worker.addEventListener("message", event => {
+            assert.isDefined(event.data);
+            assert.equal(event.data.hello, "world");
+            done();
+        });
+        worker.addEventListener("error", msg => {
+            done(new Error("received error event"));
+        });
+    });
+});
+
 describe("WorkerLoader", function() {
     let sandbox: sinon.SinonSandbox;
+    let restoreMochaGlobalExceptionHandler: boolean = false;
     beforeEach(function() {
         sandbox = sinon.createSandbox();
         if (typeof window === "undefined") {
@@ -35,143 +76,220 @@ describe("WorkerLoader", function() {
         if (typeof window === "undefined") {
             delete global.Worker;
         }
-
+        if (restoreMochaGlobalExceptionHandler) {
+            (Mocha as any).process.addListener("uncaughtException");
+        }
         WorkerLoader.directlyFallbackToBlobBasedLoading = false;
     });
 
-    const testWorkerUrl = getTestResourceUrl("@here/harp-mapview", "test/resources/testWorker.js");
+    describe("works in mocked environment", function() {
+        it("#startWorker starts worker not swalling first message", async function() {
+            const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
+            willExecuteWorkerScript(workerConstructorStub, (self, scriptUrl) => {
+                self.postMessage({ hello: "world" });
+            });
 
-    it("WorkerLoader falls back to blob / sync", async function() {
-        // setup an environment in which any attempt to load worker from from non-blob URL
-        // fails, so we check if WorkerLoader does it's job
-        //
-        // sync version - mimics Chrome, which in case of CSP violation throws error
-        // immediately from Worker constructor
+            const worker = await WorkerLoader.startWorker(testWorkerUrl);
+            await new Promise((resolve, reject) => {
+                worker.addEventListener("message", event => {
+                    assert.isDefined(event.data);
+                    assert.equal(event.data.hello, "world");
+                    resolve();
+                });
+                worker.addEventListener("error", msg => {
+                    reject(new Error("received error event"));
+                });
+            });
 
-        const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
-        willExecuteWorkerScript(workerConstructorStub, self => {
-            self.postMessage({ hello: "world" });
+            assert.equal(workerConstructorStub.callCount, 1);
+            assert.equal(workerConstructorStub.firstCall.args[0], testWorkerUrl);
         });
 
-        const worker = await WorkerLoader.startWorker(testWorkerUrl);
-        await new Promise((resolve, reject) => {
-            worker.addEventListener("message", event => {
-                assert.isDefined(event.data);
-                assert.equal(event.data.hello, "world");
-                resolve();
+        it("#startWorker fails on timeout", async function() {
+            const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
+            willExecuteWorkerScript(workerConstructorStub, () => {
+                // We intentionally do not send anything, so waitForWorkerInitialized
+                // should raise timeout error.
+                // self.postMessage({ hello: "world" });
             });
-            worker.addEventListener("error", msg => {
-                reject(new Error("received error event"));
-            });
+
+            await assertRejected(WorkerLoader.startWorker(testWorkerUrl, 10), /timeout/i);
         });
 
-        assert.equal(workerConstructorStub.callCount, 1);
-        assert.equal(workerConstructorStub.firstCall.args[0], testWorkerUrl);
+        it("#startWorker fails on error in script", async function() {
+            const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker");
+            willExecuteWorkerScript(workerConstructorStub, () => {
+                // We intentionally throw error in global context to see if it is caught by
+                // workerLoader.
+
+                (null as any).foo = "aa";
+            });
+
+            await assertRejected(
+                WorkerLoader.startWorker(testWorkerUrl, 50),
+                /Error during worker initialization/i
+            );
+        });
     });
 
     describeWithWorker("real Workers integration", function() {
-        it("WorkerLoader falls back to blob / sync", async function() {
-            // setup an environment in which any attempt to load worker from from non-blob URL
-            // fails, so we check if WorkerLoader does it's job
-            //
-            // sync version - mimics Chrome, which in case of CSP violation throws error
-            // immediately from Worker constructor
+        describe("basic operations", function() {
+            it("#startWorker starts worker not swalling first message", async function() {
+                const script = `
+                    self.postMessage({ hello: 'world' });
+                `;
+                assert.isDefined(Blob);
 
-            const originalWorkerConstructor = Worker;
-            const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker") as any;
-            workerConstructorStub.callsFake(function(this: Worker, scriptUrl: string) {
-                if (!scriptUrl.startsWith("blob:")) {
-                    throw new Error("content policy violated, ouch");
-                } else {
-                    return new originalWorkerConstructor(scriptUrl);
-                }
-            });
+                const blob = new Blob([script], { type: "application/javascript" });
 
-            const worker = await WorkerLoader.startWorker(testWorkerUrl);
-            await new Promise((resolve, reject) => {
-                worker.addEventListener("message", event => {
-                    assert.isDefined(event.data);
-                    assert.equal(event.data.hello, "world");
-                    resolve();
-                });
-                worker.addEventListener("error", msg => {
-                    reject(new Error("received error event"));
+                const worker = await WorkerLoader.startWorker(URL.createObjectURL(blob));
+                await new Promise((resolve, reject) => {
+                    worker.addEventListener("message", event => {
+                        assert.isDefined(event.data);
+                        assert.equal(event.data.hello, "world");
+                        resolve();
+                    });
+                    worker.addEventListener("error", msg => {
+                        reject(new Error("received error event"));
+                    });
                 });
             });
+            it("#startWorker fails on timeout", async function() {
+                const script = `
+                    // We intentionally throw error in global context to see if it is caught by
+                    // workerLoader.
+                    //self.postMessage({ hello: 'world' });
+                `;
+                assert.isDefined(Blob);
 
-            assert.equal(workerConstructorStub.callCount, 2);
-            assert.equal(workerConstructorStub.firstCall.args[0], testWorkerUrl);
-            assert(workerConstructorStub.secondCall.args[0].startsWith, "blob:");
-        });
+                const blob = new Blob([script], { type: "application/javascript" });
 
-        it("WorkerLoader falls back to blob / async", async function() {
-            // setup an environment in which any attempt to load worker from from non-blob URL
-            // fails, so we check if WorkerLoader does it's job
-            //
-            // async version - mimics Firefox, which in case of CSP violation signals error
-            // asynchronously with 'error' event
-
-            const originalWorkerConstructor = Worker;
-            const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker") as any;
-            workerConstructorStub.callsFake(function(this: Worker, scriptUrl: string) {
-                const actualWorker = new originalWorkerConstructor(scriptUrl);
-                if (!scriptUrl.startsWith("blob:")) {
-                    setTimeout(() => {
-                        actualWorker.dispatchEvent(new ErrorEvent("error"));
-                    }, 0);
-                }
-                return actualWorker;
+                await assertRejected(
+                    WorkerLoader.startWorker(URL.createObjectURL(blob), 10),
+                    /timeout/i
+                );
             });
-            const worker = await WorkerLoader.startWorker(testWorkerUrl);
 
-            await new Promise((resolve, reject) => {
-                worker.addEventListener("message", event => {
-                    assert.isDefined(event.data);
-                    assert.equal(event.data.hello, "world");
-                    resolve();
-                });
-                worker.addEventListener("error", msg => {
-                    reject(new Error("received error event"));
-                });
-            });
-            assert.equal(workerConstructorStub.callCount, 2);
-            assert.equal(workerConstructorStub.firstCall.args[0], testWorkerUrl);
-            assert(workerConstructorStub.secondCall.args[0].startsWith, "blob:");
-        });
+            it("#startWorker catches error in worker global context", async function() {
+                const script = `
+                    // We intentionally do not send anything, so waitForWorkerInitialized
+                    // should raise timeout error.
+                    null.foo = "aa";
+                `;
+                assert.isDefined(Blob);
 
-        it("browser is able to load worker from blob", done => {
-            // note, for this test to work, CSP (Content Security Policy)
-            // must allow for executing workers from blob:
-            // example:
-            //   child-src blob:   (legacy)
-            //   worker-src: blob: (new, but not yet recognized by browsers)
-            const script = `
-                self.postMessage({ hello: 'world' });
-            `;
-            assert.isDefined(Blob);
+                // For some reason, both Chrome and Firefox call global exception handler
+                // for error in global worker context (probably to help lazy developers) even
+                // if we subscribe to `onerror`.
+                // It's reported on console and to mocha, so we
+                //  1) Show log message, so random developer is not worried about error in developer
+                //     console
+                // tslint:disable-next-line:no-console
+                console.log(
+                    "Next 'TypeError' about accessing null in some blob based worker is handled. " +
+                        "Don't worry"
+                );
 
-            const blob = new Blob([script], { type: "application/javascript" });
-            assert.isTrue(blob.size > 0);
-            const worker = new Worker(URL.createObjectURL(blob));
-            worker.addEventListener("message", event => {
-                assert.isDefined(event.data);
-                assert.equal(event.data.hello, "world");
-                done();
-            });
-            worker.addEventListener("error", msg => {
-                done(new Error("received error event"));
+                //  2) Temporarily disable global exception handler, so mocha doesn't report
+                //     this as error
+                restoreMochaGlobalExceptionHandler = true;
+                (Mocha as any).process.removeListener("uncaughtException");
+                const blob = new Blob([script], { type: "application/javascript" });
+                await assertRejected(
+                    WorkerLoader.startWorker(URL.createObjectURL(blob)),
+                    /Error during worker initialization/i
+                );
             });
         });
 
-        it("browser is able to load worker from URL", done => {
-            const worker = new Worker(testWorkerUrl);
-            worker.addEventListener("message", event => {
-                assert.isDefined(event.data);
-                assert.equal(event.data.hello, "world");
-                done();
+        describe("loading of cross-origin scripts", function() {
+            const cspTestScriptUrl = "https://example.com/foo.js";
+
+            it("#startWorker falls back to blob in case of sync error", async function() {
+                // setup an environment in which any attempt to load worker from from non-blob,
+                // cross-origin URL which fails, so we check if WorkerLoader will attempt to
+                // load using blob: fallback
+                //
+                // sync version - mimics Chrome, which in case of CSP violation throws error
+                // immediately from Worker constructor
+
+                const originalWorkerConstructor = Worker;
+                const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker") as any;
+                workerConstructorStub.callsFake(function(this: Worker, scriptUrl: string) {
+                    if (!scriptUrl.startsWith("blob:")) {
+                        throw new Error("content policy violated, ouch");
+                    } else {
+                        return new originalWorkerConstructor(scriptUrl);
+                    }
+                });
+
+                const originalFetch = fetch;
+                const fetchStub = sandbox.stub(window, "fetch");
+                fetchStub.callsFake(async (url: RequestInfo) => {
+                    assert.equal(url, cspTestScriptUrl);
+                    return originalFetch(testWorkerUrl);
+                });
+
+                const worker = await WorkerLoader.startWorker(cspTestScriptUrl);
+                await new Promise((resolve, reject) => {
+                    worker.addEventListener("message", event => {
+                        assert.isDefined(event.data);
+                        assert.equal(event.data.hello, "world");
+                        resolve();
+                    });
+                    worker.addEventListener("error", msg => {
+                        reject(new Error("received error event"));
+                    });
+                });
+
+                assert.isTrue(fetchStub.calledOnce);
+                assert.equal(workerConstructorStub.callCount, 2);
+                assert.equal(workerConstructorStub.firstCall.args[0], cspTestScriptUrl);
+                assert(workerConstructorStub.secondCall.args[0].startsWith, "blob:");
             });
-            worker.addEventListener("error", msg => {
-                done(new Error("received error event"));
+
+            it("#startWorker falls back to blob in case of async error", async function() {
+                // setup an environment in which any attempt to load worker from from non-blob,
+                // cross-origin URL which fails, so we check if WorkerLoader will attempt to
+                // load using blob: fallback
+                //
+                // async version - mimics Firefox, which in case of CSP violation signals error
+                // asynchronously with 'error' event
+
+                const originalWorkerConstructor = Worker;
+                const workerConstructorStub = stubGlobalConstructor(sandbox, "Worker") as any;
+                workerConstructorStub.callsFake(function(this: Worker, scriptUrl: string) {
+                    const actualWorker = new originalWorkerConstructor(scriptUrl);
+                    if (!scriptUrl.startsWith("blob:")) {
+                        setTimeout(() => {
+                            actualWorker.dispatchEvent(new ErrorEvent("error"));
+                        }, 0);
+                    }
+                    return actualWorker;
+                });
+
+                const originalFetch = fetch;
+                const fetchStub = sandbox.stub(window, "fetch");
+                fetchStub.callsFake(async (url: RequestInfo) => {
+                    assert.equal(url, cspTestScriptUrl);
+                    return originalFetch(testWorkerUrl);
+                });
+                const worker = await WorkerLoader.startWorker(cspTestScriptUrl);
+
+                await new Promise((resolve, reject) => {
+                    worker.addEventListener("message", event => {
+                        assert.isDefined(event.data);
+                        assert.equal(event.data.hello, "world");
+                        resolve();
+                    });
+                    worker.addEventListener("error", msg => {
+                        reject(new Error("received error event"));
+                    });
+                });
+                assert.isTrue(fetchStub.calledOnce);
+                assert.equal(workerConstructorStub.callCount, 2);
+                assert.equal(workerConstructorStub.firstCall.args[0], cspTestScriptUrl);
+                assert(workerConstructorStub.secondCall.args[0].startsWith, "blob:");
             });
         });
     });

--- a/@here/harp-test-utils/lib/TestUtils.ts
+++ b/@here/harp-test-utils/lib/TestUtils.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { assert } from "chai";
 import * as sinon from "sinon";
 
 /**
@@ -139,6 +140,29 @@ export function willEventually<T = void>(test: () => T): Promise<T> {
         }
         setTimeout(iteration, 1);
     });
+}
+
+/**
+ * Assert that promise is rejected.
+ *
+ * Check that promise `v` (passed directly or result of function) is eventually rejected with error
+ * that matches `errorMessagePattern`.
+ */
+export async function assertRejected(
+    v: Promise<any> | (() => Promise<any>),
+    errorMessagePattern: string | RegExp
+) {
+    let r: any;
+    try {
+        r = await Promise.resolve(typeof v === "function" ? v() : v);
+    } catch (error) {
+        if (typeof errorMessagePattern === "string") {
+            errorMessagePattern = new RegExp(errorMessagePattern);
+        }
+        assert.match(error.message, errorMessagePattern);
+        return;
+    }
+    assert.fail(`expected exception that matches ${errorMessagePattern}, but received '${r}'`);
 }
 
 export interface EventSource<T> {

--- a/@here/harp-test-utils/package.json
+++ b/@here/harp-test-utils/package.json
@@ -20,15 +20,17 @@
         "url": "https://here.com"
     },
     "license": "Apache-2.0",
+    "dependencies": {
+        "chai": "^4.1.2",
+        "sinon": "^7.3.2"
+    },
     "devDependencies": {
         "@here/harp-fetch": "^0.3.6",
         "@here/harp-utils": "^0.10.0",
         "@types/chai": "^4.0.4",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.0.8",
-        "chai": "^4.1.2",
         "cross-env": "^5.2.0",
-        "sinon": "^7.3.2",
         "source-map-support": "^0.5.3",
         "typescript": "^3.5.2"
     },


### PR DESCRIPTION
Followup of #760 

* `ConcurrentWorkerSet#connect` now
  * properly waits for all workers (and rejects if any of them failed)
  * throws meaningful message if trying to connect to unknown service
  * timeouts if created worker doesn't respond at all
* implementations of `DataSource`/`DataProvider` pass `connect` failures up
  to `MapView`
* `MapView#addDataSource` handles and logs `DS#connect` errors
* `OmvDataSource#connect` shows hint, if `omv-decoder` service is not
  registered in decoder
* `GeoJsonDataProvider` shows hint in console, if `omv-tiler` service
  is not registered in decoder

TODO:
* [x] - show hints only once