### PR TITLE
HARP-6982: Correct normals on spherically projected extruded buildings.

### DIFF
--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -23,6 +23,7 @@ attribute vec4 color;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
+uniform mat3 normalMatrix;
 uniform vec3 edgeColor;
 uniform float edgeColorMix;
 

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -625,6 +625,11 @@ export namespace ExtrusionFeature {
             "extrusion_pars_fragment"
         );
 
+        shader.fragmentShader = shader.fragmentShader.replace(
+            "#include <normal_fragment_begin>",
+            "#include <extrusion_normal_fragment_begin>"
+        );
+
         shader.fragmentShader = insertShaderInclude(
             shader.fragmentShader,
             "fog_fragment",

--- a/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
@@ -6,14 +6,50 @@
 
 export default {
     extrusion_pars_vertex: `
-attribute vec3 extrusionAxis;
+// Extrusion axis (xyz: vector, w: factor).
+attribute vec4 extrusionAxis;
 uniform float extrusionRatio;
+varying vec4 vExtrusionAxis;
 `,
     extrusion_vertex: `
-transformed = transformed - extrusionAxis + extrusionAxis * extrusionRatio;
+transformed = transformed - extrusionAxis.xyz + extrusionAxis.xyz * extrusionRatio;
+vExtrusionAxis = vec4(normalMatrix * extrusionAxis.xyz, extrusionAxis.w);
+`,
+    // Modified version of THREE <normal_fragment_begin> shader chunk which, for flat shaded
+    // geometries, computes the normal either with the extrusion axis or fragment derivatives based
+    // on the extrusion factor (1.0 = ceiling, 0.0 = footprint).
+    extrusion_normal_fragment_begin: `
+#ifdef FLAT_SHADED
+    vec3 normal = vec3(0.0);
+    if (vExtrusionAxis.w > 0.999999) {
+        normal = normalize(vExtrusionAxis.xyz);
+    }
+    else  {
+        // Workaround for Adreno/Nexus5 not able able to do dFdx( vViewPosition ) ...
+        vec3 fdx = vec3(dFdx(vViewPosition.x), dFdx(vViewPosition.y), dFdx(vViewPosition.z));
+        vec3 fdy = vec3(dFdy(vViewPosition.x), dFdy(vViewPosition.y), dFdy(vViewPosition.z));
+        normal = normalize( cross( fdx, fdy ) );
+    }
+#else
+	vec3 normal = normalize( vNormal );
+	#ifdef DOUBLE_SIDED
+		normal = normal * (float(gl_FrontFacing) * 2.0 - 1.0);
+	#endif
+	#ifdef USE_TANGENT
+		vec3 tangent = normalize( vTangent );
+		vec3 bitangent = normalize( vBitangent );
+		#ifdef DOUBLE_SIDED
+			tangent = tangent * (float(gl_FrontFacing) * 2.0 - 1.0);
+			bitangent = bitangent * (float(gl_FrontFacing) * 2.0 - 1.0);
+		#endif
+	#endif
+#endif
+// non perturbed normal for clearcoat among others
+vec3 geometryNormal = normal;
 `,
     extrusion_pars_fragment: `
 uniform float extrusionRatio;
+varying vec4 vExtrusionAxis;
 `,
     extrusion_fragment: `
 gl_FragColor.a *= smoothstep( 0.0, 0.25, extrusionRatio );

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -1238,12 +1238,14 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                                 tmpV3.z + tempRoofDisp.z
                             );
                             extrusionAxis.push(
-                                0,
-                                0,
-                                0,
                                 tempRoofDisp.x - tempFootDisp.x,
                                 tempRoofDisp.y - tempFootDisp.y,
-                                tempRoofDisp.z - tempFootDisp.z
+                                tempRoofDisp.z - tempFootDisp.z,
+                                0.0,
+                                tempRoofDisp.x - tempFootDisp.x,
+                                tempRoofDisp.y - tempFootDisp.y,
+                                tempRoofDisp.z - tempFootDisp.z,
+                                1.0
                             );
                             if (texCoordType !== undefined) {
                                 textureCoordinates.push(vertices[i + 2], vertices[i + 3]);
@@ -1453,7 +1455,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
             if (meshBuffers.extrusionAxis.length > 0) {
                 const extrusionAxis = new Float32Array(meshBuffers.extrusionAxis);
                 assert(
-                    extrusionAxis.length === positionElements.length,
+                    extrusionAxis.length / 4 === positionElements.length / 3,
                     "length of extrusionAxis buffer is different than the length of the " +
                         "position buffer"
                 );
@@ -1461,7 +1463,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 geometry.vertexAttributes.push({
                     name: "extrusionAxis",
                     buffer: extrusionAxis.buffer as ArrayBuffer,
-                    itemCount: 3,
+                    itemCount: 4,
                     type: "float"
                 });
             }


### PR DESCRIPTION
- Added custom shaderChunk for extruded buildings normals.
- Extruded buildings normals on spherical projection look correct after this change.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.


Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!