### PR TITLE
HARP-7072: Basic support for scene state dependent dynamic expressions.

### DIFF
--- a/@here/harp-datasource-protocol/index-decoder.ts
+++ b/@here/harp-datasource-protocol/index-decoder.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./lib/StyleSetEvaluator";
+export * from "./lib/FeatureEnv";
 export * from "./lib/Extruder";
 export * from "./lib/IMeshBuffers";
 export * from "./lib/Outliner";

--- a/@here/harp-datasource-protocol/index-decoder.ts
+++ b/@here/harp-datasource-protocol/index-decoder.ts
@@ -10,3 +10,4 @@ export * from "./lib/Extruder";
 export * from "./lib/IMeshBuffers";
 export * from "./lib/Outliner";
 export * from "./lib/Expr";
+export * from "./lib/DecodedTechnique";

--- a/@here/harp-datasource-protocol/lib/DecodedTechnique.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTechnique.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RemoveExpr } from "./DynamicTechniqueAttr";
+import { Expr, JsonExpr } from "./Expr";
+import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
+import { IndexedTechnique, Technique } from "./Techniques";
+
+/**
+ * Make dependent type from particular [[Technique]] that maps dynamic attributes to transferable,
+ * representation: [[DecodedTechniqueExpr]]
+ */
+
+export type MakeDecodedTechnique<T extends Technique> = {
+    [P in keyof T]: (T[P] | Expr | InterpolatedProperty<any>) extends T[P]
+        ? RemoveExpr<T[P]> | JsonExpr
+        : T[P];
+};
+
+/**
+ * Technique-dependent type that can be transfered through context boundaries.
+ */
+export type DecodedTechnique = MakeDecodedTechnique<Technique>;
+
+/**
+ * Create transferable representation of dynamic technique.
+ */
+export function makeDecodedTechnique(technique: IndexedTechnique): DecodedTechnique {
+    const result: Partial<DecodedTechnique> = {};
+    for (const attrName in technique) {
+        if (!technique.hasOwnProperty(attrName)) {
+            continue;
+        }
+        let attrValue: any = (technique as any)[attrName];
+        if (attrValue instanceof Expr) {
+            attrValue = attrValue.toJSON();
+        }
+        (result as any)[attrName] = attrValue;
+    }
+    return (result as any) as DecodedTechnique;
+}

--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -13,7 +13,7 @@ import {
     sphereProjection,
     webMercatorProjection
 } from "@here/harp-geoutils";
-import { Technique } from "./Techniques";
+import { DecodedTechnique } from "./DecodedTechnique";
 import { TileInfo } from "./TileInfo";
 
 /**
@@ -22,7 +22,7 @@ import { TileInfo } from "./TileInfo";
  * metadata describing these buffers.
  */
 export interface DecodedTile {
-    techniques: Technique[];
+    techniques: DecodedTechnique[];
     geometries: Geometry[];
     textPathGeometries?: TextPathGeometry[];
     textGeometries?: TextGeometry[]; // ### deprecate

--- a/@here/harp-datasource-protocol/lib/DynamicTechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/DynamicTechniqueAttr.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Env, Expr, JsonExpr, Value } from "./Expr";
+import { isInterpolatedProperty } from "./InterpolatedProperty";
+import { InterpolatedProperty, InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
+import { IndexedTechniqueParams } from "./Techniques";
+
+export interface SceneState {
+    /**
+     * Time as received in `requestAnimationFrame` callback..
+     *
+     * Interpolators may use it cache last values, if they expect many invocations per because they
+     * were used by several objects.
+     */
+    time: number;
+
+    /**
+     * Frame number.
+     *
+     * Interpolators may use it cache last values, if they expect many invocations per because they
+     * were used by several object.
+     */
+    frameNumber: number;
+    zoomLevel: number;
+    pixelToMeters: number;
+
+    /**
+     * Used for fading feature.
+     */
+    maxVisibility: number;
+}
+
+export class SceneStateEnv extends Env {
+    constructor(readonly sceneState: SceneState) {
+        super();
+    }
+    lookup(name: string): Value {
+        return (this.sceneState as any)[name] as Value;
+    }
+    unmap(): any {
+        return { ...this.sceneState };
+    }
+}
+
+export type RemoveType<T, R> = (T | R) extends T ? Exclude<T, R> : T;
+
+// TODO: Can be removed, when all when interpolators are implemented as [[Expr]]s
+export type RemoveInterpolatedPropDefinition<T> = RemoveType<
+    T,
+    InterpolatedPropertyDefinition<any>
+>;
+export type RemoveInterpolatedProperty<T> = (T | InterpolatedProperty<any>) extends T
+    ? Exclude<T, InterpolatedProperty<any>>
+    : T;
+export type RemoveJsonExpr<T> = (T | JsonExpr) extends T ? Exclude<T, JsonExpr> : T;
+export type RemoveExpr<T> = (T | Expr) extends T ? Exclude<T, Expr> : T;
+
+export type DynamicTechniqueAttr<T = Value> = Expr | InterpolatedProperty<T>;
+
+/**
+ * Make runtime representation of technique attributes from JSON-compatible typings.
+ *
+ * Translates
+ *  - InterpolatedPropertyDefinition -> InterpolatedProperty
+ *  - JsonExpr -> Expr
+ */
+
+export type MakeTechniqueAttrs<T> = {
+    [P in keyof T]: (T[P] | JsonExpr) extends T[P]
+        ?
+              | RemoveInterpolatedPropDefinition<RemoveJsonExpr<T[P]>>
+              | Expr
+              | InterpolatedProperty<unknown>
+        : T[P];
+};
+export type MakeTechnique<T> = MakeTechniqueAttrs<T> & Partial<IndexedTechniqueParams>;
+
+export function isDynamicTechniqueExpr(x: any): x is DynamicTechniqueAttr {
+    return x instanceof Expr || isInterpolatedProperty(x) || typeof x === "function";
+}
+
+export interface IDynamicTechniqueHandler {
+    addDynamicAttrHandler<T>(
+        attrValue: T | DynamicTechniqueAttr<T>,
+        defaultValue: T | undefined,
+        callback: (v: T, sceneState: SceneState) => void
+    ): void;
+
+    getSharedExpr(expr: JsonExpr): Expr;
+}

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -23,6 +23,12 @@ export interface ExprVisitor<Result, Context> {
     visitCaseExpr(expr: CaseExpr, context: Context): Result;
 }
 
+export type JsonExpr = unknown[];
+
+export function isJsonExpr(v: any): v is JsonExpr {
+    return Array.isArray(v) && v.length > 0 && typeof v[0] === "string";
+}
+
 /**
  * Abstract class defining a shape of a [[Theme]]'s expression
  */

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -22,6 +22,7 @@ import {
 } from "./Expr";
 
 import { CastOperators } from "./operators/CastOperators";
+import { ColorOperators } from "./operators/ColorOperators";
 import { ComparisonOperators } from "./operators/ComparisonOperators";
 import { FlowOperators } from "./operators/FlowOperators";
 import { MathOperators } from "./operators/MathOperators";
@@ -189,6 +190,7 @@ ExprEvaluator.defineOperators(CastOperators);
 ExprEvaluator.defineOperators(ComparisonOperators);
 ExprEvaluator.defineOperators(MathOperators);
 ExprEvaluator.defineOperators(StringOperators);
+ExprEvaluator.defineOperators(ColorOperators);
 ExprEvaluator.defineOperators(TypeOperators);
 ExprEvaluator.defineOperators(MiscOperators);
 ExprEvaluator.defineOperators(FlowOperators);

--- a/@here/harp-datasource-protocol/lib/FeatureEnv.ts
+++ b/@here/harp-datasource-protocol/lib/FeatureEnv.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SceneState } from "./DynamicTechniqueAttr";
 import { Expr, MapEnv, Value, ValueMap } from "./Expr";
 import { getPropertyValue, isInterpolatedProperty } from "./InterpolatedProperty";
 import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
@@ -75,7 +76,9 @@ export class FeatureEnv implements MapEnv {
         if (attrValue instanceof Expr) {
             evaluated = attrValue.evaluate(this, this.cachedExprResults);
         } else if (isInterpolatedProperty(attrValue)) {
-            evaluated = getPropertyValue(attrValue, this.storageLevel);
+            evaluated = getPropertyValue(attrValue, ({
+                zoomLevel: this.storageLevel
+            } as unknown) as SceneState);
         } else {
             evaluated = (attrValue as unknown) as Value;
         }

--- a/@here/harp-datasource-protocol/lib/FeatureEnv.ts
+++ b/@here/harp-datasource-protocol/lib/FeatureEnv.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Expr, MapEnv, Value, ValueMap } from "./Expr";
+import { getPropertyValue, isInterpolatedProperty } from "./InterpolatedProperty";
+import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
+
+/**
+ * Environment needed to evaluate technique properties dependent on feature attributes.
+ */
+export class FeatureEnv implements MapEnv {
+    /**
+     * Feature properties.
+     */
+    readonly env: MapEnv;
+
+    /**
+     * Storage level of tile containing this feature.
+     */
+    readonly storageLevel: number;
+
+    /**
+     * Optional, cache of expression results.
+     *
+     * @see [[Expr.evaluate]]
+     */
+    cachedExprResults?: Map<Expr, Value>;
+
+    constructor(
+        env: MapEnv | ValueMap,
+        storageLevel: number,
+        cachedExprResults?: Map<Expr, Value>
+    ) {
+        this.env = env instanceof MapEnv ? env : new MapEnv(env);
+        this.storageLevel = storageLevel;
+        this.cachedExprResults = cachedExprResults;
+    }
+
+    lookup(name: string): Value | undefined {
+        return this.env.lookup(name);
+    }
+
+    unmap() {
+        return this.env.unmap();
+    }
+
+    get entries() {
+        return this.env.entries;
+    }
+    /**
+     * Evaluate feature attr _without_ default value.
+     *
+     * @returns actual value or `undefined`
+     */
+    evaluate<T = Value>(attrValue: T | Expr | InterpolatedProperty<T> | undefined): T | undefined;
+
+    /**
+     * Evaluate feature attr _with_ default value.
+     *
+     * @returns actual value or `defaultValue`
+     */
+    evaluate<T = Value>(
+        attrValue: T | Expr | InterpolatedProperty<T> | undefined,
+        defaultValue: T
+    ): T;
+
+    evaluate<T = Value>(
+        attrValue: T | Expr | InterpolatedProperty<T> | undefined,
+        defaultValue?: T
+    ): T | undefined {
+        let evaluated: Value | undefined;
+        if (attrValue instanceof Expr) {
+            evaluated = attrValue.evaluate(this, this.cachedExprResults);
+        } else if (isInterpolatedProperty(attrValue)) {
+            evaluated = getPropertyValue(attrValue, this.storageLevel);
+        } else {
+            evaluated = (attrValue as unknown) as Value;
+        }
+        if (evaluated === undefined) {
+            return defaultValue;
+        } else {
+            return (evaluated as unknown) as T;
+        }
+    }
+}

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -8,11 +8,11 @@ import { Color, CubicInterpolant, DiscreteInterpolant, LinearInterpolant } from 
 
 import { LoggerManager } from "@here/harp-utils";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
