### PR TITLE
HARP-7103: Support for 'ref' in Expr.fromJSON

### DIFF
--- a/@here/harp-datasource-protocol/lib/ITileDecoder.ts
+++ b/@here/harp-datasource-protocol/lib/ITileDecoder.ts
@@ -6,7 +6,7 @@
 import { Projection, TileKey } from "@here/harp-geoutils";
 
 import { DecodedTile } from "./DecodedTile";
-import { StyleSet } from "./Theme";
+import { Definitions, StyleSet } from "./Theme";
 import { TileInfo } from "./TileInfo";
 import { OptionsMap, RequestController } from "./WorkerDecoderProtocol";
 
@@ -58,10 +58,16 @@ export interface ITileDecoder {
      * Non-existing (`undefined`) options (including styleSet) are not changed.
      *
      * @param styleSet optional, new style set.
+     * @param definitions optional, definitions used to resolve references in `styleSet`
      * @param languages optional, language list
      * @param options optional, new options - shape is specific for each decoder
      */
-    configure(styleSet?: StyleSet, languages?: string[], options?: OptionsMap): void;
+    configure(
+        styleSet?: StyleSet,
+        definitions?: Definitions,
+        languages?: string[],
+        options?: OptionsMap
+    ): void;
 
     /**
      * Free all resources associated with this decoder.

--- a/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StyleSet } from "./Theme";
+import { Definitions, StyleSet } from "./Theme";
 import { WorkerServiceProtocol } from "./WorkerServiceProtocol";
 
 /**
@@ -72,6 +72,7 @@ export namespace WorkerDecoderProtocol {
     export interface ConfigurationMessage extends DecoderMessage {
         type: DecoderMessageName.Configuration;
         styleSet?: StyleSet;
+        definitions?: Definitions;
         options?: OptionsMap;
         languages?: string[];
     }

--- a/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
@@ -29,7 +29,6 @@ const operators = {
             const a = context.evaluate(args[0]);
             const b = context.evaluate(args[1]);
             if (typeof a !== "number" || typeof b !== "number") {
-                // tslint:disable-next-line: max-line-length
                 throw new Error(
                     `invalid operands '${typeof a}' and '${typeof b}' for operator '-'`
                 );

--- a/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
+++ b/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
@@ -6,6 +6,7 @@
 
 import {
     DecodedTile,
+    Definitions,
     ITileDecoder,
     OptionsMap,
     StyleSet,
@@ -52,11 +53,16 @@ export abstract class ThemedTileDecoder implements ITileDecoder {
     ): Promise<TileInfo | undefined> {
         return Promise.resolve(undefined);
     }
-
     // tslint:disable:no-unused-variable
-    configure(styleSet?: StyleSet, languages?: string[], options?: OptionsMap): void {
+
+    configure(
+        styleSet?: StyleSet,
+        definitions?: Definitions,
+        languages?: string[],
+        options?: OptionsMap
+    ): void {
         if (styleSet !== undefined) {
-            this.m_styleSetEvaluator = new StyleSetEvaluator(styleSet);
+            this.m_styleSetEvaluator = new StyleSetEvaluator(styleSet, definitions);
         }
         if (languages !== undefined) {
             this.languages = languages;

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ITileDecoder, StyleSet, TileInfo } from "@here/harp-datasource-protocol";
+import {
+    Definitions,
+    ITileDecoder,
+    StyleSet,
+    Theme,
+    TileInfo
+} from "@here/harp-datasource-protocol";
 import { TileKey, TilingScheme } from "@here/harp-geoutils";
 import {
     ConcurrentDecoderFacade,
@@ -183,15 +189,22 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
         await Promise.all([this.m_options.dataProvider.connect(), this.m_decoder.connect()]);
         this.m_isReady = true;
 
-        this.m_decoder.configure(undefined, undefined, {
+        this.m_decoder.configure(undefined, undefined, undefined, {
             storageLevelOffset: this.m_options.storageLevelOffset
         });
     }
 
-    setStyleSet(styleSet?: StyleSet, languages?: string[]): void {
-        this.m_tileLoaderCache.clear();
-        this.m_decoder.configure(styleSet, languages);
+    setStyleSet(styleSet?: StyleSet, definitions?: Definitions, languages?: string[]): void {
+        this.m_decoder.configure(styleSet, definitions, languages);
         this.mapView.markTilesDirty(this);
+    }
+
+    setTheme(theme: Theme, languages?: string[]): void {
+        const styleSet =
+            (this.styleSetName !== undefined && theme.styles && theme.styles[this.styleSetName]) ||
+            [];
+
+        this.setStyleSet(styleSet, theme.definitions, languages);
     }
 
     clearCache() {

--- a/@here/harp-mapview-decoder/lib/TileDecoderService.ts
+++ b/@here/harp-mapview-decoder/lib/TileDecoderService.ts
@@ -137,6 +137,11 @@ export class TileDecoderService extends WorkerService {
     }
 
     private handleConfigurationMessage(message: WorkerDecoderProtocol.ConfigurationMessage) {
-        this.m_decoder.configure(message.styleSet, message.languages, message.options);
+        this.m_decoder.configure(
+            message.styleSet,
+            message.definitions,
+            message.languages,
+            message.options
+        );
     }
 }

--- a/@here/harp-mapview/lib/BackgroundDataSource.ts
+++ b/@here/harp-mapview/lib/BackgroundDataSource.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Theme } from "@here/harp-datasource-protocol";
 import { TileKey, TilingScheme, webMercatorTilingScheme } from "@here/harp-geoutils";
 import { DataSource } from "./DataSource";
 import { TileGeometryCreator } from "./geometry/TileGeometryCreator";
@@ -45,6 +46,10 @@ export class BackgroundDataSource extends DataSource {
             this.storageLevelOffset = storageLevelOffset;
             this.mapView.clearTileCache(this.name);
         }
+    }
+
+    setTheme(theme: Theme, languages?: string[]) {
+        this.mapView.clearTileCache(this.name);
     }
 
     setTilingScheme(tilingScheme?: TilingScheme) {

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -3,7 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { StyleSet } from "@here/harp-datasource-protocol";
+import { Definitions, StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { Projection, TileKey, TilingScheme } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
@@ -112,17 +112,13 @@ export abstract class DataSource extends THREE.EventDispatcher {
 
     /**
      * Sets the name of the [[StyleSet]] to use for the decoding. If this [[DataSource]] is already
-     * attached to a [[MapView]], this setter then looks for a [[StyleSet]] with this name and
-     * applies it.
+     * attached to a [[MapView]], this setter then reapplies [[StyleSet]] with this name found in
+     * [[MapView]]s theme.
      */
     set styleSetName(styleSetName: string | undefined) {
         this.m_styleSetName = styleSetName;
-        if (
-            this.m_mapView !== undefined &&
-            styleSetName !== undefined &&
-            this.m_mapView.theme.styles !== undefined
-        ) {
-            this.setStyleSet(this.m_mapView.theme.styles[styleSetName]);
+        if (this.m_mapView !== undefined && styleSetName !== undefined) {
+            this.setTheme(this.m_mapView.theme);
         }
     }
 
@@ -209,13 +205,26 @@ export abstract class DataSource extends THREE.EventDispatcher {
     /**
      * Invoked by [[MapView]] to notify when the [[Theme]] has been changed.
      *
-     * If `DataSource` depends on a theme, it must update its tiles' geometry.
+     * If `DataSource` depends on a `styleSet` or `languages`, it must update its tiles' geometry.
+     *
+     * @deprecated, Use [[setTheme]].
      *
      * @param styleSet The new theme that [[MapView]] uses.
      * @param languages An optional list of languages for the `DataSource`.
      */
     // tslint:disable-next-line:no-unused-variable
-    setStyleSet(styleSet?: StyleSet, languages?: string[]): void {
+    setStyleSet(styleSet?: StyleSet, definitions?: Definitions, languages?: string[]): void {
+        // to be overwritten by subclasses
+    }
+
+    /**
+     * Invoked by [[MapView]] to apply new [[Theme]].
+     *
+     * If `DataSource` depends on a `styleSet` or `languages`, it must update its tiles' geometry.
+     *
+     * @param languages
+     */
+    setTheme(theme: Theme, languages?: string[]): void {
         // to be overwritten by subclasses
     }
 

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1189,17 +1189,14 @@ export class MapView extends THREE.EventDispatcher {
         if (this.m_theme.styles === undefined) {
             this.m_theme.styles = {};
         }
+        if (this.m_backgroundDataSource) {
+            this.m_backgroundDataSource.setTheme(this.m_theme);
+        }
+        this.m_theme.styles = theme.styles || {};
+        this.m_theme.definitions = theme.definitions;
 
-        if (theme.styles !== undefined) {
-            for (const styleSetName in theme.styles) {
-                if (theme.styles[styleSetName] !== undefined) {
-                    const styleSet = theme.styles[styleSetName];
-                    this.getDataSourcesByStyleSetName(styleSetName).forEach(ds =>
-                        ds.setStyleSet(styleSet)
-                    );
-                    this.m_theme.styles[styleSetName] = styleSet;
-                }
-            }
+        for (const dataSource of this.m_tileDataSources) {
+            dataSource.setTheme(this.m_theme);
         }
         this.dispatchEvent(THEME_LOADED_EVENT);
         this.update();
@@ -1686,10 +1683,7 @@ export class MapView extends THREE.EventDispatcher {
                     this.update();
                 });
 
-                if (this.m_theme.styles !== undefined && dataSource.styleSetName !== undefined) {
-                    const styleSet = this.m_theme.styles[dataSource.styleSetName];
-                    dataSource.setStyleSet(styleSet, this.m_languages);
-                }
+                dataSource.setTheme(this.m_theme);
 
                 this.m_connectedDataSources.add(dataSource.name);
 

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -40,7 +40,7 @@ export interface ThemeLoadOptions {
     /**
      * Whether to resolve `ref` expressions in `definition` and `styles` elements.
      *
-     * @default `true`
+     * @default `false`, as datasources resolve definitions in [[StyleSetEvaluator]].
      */
     resolveDefinitions?: boolean;
 
@@ -112,7 +112,7 @@ export class ThemeLoader {
 
         theme = this.resolveUrls(theme);
 
-        const resolveDefinitions = getOptionValue<boolean>(options.resolveDefinitions, true);
+        const resolveDefinitions = getOptionValue<boolean>(options.resolveDefinitions, false);
         theme = await ThemeLoader.resolveBaseTheme(theme, options);
         if (resolveDefinitions) {
             const contextLoader = new ContextLogger(

--- a/@here/harp-mapview/lib/WorkerBasedDecoder.ts
+++ b/@here/harp-mapview/lib/WorkerBasedDecoder.ts
@@ -5,6 +5,7 @@
  */
 import {
     DecodedTile,
+    Definitions,
     getProjectionName,
     ITileDecoder,
     OptionsMap,
@@ -156,11 +157,17 @@ export class WorkerBasedDecoder implements ITileDecoder {
      * @param languages new list of languages
      * @param options   new options, undefined options are not changed
      */
-    configure(styleSet?: StyleSet, languages?: string[], options?: OptionsMap): void {
+    configure(
+        styleSet?: StyleSet,
+        definitions?: Definitions,
+        languages?: string[],
+        options?: OptionsMap
+    ): void {
         const message: WorkerDecoderProtocol.ConfigurationMessage = {
             service: this.serviceId,
             type: WorkerDecoderProtocol.DecoderMessageName.Configuration,
             styleSet,
+            definitions,
             options,
             languages
         };

--- a/@here/harp-mapview/test/ThemeLoaderTest.ts
+++ b/@here/harp-mapview/test/ThemeLoaderTest.ts
@@ -174,7 +174,7 @@ describe("ThemeLoader", function() {
         });
     });
 
-    describe("#load support for inheritance and definitions", function() {
+    describe("#load support for inheritance and optional reference resolving", function() {
         const baseThemeUrl = getTestResourceUrl(
             "@here/harp-mapview",
             "test/resources/baseTheme.json"
@@ -212,7 +212,7 @@ describe("ThemeLoader", function() {
             }
         ];
         it("loads theme from actual URL and resolves definitions", async function() {
-            const result = await ThemeLoader.load(baseThemeUrl);
+            const result = await ThemeLoader.load(baseThemeUrl, { resolveDefinitions: true });
             assert.exists(result);
             assert.exists(result.styles!.tilezen);
             assert.deepEqual(result.styles!.tilezen, expectedBaseStyleSet);
@@ -223,26 +223,32 @@ describe("ThemeLoader", function() {
                 "@here/harp-mapview",
                 "test/resources/inheritedStyleBasic.json"
             );
-            const result = await ThemeLoader.load(inheritedThemeUrl);
+            const result = await ThemeLoader.load(inheritedThemeUrl, { resolveDefinitions: true });
             assert.exists(result);
             assert.exists(result.styles!.tilezen);
             assert.deepEqual(result.styles!.tilezen, expectedOverridenStyleSet);
         });
 
         it("empty inherited theme just loads base", async function() {
-            const result = await ThemeLoader.load({ extends: baseThemeUrl });
+            const result = await ThemeLoader.load(
+                { extends: baseThemeUrl },
+                { resolveDefinitions: true }
+            );
             assert.exists(result);
             assert.exists(result.styles!.tilezen);
             assert.deepEqual(result.styles!.tilezen, expectedBaseStyleSet);
         });
 
         it("supports local definitions override", async function() {
-            const result = await ThemeLoader.load({
-                extends: baseThemeUrl,
-                definitions: {
-                    roadColor: { type: "color", value: "#fff" }
-                }
-            });
+            const result = await ThemeLoader.load(
+                {
+                    extends: baseThemeUrl,
+                    definitions: {
+                        roadColor: { type: "color", value: "#fff" }
+                    }
+                },
+                { resolveDefinitions: true }
+            );
             assert.exists(result);
             assert.exists(result.styles!.tilezen);
             assert.deepEqual(result.styles!.tilezen, expectedOverridenStyleSet);
@@ -274,7 +280,7 @@ describe("ThemeLoader", function() {
                         tilezen: [["ref", "roadStyle"], ["ref", "badStyleRef"]]
                     }
                 },
-                { logger: loggerMock }
+                { logger: loggerMock, resolveDefinitions: true }
             );
 
             // Check that invalid style was removed from SS

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+    Definitions,
     GeometryType,
     ITileDecoder,
     OptionsMap,
@@ -241,7 +242,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
             }
             throw error;
         }
-        this.configureDecoder(undefined, undefined, this.m_decoderOptions);
+        this.configureDecoder(undefined, undefined, undefined, this.m_decoderOptions);
     }
 
     /**
@@ -249,7 +250,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
      * Will be applied to the decoder, which might be shared with other omv datasources.
      */
     removeDataFilter(): void {
-        this.configureDecoder(undefined, undefined, {
+        this.configureDecoder(undefined, undefined, undefined, {
             filterDescription: null
         });
     }
@@ -265,7 +266,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
         this.m_decoderOptions.filterDescription =
             filterDescription !== null ? filterDescription : undefined;
 
-        this.configureDecoder(undefined, undefined, {
+        this.configureDecoder(undefined, undefined, undefined, {
             filterDescription
         });
     }
@@ -293,7 +294,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
 
     setLanguages(languages?: string[]): void {
         if (languages !== undefined) {
-            this.configureDecoder(undefined, languages);
+            this.configureDecoder(undefined, undefined, languages, undefined);
         }
     }
 
@@ -304,7 +305,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
     set storageLevelOffset(levelOffset: number) {
         super.storageLevelOffset = levelOffset;
         this.m_decoderOptions.storageLevelOffset = this.storageLevelOffset;
-        this.configureDecoder(undefined, undefined, {
+        this.configureDecoder(undefined, undefined, undefined, {
             storageLevelOffset: this.storageLevelOffset
         });
     }
@@ -312,15 +313,20 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
     setEnableElevationOverlay(enable: boolean) {
         if (this.m_decoderOptions.enableElevationOverlay !== enable) {
             this.m_decoderOptions.enableElevationOverlay = enable;
-            this.configureDecoder(undefined, undefined, {
+            this.configureDecoder(undefined, undefined, undefined, {
                 enableElevationOverlay: enable
             });
         }
     }
 
-    private configureDecoder(styleSet?: StyleSet, languages?: string[], options?: OptionsMap) {
+    private configureDecoder(
+        styleSet?: StyleSet,
+        definitions?: Definitions,
+        languages?: string[],
+        options?: OptionsMap
+    ) {
         this.m_tileLoaderCache.clear();
-        this.decoder.configure(styleSet, languages, options);
+        this.decoder.configure(styleSet, definitions, languages, options);
         this.mapView.markTilesDirty(this);
     }
 }

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -6,6 +6,7 @@
 
 import {
     DecodedTile,
+    Definitions,
     ExtendedTileInfo,
     GeometryKind,
     IndexedTechnique,
@@ -622,8 +623,13 @@ export class OmvTileDecoder extends ThemedTileDecoder {
         return Promise.resolve(tileInfo);
     }
 
-    configure(styleSet: StyleSet, languages?: string[], options?: OptionsMap): void {
-        super.configure(styleSet, languages, options);
+    configure(
+        styleSet: StyleSet,
+        definitions?: Definitions,
+        languages?: string[],
+        options?: OptionsMap
+    ): void {
+        super.configure(styleSet, definitions, languages, options);
 
         if (options) {
             const omvOptions = options as OmvDecoderOptions;


### PR DESCRIPTION
Support for 'compile'-time' (`Expr.fromJSON`) reference resolving.

MapView changes:

* `DataSource.setTheme` revived as main theming interface for
  datasources because decoder based datasources require
  `theme.definitions` too
* `Definitions` are communicated from `MapView` to decoder
* `StyleSetEvaluator` now resolves references using `Expr.fromJSON`
* `ThemeLoader` doesn't resolve references by default
* (minor) BackgroundDataSource reacts to theme change

Rationale
We expect that objects and expressions in `Theme.definitions` can be big and this should be sent as one to decoders and we should reuse their instances to save memory.