### PR TITLE
MINOR: Improve performance of Berlin theme

### DIFF
--- a/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
+++ b/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
@@ -75,7 +75,7 @@
             const mapControls = new harp.MapControls(map);
             mapControls.maxTiltAngle = 50;
             const NY = new harp.GeoCoordinates(40.707, -74.01);
-            map.lookAt(NY, 4000, 50);
+            map.lookAt(NY, 3200, 50);
 
             const ui = new harp.MapControlsUI(mapControls);
             canvas.parentElement.appendChild(ui.domElement);

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -88,7 +88,7 @@ export namespace HelloWorldExample {
         // snippet:harp_gl_hello_world_example_look_at.ts
         // Look at New York.
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 4000, 50, -20);
+        map.lookAt(NY, 3200, 50, -20);
         // end:harp_gl_hello_world_example_look_at.ts
 
         // Add an UI.

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -29,7 +29,7 @@ export namespace ThemesExample {
         mapControls.maxTiltAngle = 50;
 
         const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 5000, 50);
+        map.lookAt(NY, 3200, 50);
 
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -9,6 +9,7 @@
             "type": "selector",
             "value": [
                 "all",
+                [">=", ["get", "$level"], 15],
                 ["==", ["get", "$layer"], "buildings"],
                 ["==", ["get", "$geometryType"], "polygon"]
             ]
@@ -328,7 +329,7 @@
                 "description": "primary-road-shield-2, level > 10",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
@@ -362,7 +363,7 @@
                 "description": "primary-road-shield-3, level > 10",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
@@ -396,7 +397,7 @@
                 "description": "primary-road-shield-4, level > 10",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
@@ -430,7 +431,7 @@
                 "description": "primary-road-shield-5, level > 10",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
@@ -464,7 +465,7 @@
                 "description": "primary-road-shield-5+, level > 10",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
@@ -540,6 +541,26 @@
                 "final": true
             },
             {
+                "description": "primary - labels",
+                "when": [
+                    "all",
+                    ["==", ["get", "$layer"], "road_labels"],
+                    ["==", ["get", "kind"], "major_road"],
+                    ["in", ["get", "kind_detail"], ["primary"]]
+                ],
+                "technique": "text",
+                "attr": {
+                    "color": "#000000",
+                    "backgroundColor": "#FFFFFF",
+                    "backgroundOpacity": 0.5,
+                    "size": 16,
+                    "priority": 16,
+                    "fadeNear": 0.8,
+                    "fadeFar": 0.9
+                },
+                "renderOrder": 12
+            },
+            {
                 "description": "highway-trunk-outline",
                 "when": [
                     "all",
@@ -588,7 +609,7 @@
                 "description": "secondary-road-shield, level > 11",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "secondary"],
                     ["has", "ref"],
@@ -652,10 +673,30 @@
                 "final": true
             },
             {
+                "description": "secondary - labels",
+                "when": [
+                    "all",
+                    ["==", ["get", "$layer"], "road_labels"],
+                    ["==", ["get", "kind"], "major_road"],
+                    ["==", ["get", "kind_detail"], "secondary"]
+                ],
+                "technique": "text",
+                "attr": {
+                    "color": "#000000",
+                    "backgroundColor": "#FFFFFF",
+                    "backgroundOpacity": 0.5,
+                    "size": 16,
+                    "priority": 15,
+                    "fadeNear": 0.8,
+                    "fadeFar": 0.9
+                },
+                "renderOrder": 12
+            },
+            {
                 "description": "tertiary-road-shield, level > 13",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "tertiary"],
                     ["has", "ref"],
@@ -734,9 +775,30 @@
                 "final": true
             },
             {
+                "description": "tertiary - labels",
+                "when": [
+                    "all",
+                    ["==", ["get", "$layer"], "road_labels"],
+                    ["==", ["get", "kind"], "major_road"],
+                    ["in", ["get", "kind_detail"], ["tertiary"]]
+                ],
+                "technique": "text",
+                "attr": {
+                    "color": "#000000",
+                    "backgroundColor": "#FFFFFF",
+                    "backgroundOpacity": 0.5,
+                    "size": 16,
+                    "priority": 14,
+                    "fadeNear": 0.8,
+                    "fadeFar": 0.9
+                },
+                "renderOrder": 12
+            },
+            {
                 "description": "residential - background",
                 "when": [
                     "all",
+                    [">=", ["get", "$level"], 13],
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "minor_road"],
                     [
@@ -764,6 +826,7 @@
                 "description": "residential - foreground",
                 "when": [
                     "all",
+                    [">=", ["get", "$level"], 13],
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "minor_road"],
                     [
@@ -791,7 +854,8 @@
                 "description": "residential - labels",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    [">=", ["get", "$level"], 13],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "minor_road"],
                     [
                         "any",
@@ -816,6 +880,7 @@
                 "description": "pedestrian - background",
                 "when": [
                     "all",
+                    [">=", ["get", "$level"], 14],
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "path"],
                     ["in", ["get", "kind_detail"], ["pedestrian", "footway"]]
@@ -838,6 +903,7 @@
                 "description": "pedestrian - foreground",
                 "when": [
                     "all",
+                    [">=", ["get", "$level"], 14],
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "path"],
                     ["in", ["get", "kind_detail"], ["pedestrian", "footway"]]
@@ -860,7 +926,8 @@
                 "description": "pedestrian - labels",
                 "when": [
                     "all",
-                    ["==", ["get", "$layer"], "roads"],
+                    [">=", ["get", "$level"], 14],
+                    ["==", ["get", "$layer"], "road_labels"],
                     ["==", ["get", "kind"], "path"],
                     ["in", ["get", "kind_detail"], ["pedestrian", "footway"]]
                 ],


### PR DESCRIPTION
* Show extruded buildings starting from zoomlevel 16
* show minor roads starting from zoomlevel 14
* use road_labels layer
* enable missing road labels or primary, secondary and tertiary roads