+import { Expr, Value } from "./Expr";
 import {
     InterpolatedProperty,
     InterpolatedPropertyDefinition,
-    InterpolationMode,
-    MaybeInterpolatedProperty
+    InterpolationMode
 } from "./InterpolatedPropertyDefs";
 import {
     StringEncodedHex,
@@ -86,7 +86,7 @@ export function isInterpolatedProperty<T>(p: any): p is InterpolatedProperty<T> 
  *
  */
 export function getPropertyValue<T>(
-    property: InterpolatedProperty<T> | MaybeInterpolatedProperty<T>,
+    property: Value | Expr | InterpolatedProperty<T> | undefined,
     level: number,
     pixelToMeters: number = 1.0
 ): number {

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -3,19 +3,30 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { Color, CubicInterpolant, DiscreteInterpolant, LinearInterpolant } from "three";
 
+import { LoggerManager } from "@here/harp-utils";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
-import { StringEncodedNumeralFormats, StringEncodedNumeralType } from "./StringEncodedNumeral";
-
 import {
     InterpolatedProperty,
     InterpolatedPropertyDefinition,
     InterpolationMode,
     MaybeInterpolatedProperty
 } from "./InterpolatedPropertyDefs";
-
+import {
+    StringEncodedHex,
+    StringEncodedHSL,
+    StringEncodedMeters,
+    StringEncodedNumeralFormat,
+    StringEncodedNumeralFormats,
+    StringEncodedNumeralType,
+    StringEncodedPixels,
+    StringEncodedRGB
+} from "./StringEncodedNumeral";
 import { StyleColor, StyleLength } from "./TechniqueParams";
+
+const logger = LoggerManager.instance.create("InterpolatedProperty");
 
 const interpolants = [
     DiscreteInterpolant,
@@ -183,4 +194,124 @@ function getInterpolatedColor(property: InterpolatedProperty<StyleColor>, level:
             interpolant.resultBuffer[2]
         )
         .getHex();
+}
+
+/**
+ * Convert JSON representation of interpolated property to internal, normalized version that
+ * can be evaluated by [[getPropertyValue]].
+ */
+export function createInterpolatedProperty(
+    prop: InterpolatedPropertyDefinition<unknown>
+): InterpolatedProperty<unknown> | undefined {
+    removeDuplicatePropertyValues(prop);
+    const propKeys = new Float32Array(prop.zoomLevels);
+    let propValues;
+    let maskValues;
+    const firstValue = prop.values[0];
+    switch (typeof firstValue) {
+        default:
+        case "number":
+            propValues = new Float32Array((prop.values as any[]) as number[]);
+            return {
+                interpolationMode:
+                    prop.interpolation !== undefined
+                        ? InterpolationMode[prop.interpolation]
+                        : InterpolationMode.Discrete,
+                zoomLevels: propKeys,
+                values: propValues,
+                exponent: prop.exponent
+            };
+        case "boolean":
+            propValues = new Float32Array(prop.values.length);
+            for (let i = 0; i < prop.values.length; ++i) {
+                propValues[i] = ((prop.values[i] as unknown) as boolean) ? 1 : 0;
+            }
+            return {
+                interpolationMode: InterpolationMode.Discrete,
+                zoomLevels: propKeys,
+                values: propValues,
+                exponent: prop.exponent
+            };
+        case "string":
+            let needsMask = false;
+
+            const matchedFormat = StringEncodedNumeralFormats.find(format =>
+                format.regExp.test(firstValue)
+            );
+            if (matchedFormat === undefined) {
+                logger.error(`No StringEncodedNumeralFormat matched ${firstValue}.`);
+                return undefined;
+            }
+            propValues = new Float32Array(prop.values.length * matchedFormat.size);
+            maskValues = new Float32Array(prop.values.length);
+            needsMask = procesStringEnocodedNumeralInterpolatedProperty(
+                matchedFormat,
+                prop as InterpolatedPropertyDefinition<string>,
+                propValues,
+                maskValues
+            );
+
+            return {
+                interpolationMode:
+                    prop.interpolation !== undefined
+                        ? InterpolationMode[prop.interpolation]
+                        : InterpolationMode.Discrete,
+                zoomLevels: propKeys,
+                values: propValues,
+                exponent: prop.exponent,
+                _stringEncodedNumeralType: matchedFormat.type,
+                _stringEncodedNumeralDynamicMask: needsMask ? maskValues : undefined
+            };
+    }
+}
+
+function removeDuplicatePropertyValues<T>(p: InterpolatedPropertyDefinition<T>) {
+    for (let i = 0; i < p.values.length; ++i) {
+        const firstIdx = p.zoomLevels.findIndex((a: number) => {
+            return a === p.zoomLevels[i];
+        });
+        if (firstIdx !== i) {
+            p.zoomLevels.splice(--i, 1);
+            p.values.splice(--i, 1);
+        }
+    }
+}
+
+const colorFormats = [StringEncodedHSL, StringEncodedHex, StringEncodedRGB];
+const worldSizeFormats = [StringEncodedMeters, StringEncodedPixels];
+
+function procesStringEnocodedNumeralInterpolatedProperty(
+    baseFormat: StringEncodedNumeralFormat,
+    prop: InterpolatedPropertyDefinition<string>,
+    propValues: Float32Array,
+    maskValues: Float32Array
+): boolean {
+    let needsMask = false;
+    const allowedValueFormats =
+        baseFormat.type === StringEncodedNumeralType.Meters ||
+        baseFormat.type === StringEncodedNumeralType.Pixels
+            ? worldSizeFormats
+            : colorFormats;
+
+    for (let valueIdx = 0; valueIdx < prop.values.length; ++valueIdx) {
+        for (const valueFormat of allowedValueFormats) {
+            const value = prop.values[valueIdx];
+            if (!valueFormat.regExp.test(value)) {
+                continue;
+            }
+
+            if (valueFormat.mask !== undefined) {
+                maskValues[valueIdx] = valueFormat.mask;
+                needsMask = true;
+            }
+
+            const result = valueFormat.decoder(value);
+            for (let i = 0; i < result.length; ++i) {
+                propValues[valueIdx * valueFormat.size + i] = result[i];
+            }
+            break;
+        }
+    }
+
+    return needsMask;
 }

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -34,8 +34,6 @@ export interface InterpolatedPropertyDefinition<T> {
     exponent?: number;
 }
 
-export type MaybeInterpolatedProperty<T> = T | InterpolatedPropertyDefinition<T>;
-
 /**
  * Property which value is interpolated across different zoom levels.
  */

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -11,10 +11,12 @@ import {
     CallExpr,
     CaseExpr,
     ContainsExpr,
+    Env,
     Expr,
     ExprVisitor,
     HasAttributeExpr,
-    MapEnv,
+    isJsonExpr,
+    JsonExpr,
     MatchExpr,
     NullLiteralExpr,
     NumberLiteralExpr,
@@ -27,10 +29,14 @@ import {
     createInterpolatedProperty,
     isInterpolatedPropertyDefinition
 } from "./InterpolatedProperty";
-import { IndexedTechnique, Technique } from "./Techniques";
-import { isReference, Style, StyleDeclaration, StyleSelector, StyleSet } from "./Theme";
+import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
+import { AttrScope, mergeTechniqueDescriptor, TechniquePropNames } from "./TechniqueDescriptor";
+import { IndexedTechnique, Technique, techniqueDescriptors } from "./Techniques";
+import { isReference, LineStyle, Style, StyleDeclaration, StyleSelector, StyleSet } from "./Theme";
 
 const logger = LoggerManager.instance.create("StyleSetEvaluator");
+
+const emptyTechniqueDescriptor = mergeTechniqueDescriptor<Technique>({});
 
 interface StyleInternalParams {
     /**
@@ -38,11 +44,40 @@ interface StyleInternalParams {
      */
     _whenExpr?: Expr;
 
+    _staticAttributes?: Array<[string, Value | InterpolatedProperty<unknown>]>;
+
+    /**
+     * These attributes are used to instantiate Technique variants.
+     *
+     * @see [[TechiqueDescriptor.techniquePropNames]]
+     */
+    _dynamicTechniqueAttributes?: Array<[string, Expr]>;
+
+    /**
+     * These attributes must be evaluated basing with feature env.
+     *
+     * They are not propagated to rendering scope.
+     *
+     * @see [[TechniqueAttrScope.Feature]]
+     */
+    _dynamicFeatureAttributes?: Array<[string, Expr | InterpolatedProperty<unknown>]>;
+
+    /**
+     * These attributes are forwarded as serialized by decoder to main thread, so they are resolved
+     * directly in render loop.
+     *
+     * Will contain attributes from these lists
+     *  - interpolants from [[TechiqueDescriptor.techniquePropNames]]
+     *  - expressions [[TechniqueDescriptor.dynamicPropNames]] (Future)
+     */
+    _dynamicForwaredAttributes?: Array<[string, Expr | InterpolatedProperty<unknown>]>;
+    _dynamicTechniques?: Map<string, IndexedTechnique>;
+
     /**
      * Optimization: Index into table in StyleSetEvaluator.
      * @hidden
      */
-    _index?: number;
+    _staticTechnique?: IndexedTechnique;
 
     /**
      * Optimization: StyleSet index.
@@ -57,7 +92,7 @@ interface StyleInternalParams {
     _layer?: string;
 }
 
-type InternalStyle = Style & StyleSelector & Partial<StyleInternalParams>;
+type InternalStyle = Style & StyleSelector & StyleInternalParams;
 
 /**
  * [[ExprClassifier]] searches for usages of `$layer` in `when` conditions
@@ -194,7 +229,7 @@ export class StyleSetEvaluator {
         let techniqueRenderOrder = 0;
         let styleSetIndex = 0;
 
-        const cloneStyle = (style: StyleDeclaration): InternalStyle | undefined => {
+        const cloneStyle = (style: StyleDeclaration): StyleDeclaration | undefined => {
             if (isReference(style)) {
                 return undefined;
             }
@@ -208,10 +243,7 @@ export class StyleSetEvaluator {
                         : undefined
             };
         };
-        this.styleSet = styleSet
-            .map(style => cloneStyle(style))
-            .filter(subStyle => subStyle !== undefined) as InternalStyle[];
-
+        styleSet = styleSet.map(style => cloneStyle(style) as StyleDeclaration);
         const computeDefaultRenderOrder = (style: InternalStyle): void => {
             if (style.renderOrderBiasGroup !== undefined) {
                 const renderOrderBiasGroupOrder = style.renderOrderBiasGroup
@@ -258,17 +290,18 @@ export class StyleSetEvaluator {
                     computeDefaultRenderOrder(currStyle as InternalStyle);
                 }
             } else {
-                style._styleSetIndex = styleSetIndex++;
+                (style as InternalStyle)._styleSetIndex = styleSetIndex++;
                 if (style.technique !== undefined && style.renderOrder === undefined) {
                     style.renderOrder = techniqueRenderOrder++;
                 }
             }
         };
 
-        for (const style of this.styleSet) {
-            computeDefaultRenderOrder(style);
+        for (const style of styleSet) {
+            computeDefaultRenderOrder(style as InternalStyle);
         }
 
+        this.styleSet = styleSet as InternalStyle[];
         this.compileStyleSet();
     }
 
@@ -280,7 +313,7 @@ export class StyleSetEvaluator {
      * @param env The objects environment, i.e. the attributes that are relevant for its
      * representation.
      */
-    getMatchingTechniques(env: MapEnv): IndexedTechnique[] {
+    getMatchingTechniques(env: Env): IndexedTechnique[] {
         const result: IndexedTechnique[] = [];
         const styleStack = new Array<InternalStyle>();
         this.m_cachedResults.clear();
@@ -307,6 +340,16 @@ export class StyleSetEvaluator {
 
         return result;
     }
+
+    /**
+     * Get the expression evaluation cache, for further feature processing.
+     *
+     * This object is valid until next `getMatchingTechniques` call.
+     */
+    get expressionEvaluatorCache() {
+        return this.m_cachedResults;
+    }
+
     /**
      * Get the (current) array of techniques that have been created during decoding.
      */
@@ -314,28 +357,17 @@ export class StyleSetEvaluator {
         return this.m_techniques;
     }
 
+    /**
+     * Get the (current) array of techniques that have been created during decoding.
+     */
+    get decodedTechniques(): IndexedTechnique[] {
+        return this.m_techniques.map(makeDecodedTechnique);
+    }
+
     private changeLayer(layer: string | undefined) {
         const savedLayer = this.m_layer;
         this.m_layer = layer;
         return savedLayer;
-    }
-
-    /**
-     * Shorten the style object for debug log. Remove special strings (starting with "_") as well
-     * as the sub-styles of style groups.
-     *
-     * @param key Key in object
-     * @param value value in object
-     */
-    private cleanupStyle(key: string, value: any): any {
-        // Filtering out properties
-        if (key === "styles") {
-            return "[...]";
-        }
-        if (key.startsWith("_")) {
-            return undefined;
-        }
-        return value;
     }
 
     /**
@@ -395,7 +427,7 @@ export class StyleSetEvaluator {
      *          more than one technique should be applied.
      */
     private processStyle(
-        env: MapEnv,
+        env: Env,
         styleStack: InternalStyle[],
         style: InternalStyle,
         result: Technique[]
@@ -420,14 +452,6 @@ export class StyleSetEvaluator {
         }
 
         if (style.styles !== undefined) {
-            if (style.debug) {
-                logger.log(
-                    "\n======== style group =========\nenv:",
-                    JSON.stringify(env.unmap(), undefined, 2),
-                    "\nstyle group:",
-                    JSON.stringify(style, this.cleanupStyle, 2)
-                );
-            }
             styleStack.push(style);
             for (const currStyle of style.styles) {
                 if (this.processStyle(env, styleStack, currStyle as InternalStyle, result)) {
@@ -436,87 +460,210 @@ export class StyleSetEvaluator {
                 }
             }
             styleStack.pop();
-        } else {
-            // we found a technique!
-            if (style.technique !== undefined) {
-                if (style.technique !== "none") {
-                    // Check if we already assembled the technique for exactly this style. If we
-                    // have, we return the preassembled technique object. Otherwise we assemble the
-                    // technique from all parent styles' attributes and the current stales'
-                    // attributes, and add it to the cached techniques.
-                    if (style._index === undefined) {
-                        const technique = this.createTechnique(style, styleStack);
-                        result.push(technique);
-                        if (style.debug) {
-                            logger.log(
-                                "\n======== style w/ technique =========\nenv:",
-                                JSON.stringify(env.unmap(), undefined, 2),
-                                "\nstyle:",
-                                JSON.stringify(style, this.cleanupStyle, 2),
-                                "\ntechnique:",
-                                JSON.stringify(technique, this.cleanupStyle, 2)
-                            );
+            return false;
+        }
+
+        if (style.technique === undefined) {
+            return false;
+        }
+        // we found a technique!
+        if (style.technique !== "none") {
+            this.checkStyleDynamicAttributes(style, styleStack);
+
+            if (style._dynamicTechniques !== undefined) {
+                const dynamicAttributes = this.evaluateTechniqueProperties(style, env);
+                const dynamicAttrKey = dynamicAttributes
+                    .map(([attrName, attrValue]) => {
+                        if (attrValue === undefined) {
+                            return "U";
+                        } else {
+                            return JSON.stringify(attrValue);
                         }
-                    } else {
-                        result.push(this.m_techniques[style._index]);
-                    }
+                    })
+                    .join(":");
+                const key = `${style._styleSetIndex!}:${dynamicAttrKey}`;
+                let technique = style._dynamicTechniques!.get(key);
+                if (technique === undefined) {
+                    technique = this.createTechnique(style, key, dynamicAttributes);
+                    style._dynamicTechniques!.set(key, technique);
                 }
-                // stop processing if "final" is set
-                return style.final === true;
+                result.push(technique);
+            } else {
+                let technique = style._staticTechnique;
+                if (technique === undefined) {
+                    style._staticTechnique = technique = this.createTechnique(
+                        style,
+                        `${style._styleSetIndex}`,
+                        []
+                    ) as IndexedTechnique;
+                }
+                result.push(technique as IndexedTechnique);
             }
         }
-        return false;
+        // stop processing if "final" is set
+        return style.final === true;
     }
 
-    private createTechnique(style: InternalStyle, styleStack: InternalStyle[]) {
-        const technique = {} as any;
-        technique.name = style.technique;
-        const addAttributes = (currStyle: InternalStyle) => {
-            if (currStyle.renderOrder !== undefined) {
-                technique.renderOrder = currStyle.renderOrder;
+    private checkStyleDynamicAttributes(style: InternalStyle, styleStack: InternalStyle[]) {
+        if (style._dynamicTechniqueAttributes !== undefined || style.technique === "none") {
+            return;
+        }
+
+        style._dynamicTechniqueAttributes = [];
+        style._dynamicFeatureAttributes = [];
+        style._dynamicForwaredAttributes = [];
+        style._staticAttributes = [];
+
+        const dynamicFeatureAttributes = style._dynamicFeatureAttributes;
+        const dynamicTechniqueAttributes = style._dynamicTechniqueAttributes;
+        const dynamicForwardedAttributes = style._dynamicForwaredAttributes;
+        const targetStaticAttributes = style._staticAttributes;
+
+        const techniqueDescriptor =
+            techniqueDescriptors[style.technique] || emptyTechniqueDescriptor;
+
+        const processAttribute = (
+            attrName: TechniquePropNames<Technique>,
+            attrValue: Value | JsonExpr | undefined
+        ) => {
+            if (attrValue === undefined) {
+                return;
             }
-            if (currStyle.transient !== undefined) {
-                technique.transient = currStyle.transient;
-            }
-            if (currStyle.renderOrderBiasProperty !== undefined) {
-                technique.renderOrderBiasProperty = currStyle.renderOrderBiasProperty;
-            }
-            if (currStyle.labelProperty !== undefined) {
-                technique.label = currStyle.labelProperty;
-            }
-            if (currStyle.renderOrderBiasRange !== undefined) {
-                technique.renderOrderBiasRange = currStyle.renderOrderBiasRange;
-            }
-            if (currStyle.renderOrderBiasGroup !== undefined) {
-                technique.renderOrderBiasGroup = currStyle.renderOrderBiasGroup;
-            }
-            if ((currStyle as any).secondaryRenderOrder !== undefined) {
-                technique.secondaryRenderOrder = (currStyle as any).secondaryRenderOrder;
-            }
-            if (currStyle.attr !== undefined) {
-                Object.getOwnPropertyNames(currStyle.attr).forEach(property => {
-                    const prop = (currStyle.attr as any)[property];
-                    if (isInterpolatedPropertyDefinition(prop)) {
-                        const interpolatedProperty = createInterpolatedProperty(prop);
-                        if (interpolatedProperty !== undefined) {
-                            technique[property] = interpolatedProperty;
-                        }
-                    } else if (prop !== undefined) {
-                        technique[property] = prop;
-                    }
-                });
+
+            const attrScope: AttrScope | undefined = (techniqueDescriptor.attrScopes as any)[
+                attrName as any
+            ];
+
+            if (isJsonExpr(attrValue)) {
+                const expr = Expr.fromJSON(attrValue).intern(this.m_exprPool);
+                switch (attrScope) {
+                    case AttrScope.FeatureGeometry:
+                        dynamicFeatureAttributes.push([attrName, expr]);
+                        break;
+                    case AttrScope.TechniqueGeometry:
+                    case AttrScope.TechniqueRendering:
+                        dynamicTechniqueAttributes.push([attrName, expr]);
+                        break;
+                }
+            } else if (isInterpolatedPropertyDefinition(attrValue)) {
+                const interpolatedProperty = createInterpolatedProperty(attrValue);
+                if (!interpolatedProperty) {
+                    return;
+                }
+                switch (attrScope) {
+                    case AttrScope.FeatureGeometry:
+                        dynamicFeatureAttributes.push([attrName, interpolatedProperty]);
+                        break;
+                    case AttrScope.TechniqueRendering:
+                    case AttrScope.TechniqueGeometry:
+                        dynamicForwardedAttributes.push([attrName, interpolatedProperty]);
+                        break;
+                }
+            } else {
+                targetStaticAttributes.push([attrName, attrValue]);
             }
         };
-        for (const currStyle of styleStack) {
-            addAttributes(currStyle);
+
+        function processAttributes(style2: Style) {
+            processAttribute("renderOrder", style2.renderOrder);
+            processAttribute("renderOrderOffset", style2.renderOrderOffset);
+
+            // TODO: What the heck is that !?
+            processAttribute("label", style2.labelProperty);
+
+            // line & solid-line secondaryRenderOrder should be generic attr
+            // TODO: maybe just warn and force move it to `attr` ?
+            processAttribute("secondaryRenderOrder", (style2 as LineStyle).secondaryRenderOrder);
+
+            if (style2.attr !== undefined) {
+                for (const attrName in style2.attr) {
+                    if (!style2.attr.hasOwnProperty(attrName)) {
+                        continue;
+                    }
+                    processAttribute(
+                        attrName as TechniquePropNames<Technique>,
+                        (style2.attr as any)[attrName]
+                    );
+                }
+            }
         }
-        addAttributes(style);
 
-        style._index = this.m_techniques.length;
-        (technique as IndexedTechnique)._index = style._index;
-        (technique as IndexedTechnique)._styleSetIndex = style._styleSetIndex!;
-        this.m_techniques.push(technique as IndexedTechnique);
+        for (const parentStyle of styleStack) {
+            processAttributes(parentStyle);
+        }
+        processAttributes(style);
 
-        return technique as Technique;
+        if (dynamicTechniqueAttributes.length > 0) {
+            style._dynamicTechniques = new Map();
+        }
     }
+
+    private evaluateTechniqueProperties(style: InternalStyle, env: Env): Array<[string, Value]> {
+        if (style._dynamicTechniqueAttributes === undefined) {
+            return [];
+        }
+        return style._dynamicTechniqueAttributes.map(([attrName, attrExpr]) => {
+            const evaluatedValue = attrExpr.evaluate(env, this.m_cachedResults);
+            return [attrName, evaluatedValue];
+        });
+    }
+
+    private createTechnique(
+        style: InternalStyle,
+        key: string,
+        dynamicAttrs: Array<[string, Value]>
+    ) {
+        const technique: any = {};
+        technique.name = style.technique;
+        if (style._staticAttributes !== undefined) {
+            for (const [attrName, attrValue] of style._staticAttributes) {
+                technique[attrName] = attrValue;
+            }
+        }
+        for (const [attrName, attrValue] of dynamicAttrs) {
+            technique[attrName] = attrValue;
+        }
+
+        if (style._dynamicFeatureAttributes !== undefined) {
+            for (const [attrName, attrValue] of style._dynamicFeatureAttributes) {
+                technique[attrName] = attrValue;
+            }
+        }
+
+        if (style._dynamicForwaredAttributes !== undefined) {
+            for (const [attrName, attrValue] of style._dynamicForwaredAttributes) {
+                if (attrValue instanceof Expr) {
+                    // TODO: We don't support `Expr` instances in main thread yet.
+                    continue;
+                }
+                technique[attrName] = attrValue;
+            }
+        }
+
+        technique._index = this.m_techniques.length;
+        technique._styleSetIndex = style._styleSetIndex!;
+        technique._key = key;
+        this.m_techniques.push(technique as IndexedTechnique);
+        return technique as IndexedTechnique;
+    }
+}
+
+/**
+ * Create transferable representation of dynamic technique.
+ *
+ * As for now, we remove all `Expr` as they are not supported on other side.
+ */
+export function makeDecodedTechnique(technique: IndexedTechnique): IndexedTechnique {
+    const result: Partial<IndexedTechnique> = {};
+    for (const attrName in technique) {
+        if (!technique.hasOwnProperty(attrName)) {
+            continue;
+        }
+        const attrValue: any = (technique as any)[attrName];
+        if (attrValue instanceof Expr) {
+            continue;
+        }
+        (result as any)[attrName] = attrValue;
+    }
+    return (result as any) as IndexedTechnique;
 }

--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Technique } from "./Techniques";
+
+export enum AttrScope {
+    /**
+     * Attributes that affect generation of feature geometry and thus must be resolved at decoding
+     * time.
+     *
+     * They may have huge variancy as they are implemented as vertex attributes or embedded in
+     * generated meshes.
+     *
+     * These attributes are available only in decoding scope.
+     */
+    FeatureGeometry,
+
+    /**
+     * Attributes that are common to whole group of features drawn with this technique.
+     * These attributes affect generated geometry and  thus must be resolved at decoding time.
+     *
+     * They shouldn't have big variancy and evaluate to at least dozens of values as each
+     * combination of these attributes consitute new technique and material.
+     *
+     * These attributes are available in decoding and rendering scope.
+     */
+    TechniqueGeometry,
+
+    /**
+     * Attributes that are common to whole group of features drawn with this technique.
+     * Attributes that can be changed in resulting object/material from frame to frame. They are
+     * usually implemented as uniforms.
+     *
+     * These attributes may be available only at rendering scope.
+     */
+    TechniqueRendering
+}
+
+/**
+ * Extract  property names from [[Technique]]-like interface (excluding `name`) as union of string
+ * literals.
+ *
+ * TechniquePropName<Base
+ *
+ */
+export type TechniquePropNames<T> = T extends { name: any } ? keyof Omit<T, "name"> : keyof T;
+
+export type TechniquePropScopes<T> = {
+    [P in TechniquePropNames<T>]?: AttrScope;
+};
+
+export interface TechniqueDescriptor<T> {
+    attrScopes: TechniquePropScopes<T>;
+}
+
+type OneThatMatches<T, P> = T extends P ? T : never;
+type TechniqueByName<K extends Technique["name"]> = OneThatMatches<Technique, { name: K }>;
+
+export type TechniqueDescriptorRegistry = {
+    [P in Technique["name"]]?: TechniqueDescriptor<TechniqueByName<P>>;
+};
+
+export function mergeTechniqueDescriptor<T>(
+    ...descriptors: Array<Partial<TechniqueDescriptor<T>>>
+): TechniqueDescriptor<T> {
+    const result: TechniqueDescriptor<T> = {
+        attrScopes: {}
+    };
+    for (const descriptor of descriptors) {
+        if (descriptor.attrScopes !== undefined) {
+            result.attrScopes = { ...result.attrScopes, ...descriptor.attrScopes };
+        }
+    }
+    return result;
+}

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -25,14 +25,14 @@ import {
     TextureCoordinateType
 } from "./TechniqueParams";
 
-import { Expr, JsonExpr } from "./Expr";
-import { InterpolatedProperty, InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
+import { MakeTechnique } from "./DynamicTechniqueAttr";
 import {
     AttrScope,
     mergeTechniqueDescriptor,
     TechniqueDescriptor,
     TechniqueDescriptorRegistry
 } from "./TechniqueDescriptor";
+
 /**
  * Names of the supported texture properties.
  */
@@ -46,25 +46,6 @@ export const TEXTURE_PROPERTY_KEYS = [
     "metalnessMap",
     "bumpMap"
 ];
-
-// TODO: Can be removed, when all when interpolators are implemented as [[Expr]]s
-export type RemoveInterpolatedPropDef<T> = (T | InterpolatedPropertyDefinition<any>) extends T
-    ? Exclude<T, InterpolatedPropertyDefinition<any>>
-    : T;
-export type RemoveJsonExpr<T> = (T | JsonExpr) extends T ? Exclude<T, JsonExpr> : T;
-
-/**
- * Make runtime representation of technique attributes from JSON-compatible typings.
- *
- * Translates
- *  - InterpolatedPropertyDefinition -> InterpolatedProperty
- *  - JsonExpr -> Expr
- */
-export type MakeTechniqueAttrs<T> = {
-    [P in keyof T]: (T[P] | JsonExpr) extends T[P]
-        ? RemoveInterpolatedPropDef<RemoveJsonExpr<T[P]>> | Expr | InterpolatedProperty<number>
-        : T[P];
-};
 
 export const techniqueDescriptors: TechniqueDescriptorRegistry = {};
 
@@ -96,7 +77,7 @@ export const pointTechniquePropTypes = mergeTechniqueDescriptor<PointTechniquePa
 /**
  * Runtime representation of [[SquaresStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface SquaresTechnique extends MakeTechniqueAttrs<PointTechniqueParams> {
+export interface SquaresTechnique extends MakeTechnique<PointTechniqueParams> {
     name: "squares";
 }
 
@@ -109,7 +90,7 @@ techniqueDescriptors.squares = squaresTechniquePropTypes;
 /**
  * Runtime representation of [[CirclesStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface CirclesTechnique extends MakeTechniqueAttrs<PointTechniqueParams> {
+export interface CirclesTechnique extends MakeTechnique<PointTechniqueParams> {
     name: "circles";
 }
 
@@ -122,14 +103,14 @@ techniqueDescriptors.circles = circlesTechniquePropTypes;
 /**
  * Runtime representation of [[PoiStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface PoiTechnique extends MakeTechniqueAttrs<MarkerTechniqueParams> {
+export interface PoiTechnique extends MakeTechnique<MarkerTechniqueParams> {
     name: "labeled-icon";
 }
 
 /**
  * Runtime representation of [[LineMarkerStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface LineMarkerTechnique extends MakeTechniqueAttrs<MarkerTechniqueParams> {
+export interface LineMarkerTechnique extends MakeTechnique<MarkerTechniqueParams> {
     name: "line-marker";
 }
 
@@ -203,7 +184,7 @@ techniqueDescriptors["labeled-icon"] = lineMarkerTechniquePropTypes;
 /**
  * Runtime representation of [[SegmentsStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface SegmentsTechnique extends MakeTechniqueAttrs<SegmentsTechniqueParams> {
+export interface SegmentsTechnique extends MakeTechnique<SegmentsTechniqueParams> {
     name: "segments";
 }
 
@@ -221,7 +202,7 @@ const polygonalTechniqueDescriptor: TechniqueDescriptor<PolygonalTechniqueParams
  * Runtime representation of [[BasicExtrudedLineStyle]] as parsed by [[StyleSetEvaluator]].
  */
 export interface BasicExtrudedLineTechnique
-    extends MakeTechniqueAttrs<BasicExtrudedLineTechniqueParams> {
+    extends MakeTechnique<BasicExtrudedLineTechniqueParams> {
     name: "extruded-line";
 }
 
@@ -229,14 +210,14 @@ export interface BasicExtrudedLineTechnique
  * Runtime representation of [[StandardExtrudedLineStyle]] as parsed by [[StyleSetEvaluator]].
  */
 export interface StandardExtrudedLineTechnique
-    extends MakeTechniqueAttrs<StandardExtrudedLineTechniqueParams> {
+    extends MakeTechnique<StandardExtrudedLineTechniqueParams> {
     name: "extruded-line";
 }
 
 /**
  * Runtime representation of [[SolidLineStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface SolidLineTechnique extends MakeTechniqueAttrs<SolidLineTechniqueParams> {
+export interface SolidLineTechnique extends MakeTechnique<SolidLineTechniqueParams> {
     name: "solid-line";
 }
 
@@ -261,7 +242,7 @@ techniqueDescriptors["solid-line"] = solidLineTechniqueDescriptor;
 /**
  * Runtime representation of [[DashedLineStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface DashedLineTechnique extends MakeTechniqueAttrs<DashedLineTechniqueParams> {
+export interface DashedLineTechnique extends MakeTechnique<DashedLineTechniqueParams> {
     name: "dashed-line";
 }
 
@@ -286,7 +267,7 @@ techniqueDescriptors["dashed-line"] = dashedLineTechniqueDescriptor;
 /**
  * Runtime representation of [[LineStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface LineTechnique extends MakeTechniqueAttrs<LineTechniqueParams> {
+export interface LineTechnique extends MakeTechnique<LineTechniqueParams> {
     name: "line";
 }
 
@@ -308,7 +289,7 @@ techniqueDescriptors.line = lineTechniqueDescriptor;
 /**
  * Runtime representation of [[FillStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface FillTechnique extends MakeTechniqueAttrs<FillTechniqueParams> {
+export interface FillTechnique extends MakeTechnique<FillTechniqueParams> {
     name: "fill";
 }
 
@@ -329,7 +310,7 @@ techniqueDescriptors.fill = fillTechniqueDescriptor;
 /**
  * Technique used to render a mesh geometry.
  */
-export interface StandardTechnique extends MakeTechniqueAttrs<StandardTechniqueParams> {
+export interface StandardTechnique extends MakeTechnique<StandardTechniqueParams> {
     name: "standard";
 }
 const standardTechniqueDescriptor = mergeTechniqueDescriptor<StandardTechnique>(
@@ -372,8 +353,7 @@ techniqueDescriptors.standard = standardTechniqueDescriptor;
 /**
  * Runtime representation of [[ExtrudedPolygonStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface ExtrudedPolygonTechnique
-    extends MakeTechniqueAttrs<ExtrudedPolygonTechniqueParams> {
+export interface ExtrudedPolygonTechnique extends MakeTechnique<ExtrudedPolygonTechniqueParams> {
     name: "extruded-polygon";
 }
 
@@ -408,7 +388,7 @@ techniqueDescriptors["extruded-polygon"] = extrudedPolygonTechniqueDescriptor;
 /**
  * Runtime representation of [[TextStyle]] as parsed by [[StyleSetEvaluator]].
  */
-export interface TextTechnique extends MakeTechniqueAttrs<TextTechniqueParams> {
+export interface TextTechnique extends MakeTechnique<TextTechniqueParams> {
     name: "text";
 }
 
@@ -455,7 +435,7 @@ const textTechniqueDescriptor = mergeTechniqueDescriptor<TextTechnique>(
 );
 techniqueDescriptors.text = textTechniqueDescriptor;
 
-export interface ShaderTechnique extends MakeTechniqueAttrs<ShaderTechniqueParams> {
+export interface ShaderTechnique extends MakeTechnique<ShaderTechniqueParams> {
     /**
      * Name of technique. Is used in the theme file.
      */
@@ -477,7 +457,7 @@ techniqueDescriptors.shader = shaderTechniqueDescriptor;
 /**
  * Technique used to render a terrain geometry with textures.
  */
-export interface TerrainTechnique extends MakeTechniqueAttrs<TerrainTechniqueParams> {
+export interface TerrainTechnique extends MakeTechnique<TerrainTechniqueParams> {
     name: "terrain";
 }
 

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -5,10 +5,11 @@
  */
 
 import { Vector3Like } from "@here/harp-geoutils/lib/math/Vector3Like";
-import { MaybeInterpolatedProperty } from "./InterpolatedPropertyDefs";
+import { JsonExpr } from "./Expr";
 import {
     BasicExtrudedLineTechniqueParams,
     DashedLineTechniqueParams,
+    DynamicProperty,
     ExtrudedPolygonTechniqueParams,
     FillTechniqueParams,
     MarkerTechniqueParams,
@@ -169,7 +170,7 @@ export interface BooleanValueDefinition extends BaseValueDefinition {
     /**
      * The value of the definition.
      */
-    value: MaybeInterpolatedProperty<boolean>;
+    value: DynamicProperty<boolean>;
 }
 
 /**
@@ -184,7 +185,7 @@ export interface NumericValueDefinition extends BaseValueDefinition {
     /**
      * The value of the definition.
      */
-    value: MaybeInterpolatedProperty<number>;
+    value: DynamicProperty<number>;
 }
 
 /**
@@ -214,7 +215,7 @@ export interface ColorValueDefinition extends BaseValueDefinition {
     /**
      * The value of the definition.
      */
-    value: MaybeInterpolatedProperty<string>;
+    value: DynamicProperty<string>;
 }
 
 export interface SelectorValueDefinition extends BaseValueDefinition {
@@ -228,7 +229,7 @@ export interface SelectorValueDefinition extends BaseValueDefinition {
      *
      * See [[BaseStyle.when]].
      */
-    value: string | unknown[];
+    value: string | JsonExpr;
 }
 
 /**
@@ -339,12 +340,29 @@ export interface BaseStyle {
     technique?: string;
 
     /**
-     * Specify `renderOrder` of object.
+     * Specify `renderOrder` of value.
+     *
+     * @default If not specified in style file, `renderOrder` will be assigned with monotonically
+     * increasing values according to style position in file.
      */
-    renderOrder?: number;
+    renderOrder?: number | JsonExpr;
 
     /**
-     * Property that is used to hold the z-order delta.
+     * Offset added on top of `renderOrder` of object.
+     *
+     * May be uses to adjust final `renderOrder` without interferring with automatically assigned
+     * values.
+     *
+     * Using [[renderOrderBiasProperty]]
+     *
+     * @default 0
+     */
+    renderOrderOffset?: number | JsonExpr;
+
+    /**
+     * Property that is used to hold the z-order delta in [[renderOrderBiasRange]].
+     *
+     * @deprecated, Use `renderOrderOffset` with `["get", "<propName>"]` instead.
      */
     renderOrderBiasProperty?: string;
 
@@ -374,6 +392,8 @@ export interface BaseStyle {
     // TODO: Make pixel units default.
     /**
      * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
+     *
+     * @deprecated use "string encoded numerals" as documented in TODO, wher eis the doc ?
      */
     metricUnit?: "Meter" | "Pixel";
 
@@ -665,7 +685,7 @@ export function isReference(value: any): value is Reference {
 /**
  * The attributes of a technique.
  */
-export type Attr<T> = { [P in keyof T]?: T[P] | Reference };
+export type Attr<T> = { [P in keyof T]?: T[P] | JsonExpr | Reference };
 
 /**
  * Render feature as set of squares rendered in screen space.

--- a/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import { Expr } from "../Expr";
+
+import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
+
+const tmpColor = new THREE.Color();
+const operators = {
+    rgb: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            const r = Number(context.evaluate(args[0]));
+            const g = Number(context.evaluate(args[1]));
+            const b = Number(context.evaluate(args[2]));
+            tmpColor.setRGB(r, g, b);
+            return "#" + tmpColor.getHexString();
+        }
+    }
+};
+
+export const ColorOperators: OperatorDescriptorMap = operators;
+export type ColorOperatorNames = keyof typeof operators;

--- a/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MathUtils } from "@here/harp-geoutils";
 import { Expr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
@@ -191,6 +192,27 @@ const operators = {
     min: {
         call: (context: ExprEvaluatorContext, args: Expr[]) => {
             return Math.min(...args.map(v => Number(context.evaluate(v))));
+        }
+    },
+
+    /**
+     * Clamp numeric value to given range, inclusive.
+     *
+     * Synopsis:
+     * ```
+     * ["clamp", v: number, min: number, max: number]`
+     * ```
+     */
+    clamp: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            const v = context.evaluate(args[0]);
+            const min = context.evaluate(args[1]);
+            const max = context.evaluate(args[2]);
+
+            if (typeof v !== "number" || typeof min !== "number" || typeof max !== "number") {
+                throw new Error(`invalid operands '${v}', ${min}, ${max} for operator 'clamp'`);
+            }
+            return MathUtils.clamp(v, min, max);
         }
     },
 

--- a/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
@@ -16,6 +16,17 @@ const operators = {
             }
             throw new Error(`invalid operand '${value}' for operator 'length'`);
         }
+    },
+    coalesce: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            for (const childExpr of args) {
+                const value = context.evaluate(childExpr);
+                if (value !== null) {
+                    return value;
+                }
+            }
+            return null;
+        }
     }
 };
 

--- a/@here/harp-datasource-protocol/lib/operators/SceneStateOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/SceneStateOperators.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { assert } from "@here/harp-utils";
+import { SceneStateEnv } from "../DynamicTechniqueAttr";
+import { Expr } from "../Expr";
+import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
+
+const operators = {
+    /**
+     * Access [[SceneState]] attribute.
+     *
+     * Synopsis:
+     *
+     *    `["scene", "zoom"]` - get zoom level
+     *    `["scene", "pixel2world"]` - get pixel2world ratio
+     *    ...
+     */
+    scene: (context: ExprEvaluatorContext, args: Expr[]) => {
+        const sceneEnv = context.env as SceneStateEnv;
+        const v = context.evaluate(args[0]);
+        if (v === "zoom") {
+            return sceneEnv.sceneState.zoomLevel;
+        } else if (v === "pixel2world") {
+            return sceneEnv.sceneState.pixelToMeters;
+        } else if (v === "time") {
+            return sceneEnv.sceneState.time;
+        } else if (v === "frame") {
+            return sceneEnv.sceneState.frameNumber;
+        } else if (v === "maxVisibility") {
+            return sceneEnv.sceneState.maxVisibility;
+        } else {
+            return null;
+        }
+    },
+    time: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            assert(context.env instanceof SceneStateEnv);
+            return (context.env as SceneStateEnv).sceneState.time;
+        }
+    },
+    frameNumber: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            assert(context.env instanceof SceneStateEnv);
+            return (context.env as SceneStateEnv).sceneState.frameNumber;
+        }
+    },
+    zoom: {
+        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+            assert(context.env instanceof SceneStateEnv);
+            return (context.env as SceneStateEnv).sceneState.zoomLevel;
+        }
+    }
+};
+
+export const SceneStateOperators: OperatorDescriptorMap = operators;
+export type SceneStateOperatorNames = keyof typeof operators;

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -8,6 +8,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+import { SceneState } from "../lib/DynamicTechniqueAttr";
 import { getPropertyValue } from "../lib/InterpolatedProperty";
 import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
@@ -30,90 +31,96 @@ const colorProperty: InterpolatedProperty<string> = {
     _stringEncodedNumeralType: StringEncodedNumeralType.Hex
 };
 
+function getPropertyValueZoom(
+    value: InterpolatedProperty<any> | number | string,
+    zoomLevel: number
+) {
+    return getPropertyValue(value, ({ zoomLevel } as unknown) as SceneState);
+}
 describe("Interpolation", function() {
     it("Discrete", () => {
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 0);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 100);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, -Infinity), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 0), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 2.5), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 5), 100);
+        assert.equal(getPropertyValueZoom(numberProperty, 7.5), 100);
+        assert.equal(getPropertyValueZoom(numberProperty, 10), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(booleanProperty, -Infinity), 1);
-        assert.equal(getPropertyValue(booleanProperty, 0), 1);
-        assert.equal(getPropertyValue(booleanProperty, 2.5), 1);
-        assert.equal(getPropertyValue(booleanProperty, 5), 0);
-        assert.equal(getPropertyValue(booleanProperty, 7.5), 0);
-        assert.equal(getPropertyValue(booleanProperty, 10), 1);
-        assert.equal(getPropertyValue(booleanProperty, Infinity), 1);
+        assert.equal(getPropertyValueZoom(booleanProperty, -Infinity), 1);
+        assert.equal(getPropertyValueZoom(booleanProperty, 0), 1);
+        assert.equal(getPropertyValueZoom(booleanProperty, 2.5), 1);
+        assert.equal(getPropertyValueZoom(booleanProperty, 5), 0);
+        assert.equal(getPropertyValueZoom(booleanProperty, 7.5), 0);
+        assert.equal(getPropertyValueZoom(booleanProperty, 10), 1);
+        assert.equal(getPropertyValueZoom(booleanProperty, Infinity), 1);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 2.5), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 7.5), 0x00ff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Linear", () => {
         numberProperty.interpolationMode = InterpolationMode.Linear;
         colorProperty.interpolationMode = InterpolationMode.Linear;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 50);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 300);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, -Infinity), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 0), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 2.5), 50);
+        assert.equal(getPropertyValueZoom(numberProperty, 5), 100);
+        assert.equal(getPropertyValueZoom(numberProperty, 7.5), 300);
+        assert.equal(getPropertyValueZoom(numberProperty, 10), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xfeff00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00feff);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 2.5), 0xfeff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 7.5), 0x00feff);
+        assert.equal(getPropertyValueZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Cubic", () => {
         numberProperty.interpolationMode = InterpolationMode.Cubic;
         colorProperty.interpolationMode = InterpolationMode.Cubic;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 31.25);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 281.25);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, -Infinity), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 0), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 2.5), 31.25);
