### PR TITLE
Fix theme handling in TileDataSource.

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -199,12 +199,21 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
         this.mapView.markTilesDirty(this);
     }
 
+    /**
+     * Apply the [[Theme]] to this data source.
+     *
+     * Applies new [[StyleSet]] and definitions from theme only if matching styleset (see
+     * `styleSetName` property) is found in `theme`.
+     */
     setTheme(theme: Theme, languages?: string[]): void {
         const styleSet =
-            (this.styleSetName !== undefined && theme.styles && theme.styles[this.styleSetName]) ||
-            [];
+            this.styleSetName !== undefined && theme.styles
+                ? theme.styles[this.styleSetName]
+                : undefined;
 
-        this.setStyleSet(styleSet, theme.definitions, languages);
+        if (styleSet !== undefined) {
+            this.setStyleSet(styleSet, theme.definitions, languages);
+        }
     }
 
     clearCache() {

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -218,9 +218,10 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Invoked by [[MapView]] to apply new [[Theme]].
+     * Apply the [[Theme]] to this data source.
      *
-     * If `DataSource` depends on a `styleSet` or `languages`, it must update its tiles' geometry.
+     * If `DataSource` depends on a `styleSet` defined by this theme or `languages`, it must update
+     * its tiles' geometry.
      *
      * @param languages
      */


### PR DESCRIPTION
TileDataSource shouldn't update styleset in `setTheme` if theme doesn't
define styleset with `styleSetName` of datasource.

This fixes backwards compatibility bug introduced in #796.

Among others fixes `datasource_features_polygons` demo.
