### PR TITLE
Support for continous zoom level inteprpolation in RoadPicker.

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -134,7 +134,7 @@ export interface RoadIntersectionData {
     /**
      * An array of widths of the roads. The lists of IDs and widths have the same size.
      */
-    widths: number[];
+    widths: Array<number | (() => number)>;
 
     /**
      * An array of 2D numbers that make up the road geometry.


### PR DESCRIPTION
Support for continous zoom level inteprpolation in RoadPicker.
    
Makes road picking accurate when tilting map.

Width properties of `solid-line`s can be dynamically interpolated
in scope of one zoom level, so `widths` of road data have to be
interpolated based on actual zoom level.
    
    
Improvement will be visible once #734, is merged.