+        assert.equal(getPropertyValueZoom(numberProperty, 5), 100);
+        assert.equal(getPropertyValueZoom(numberProperty, 7.5), 281.25);
+        assert.equal(getPropertyValueZoom(numberProperty, 10), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xfeff00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00feff);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 2.5), 0xfeff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 7.5), 0x00feff);
+        assert.equal(getPropertyValueZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Exponential", () => {
         numberProperty.interpolationMode = InterpolationMode.Exponential;
         colorProperty.interpolationMode = InterpolationMode.Exponential;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 25);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 200);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, -Infinity), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 0), 0);
+        assert.equal(getPropertyValueZoom(numberProperty, 2.5), 25);
+        assert.equal(getPropertyValueZoom(numberProperty, 5), 100);
+        assert.equal(getPropertyValueZoom(numberProperty, 7.5), 200);
+        assert.equal(getPropertyValueZoom(numberProperty, 10), 500);
+        assert.equal(getPropertyValueZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xff7f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00ff7f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 0), 0xff0000);
+        assert.equal(getPropertyValueZoom(colorProperty, 2.5), 0xff7f00);
+        assert.equal(getPropertyValueZoom(colorProperty, 5), 0x00ff00);
+        assert.equal(getPropertyValueZoom(colorProperty, 7.5), 0x00ff7f);
+        assert.equal(getPropertyValueZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(getPropertyValueZoom(colorProperty, Infinity), 0x0000ff);
     });
 });

