### PR TITLE
MINOR: Fix MapView.nativeWebglAntialiasEnabled property getter.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -853,10 +853,7 @@ export class MapView extends THREE.EventDispatcher {
         // Initialization of the renderer
         this.m_renderer = new THREE.WebGLRenderer({
             canvas: this.canvas,
-            antialias:
-                this.m_options.enableNativeWebglAntialias === undefined
-                    ? this.pixelRatio < 2.0
-                    : this.m_options.enableNativeWebglAntialias,
+            antialias: this.nativeWebglAntialiasEnabled,
             alpha: this.m_options.alpha,
             preserveDrawingBuffer: this.m_options.preserveDrawingBuffer === true,
             powerPreference:
@@ -1595,9 +1592,13 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Returns `true` if the native WebGL antialiasing is enabled.
+     *
+     * @default `true` for `pixelRatio` < `2.0`, `false` otherwise.
      */
     get nativeWebglAntialiasEnabled(): boolean {
-        return this.m_options.enableNativeWebglAntialias !== false;
+        return this.m_options.enableNativeWebglAntialias === undefined
+            ? this.pixelRatio < 2.0
+            : this.m_options.enableNativeWebglAntialias;
     }
 
     /**


### PR DESCRIPTION
Fixes getter to properly reflect current situation, before it would happen
that anti-aliasing was enabled due to pixelRatio, but getter returns false.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
