### PR TITLE
HARP-7271: Tune the styling rules for the extruded buildings.

### DIFF
--- a/@here/harp-examples/src/datasource_custom.ts
+++ b/@here/harp-examples/src/datasource_custom.ts
@@ -235,7 +235,7 @@ export namespace CustomDatasourceExample {
         mapControls.maxTiltAngle = 50;
 
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 4000, 50, -20);
+        map.lookAt(NY, 3500, 50, -20);
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);
         map.resize(window.innerWidth, window.innerHeight);

--- a/@here/harp-examples/src/datasource_xyzmvt.ts
+++ b/@here/harp-examples/src/datasource_xyzmvt.ts
@@ -87,7 +87,7 @@ export namespace DatasourceXYZMVTExample {
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 4000, 50);
+        map.lookAt(NY, 3500, 50);
         // end:harp_gl_datasource_xyzmvt_example_2.ts
 
         // snippet:harp_gl_datasource_xyzmvt_example_3.ts

--- a/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
+++ b/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
@@ -75,7 +75,7 @@
             const mapControls = new harp.MapControls(map);
             mapControls.maxTiltAngle = 50;
             const NY = new harp.GeoCoordinates(40.707, -74.01);
-            map.lookAt(NY, 4000, 50);
+            map.lookAt(NY, 3500, 50);
 
             const ui = new harp.MapControlsUI(mapControls);
             canvas.parentElement.appendChild(ui.domElement);

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -88,7 +88,7 @@ export namespace HelloWorldExample {
         // snippet:harp_gl_hello_world_example_look_at.ts
         // Look at New York.
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 4000, 50, -20);
+        map.lookAt(NY, 3500, 50, -20);
         // end:harp_gl_hello_world_example_look_at.ts
 
         // Add an UI.

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -29,7 +29,7 @@ export namespace ThemesExample {
         mapControls.maxTiltAngle = 50;
 
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 5000, 50);
+        map.lookAt(NY, 3500, 50);
 
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);

--- a/@here/harp-examples/src/rendering_post-effects_all.ts
+++ b/@here/harp-examples/src/rendering_post-effects_all.ts
@@ -40,7 +40,7 @@ export namespace EffectsAllExample {
         const mapControls = new MapControls(mapView);
         mapControls.maxTiltAngle = 60;
         const NY = new GeoCoordinates(40.707, -74.01);
-        mapView.lookAt(NY, 4000, 50);
+        mapView.lookAt(NY, 3500, 50);
 
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -83,7 +83,7 @@ export namespace HelloCustomThemeExample {
 
         // Look at New York.
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 4000, 50, -20);
+        map.lookAt(NY, 3500, 50, -20);
 
         // Add an UI.
         const ui = new MapControlsUI(mapControls);

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -10,7 +10,8 @@
             "value": [
                 "all",
                 ["==", ["get", "$layer"], "buildings"],
-                ["==", ["get", "$geometryType"], "polygon"]
+                ["==", ["get", "$geometryType"], "polygon"],
+                [">", ["zoom"], 15]
             ]
         },
         "defaultBuildingColor": {
@@ -1916,9 +1917,9 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "kind"], "address"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["get", "label_placement"]
+                    ["==", ["get", "kind"], "address"],
+                    [">", ["zoom"], "15"]
                 ],
                 "technique": "text",
                 "attr": {

--- a/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
@@ -1605,7 +1605,8 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["get", "$geometryType"], "polygon"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "extruded-polygon",
                 "attr": {
@@ -1632,9 +1633,9 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "kind"], "address"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["get", "label_placement"]
+                    ["==", ["get", "kind"], "address"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "text",
                 "attr": {

--- a/@here/harp-map-theme/resources/berlin_tilezen_effects_outlines.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_effects_outlines.json
@@ -1566,7 +1566,8 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["get", "$geometryType"], "polygon"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "extruded-polygon",
                 "attr": {
@@ -1594,9 +1595,9 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "kind"], "address"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["get", "label_placement"]
+                    ["==", ["get", "kind"], "address"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "text",
                 "attr": {

--- a/@here/harp-map-theme/resources/berlin_tilezen_effects_streets.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_effects_streets.json
@@ -1566,7 +1566,8 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["get", "$geometryType"], "polygon"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "extruded-polygon",
                 "attr": {
@@ -1594,9 +1595,9 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "kind"], "address"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["get", "label_placement"]
+                    ["==", ["get", "kind"], "address"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "text",
                 "attr": {

--- a/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
@@ -1618,7 +1618,8 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["get", "$geometryType"], "polygon"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "extruded-polygon",
                 "attr": {
@@ -1645,9 +1646,9 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "kind"], "address"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["get", "label_placement"]
+                    ["==", ["get", "kind"], "address"],
+                    [">", ["zoom"], 15]
                 ],
                 "technique": "text",
                 "attr": {


### PR DESCRIPTION
Show extruded buildings only when the zoom level is greater than 15.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
