### PR TITLE
HARP-7278: Add support for !in and !has operators.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -69,6 +69,10 @@ export abstract class Expr {
         }
 
         switch (op) {
+            case "!has":
+            case "!in":
+                return new CallExpr("!", [this.parseCall([op.slice(1), ...node.slice(1)])]);
+
             case "get":
                 if (node[2] !== undefined) {
                     return Expr.makeCallExpr(op, node);

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -125,6 +125,29 @@ describe("ExprEvaluator", function() {
         });
     });
 
+    describe("Operator '!has'", function() {
+        Object.getOwnPropertyNames(defaultEnv).forEach(property => {
+            it(`has property '${property}'`, function() {
+                assert.isFalse(evaluate(["!has", property]));
+            });
+        });
+
+        it("Ensure builtin symbols are not accessible", function() {
+            assert.isTrue(evaluate(["!has", "has"]));
+            assert.isTrue(evaluate(["!has", "get"]));
+            assert.isTrue(evaluate(["!has", "length"]));
+        });
+
+        it("Object access", function() {
+            const object = { x: 1, y: 2, z: 3, k: "point" };
+            assert.isFalse(evaluate(["!has", "x", ["literal", object]]));
+            assert.isFalse(evaluate(["!has", "y", ["literal", object]]));
+            assert.isFalse(evaluate(["!has", "z", ["literal", object]]));
+            assert.isFalse(evaluate(["!has", "k", ["literal", object]]));
+            assert.isTrue(evaluate(["!has", "w", ["literal", object]]));
+        });
+    });
+
     describe("Operator 'length'", function() {
         it("evaluate", function() {
             assert.strictEqual(evaluate(["length", "ciao"]), 4);
@@ -158,6 +181,18 @@ describe("ExprEvaluator", function() {
             assert.isTrue(evaluate(["in", ["get", "emptyText"], [defaultEnv.emptyText]]));
 
             assert.throw(() => evaluate(["in", ["get", "someText"]]));
+        });
+    });
+
+    describe("Operator '!in'", function() {
+        it("evaluate", function() {
+            assert.isFalse(evaluate(["!in", "x", ["x"]]));
+            assert.isTrue(evaluate(["!in", "x", ["y"]]));
+
+            assert.isFalse(evaluate(["!in", ["get", "someText"], [defaultEnv.someText]]));
+            assert.isFalse(evaluate(["!in", ["get", "emptyText"], [defaultEnv.emptyText]]));
+
+            assert.throw(() => evaluate(["!in", ["get", "someText"]]));
         });
     });
 


### PR DESCRIPTION
Implemented !in and !has as operator aliases.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
