### PR TITLE
HARP-7107: Introduce the property 'layer'.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -84,12 +84,6 @@ interface StyleInternalParams {
      * @hidden
      */
     _styleSetIndex?: number;
-
-    /**
-     * Optimization: The `$layer` requested by the `when` condition of this style.
-     * @hidden
-     */
-    _layer?: string;
 }
 
 type InternalStyle = Style & StyleSelector & StyleInternalParams;
@@ -161,13 +155,13 @@ class StyleConditionClassifier implements ExprVisitor<Expr | undefined, Expr | u
             // `call` is a direct child expression of an `"all"` operator.
             const matched = this.matchVarStringComparison(call);
 
-            if (matched && this._style._layer === undefined && matched.name === "$layer") {
+            if (matched && this._style.layer === undefined && matched.name === "$layer") {
                 // found a subexpression `["==", ["get", "$layer"], "some layer name"]`
                 // enclosed in an `["all", e1...eN]` expression. Remove it from
                 // its parent expression and store the value of the expected $layer in
                 // [[StyleInternalParams]].
 
-                this._style._layer = matched.value;
+                this._style.layer = matched.value;
 
                 // return `undefined` to remove this sub expression from its parent.
                 return undefined;
@@ -435,8 +429,8 @@ export class StyleSetEvaluator {
         if (style._whenExpr) {
             if (
                 this.m_layer !== undefined &&
-                style._layer !== undefined &&
-                this.m_layer !== style._layer
+                style.layer !== undefined &&
+                this.m_layer !== style.layer
             ) {
                 // skip this rule because its requested layer is different than the
                 // layer defined in $layer variable.

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -278,6 +278,11 @@ export interface StyleSelector {
     when: string | JsonExpr;
 
     /**
+     * The layer containing the carto features processed by this style rule.
+     */
+    layer?: string;
+
+    /**
      * Array of substyles.
      */
     styles?: StyleDeclaration[];

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -236,4 +236,65 @@ describe("StyleSetEvaluator", function() {
             assert.deepEqual(techniquesTileA[0], techniquesTileC[1]);
         });
     });
+
+    it("Filter techniques by layer", function() {
+        const styleSet: StyleSet = [
+            {
+                when: [
+                    "all",
+                    ["==", ["get", "$layer"], "buildings"],
+                    ["==", ["get", "$geometryType"], "polygon"]
+                ],
+                technique: "extruded-polygon"
+            },
+            {
+                layer: "buildings",
+                when: ["all", ["==", ["get", "$geometryType"], "polygon"]],
+                technique: "text"
+            },
+
+            {
+                layer: "buildings",
+                when: [
+                    "all",
+                    ["==", ["get", "$layer"], "buildings"],
+                    ["==", ["get", "$geometryType"], "polygon"]
+                ],
+                technique: "solid-line"
+            },
+
+            {
+                layer: "buildings",
+                when: ["all", ["==", ["get", "$layer"], "buildings"]],
+                technique: "fill"
+            },
+
+            {
+                layer: "water",
+                when: ["all", ["==", ["get", "$layer"], "buildings"]],
+                technique: "fill"
+            },
+
+            {
+                when: [
+                    "all",
+                    ["==", ["get", "$layer"], "water"],
+                    ["==", ["get", "$geometryType"], "polygon"]
+                ],
+                technique: "solid-line"
+            }
+        ];
+
+        const ev = new StyleSetEvaluator(styleSet);
+
+        const techniques = ev.getMatchingTechniques(
+            new MapEnv({ $layer: "buildings", $geometryType: "polygon" })
+        );
+
+        assert.equal(techniques.length, 4);
+        assert.equal(techniques[0].name, "extruded-polygon");
+        assert.equal(techniques[1].name, "text");
+        assert.equal(techniques[2].name, "solid-line");
+        assert.equal(techniques[3].name, "fill");
+    });
 });


### PR DESCRIPTION
The newly introduced property 'layer' can be used to restrict the
matching of techniques to a specific layer. For example, the following
two style conditions are equivalent:

            {
                "when": [
                    "all",
                    ["==", ["get", "$layer"], "water"],
                    ["==", ["get", "$geometryType"], "polygon"]
                ],
                ...
            }

            {
                "layer": "water",
                "when": [
                    "all",
                    ["==", ["get", "$geometryType"], "polygon"]
                ],
                ...
            }
