### PR TITLE
MINOR: Tune the size of the default tile cache.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -585,7 +585,7 @@ export const MapViewDefaults = {
     maxVisibleDataSourceTiles: 120,
     extendedFrustumCulling: true,
 
-    tileCacheSize: 20,
+    tileCacheSize: 200,
     resourceComputationType: ResourceComputationType.EstimationInMb,
     quadTreeSearchDistanceUp: 3,
     quadTreeSearchDistanceDown: 2,


### PR DESCRIPTION
The default size of just 20MBs is too small to efficiently renderer
city centers with many extruded buildings.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>