### PR TITLE
Fixing obviously wrong code

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -283,7 +283,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                     featureIds.push(featureId);
                     objInfos.push(env.entries);
                 }
-                if (isPoiTechnique) {
+                if (wantsPoi) {
                     if (imageTexture === undefined) {
                         imageTextures.push(INVALID_ARRAY_INDEX);
                     } else {


### PR DESCRIPTION
At first this innocent line causes, that we fill `imageTextures`
for _every_ point feature, even if technique is not poi.

This is bug for sure, to be checked what are consequences.
