### PR TITLE
HARP-7113: Make phased loading disabled by default

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -910,9 +910,9 @@ export class MapView extends THREE.EventDispatcher {
         );
 
         this.m_tileGeometryManager =
-            this.m_options.enablePhasedLoading === false
-                ? new SimpleTileGeometryManager(this)
-                : new PhasedTileGeometryManager(this);
+            this.m_options.enablePhasedLoading === true
+                ? new PhasedTileGeometryManager(this)
+                : new SimpleTileGeometryManager(this);
 
         this.m_visibleTiles = new VisibleTileSet(
             new FrustumIntersection(


### PR DESCRIPTION
Disable phased loading until the tile's flickering issue is fixed (https://github.com/heremaps/harp.gl/pull/812)