### PR TITLE
Revert "HARP-6982: Correct normals on spherically projected extruded …

### DIFF
--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -23,7 +23,6 @@ attribute vec4 color;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
-uniform mat3 normalMatrix;
 uniform vec3 edgeColor;
 uniform float edgeColorMix;
 

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -625,11 +625,6 @@ export namespace ExtrusionFeature {
             "extrusion_pars_fragment"
         );
 
-        shader.fragmentShader = shader.fragmentShader.replace(
-            "#include <normal_fragment_begin>",
-            "#include <extrusion_normal_fragment_begin>"
-        );
-
         shader.fragmentShader = insertShaderInclude(
             shader.fragmentShader,
             "fog_fragment",

--- a/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
@@ -6,50 +6,14 @@
 
 export default {
     extrusion_pars_vertex: `
-// Extrusion axis (xyz: vector, w: factor).
-attribute vec4 extrusionAxis;
+attribute vec3 extrusionAxis;
 uniform float extrusionRatio;
-varying vec4 vExtrusionAxis;
 `,
     extrusion_vertex: `
-transformed = transformed - extrusionAxis.xyz + extrusionAxis.xyz * extrusionRatio;
-vExtrusionAxis = vec4(normalMatrix * extrusionAxis.xyz, extrusionAxis.w);
-`,
-    // Modified version of THREE <normal_fragment_begin> shader chunk which, for flat shaded
-    // geometries, computes the normal either with the extrusion axis or fragment derivatives based
-    // on the extrusion factor (1.0 = ceiling, 0.0 = footprint).
-    extrusion_normal_fragment_begin: `
-#ifdef FLAT_SHADED
-    vec3 normal = vec3(0.0);
-    if (vExtrusionAxis.w > 0.999999) {
-        normal = normalize(vExtrusionAxis.xyz);
-    }
-    else  {
-        // Workaround for Adreno/Nexus5 not able able to do dFdx( vViewPosition ) ...
-        vec3 fdx = vec3(dFdx(vViewPosition.x), dFdx(vViewPosition.y), dFdx(vViewPosition.z));
-        vec3 fdy = vec3(dFdy(vViewPosition.x), dFdy(vViewPosition.y), dFdy(vViewPosition.z));
-        normal = normalize( cross( fdx, fdy ) );
-    }
-#else
-	vec3 normal = normalize( vNormal );
-	#ifdef DOUBLE_SIDED
-		normal = normal * (float(gl_FrontFacing) * 2.0 - 1.0);
-	#endif
-	#ifdef USE_TANGENT
-		vec3 tangent = normalize( vTangent );
-		vec3 bitangent = normalize( vBitangent );
-		#ifdef DOUBLE_SIDED
-			tangent = tangent * (float(gl_FrontFacing) * 2.0 - 1.0);
-			bitangent = bitangent * (float(gl_FrontFacing) * 2.0 - 1.0);
-		#endif
-	#endif
-#endif
-// non perturbed normal for clearcoat among others
-vec3 geometryNormal = normal;
+transformed = transformed - extrusionAxis + extrusionAxis * extrusionRatio;
 `,
     extrusion_pars_fragment: `
 uniform float extrusionRatio;
-varying vec4 vExtrusionAxis;
 `,
     extrusion_fragment: `
 gl_FragColor.a *= smoothstep( 0.0, 0.25, extrusionRatio );

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -1238,14 +1238,12 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                                 tmpV3.z + tempRoofDisp.z
                             );
                             extrusionAxis.push(
+                                0,
+                                0,
+                                0,
                                 tempRoofDisp.x - tempFootDisp.x,
                                 tempRoofDisp.y - tempFootDisp.y,
-                                tempRoofDisp.z - tempFootDisp.z,
-                                0.0,
-                                tempRoofDisp.x - tempFootDisp.x,
-                                tempRoofDisp.y - tempFootDisp.y,
-                                tempRoofDisp.z - tempFootDisp.z,
-                                1.0
+                                tempRoofDisp.z - tempFootDisp.z
                             );
                             if (texCoordType !== undefined) {
                                 textureCoordinates.push(vertices[i + 2], vertices[i + 3]);
@@ -1455,7 +1453,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
             if (meshBuffers.extrusionAxis.length > 0) {
                 const extrusionAxis = new Float32Array(meshBuffers.extrusionAxis);
                 assert(
-                    extrusionAxis.length / 4 === positionElements.length / 3,
+                    extrusionAxis.length === positionElements.length,
                     "length of extrusionAxis buffer is different than the length of the " +
                         "position buffer"
                 );
@@ -1463,7 +1461,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 geometry.vertexAttributes.push({
                     name: "extrusionAxis",
                     buffer: extrusionAxis.buffer as ArrayBuffer,
-                    itemCount: 4,
+                    itemCount: 3,
                     type: "float"
                 });
             }


### PR DESCRIPTION
…buildings."

This reverts commit 7744bbeca0596d753db3fe832fc94ab5565bd917 b/c it was introducing follwoing regressions:
1. Building outlines are heavily aliased on Linux
2. Buildings without height are rendered completely black
