### PR TITLE
Disable flaky picking tests.

### DIFF
--- a/@here/harp-omv-datasource/test/MapViewPickingTest.ts
+++ b/@here/harp-omv-datasource/test/MapViewPickingTest.ts
@@ -53,7 +53,7 @@ async function displayLocation(mapView: MapView, location: GeoCoordinates) {
     });
 }
 
-describe("MapView Picking", async function() {
+describe.skip("MapView Picking", async function() {
     const inNodeContext = typeof window === "undefined";
     const tileKey = new TileKey(0, 0, 0);
 


### PR DESCRIPTION
Temporarily disable flaky picking tests.

Travis Ci is broken since unit-tests for picking PR: https://github.com/heremaps/harp.gl/pull/733

Example:
  master https://travis-ci.com/heremaps/harp.gl/jobs/234907907 (restarted 3 times, always failure)
  random PR: https://github.com/heremaps/harp.gl/pull/796/checks?check_run_id=223384743

Interesting fact - they fail only in Travis CI (unit-tests are "passing" in Github and in internal CI).

Nevertheless, i believe these tests are broken as async callbacks from TextElementsRenderer are crossing test boundary.