### PR TITLE
HARP-7201: All examples from Labeling section are broken

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -589,6 +589,13 @@ export class Tile implements CachedResource {
     }
 
     /**
+     * Returns true if the `Tile` has any text elements to render.
+     */
+    hasTextElements(): boolean {
+        return this.m_textElementGroups.count() > 0 || this.m_userTextElements.length > 0;
+    }
+
+    /**
      * Called by [[VisibleTileSet]] to mark that [[Tile]] is visible and it should prepare its road
      * geometry for picking.
      */

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -590,9 +590,19 @@ export class PoiManager {
         const mapView = this.mapView;
         const zoomLevel = mapView.zoomLevel;
         const cacheId = computeStyleCacheId(dataSourceName, technique, Math.floor(zoomLevel));
+        const renderer = this.mapView.textElementsRenderer;
         let renderStyle = mapView.textRenderStyleCache.get(cacheId);
         if (renderStyle === undefined) {
-            const defaultRenderParams = mapView.textElementsRenderer!.defaultStyle.renderParams;
+            const defaultRenderParams =
+                renderer !== undefined
+                    ? renderer.defaultStyle.renderParams
+                    : {
+                          fontSize: {
+                              unit: FontUnit.Pixel,
+                              size: 32,
+                              backgroundSize: 8
+                          }
+                      };
 
             if (technique.color !== undefined) {
                 const hexColor = getPropertyValue(technique.color, Math.floor(zoomLevel));
@@ -676,10 +686,11 @@ export class PoiManager {
             technique,
             Math.floor(this.mapView.zoomLevel)
         );
+        const renderer = this.mapView.textElementsRenderer;
         let layoutStyle = this.mapView.textLayoutStyleCache.get(cacheId);
         if (layoutStyle === undefined) {
-            const defaultLayoutParams = this.mapView.textElementsRenderer!.defaultStyle
-                .layoutParams;
+            const defaultLayoutParams =
+                renderer !== undefined ? renderer.defaultStyle.layoutParams : {};
 
             const layoutParams = {
                 tracking: getOptionValue(technique.tracking, defaultLayoutParams.tracking),


### PR DESCRIPTION
Create `TextElementsRenderer` only if there's actual text elements created for any of the tiles, or overlay text exists. The `MapView` knows if there's text elements on the tile from the `Tile::hasTextElements()` that is checked for every tile every frame before one is found. Then the renderer creation is delayed to avoid affecting frame time.

If `MapView`'s theme was changed, remove text renderer completely. That allows to create new renderer with font catalogs and text styles changed if any text will be rendererd. And disable text rendering at all if none.

Has a drawback of loading font catalog files (json and png) every time the theme changes, even if they are the same. Not really crucial as files are taken from browser cache, but still.
Also there's a small overhead if no text is going to be rendered - checking every frame every tile owning some text elements, but it's can be avoided by using `mapView.renderLabels = false`.