### PR TITLE
Move InterpolatedProperty handling outside of StyleSetEvaluator.

### DIFF
--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -3,19 +3,30 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { Color, CubicInterpolant, DiscreteInterpolant, LinearInterpolant } from "three";
 
+import { LoggerManager } from "@here/harp-utils";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
-import { StringEncodedNumeralFormats, StringEncodedNumeralType } from "./StringEncodedNumeral";
-
 import {
     InterpolatedProperty,
     InterpolatedPropertyDefinition,
     InterpolationMode,
     MaybeInterpolatedProperty
 } from "./InterpolatedPropertyDefs";
-
+import {
+    StringEncodedHex,
+    StringEncodedHSL,
+    StringEncodedMeters,
+    StringEncodedNumeralFormat,
+    StringEncodedNumeralFormats,
+    StringEncodedNumeralType,
+    StringEncodedPixels,
+    StringEncodedRGB
+} from "./StringEncodedNumeral";
 import { StyleColor, StyleLength } from "./TechniqueParams";
+
+const logger = LoggerManager.instance.create("InterpolatedProperty");
 
 const interpolants = [
     DiscreteInterpolant,
@@ -183,4 +194,124 @@ function getInterpolatedColor(property: InterpolatedProperty<StyleColor>, level:
             interpolant.resultBuffer[2]
         )
         .getHex();
+}
+
+/**
+ * Convert JSON representation of interpolated property to internal, normalized version that
+ * can be evaluated by [[getPropertyValue]].
+ */
+export function createInterpolatedProperty(
+    prop: InterpolatedPropertyDefinition<unknown>
+): InterpolatedProperty<unknown> | undefined {
+    removeDuplicatePropertyValues(prop);
+    const propKeys = new Float32Array(prop.zoomLevels);
+    let propValues;
+    let maskValues;
+    const firstValue = prop.values[0];
+    switch (typeof firstValue) {
+        default:
+        case "number":
+            propValues = new Float32Array((prop.values as any[]) as number[]);
+            return {
+                interpolationMode:
+                    prop.interpolation !== undefined
+                        ? InterpolationMode[prop.interpolation]
+                        : InterpolationMode.Discrete,
+                zoomLevels: propKeys,
+                values: propValues,
+                exponent: prop.exponent
+            };
+        case "boolean":
+            propValues = new Float32Array(prop.values.length);
+            for (let i = 0; i < prop.values.length; ++i) {
+                propValues[i] = ((prop.values[i] as unknown) as boolean) ? 1 : 0;
+            }
+            return {
+                interpolationMode: InterpolationMode.Discrete,
+                zoomLevels: propKeys,
+                values: propValues,
+                exponent: prop.exponent
+            };
+        case "string":
+            let needsMask = false;
+
+            const matchedFormat = StringEncodedNumeralFormats.find(format =>
+                format.regExp.test(firstValue)
+            );
+            if (matchedFormat === undefined) {
+                logger.error(`No StringEncodedNumeralFormat matched ${firstValue}.`);
+                return undefined;
+            }
+            propValues = new Float32Array(prop.values.length * matchedFormat.size);
+            maskValues = new Float32Array(prop.values.length);
+            needsMask = procesStringEnocodedNumeralInterpolatedProperty(
+                matchedFormat,
+                prop as InterpolatedPropertyDefinition<string>,
+                propValues,
+                maskValues
+            );
+
+            return {
+                interpolationMode:
+                    prop.interpolation !== undefined
+                        ? InterpolationMode[prop.interpolation]
+                        : InterpolationMode.Discrete,
+                zoomLevels: propKeys,
+                values: propValues,
+                exponent: prop.exponent,
+                _stringEncodedNumeralType: matchedFormat.type,
+                _stringEncodedNumeralDynamicMask: needsMask ? maskValues : undefined
+            };
+    }
+}
+
+function removeDuplicatePropertyValues<T>(p: InterpolatedPropertyDefinition<T>) {
+    for (let i = 0; i < p.values.length; ++i) {
+        const firstIdx = p.zoomLevels.findIndex((a: number) => {
+            return a === p.zoomLevels[i];
+        });
+        if (firstIdx !== i) {
+            p.zoomLevels.splice(--i, 1);
+            p.values.splice(--i, 1);
+        }
+    }
+}
+
+const colorFormats = [StringEncodedHSL, StringEncodedHex, StringEncodedRGB];
+const worldSizeFormats = [StringEncodedMeters, StringEncodedPixels];
+
+function procesStringEnocodedNumeralInterpolatedProperty(
+    baseFormat: StringEncodedNumeralFormat,
+    prop: InterpolatedPropertyDefinition<string>,
+    propValues: Float32Array,
+    maskValues: Float32Array
+): boolean {
+    let needsMask = false;
+    const allowedValueFormats =
+        baseFormat.type === StringEncodedNumeralType.Meters ||
+        baseFormat.type === StringEncodedNumeralType.Pixels
+            ? worldSizeFormats
+            : colorFormats;
+
+    for (let valueIdx = 0; valueIdx < prop.values.length; ++valueIdx) {
+        for (const valueFormat of allowedValueFormats) {
+            const value = prop.values[valueIdx];
+            if (!valueFormat.regExp.test(value)) {
+                continue;
+            }
+
+            if (valueFormat.mask !== undefined) {
+                maskValues[valueIdx] = valueFormat.mask;
+                needsMask = true;
+            }
+
+            const result = valueFormat.decoder(value);
+            for (let i = 0; i < result.length; ++i) {
+                propValues[valueIdx * valueFormat.size + i] = result[i];
+            }
+            break;
+        }
+    }
+
+    return needsMask;
 }


### PR DESCRIPTION
Interpolator related code moved away from `StyleSetEvaluator`.
Only code move, no functional change.
(Needed by #695)