### PR TITLE
HARP-6728: Cleanup configure/setStyleSet flow in TileDataSource

### DIFF
--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -209,8 +209,6 @@ export namespace GeoJsonStylingGame {
             styleSet.push(activeRegionStyle);
         }
         geoJsonDataSource.setStyleSet(styleSet);
-        mapView.clearTileCache("geojson");
-        mapView.update();
     }
     // end:harp_gl_gamestyleset.ts
 

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -81,7 +81,6 @@ export namespace ThemesExample {
                     return response.json();
                 })
                 .then((theme: any) => {
-                    mapView.clearTileCache();
                     mapView.theme = theme;
                 });
         })

--- a/@here/harp-features-datasource/lib/FeaturesDataSource.ts
+++ b/@here/harp-features-datasource/lib/FeaturesDataSource.ts
@@ -141,7 +141,6 @@ export class FeaturesDataSource extends OmvDataSource {
     private update() {
         (this.dataProvider() as GeoJsonDataProvider).updateInput(this.m_featureCollection);
         this.mapView.markTilesDirty(this);
-        this.mapView.clearTileCache(this.name);
     }
 
     private emptyGeojson(): FeatureCollection {

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -158,10 +158,6 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
             );
         }
 
-        this.m_decoder.configure(undefined, undefined, {
-            storageLevelOffset: this.m_options.storageLevelOffset
-        });
-
         this.useGeometryLoader = true;
         this.cacheable = true;
         this.m_tileLoaderCache = new LRUCache<number, TileLoader>(this.getCacheCount());
@@ -186,6 +182,10 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
     async connect() {
         await Promise.all([this.m_options.dataProvider.connect(), this.m_decoder.connect()]);
         this.m_isReady = true;
+
+        this.m_decoder.configure(undefined, undefined, {
+            storageLevelOffset: this.m_options.storageLevelOffset
+        });
     }
 
     setStyleSet(styleSet?: StyleSet, languages?: string[]): void {

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -241,17 +241,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
             }
             throw error;
         }
-    }
-
-    /**
-     * Set a theme for the data source instance.
-     * @param styleSet The [[Theme]] to be added.
-     */
-    setStyleSet(styleSet?: StyleSet, languages?: string[]): void {
-        if (styleSet === undefined) {
-            return;
-        }
-        this.configureDecoder(styleSet, languages, this.m_decoderOptions);
+        this.configureDecoder(undefined, undefined, this.m_decoderOptions);
     }
 
     /**
@@ -303,7 +293,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
 
     setLanguages(languages?: string[]): void {
         if (languages !== undefined) {
-            this.configureDecoder(undefined, languages, undefined);
+            this.configureDecoder(undefined, languages);
         }
     }
 


### PR DESCRIPTION
`TileDataSource` and `OmvDataSource` now automatically updates
owned tiles when decoder configuration (style, languages, options)
is changed.

Additionally, configure decoder only after successfull `#connect`.