--- a/@here/harp-datasource-protocol/test/TileInfoTest.ts
+++ b/@here/harp-datasource-protocol/test/TileInfoTest.ts
@@ -21,6 +21,7 @@ import {
 } from "../lib/TileInfo";
 
 import { assert } from "chai";
+import { FeatureEnv } from "../index-decoder";
 
 describe("ExtendedTileInfo", function() {
     const tileKey = new TileKey(0, 0, 0);
@@ -210,14 +211,15 @@ describe("ExtendedTileInfo", function() {
 
     function createPointInfo(
         index: number
-    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: MapEnv } {
+    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: FeatureEnv } {
         const technique: IndexedTechnique = {
             name: "squares",
             color: "#F00",
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const storedTechnique: IndexedTechnique = {
             name: "squares",
@@ -225,14 +227,18 @@ describe("ExtendedTileInfo", function() {
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
-        const env = new MapEnv({
-            $layer: "point_layer-" + index,
-            class: "point_class-" + index,
-            type: "point_type-" + index,
-            name: "point_label-" + index
-        });
+        const env = new FeatureEnv(
+            new MapEnv({
+                $layer: "point_layer-" + index,
+                class: "point_class-" + index,
+                type: "point_type-" + index,
+                name: "point_label-" + index
+            }),
+            10
+        );
 
         return {
             technique,
@@ -243,14 +249,15 @@ describe("ExtendedTileInfo", function() {
 
     function createLineInfo(
         index: number
-    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: MapEnv } {
+    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: FeatureEnv } {
         const technique: IndexedTechnique = {
             name: "line",
             color: "#0F0",
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const storedTechnique: IndexedTechnique = {
             name: "line",
@@ -258,14 +265,18 @@ describe("ExtendedTileInfo", function() {
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
-        const env = new MapEnv({
-            $layer: "line_layer-" + index,
-            class: "line_class-" + index,
-            type: "line_type-" + index,
-            name: "lineLabel-" + index
-        });
+        const env = new FeatureEnv(
+            new MapEnv({
+                $layer: "line_layer-" + index,
+                class: "line_class-" + index,
+                type: "line_type-" + index,
+                name: "lineLabel-" + index
+            }),
+            15
+        );
 
         return {
             technique,
@@ -276,27 +287,32 @@ describe("ExtendedTileInfo", function() {
 
     function createPolygonInfo(
         index: number
-    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: MapEnv } {
+    ): { technique: IndexedTechnique; storedTechnique: IndexedTechnique; env: FeatureEnv } {
         const technique: IndexedTechnique = {
             name: "fill",
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
         const storedTechnique: IndexedTechnique = {
             name: "fill",
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index
+            _styleSetIndex: index,
+            _key: `${index}`
         };
-        const env = new MapEnv({
-            $layer: "fill_layer-" + index,
-            class: "fill_class-" + index,
-            type: "fill_type-" + index,
-            name: "fillLabel-" + index
-        });
+        const env = new FeatureEnv(
+            new MapEnv({
+                $layer: "fill_layer-" + index,
+                class: "fill_class-" + index,
+                type: "fill_type-" + index,
+                name: "fillLabel-" + index
+            }),
+            10
+        );
 
         return {
             technique,

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -24,7 +24,7 @@ export namespace TiledGeoJsonTechniquesExample {
         </style>
     `;
 
-    const theme: Theme = ({
+    const theme: Theme = {
         clearColor: "#234152",
         styles: {
             tilezen: [
@@ -409,8 +409,7 @@ export namespace TiledGeoJsonTechniquesExample {
                 }
             ]
         }
-        // TODO: as Theme is needed to satisfy `typedoc`
-    } as any) as Theme;
+    };
 
     /**
      * Creates a new MapView for the HTMLCanvasElement of the given id.

--- a/@here/harp-examples/src/theme_data-driven.ts
+++ b/@here/harp-examples/src/theme_data-driven.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GeoCoordinates } from "@here/harp-geoutils";
+import { MapControls, MapControlsUI } from "@here/harp-map-controls";
+import { CopyrightElementHandler, CopyrightInfo, MapView } from "@here/harp-mapview";
+import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { accessToken } from "../config";
+
+export namespace DataDrivenThemeExample {
+    function initializeMapView(id: string): MapView {
+        const canvas = document.getElementById(id) as HTMLCanvasElement;
+
+        const mapView = new MapView({
+            canvas,
+            theme: {
+                extends: "resources/berlin_tilezen_base.json",
+                definitions: {
+                    countryPopulationLevel: {
+                        type: "number",
+                        value: ["-", ["log10", ["number", ["get", "population"], 1000]], 3]
+                    }
+                },
+                styles: {
+                    tilezen: [
+                        ["ref", "countryBorderOutline"],
+                        ["ref", "waterPolygons"],
+                        {
+                            when: [
+                                "all",
+                                ["==", ["get", "$layer"], "places"],
+                                ["in", ["get", "kind"], ["country"]]
+                            ],
+                            technique: "text",
+                            attr: {
+                                priority: ["+", 100, ["^", 2, ["ref", "countryPopulationLevel"]]],
+                                size: ["+", 8, ["^", 1.7, ["ref", "countryPopulationLevel"]]],
+                                text: [
+                                    "concat",
+                                    ["coalesce", ["get", "name:en"], ["get", "name"]],
+                                    "\n",
+                                    ["coalesce", ["get", "population"], "n/a"]
+                                ],
+                                color: "#3F1821",
+                                backgroundColor: "#FFFFFF",
+                                backgroundOpacity: 0.7,
+                                fontVariant: "SmallCaps",
+                                opacity: 0.9
+                            }
+                        }
+                    ]
+                }
+            },
+            disableFading: true
+        });
+
+        CopyrightElementHandler.install("copyrightNotice", mapView);
+
+        mapView.resize(window.innerWidth, window.innerHeight);
+
+        window.addEventListener("resize", () => {
+            mapView.resize(window.innerWidth, window.innerHeight);
+        });
+
+        return mapView;
+    }
+
+    function main() {
+        const map = initializeMapView("mapCanvas");
+
+        const hereCopyrightInfo: CopyrightInfo = {
+            id: "here.com",
+            year: new Date().getFullYear(),
+            label: "HERE",
+            link: "https://legal.here.com/terms"
+        };
+
+        const copyrights: CopyrightInfo[] = [hereCopyrightInfo];
+
+        const omvDataSource = new OmvDataSource({
+            baseUrl: "https://xyz.api.here.com/tiles/osmbase/512/all",
+            apiFormat: APIFormat.XYZMVT,
+            styleSetName: "tilezen",
+            maxZoomLevel: 17,
+            authenticationCode: accessToken,
+            copyrightInfo: copyrights
+        });
+
+        const mapControls = MapControls.create(map);
+
+        const ui = new MapControlsUI(mapControls);
+        map.canvas.parentElement!.appendChild(ui.domElement);
+
+        map.setCameraGeolocationAndZoom(new GeoCoordinates(50.443041, 11.4229649), 5);
+        map.addDataSource(omvDataSource);
+    }
+
+    main();
+}

--- a/@here/harp-geojson-datasource/lib/GeoJsonDecoder.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonDecoder.ts
@@ -126,7 +126,7 @@ class GeoJsonDecoder {
 
         const tile: DecodedTile = {
             geometries: geometries.geometries,
-            techniques: this.m_styleSetEvaluator.techniques,
+            techniques: this.m_styleSetEvaluator.decodedTechniques,
             tileInfo: this.getTileInfo(extendedTile)
         };
 

--- a/@here/harp-geojson-datasource/lib/GeoJsonParser.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonParser.ts
@@ -22,6 +22,7 @@ import {
     LineFeatureGroup
 } from "@here/harp-datasource-protocol";
 import {
+    FeatureEnv,
     MapEnv,
     StyleSetEvaluator,
     Value,
@@ -466,7 +467,10 @@ export class GeoJsonParser {
             featureDetails.featureId = featureId;
         }
 
-        const env = new MapEnv({ type: "line", ...(featureDetails as ValueMap) });
+        const env = new FeatureEnv(
+            { type: "line", ...(featureDetails as ValueMap) },
+            extendedTile.info.tileKey.level
+        );
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
         const featureIdNumber = 0; //geojsonTile do not have an integer for the featureId. Use 0.
         if (buffer.lines.vertices.length !== buffer.lines.geojsonProperties.length) {
@@ -524,7 +528,10 @@ export class GeoJsonParser {
             featureDetails.featureId = featureId;
         }
 
-        const env = new MapEnv({ type: "line", ...(featureDetails as ValueMap) });
+        const env = new FeatureEnv(
+            { type: "line", ...(featureDetails as ValueMap) },
+            extendedTile.info.tileKey.level
+        );
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
         const featureIdNumber = 0; //geojsonTile do not have an integer for the featureId. Use 0.
         if (buffer.lines.vertices.length !== buffer.lines.geojsonProperties.length) {
@@ -742,7 +749,7 @@ export class GeoJsonParser {
         techniques: IndexedTechnique[],
         lines: number[][],
         featureId: number,
-        env: MapEnv,
+        env: FeatureEnv,
         geojsonProperties: Array<{} | undefined>
     ) {
         if (geojsonProperties.length !== lines.length) {

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -216,7 +216,7 @@ export class GeoJsonTile extends Tile {
             path,
             tileGeometryCreator.getRenderStyle(this, technique),
             tileGeometryCreator.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.sceneState),
             xOffset,
             yOffset,
             featureId
@@ -303,7 +303,7 @@ export class GeoJsonTile extends Tile {
             position,
             tileGeometryCreator.getRenderStyle(this, technique),
             tileGeometryCreator.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.sceneState),
             xOffset,
             yOffset,
             featureId
@@ -385,7 +385,7 @@ export class GeoJsonTile extends Tile {
             position,
             tileGeometryCreator.getRenderStyle(this, technique),
             tileGeometryCreator.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.sceneState),
             xOffset,
             yOffset,
             featureId

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -13,12 +13,45 @@
                 ["==", ["get", "$geometryType"], "polygon"]
             ]
         },
+        "defaultBuildingColor": {
+            "type": "color",
+            "value": "#EDE7E1"
+        },
         "extrudedBuildings": {
-            "description": "building_geometry",
+            "description": "buildings with pre-defined color",
             "technique": "extruded-polygon",
-            "when": ["ref", "extrudedBuildingsCondition"],
+            "when": ["all", ["ref", "extrudedBuildingsCondition"], ["!", ["has", "color"]]],
             "attr": {
-                "color": "#EDE7E1",
+                "color": ["ref", "defaultBuildingColor"],
+                "opacity": 0.9,
+                "roughness": 1,
+                "metalness": 0.8,
+                "emissive": "#78858C",
+                "emissiveIntensity": 0.85,
+                "footprint": true,
+                "maxSlope": 0.8799999999999999,
+                "lineWidth": 1,
+                "lineColor": "#172023",
+                "lineColorMix": 0.6,
+                "fadeNear": 0.9,
+                "fadeFar": 1,
+                "lineFadeNear": -0.75,
+                "lineFadeFar": 1,
+                "animateExtrusion": {
+                    "interpolation": "Discrete",
+                    "zoomLevels": [14, 15],
+                    "values": [false, true]
+                }
+            },
+            "renderOrder": 2000
+        },
+        "coloredExtrudedBuildings": {
+            "description": "buildings with varying colors",
+            "technique": "extruded-polygon",
+            "when": ["all", ["ref", "extrudedBuildingsCondition"], ["has", "color"]],
+            "attr": {
+                "vertexColors": true,
+                "defaultColor": ["ref", "defaultBuildingColor"],
                 "opacity": 0.9,
                 "roughness": 1,
                 "metalness": 0.8,
@@ -2303,6 +2336,7 @@
                 "final": true
             },
             ["ref", "extrudedBuildings"],
+            ["ref", "coloredExtrudedBuildings"],
             {
                 "description": "building_address",
                 "when": [

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -17,11 +17,29 @@
             "type": "color",
             "value": "#EDE7E1"
         },
+        "waterColor": {
+            "type": "color",
+            "value": "#436981"
+        },
+        "waterPolygons": {
+            "description": "water",
+            "when": [
+                "all",
+                ["==", ["get", "$layer"], "water"],
+                ["==", ["get", "$geometryType"], "polygon"]
+            ],
+            "technique": "fill",
+            "attr": {
+                "color": ["ref", "waterColor"]
+            },
+            "renderOrder": 5
+        },
         "extrudedBuildings": {
             "description": "buildings with pre-defined color",
             "technique": "extruded-polygon",
             "when": ["all", ["ref", "extrudedBuildingsCondition"], ["!", ["has", "color"]]],
             "attr": {
+                "height": ["get", "height"],
                 "color": ["ref", "defaultBuildingColor"],
                 "opacity": 0.9,
                 "roughness": 1,
@@ -50,8 +68,9 @@
             "technique": "extruded-polygon",
             "when": ["all", ["ref", "extrudedBuildingsCondition"], ["has", "color"]],
             "attr": {
+                "height": ["get", "height"],
                 "vertexColors": true,
-                "defaultColor": ["ref", "defaultBuildingColor"],
+                "color": ["string", ["get", "color", ["ref", "defaultBuildingColor"]]],
                 "opacity": 0.9,
                 "roughness": 1,
                 "metalness": 0.8,
@@ -92,6 +111,45 @@
         "roadsFadeFar": {
             "type": "number",
             "value": 0.95
+        },
+
+        "countryBorderOutlineWidth": {
+            "type": "number",
+            "value": {
+                "interpolation": "Linear",
+                "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+                "values": [10000, 8000, 7000, 5000, 3000, 2000, 1000, 500, 250, 120, 80, 40, 20, 10]
+            }
+        },
+        "countryBorderLine": {
+            "description": "country border",
+            "when": [
+                "all",
+                ["==", ["get", "$layer"], "boundaries"],
+                ["==", ["get", "$geometryType"], "line"],
+                ["==", ["get", "kind"], "country"]
+            ],
+            "technique": "solid-line",
+            "attr": {
+                "color": "#2F444B",
+                "lineWidth": ["ref", "countryBorderLineWidth"]
+            },
+            "renderOrder": 4.1
+        },
+        "countryBorderOutline": {
+            "description": "country border - outline",
+            "when": [
+                "all",
+                ["==", ["get", "$layer"], "boundaries"],
+                ["==", ["get", "$geometryType"], "line"],
+                ["==", ["get", "kind"], "country"]
+            ],
+            "technique": "solid-line",
+            "attr": {
+                "color": "#52676E",
+                "lineWidth": ["ref", "countryBorderOutlineWidth"]
+            },
+            "renderOrder": 4
         }
     },
     "sky": {
@@ -186,46 +244,13 @@
     "styles": {
         "tilezen": [
             {
-                "description": "highway-roadshield-2",
+                "description": "highway-roadshield",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "highway"],
                     ["==", ["get", "kind_detail"], "motorway"],
                     ["has", "ref"],
-                    ["<=", ["length", ["get", "ref"]], 2]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-2",
-                    "iconScale": 1.28,
-                    "priority": 35,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-3, level > 7",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
                     [">", ["get", "$level"], 7]
                 ],
                 "technique": "line-marker",
@@ -233,108 +258,13 @@
                     "style": "smallSign",
                     "label": "ref",
                     "size": 12.8,
-                    "imageTexture": "default-3",
+                    "imageTexture": [
+                        "concat",
+                        "default-",
+                        ["clamp", ["length", ["get", "ref"]], 2, 6]
+                    ],
                     "iconScale": 1.28,
-                    "priority": 34,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-4, level > 8",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["get", "$level"], 8]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-4",
-                    "iconScale": 1.28,
-                    "priority": 33,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-5, level > 8",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 8]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-5",
-                    "iconScale": 1.28,
-                    "priority": 32,
-                    "minDistance": 200,
-                    "vAlignment": "Center",
-                    "hAlignment": "Center",
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "color": "#000000",
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "highway-roadshield-5+, invisible",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "highway"],
-                    ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 8]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "style": "smallSign",
-                    "label": "ref",
-                    "size": 12.8,
-                    "imageTexture": "default-6",
-                    "iconScale": 1.28,
-                    "priority": 31,
+                    "priority": ["-", 37, ["length", ["get", "ref"]]],
                     "minDistance": 200,
                     "vAlignment": "Center",
                     "hAlignment": "Center",
@@ -685,14 +615,13 @@
                 "final": true
             },
             {
-                "description": "secondary-road-shield-2, level > 11",
+                "description": "secondary-road-shield, level > 11",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "secondary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 2],
                     [">", ["get", "$level"], 11]
                 ],
                 "technique": "line-marker",
@@ -702,151 +631,19 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "size": 12.8,
-                    "imageTexture": "default-2",
+                    "imageTexture": [
+                        "concat",
+                        "default-",
+                        ["clamp", ["length", ["get", "ref"]], 2, 6]
+                    ],
                     "iconScale": 1.28,
-                    "priority": 25,
+                    "priority": ["-", 26, ["length", ["get", "ref"]]],
                     "fadeNear": 0.8,
                     "fadeFar": 0.9,
                     "minDistance": 300,
                     "textIsOptional": false,
                     "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-3, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-3",
-                    "iconScale": 1.28,
-                    "priority": 24,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-4, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-4",
-                    "iconScale": 1.28,
-                    "priority": 23,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-5, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-5",
-                    "iconScale": 1.28,
-                    "priority": 22,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "secondary-road-shield-5+, level > 11",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 11]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-6",
-                    "iconScale": 1.28,
-                    "priority": 21,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 300,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
+                    "textMayOverlap": true,
                     "textReserveSpace": true,
                     "iconMayOverlap": true,
                     "iconReserveSpace": false,
@@ -885,14 +682,13 @@
                 "final": true
             },
             {
-                "description": "tertiary-road-shield-2, level > 13",
+                "description": "tertiary-road-shield, level > 13",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "tertiary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 2],
                     [">", ["get", "$level"], 13]
                 ],
                 "technique": "line-marker",
@@ -902,145 +698,13 @@
                     "backgroundColor": "#FFFFFF",
                     "backgroundOpacity": 0.5,
                     "size": 12.8,
-                    "imageTexture": "default-2",
+                    "imageTexture": [
+                        "concat",
+                        "default-",
+                        ["clamp", ["length", ["get", "ref"]], 2, 6]
+                    ],
                     "iconScale": 1.28,
-                    "priority": 20,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-3, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-3",
-                    "iconScale": 1.28,
-                    "priority": 19,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-4, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-4",
-                    "iconScale": 1.28,
-                    "priority": 18,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-5, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-5",
-                    "iconScale": 1.28,
-                    "priority": 17,
-                    "fadeNear": 0.8,
-                    "fadeFar": 0.9,
-                    "minDistance": 200,
-                    "textIsOptional": false,
-                    "iconIsOptional": false,
-                    "textMayOverlap": false,
-                    "textReserveSpace": true,
-                    "iconMayOverlap": true,
-                    "iconReserveSpace": false,
-                    "renderTextDuringMovements": true,
-                    "showOnMap": false
-                }
-            },
-            {
-                "description": "tertiary-road-shield-5+, level > 13",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "kind"], "major_road"],
-                    ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["get", "$level"], 13]
-                ],
-                "technique": "line-marker",
-                "attr": {
-                    "label": "ref",
-                    "color": "#000000",
-                    "backgroundColor": "#FFFFFF",
-                    "backgroundOpacity": 0.5,
-                    "size": 12.8,
-                    "imageTexture": "default-6",
-                    "iconScale": 1.28,
-                    "priority": 16,
+                    "priority": ["-", 22, ["length", ["get", "ref"]]],
                     "fadeNear": 0.8,
                     "fadeFar": 0.9,
                     "minDistance": 200,
@@ -1463,19 +1127,7 @@
                 "renderOrder": 5.15,
                 "final": true
             },
-            {
-                "description": "water",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "water"],
-                    ["==", ["get", "$geometryType"], "polygon"]
-                ],
-                "technique": "fill",
-                "attr": {
-                    "color": "#436981"
-                },
-                "renderOrder": 5
-            },
+            ["ref", "waterPolygons"],
             {
                 "description": "water",
                 "when": ["==", ["get", "$layer"], "water"],
@@ -1488,57 +1140,10 @@
                     "size": 12.8
                 }
             },
+            ["ref", "countryBorderOutline"],
+            ["ref", "countryBorderLine"],
             {
-                "description": "country border",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
-                    ["==", ["get", "kind"], "country"]
-                ],
-                "technique": "solid-line",
-                "attr": {
-                    "color": "#52676E",
-                    "lineWidth": {
-                        "interpolation": "Linear",
-                        "zoomLevels": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-                        "values": [
-                            10000,
-                            8000,
-                            7000,
-                            5000,
-                            3000,
-                            2000,
-                            1000,
-                            500,
-                            250,
-                            120,
-                            80,
-                            40,
-                            20,
-                            10
-                        ]
-                    }
-                },
-                "renderOrder": 4
-            },
-            {
-                "description": "country border",
-                "when": [
-                    "all",
-                    ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
-                    ["==", ["get", "kind"], "country"]
-                ],
-                "technique": "solid-line",
-                "attr": {
-                    "color": "#2F444B",
-                    "lineWidth": ["ref", "countryBorderLineWidth"]
-                },
-                "renderOrder": 4.1
-            },
-            {
-                "description": "country border",
+                "description": "country border - labels",
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExtrudedPolygonTechniqueParams } from "@here/harp-datasource-protocol";
-import { MapMeshStandardMaterial } from "@here/harp-materials";
 import * as THREE from "three";
+
+import { ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
+import { MapMeshStandardMaterial } from "@here/harp-materials";
 
 /**
  * Bitmask used for the depth pre-pass to prevent multiple fragments in the same screen position
@@ -22,7 +23,7 @@ export const DEPTH_PRE_PASS_STENCIL_MASK = 0x01;
  *
  * @param technique [[BaseStandardTechnique]] instance to be checked
  */
-export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechniqueParams) {
+export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique) {
     return (
         technique.enableDepthPrePass !== false &&
         technique.opacity !== undefined &&

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -23,6 +23,7 @@ import {
 import { assert, getOptionValue, LoggerManager, PerformanceTimer } from "@here/harp-utils";
 import * as THREE from "three";
 
+import { SceneState } from "@here/harp-datasource-protocol/lib/DynamicTechniqueAttr";
 import { AnimatedExtrusionHandler } from "./AnimatedExtrusionHandler";
 import { BackgroundDataSource } from "./BackgroundDataSource";
 import { CameraMovementDetector } from "./CameraMovementDetector";
@@ -732,6 +733,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_lastTileIds: string = "";
     private m_languages: string[] | undefined;
     private m_copyrightInfo: CopyrightInfo[] = [];
+    private m_sceneState = new MapViewSceneState(this);
 
     private m_animatedExtrusionHandler: AnimatedExtrusionHandler;
 
@@ -2280,6 +2282,10 @@ export class MapView extends THREE.EventDispatcher {
         return this.m_elevationProvider;
     }
 
+    get sceneState(): SceneState {
+        return this.m_sceneState;
+    }
+
     /**
      * Updates the camera and the projections and resets the screen collisions,
      * note, setupCamera must be called before this is called.
@@ -2458,6 +2464,7 @@ export class MapView extends THREE.EventDispatcher {
             return;
         }
         ++this.m_frameNumber;
+        this.m_sceneState.time = time;
 
         const stats = PerformanceStatistics.instance;
         const gatherStatistics: boolean = stats.enabled;
@@ -3156,5 +3163,23 @@ export class MapView extends THREE.EventDispatcher {
         } else {
             return { width: clientWidth, height: clientHeight };
         }
+    }
+}
+
+export class MapViewSceneState implements SceneState {
+    time: number = 0;
+    constructor(readonly mapView: MapView) {}
+
+    get frameNumber(): number {
+        return this.mapView.frameNumber;
+    }
+    get zoomLevel(): number {
+        return this.mapView.zoomLevel;
+    }
+    get pixelToMeters(): number {
+        return this.mapView.pixelToWorld;
+    }
+    get maxVisibility(): number {
+        return this.mapView.maxVisibility;
     }
 }

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -110,7 +110,7 @@ export class PickHandler {
         public enableRoadPicking = true
     ) {
         if (enableRoadPicking) {
-            this.m_roadPicker = new RoadPicker(mapView);
+            this.m_roadPicker = new RoadPicker();
         }
     }
 

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -146,7 +146,7 @@ export class RoadPicker {
 
             const width = Math.max(
                 1,
-                getPropertyValue(widths[i], tile.dataSource.mapView.zoomLevel) * 0.5
+                getPropertyValue(widths[i], tile.dataSource.mapView.sceneState) * 0.5
             );
             const lineWidthSqr = width * width;
 

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -121,7 +121,6 @@ export class ThemeLoader {
             );
             ThemeLoader.resolveThemeReferences(theme, contextLoader);
         }
-
         return theme;
     }
 

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -6,6 +6,8 @@
 import {
     DecodedTile,
     GeometryType,
+    InterpolatedProperty,
+    StyleLength,
     Technique,
     TextPathGeometry
 } from "@here/harp-datasource-protocol";
@@ -135,7 +137,7 @@ export interface RoadIntersectionData {
     /**
      * An array of widths of the roads. The lists of IDs and widths have the same size.
      */
-    widths: number[];
+    widths: Array<StyleLength | InterpolatedProperty<StyleLength>>;
 
     /**
      * An array of 2D numbers that make up the road geometry.

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -29,6 +29,7 @@ import {
     isTerrainTechnique,
     isTextTechnique,
     LineMarkerTechnique,
+    MakeTechniqueAttrs,
     needsVertexNormals,
     PoiTechnique,
     SolidLineTechnique,
@@ -710,7 +711,7 @@ export class TileGeometryCreator {
 
                 object.frustumCulled = false;
 
-                object.renderOrder = technique.renderOrder;
+                object.renderOrder = technique.renderOrder!;
 
                 if (group.renderOrderOffset !== undefined) {
                     object.renderOrder += group.renderOrderOffset;
@@ -1569,7 +1570,7 @@ export class TileGeometryCreator {
      */
     private getFadingParams(
         displayZoomLevel: number,
-        technique: BaseTechniqueParams
+        technique: MakeTechniqueAttrs<BaseTechniqueParams>
     ): FadingParameters {
         const fadeNear =
             technique.fadeNear !== undefined

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -491,14 +491,13 @@ export class PoiManager {
     ): TextElement {
         const priority = technique.priority !== undefined ? technique.priority : 0;
         const positions = Array.isArray(x) ? (x as THREE.Vector3[]) : new THREE.Vector3(x, y, z);
-        const displayZoomLevel = this.mapView.zoomLevel;
         const fadeNear =
             technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                ? getPropertyValue(technique.fadeNear, this.mapView.sceneState)
                 : technique.fadeNear;
         const fadeFar =
             technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                ? getPropertyValue(technique.fadeFar, this.mapView.sceneState)
                 : technique.fadeFar;
 
         const textElement: TextElement = new TextElement(
@@ -506,7 +505,7 @@ export class PoiManager {
             positions,
             this.getRenderStyle(tile.dataSource.name, technique),
             this.getLayoutStyle(tile.dataSource.name, technique),
-            getPropertyValue(priority, displayZoomLevel),
+            getPropertyValue(priority, this.mapView.sceneState),
             technique.xOffset !== undefined ? technique.xOffset : 0.0,
             technique.yOffset !== undefined ? technique.yOffset : 0.0,
             featureId,
@@ -592,17 +591,18 @@ export class PoiManager {
         const cacheId = computeStyleCacheId(dataSourceName, technique, Math.floor(zoomLevel));
         let renderStyle = mapView.textRenderStyleCache.get(cacheId);
         if (renderStyle === undefined) {
+            const frozenSceneState = {
+                ...mapView.sceneState,
+                zoomLevel: Math.floor(mapView.zoomLevel)
+            };
             const defaultRenderParams = mapView.textElementsRenderer!.defaultStyle.renderParams;
 
             if (technique.color !== undefined) {
-                const hexColor = getPropertyValue(technique.color, Math.floor(zoomLevel));
+                const hexColor = getPropertyValue(technique.color, frozenSceneState);
                 this.m_colorMap.set(cacheId, ColorCache.instance.getColor(hexColor));
             }
             if (technique.backgroundColor !== undefined) {
-                const hexBgColor = getPropertyValue(
-                    technique.backgroundColor,
-                    Math.floor(zoomLevel)
-                );
+                const hexBgColor = getPropertyValue(technique.backgroundColor, frozenSceneState);
                 this.m_colorMap.set(cacheId + "_bg", ColorCache.instance.getColor(hexBgColor));
             }
 
@@ -612,11 +612,11 @@ export class PoiManager {
                     unit: FontUnit.Pixel,
                     size:
                         technique.size !== undefined
-                            ? getPropertyValue(technique.size, Math.floor(zoomLevel))
+                            ? getPropertyValue(technique.size, frozenSceneState)
                             : defaultRenderParams.fontSize!.size,
                     backgroundSize:
                         technique.backgroundSize !== undefined
-                            ? getPropertyValue(technique.backgroundSize, Math.floor(zoomLevel))
+                            ? getPropertyValue(technique.backgroundSize, frozenSceneState)
                             : defaultRenderParams.fontSize!.backgroundSize
                 },
                 fontStyle:
@@ -640,14 +640,14 @@ export class PoiManager {
                 ),
                 opacity:
                     technique.opacity !== undefined
-                        ? getPropertyValue(technique.opacity, Math.floor(zoomLevel))
+                        ? getPropertyValue(technique.opacity, frozenSceneState)
                         : defaultRenderParams.opacity,
                 backgroundOpacity:
                     technique.backgroundOpacity !== undefined
-                        ? getPropertyValue(technique.backgroundOpacity, Math.floor(zoomLevel))
+                        ? getPropertyValue(technique.backgroundOpacity, frozenSceneState)
                         : technique.backgroundColor !== undefined &&
                           (technique.backgroundSize !== undefined &&
-                              getPropertyValue(technique.backgroundSize, Math.floor(zoomLevel)) > 0)
+                              getPropertyValue(technique.backgroundSize, frozenSceneState) > 0)
                         ? 1.0 // make label opaque when backgroundColor and backgroundSize are set
                         : defaultRenderParams.backgroundOpacity
             };

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -35,7 +35,7 @@ export function computeStyleCacheId(
     technique: Technique & Partial<IndexedTechniqueParams>,
     zoomLevel: number
 ): string {
-    return `${datasourceName}_${technique._styleSetIndex}_${zoomLevel}`;
+    return `${datasourceName}_${technique._key}_${zoomLevel}`;
 }
 
 /**

--- a/@here/harp-omv-datasource/lib/IGeometryProcessor.ts
+++ b/@here/harp-omv-datasource/lib/IGeometryProcessor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv } from "@here/harp-datasource-protocol/index-decoder";
 import { Vector2 } from "three";
 
 /**
@@ -66,8 +66,7 @@ export interface IGeometryProcessor {
         layerName: string,
         layerExtents: number,
         geometry: Vector2[],
-        env: MapEnv,
-        storageLevel: number
+        env: FeatureEnv
     ): void;
 
     /**
@@ -85,8 +84,7 @@ export interface IGeometryProcessor {
         layerName: string,
         layerExtents: number,
         geometry: ILineGeometry[],
-        env: MapEnv,
-        storageLevel: number
+        env: FeatureEnv
     ): void;
 
     /**
@@ -104,7 +102,6 @@ export interface IGeometryProcessor {
         layerName: string,
         layerExtents: number,
         geometry: IPolygonGeometry[],
-        env: MapEnv,
-        storageLevel: number
+        env: FeatureEnv
     ): void;
 }

--- a/@here/harp-omv-datasource/lib/OmvData.ts
+++ b/@here/harp-omv-datasource/lib/OmvData.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Env, MapEnv, Value, ValueMap } from "@here/harp-datasource-protocol/index-decoder";
+import {
+    Env,
+    FeatureEnv,
+    MapEnv,
+    Value,
+    ValueMap
+} from "@here/harp-datasource-protocol/index-decoder";
 import { TileKey } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
 import * as Long from "long";
@@ -313,7 +319,7 @@ function createFeatureEnv(
     storageLevel: number,
     logger?: ILogger,
     parent?: Env
-): MapEnv {
+): FeatureEnv {
     const attributes: ValueMap = {
         $layer: layer.name,
         $level: storageLevel,
@@ -330,7 +336,7 @@ function createFeatureEnv(
 
     readAttributes(layer, feature, attributes);
 
-    return new MapEnv(attributes, parent);
+    return new FeatureEnv(new MapEnv(attributes, parent), storageLevel);
 }
 
 function asGeometryType(feature: com.mapbox.pb.Tile.IFeature | undefined): OmvGeometryType {
@@ -472,7 +478,7 @@ export class OmvProtobufDataAdapter implements OmvDataAdapter, OmvVisitor {
 
         const env = createFeatureEnv(this.m_layer, feature, "point", storageLevel, this.m_logger);
 
-        this.m_processor.processPointFeature(layerName, layerExtents, geometry, env, storageLevel);
+        this.m_processor.processPointFeature(layerName, layerExtents, geometry, env);
     }
 
     /**
@@ -516,7 +522,7 @@ export class OmvProtobufDataAdapter implements OmvDataAdapter, OmvVisitor {
 
         const env = createFeatureEnv(this.m_layer, feature, "line", storageLevel, this.m_logger);
 
-        this.m_processor.processLineFeature(layerName, layerExtents, geometry, env, storageLevel);
+        this.m_processor.processLineFeature(layerName, layerExtents, geometry, env);
     }
 
     /**
@@ -566,12 +572,6 @@ export class OmvProtobufDataAdapter implements OmvDataAdapter, OmvVisitor {
 
         const env = createFeatureEnv(this.m_layer, feature, "polygon", storageLevel, this.m_logger);
 
-        this.m_processor.processPolygonFeature(
-            layerName,
-            layerExtents,
-            geometry,
-            env,
-            storageLevel
-        );
+        this.m_processor.processPolygonFeature(layerName, layerExtents, geometry, env);
     }
 }

--- a/@here/harp-omv-datasource/lib/OmvDataFilter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataFilter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { GeometryKind, GeometryKindSet } from "@here/harp-datasource-protocol";
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv, MapEnv } from "@here/harp-datasource-protocol/index-decoder";
 import {
     OmvFeatureFilterDescription,
     OmvFilterDescription,
@@ -93,7 +93,7 @@ export interface OmvFeatureModifier {
      * @param level Level of tile.
      * @returns `false` to ignore feature.
      */
-    doProcessPointFeature(layer: string, env: MapEnv, level: number): boolean;
+    doProcessPointFeature(layer: string, env: FeatureEnv): boolean;
 
     /**
      * Check if the line feature described by `env` should be processed. The properties can be
@@ -104,7 +104,7 @@ export interface OmvFeatureModifier {
      * @param level Level of tile.
      * @returns `false` to ignore feature.
      */
-    doProcessLineFeature(layer: string, env: MapEnv, level: number): boolean;
+    doProcessLineFeature(layer: string, env: FeatureEnv): boolean;
 
     /**
      * Check if the polygon feature described by `env` should be processed. The properties can be
@@ -115,7 +115,7 @@ export interface OmvFeatureModifier {
      * @param level Level of tile.
      * @returns `false` to ignore feature.
      */
-    doProcessPolygonFeature(layer: string, env: MapEnv, level: number): boolean;
+    doProcessPolygonFeature(layer: string, env: FeatureEnv): boolean;
 }
 
 /**
@@ -723,7 +723,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
 
     constructor(private description: OmvFeatureFilterDescription) {}
 
-    doProcessPointFeature(layer: string, env: MapEnv): boolean {
+    doProcessPointFeature(layer: string, env: FeatureEnv): boolean {
         return this.doProcessFeature(
             this.description.pointsToProcess,
             this.description.pointsToIgnore,
@@ -733,7 +733,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         );
     }
 
-    doProcessLineFeature(layer: string, env: MapEnv): boolean {
+    doProcessLineFeature(layer: string, env: FeatureEnv): boolean {
         return this.doProcessFeature(
             this.description.linesToProcess,
             this.description.linesToIgnore,
@@ -743,7 +743,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         );
     }
 
-    doProcessPolygonFeature(layer: string, env: MapEnv): boolean {
+    doProcessPolygonFeature(layer: string, env: FeatureEnv): boolean {
         return this.doProcessFeature(
             this.description.polygonsToProcess,
             this.description.polygonsToIgnore,
@@ -757,7 +757,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         itemsToProcess: OmvFilterDescription[],
         itemsToIgnore: OmvFilterDescription[],
         layer: string,
-        env: MapEnv,
+        env: FeatureEnv,
         defaultResult: boolean
     ): boolean {
         if (layer === undefined || (itemsToProcess.length === 0 && itemsToIgnore.length === 0)) {

--- a/@here/harp-omv-datasource/lib/OmvTileInfoEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvTileInfoEmitter.ts
@@ -10,7 +10,7 @@ import {
     FeatureGroupType,
     IndexedTechnique
 } from "@here/harp-datasource-protocol";
-import { MapEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
 import * as THREE from "three";
 
 import { ILineGeometry, IPolygonGeometry } from "./IGeometryProcessor";
@@ -49,7 +49,7 @@ export class OmvTileInfoEmitter implements IOmvEmitter {
         layer: string,
         extents: number,
         geometry: THREE.Vector2[],
-        env: MapEnv,
+        env: FeatureEnv,
         techniques: IndexedTechnique[],
         featureId: number | undefined
     ): void {
@@ -83,7 +83,7 @@ export class OmvTileInfoEmitter implements IOmvEmitter {
         layer: string,
         extents: number,
         geometry: ILineGeometry[],
-        env: MapEnv,
+        env: FeatureEnv,
         techniques: IndexedTechnique[],
         featureId: number | undefined
     ): void {
@@ -142,7 +142,7 @@ export class OmvTileInfoEmitter implements IOmvEmitter {
         layer: string,
         extents: number,
         geometry: IPolygonGeometry[],
-        env: MapEnv,
+        env: FeatureEnv,
         techniques: IndexedTechnique[],
         featureId: number | undefined
     ): void {

--- a/@here/harp-omv-datasource/lib/OmvTomTomFeatureModifier.ts
+++ b/@here/harp-omv-datasource/lib/OmvTomTomFeatureModifier.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv, MapEnv } from "@here/harp-datasource-protocol/index-decoder";
 import { LoggerManager } from "@here/harp-utils";
 import { OmvGenericFeatureModifier } from "./OmvDataFilter";
 import { OmvFeatureFilterDescription, OmvFilterDescription } from "./OmvDecoderDefs";
@@ -29,7 +29,7 @@ export class OmvTomTomFeatureModifier extends OmvGenericFeatureModifier {
         itemsToProcess: OmvFilterDescription[],
         itemsToIgnore: OmvFilterDescription[],
         layer: string,
-        env: MapEnv,
+        env: FeatureEnv,
         defaultResult: boolean
     ): boolean {
         this.rewriteEnvironment(layer, env);

--- a/@here/harp-omv-datasource/lib/VTJsonDataAdapter.ts
+++ b/@here/harp-omv-datasource/lib/VTJsonDataAdapter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapEnv, ValueMap } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv, MapEnv, ValueMap } from "@here/harp-datasource-protocol/index-decoder";
 import { GeoBox, TileKey } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
 import { Vector2 } from "three";
@@ -107,6 +107,7 @@ export class VTJsonDataAdapter implements OmvDataAdapter {
                 $level: tileKey.level,
                 id: feature.id
             });
+            const featureEnv = new FeatureEnv(env, tileKey.level);
 
             switch (feature.type) {
                 case VTJsonGeometryType.Point: {
@@ -120,8 +121,7 @@ export class VTJsonDataAdapter implements OmvDataAdapter {
                             tile.layer,
                             VT_JSON_EXTENTS,
                             [position],
-                            env,
-                            tileKey.level
+                            featureEnv
                         );
                     }
                     break;
@@ -138,8 +138,7 @@ export class VTJsonDataAdapter implements OmvDataAdapter {
                             tile.layer,
                             VT_JSON_EXTENTS,
                             [line],
-                            env,
-                            tileKey.level
+                            featureEnv
                         );
                     }
                     break;
@@ -159,9 +158,9 @@ export class VTJsonDataAdapter implements OmvDataAdapter {
                         tile.layer,
                         VT_JSON_EXTENTS,
                         [polygon],
-                        env,
-                        tileKey.level
+                        featureEnv
                     );
+
                     break;
                 }
                 case VTJsonGeometryType.Unknown: {

--- a/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -14,7 +14,11 @@ import {
     StyleSet,
     TextureCoordinateType
 } from "@here/harp-datasource-protocol";
-import { MapEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+import {
+    FeatureEnv,
+    MapEnv,
+    StyleSetEvaluator
+} from "@here/harp-datasource-protocol/index-decoder";
 import {
     GeoCoordinates,
     mercatorProjection,
@@ -120,8 +124,9 @@ describe("OmvDecodedTileEmitter", function() {
 
         const { tileEmitter, styleSetEvaluator } = createTileEmitter();
 
-        const mockEnv = new MapEnv({ layer: "mock-layer" });
-        const matchedTechniques = styleSetEvaluator.getMatchingTechniques(mockEnv);
+        const mockEnv = new FeatureEnv(new MapEnv({ layer: "mock-layer" }), 10);
+
+        const matchedTechniques = styleSetEvaluator.getMatchingTechniques(mockEnv.env);
         tileEmitter.processPolygonFeature(
             "mock-layer",
             4096,

--- a/@here/harp-omv-datasource/test/OmvTest.ts
+++ b/@here/harp-omv-datasource/test/OmvTest.ts
@@ -17,7 +17,7 @@ import {
     OmvGeometryType
 } from "../index";
 
-import { MapEnv, Value } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv, MapEnv, Value } from "@here/harp-datasource-protocol/index-decoder";
 import { assert } from "chai";
 
 /**
@@ -57,11 +57,11 @@ export class RoadFilter implements OmvFeatureFilter {
 }
 
 export class RoadFeatureFilter implements OmvFeatureModifier {
-    doProcessPointFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPointFeature(_layer: string, _env: FeatureEnv): boolean {
         return false;
     }
 
-    doProcessLineFeature(_layer: string, env: MapEnv): boolean {
+    doProcessLineFeature(_layer: string, env: FeatureEnv): boolean {
         const roadClass = env.lookup("class");
         const isRoad =
             roadClass !== undefined &&
@@ -70,23 +70,23 @@ export class RoadFeatureFilter implements OmvFeatureModifier {
         return isRoad;
     }
 
-    doProcessPolygonFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPolygonFeature(_layer: string, _env: FeatureEnv): boolean {
         return false;
     }
 }
 
 export class RoadsToRailroads implements OmvFeatureModifier {
-    doProcessPointFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPointFeature(_layer: string, _env: FeatureEnv): boolean {
         return false;
     }
 
-    doProcessLineFeature(_layer: string, env: MapEnv): boolean {
+    doProcessLineFeature(_layer: string, env: FeatureEnv): boolean {
         // turn all roads into railroads
         env.entries.class = "major_rail";
         return true;
     }
 
-    doProcessPolygonFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPolygonFeature(_layer: string, _env: FeatureEnv): boolean {
         return false;
     }
 }

--- a/@here/harp-omv-datasource/test/OmvTomTomFeatureModifierTest.ts
+++ b/@here/harp-omv-datasource/test/OmvTomTomFeatureModifierTest.ts
@@ -7,7 +7,7 @@
 // tslint:disable:only-arrow-functions
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { FeatureEnv, MapEnv } from "@here/harp-datasource-protocol/index-decoder";
 import { assert } from "chai";
 import { OmvFeatureFilterDescriptionBuilder } from "../lib/OmvDataFilter";
 import { OmvFeatureFilterDescription } from "../lib/OmvDecoderDefs";
@@ -25,7 +25,7 @@ export class OmvTomTomModifierMock extends OmvTomTomFeatureModifier {
             this.m_description.linesToProcess,
             this.m_description.linesToIgnore,
             layer,
-            env,
+            new FeatureEnv(env, 10),
             true
         );
     }


### PR DESCRIPTION
This is followup of #695 and also cutted down version of #697 

Overview:

* introduce `SceneState` - an interface providing MapView scene
  attributes that can change from frame to frame like `zoomLevel`,
  `pixel2world`
* introduce `SceneStateOperators` which allow access to these from
  expression language in `StyleSet`
* support `Expr` in all places where we supported `InterpolatedProperty`

TODO
 * [ ] support mixed scene/decoding expressions

Followup notes:
 * All the expressions and interpolators are evaluated several times per
  frame sometimes, even for no reason (it's not regression, but existing
  lack of optimization). Reuse of technique resources in #XXX.

Depends on #695, #775