### PR TITLE
GeoJsonTiler fix for empty tiles

### DIFF
--- a/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
+++ b/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
@@ -73,6 +73,6 @@ export class GeoJsonTiler implements ITiler {
         if (index === undefined) {
             throw new Error("Tile not found");
         }
-        return index.getTile(tileKey.level, tileKey.column, tileKey.row);
+        return index.getTile(tileKey.level, tileKey.column, tileKey.row) || {};
     }
 }


### PR DESCRIPTION
`geojsonvt` returns `null` for tiles with no data, so ensure we
return empty object in this case.

Among others, removes spurious errors from test logs like this:

```
TileLoader: [geojson]: failed to load tile 371506851 TypeError: Cannot read property 'byteLength' of null
    at TileLoader.onLoaded (/home/travis/build/heremaps/harp.gl/@here/harp-mapview-decoder/lib/TileLoader.ts:258:42)
    at dataProvider.getTile.then.payload (/home/travis/build/heremaps/harp.gl/@here/harp-mapview-decoder/lib/TileLoader.ts:230:22)
```