### PR TITLE
MINOR: Account for height geo-projection when calculating clip planes.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2416,12 +2416,18 @@ export class MapView extends THREE.EventDispatcher {
             this.m_forceCameraAspect !== undefined ? this.m_forceCameraAspect : width / height;
         this.setFovOnCamera(this.m_options.fovCalculation!, height);
 
+        // When calculating clip planes account for the highest building on the earth,
+        // multipling its height by projection scalling factor. This approach assumes
+        // constantHeight property of extruded polygon technique is set as default false,
+        // otherwise the near plane margins will be bigger then required, but still correct.
+        const projectionScale = this.projection.getScaleFactor(this.camera.position);
+        const maxHeight = EarthConstants.MAX_BUILDING_HEIGHT * projectionScale;
         // Copy all properties from new view ranges to our readonly object.
         // This allows to keep all view ranges references valid and keeps up-to-date
         // information within them. Works the same as copping all properties one-by-one.
         Object.assign(
             this.m_viewRanges,
-            viewRanges === undefined ? this.m_visibleTiles.updateClipPlanes() : viewRanges
+            viewRanges === undefined ? this.m_visibleTiles.updateClipPlanes(maxHeight) : viewRanges
         );
         this.m_camera.near = this.m_viewRanges.near;
         this.m_camera.far = this.m_viewRanges.far;


### PR DESCRIPTION
Because (by default) all buildings height is "projected" to preserve
consistency with other map features, we need to take it into account
when evaluating near/far planes based on ground elevation.
This patchset improves evaluation of clip planes when buildings height is
added to terrain elevation.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
