### PR TITLE
HARP-6512 Remove linear tile search from TerrainElevationProvider

### DIFF
--- a/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
+++ b/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
@@ -7,6 +7,7 @@
 import { GeoBox } from "../coordinates/GeoBox";
 import { GeoCoordinates } from "../coordinates/GeoCoordinates";
 import { GeoCoordinatesLike } from "../coordinates/GeoCoordinatesLike";
+import { Vector3Like } from "../math/Vector3Like";
 import { TileKey } from "./TileKey";
 import { TilingScheme } from "./TilingScheme";
 
@@ -17,9 +18,18 @@ export class TileKeyUtils {
         level: number
     ): TileKey | null {
         const projection = tilingScheme.projection;
-        const subdivisionScheme = tilingScheme.subdivisionScheme;
-
         const worldPoint = projection.projectPoint(geoPoint);
+
+        return this.worldCoordinatesToTileKey(tilingScheme, worldPoint, level);
+    }
+
+    static worldCoordinatesToTileKey(
+        tilingScheme: TilingScheme,
+        worldPoint: Vector3Like,
+        level: number
+    ): TileKey | null {
+        const projection = tilingScheme.projection;
+        const subdivisionScheme = tilingScheme.subdivisionScheme;
 
         const cx = subdivisionScheme.getLevelDimensionX(level);
         const cy = subdivisionScheme.getLevelDimensionY(level);

--- a/@here/harp-mapview/lib/ElevationProvider.ts
+++ b/@here/harp-mapview/lib/ElevationProvider.ts
@@ -13,8 +13,7 @@ export interface ElevationProvider {
      *
      * @param geoPoint geo position to query height for.
      * @param level Optional data level that should be used for getting the elevation.
-     *              If undefined the deepest available tile that contains the geoPoint will be
-     *              used.
+     *              If undefined, the view's visible tile containing the point will be used.
      * @returns The height at geoPoint or undefined if no tile was found that covers the geoPoint.
      */
     getHeight(geoPoint: GeoCoordinates, level?: number): number | undefined;

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2511,7 +2511,7 @@ export class MapView extends THREE.EventDispatcher {
 
             // Increment the counters for all data sources.
             renderList.forEach(({ zoomLevel, renderedTiles, visibleTiles, numTilesLoading }) => {
-                currentFrameEvent!.addValue("renderCount.numTilesRendered", renderedTiles.length);
+                currentFrameEvent!.addValue("renderCount.numTilesRendered", renderedTiles.size);
                 currentFrameEvent!.addValue("renderCount.numTilesVisible", visibleTiles.length);
                 currentFrameEvent!.addValue("renderCount.numTilesLoading", numTilesLoading);
             });
@@ -2920,7 +2920,7 @@ export class MapView extends THREE.EventDispatcher {
     private getRenderedTilesCopyrightInfo(): CopyrightInfo[] {
         let result: CopyrightInfo[] = [];
         for (const tileList of this.m_visibleTiles.dataSourceTileList) {
-            for (const tile of tileList.renderedTiles) {
+            for (const tile of tileList.renderedTiles.values()) {
                 const tileCopyrightInfo = tile.copyrightInfo;
                 if (tileCopyrightInfo === undefined || tileCopyrightInfo.length === 0) {
                     continue;

--- a/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
@@ -96,10 +96,10 @@ export interface TileGeometryManager {
     /**
      * Return all [[GeometryKind]]s that are contained in the tiles.
      *
-     * @param {Tile[]} tiles The
+     * @param {IterableIterator<Tile>} tiles The
      * @returns {GeometryKindSet}
      */
-    getAvailableKinds(tiles: Tile[]): GeometryKindSet;
+    getAvailableKinds(tiles: IterableIterator<Tile>): GeometryKindSet;
 
     /**
      * Sets a callback that will be called for every updated tile on [[updateTiles]].
@@ -218,7 +218,7 @@ export abstract class TileGeometryManagerBase implements TileGeometryManager {
         }
     }
 
-    getAvailableKinds(tiles: Tile[]): GeometryKindSet {
+    getAvailableKinds(tiles: IterableIterator<Tile>): GeometryKindSet {
         const visibleKinds: GeometryKindSet = new GeometryKindSet();
         for (const tile of tiles) {
             const geometryLoader = tile.tileGeometryLoader as TileGeometryLoader;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -2201,7 +2201,7 @@ export class TextElementsRenderer {
     }
 
     private renderTileList(
-        visibleTiles: Tile[],
+        visibleTiles: Map<number, Tile>,
         time: number,
         frameNumber: number,
         zoomLevel: number,
@@ -2209,13 +2209,13 @@ export class TextElementsRenderer {
         renderedTextElements?: TextElement[],
         secondChanceTextElements?: TextElement[]
     ) {
-        if (this.m_textRenderers.length === 0 || visibleTiles.length === 0) {
+        if (this.m_textRenderers.length === 0 || visibleTiles.size === 0) {
             return;
         }
 
         const consideredTextElements = new GroupedPriorityList<TextElement>();
 
-        for (const tile of visibleTiles) {
+        for (const tile of visibleTiles.values()) {
             consideredTextElements.merge(tile.placedTextElements);
         }
 
@@ -2259,7 +2259,7 @@ export class TextElementsRenderer {
         let numTextElementsInScene = 0;
 
         renderList.forEach(renderListEntry => {
-            for (const tile of renderListEntry.renderedTiles) {
+            for (const tile of renderListEntry.renderedTiles.values()) {
                 numTextElementsInScene += tile.textElementGroups.count();
                 numTextElementsInScene += tile.userTextElements.length;
             }

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -13,6 +13,7 @@ import { FrustumIntersection } from "../lib/FrustumIntersection";
 import { SimpleTileGeometryManager } from "../lib/geometry/TileGeometryManager";
 import { MapView, MapViewDefaults } from "../lib/MapView";
 import { Tile } from "../lib/Tile";
+import { TileOffsetUtils } from "../lib/Utils";
 import { VisibleTileSet } from "../lib/VisibleTileSet";
 import { FakeOmvDataSource } from "./FakeOmvDataSource";
 
@@ -101,7 +102,7 @@ describe("VisibleTileSet", function() {
         assert.equal(visibleTiles[1].tileKey.mortonCode(), 371506850);
 
         const renderedTiles = dataSourceTileList[0].renderedTiles;
-        assert.equal(renderedTiles.length, 0);
+        assert.equal(renderedTiles.size, 0);
     });
 
     it("#updateRenderList properly culls panorama of Berlin center", function() {
@@ -135,7 +136,7 @@ describe("VisibleTileSet", function() {
         assert.equal(visibleTiles[4].tileKey.mortonCode(), 371506827);
 
         const renderedTiles = dataSourceTileList[0].renderedTiles;
-        assert.equal(renderedTiles.length, 0);
+        assert.equal(renderedTiles.size, 0);
     });
 
     it("#updateRenderList properly finds parent loaded tiles in Berlin center", function() {
@@ -146,13 +147,12 @@ describe("VisibleTileSet", function() {
 
         // same as first found code few lines below
         const parentCode = TileKey.parentMortonCode(371506851);
+        const parentTileKey = TileKey.fromMortonCode(parentCode);
+        const parentKey = TileOffsetUtils.getKeyForTileKeyAndOffset(parentTileKey, 0);
 
         // fake MapView to think that it has already loaded
         // parent of both found tiles
-        const parentTile = fixture.vts.getTile(
-            fixture.ds[0],
-            TileKey.fromMortonCode(parentCode)
-        ) as Tile;
+        const parentTile = fixture.vts.getTile(fixture.ds[0], parentTileKey) as Tile;
         assert.exists(parentTile);
         parentTile.forceHasGeometry(true);
 
@@ -167,8 +167,9 @@ describe("VisibleTileSet", function() {
 
         // some tiles are visible ^^^, but the parent is actually rendered
         const renderedTiles = dataSourceTileList[0].renderedTiles;
-        assert.equal(renderedTiles.length, 1);
-        assert.equal(renderedTiles[0].tileKey.mortonCode(), parentCode);
+        assert.equal(renderedTiles.size, 1);
+        assert(renderedTiles.has(parentKey));
+        assert.equal(renderedTiles.get(parentKey)!.tileKey.mortonCode(), parentCode);
     });
 
     it("#markTilesDirty properly handles cached & visible tiles", async function() {


### PR DESCRIPTION
getDisplacementMap and getHeight methods in TerrainElevationProvider do a linear search over all terrain tiles cached in the VisibleTileSet until the tile with the requested key/geopoint is found.

This change improves this by getting directly the proper tile from the LRU tile cache.
For getHeight, the tile key is calculated from the given geopoint using terrainSource.getTilingScheme().getTileKey().