### PR TITLE
HARP-6886: Z-fighting improvements.

### DIFF
--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -113,8 +113,10 @@ export class InterpolatedClipPlanesEvaluator implements ClipPlanesEvaluator {
             const p = this.m_tmpVectors[0].copy(camera.position);
             p.addScaledVector(fwdRot, Math.sqrt(d * d - r * r));
             farPlane = p.sub(camera.position).dot(fwd);
-            const bias = 2000; // TODO: generalize.
-            nearPlane = Math.max(this.nearMin, projection.groundDistance(camera.position) - bias);
+            nearPlane = Math.max(
+                this.nearMin,
+                projection.groundDistance(camera.position) * this.nearMultiplier
+            );
         } else if (projection.type === ProjectionType.Planar) {
             const groundDistance = projection.groundDistance(camera.position);
             nearPlane = Math.max(this.nearMin, groundDistance * this.nearMultiplier);

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -690,17 +690,6 @@ export class TileGeometryCreator {
                         lineMaterial.defines.USE_COLOR = 1;
                     }
                 }
-                // Add polygon offset to the extruded buildings and to the fill area to avoid depth
-                // problems when rendering edges.
-                const hasExtrudedOutlines: boolean =
-                    isExtrudedPolygonTechnique(technique) && srcGeometry.edgeIndex !== undefined;
-                const hasFillOutlines: boolean =
-                    isFillTechnique(technique) && srcGeometry.edgeIndex !== undefined;
-                if (hasExtrudedOutlines || hasFillOutlines) {
-                    material.polygonOffset = true;
-                    material.polygonOffsetFactor = 0.75;
-                    material.polygonOffsetUnits = 4.0;
-                }
 
                 // Add the solid line outlines as a separate object.
                 const hasSolidLinesOutlines: boolean =
@@ -955,7 +944,7 @@ export class TileGeometryCreator {
                 objects.push(object);
 
                 // Add the extruded building edges as a separate geometry.
-                if (hasExtrudedOutlines) {
+                if (isExtrudedPolygonTechnique(technique) && srcGeometry.edgeIndex !== undefined) {
                     const edgeGeometry = new THREE.BufferGeometry();
                     edgeGeometry.addAttribute("position", bufferGeometry.getAttribute("position"));
 
@@ -1057,7 +1046,8 @@ export class TileGeometryCreator {
                 }
 
                 // Add the fill area edges as a separate geometry.
-                if (hasFillOutlines) {
+
+                if (isFillTechnique(technique) && srcGeometry.edgeIndex !== undefined) {
                     const outlineGeometry = new THREE.BufferGeometry();
                     outlineGeometry.addAttribute(
                         "position",

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -16,6 +16,8 @@ import {
 } from "./MapMeshMaterials";
 
 const vertexSource: string = `
+#define EDGE_DEPTH_OFFSET 0.00005
+
 attribute vec3 position;
 attribute vec4 color;
 
@@ -61,6 +63,7 @@ void main() {
     vec4 mvPosition = modelViewMatrix * vec4( transformed, 1.0 );
 
     gl_Position = projectionMatrix * mvPosition;
+    gl_Position.z -= EDGE_DEPTH_OFFSET * gl_Position.w;
 
     #ifdef USE_FADING
     #include <fading_vertex>

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -731,11 +731,9 @@ export class ExtrusionFeatureMixin implements ExtrusionFeature {
      * @param source The material to copy property values from.
      */
     protected copyExtrusionParameters(source: ExtrusionFeature) {
-        this.setExtrusionRatio(
-            source.extrusionRatio === undefined
-                ? AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX
-                : source.extrusionRatio
-        );
+        if (source.extrusionRatio !== undefined) {
+            this.setExtrusionRatio(source.extrusionRatio);
+        }
         return this;
     }
 }


### PR DESCRIPTION
Signed-off-by: Andrés Valencia Téllez <ext-andres.valencia-tellez@here.com>

Improved present z-fighting by:
* Fixing extrusionFeature attribute copy (broken depth pre-pass for non animated buildings).
* Removing the polygonOffset applied to meshes and applying instead a VS depth offset for edge geometries.


Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.


Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!