### PR TITLE
Support for test execution on windows.

### DIFF
--- a/.github/workflows/ci-linux.yaml
+++ b/.github/workflows/ci-linux.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node_version: [10, 11, 12]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci-windows.yaml
+++ b/.github/workflows/ci-windows.yaml
@@ -1,0 +1,79 @@
+name: CI (Windows)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    name: Test on node ${{ matrix.node_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node_version: [10, 11, 12]
+        os: [windows-latest]
+
+    steps:
+
+    - name: Reset git settings
+      # Global git config on windows has autocrlf enabled.
+      # This breaks lot of checks, including tslint.
+      run: git config --global core.autocrlf false
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node_version }}
+      uses: actions/setup-node@v1
+      with:
+        version: ${{ matrix.node_version }}
+    - name: Install dependencies
+      shell: bash
+      run: |
+        set -ex
+        # This is arbitrary version that happens to be installed in github CI env atm.
+        # As for now `chromedriver` supports only exact version, so this version have to be
+        # updated with Github CI windows infra.
+        #
+        # See
+        #  https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#windows-server-2019
+        #  https://github.com/giggio/node-chromedriver - explanation
+        #  https://sites.google.com/a/chromium.org/chromedriver/downloads - available versions
+        export CHROMEDRIVER_VERSION=75.0.3770.140
+        yarn
+    - name: Pretest
+      run: |
+        set -ex
+        npx ts-mocha -r tsconfig-paths/register ./test/*.ts
+        yarn run tslint
+        npx prettier -l '**/*.ts' '**/*.tsx' '**/*.json'
+      shell: bash
+    - name: Test on Node.js
+      run: npx ts-mocha -r tsconfig-paths/register ./@here/*/test/*.ts
+      shell: bash
+    - name: Build test bundle
+      run: yarn run build-tests
+      shell: bash
+    - name: Tests on Chrome
+      run: |
+        export PATH=`pwd`:$PATH
+        cp node_modules/chromedriver/lib/chromedriver/chromedriver.exe .
+        yarn test-browser --headless-chrome
+      shell: bash
+    - name: Tests on Firefox
+      run: |
+        export PATH=`pwd`:$PATH
+        cp node_modules/geckodriver/geckodriver.exe .
+        yarn test-browser --headless-firefox
+      shell: bash
+    - name: Build examples
+      run: yarn run build-examples
+      shell: bash
+    - name: Build harp.js
+      run: yarn run build-bundle
+      shell: bash
+    #  typedoc doesn't work on windows -> https://github.com/unstubbable/typedoc-plugin-monorepo/pull/1
+    # - name: Generate doc
+    #   run: yarn run typedoc
+    #   shell: bash

--- a/@here/harp-test-utils/lib/TestDataUtils.ts
+++ b/@here/harp-test-utils/lib/TestDataUtils.ts
@@ -29,7 +29,14 @@ export const testResourcesRoot =
  */
 export function getTestResourceUrl(module: string, fileName: string) {
     const modulePath = path.dirname(require.resolve(module + "/package.json"));
-    return path.join(testResourcesRoot, modulePath, fileName);
+    const resultPath = path.join(testResourcesRoot, modulePath, fileName);
+    if (resultPath.indexOf("\\") !== -1) {
+        // node-fetch on windows, needs proper URL
+        return "file://" + resultPath.replace(/\\/g, "/");
+    } else {
+        // node-fetch on unix is ok with just a absolute file path
+        return resultPath;
+    }
 }
 
 /**

--- a/@here/harp-test-utils/lib/TestDataUtils.web.ts
+++ b/@here/harp-test-utils/lib/TestDataUtils.web.ts
@@ -6,10 +6,6 @@
 
 // @here:check-imports:environment:node
 
-import { LoggerManager } from "@here/harp-utils";
-
-const logger = LoggerManager.instance.create("TestDataUtils");
-
 declare const TEST_RESOURCES_DIR: string | undefined;
 
 /**
@@ -89,7 +85,6 @@ export function loadTestResourceWeb(
     type: "arraybuffer" | "text" | "json"
 ): Promise<any> {
     const url = getTestResourceUrl(module, fileName);
-    logger.log("loadTestResourceWeb, url: ", url);
 
     return fetch(url).then(response => {
         if (!response.ok) {

--- a/@here/harp-test-utils/package.json
+++ b/@here/harp-test-utils/package.json
@@ -26,7 +26,6 @@
     },
     "devDependencies": {
         "@here/harp-fetch": "^0.3.6",
-        "@here/harp-utils": "^0.10.0",
         "@types/chai": "^4.0.4",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.0.8",

--- a/@here/harp-utils/package.json
+++ b/@here/harp-utils/package.json
@@ -19,6 +19,7 @@
     },
     "license": "Apache-2.0",
     "devDependencies": {
+        "@here/harp-test-utils": "^0.10.0",
         "@types/chai": "^4.1.2",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.0.8",

--- a/@here/harp-utils/test/PerformanceTimerTest.ts
+++ b/@here/harp-utils/test/PerformanceTimerTest.ts
@@ -7,19 +7,20 @@
 // tslint:disable:only-arrow-functions
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
+import { willEventually } from "@here/harp-test-utils";
 import { assert } from "chai";
 import { PerformanceTimer } from "../lib/PerformanceTimer";
 
 describe("PerformanceTimer", function() {
-    it("#now", function() {
+    it("#now", async function() {
         const t0 = PerformanceTimer.now();
         assert.isNumber(t0);
         assert.isAbove(t0, 0);
 
-        setTimeout(() => {
+        await willEventually(() => {
             const t1 = PerformanceTimer.now();
             assert.isNumber(t1);
             assert.isAbove(t1, t0);
-        }, 2);
+        });
     });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@types/chai": "^4.1.3",
         "@types/fs-extra": "^8.0.0",
         "chai": "^4.2.0",
-        "chromedriver": "^76.0.0",
+        "chromedriver": "^76.0.1",
         "commander": "^2.20.0",
         "fs-extra": "^8.1.0",
         "geckodriver": "^1.16.2",

--- a/test/LicenseHeaderTest.ts
+++ b/test/LicenseHeaderTest.ts
@@ -20,6 +20,7 @@ const license = `/*
 `;
 
 describe("LicenseHeaderCheck", function() {
+    this.timeout(4000);
     let sourceFiles: string[];
 
     before(function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,7 +1516,7 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^76.0.0:
+chromedriver@^76.0.1:
   version "76.0.1"
   resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-76.0.1.tgz#65283299c3b34b1212eef272c32bd826c6bdebd3"
   integrity sha512-+8BCemJLKPF2w/UpzA1uNgLWQrg1IgIO4ZYcsAjYYgqD8zUcvQ+RfwA/0TR1Zwv9Mkd8fdzTe21eZ2FyZ83DAg==


### PR DESCRIPTION
* github actions windows deserves it's own job definition - reenable most checks for windows
* `node-fetch` on windows, needs proper `file://` URL
* increase `LicenseHeaderCheck` as `glob` is slower on windows
* `PerformanceTimer#now` test fixed