### PR TITLE
Improve handling of url in ThemeLoader.

### DIFF
--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -20,6 +20,7 @@ import {
     composeUrlResolvers,
     ContextLogger,
     defaultUrlResolver,
+    getAppBaseUrl,
     getOptionValue,
     IContextLogger,
     ISimpleChannel,
@@ -101,7 +102,12 @@ export class ThemeLoader {
                 throw new Error(`ThemeLoader#load: cannot load theme: ${response.statusText}`);
             }
             theme = (await response.json()) as Theme;
-            theme.url = themeUrl;
+            theme.url = resolveReferenceUrl(getAppBaseUrl(), themeUrl);
+            theme = this.resolveUrls(theme);
+        } else if (theme.url === undefined) {
+            // assume that theme url is same as baseUrl
+            theme.url = getAppBaseUrl();
+            theme = this.resolveUrls(theme);
         }
 
         if (theme === null || theme === undefined) {
@@ -109,8 +115,6 @@ export class ThemeLoader {
         }
         theme = theme as Theme;
         // Remember the URL where the theme has been loaded from.
-
-        theme = this.resolveUrls(theme);
 
         const resolveDefinitions = getOptionValue<boolean>(options.resolveDefinitions, false);
         theme = await ThemeLoader.resolveBaseTheme(theme, options);
@@ -237,7 +241,6 @@ export class ThemeLoader {
      *
      * This method mutates original `theme` instance.
      */
-
     static resolveThemeReferences(theme: Theme, contextLogger: IContextLogger): Theme {
         if (theme.definitions !== undefined) {
             contextLogger.pushAttr("definitions");

--- a/@here/harp-mapview/test/resources/baseTheme.json
+++ b/@here/harp-mapview/test/resources/baseTheme.json
@@ -20,6 +20,12 @@
             }
         }
     },
+    "fontCatalogs": [
+        {
+            "name": "fira",
+            "url": "fonts/Default_FontCatalog.json"
+        }
+    ],
     "styles": {
         "tilezen": [["ref", "primaryRoadFillStyle"]]
     }

--- a/@here/harp-utils/index.ts
+++ b/@here/harp-utils/index.ts
@@ -17,4 +17,5 @@ export * from "./lib/ObjectUtils";
 export * from "./lib/OptionsUtils";
 export * from "./lib/UrlResolver";
 export * from "./lib/UrlUtils";
+export * from "./lib/UrlPlatformUtils";
 export * from "./lib/Functions";

--- a/@here/harp-utils/lib/UrlPlatformUtils.ts
+++ b/@here/harp-utils/lib/UrlPlatformUtils.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Get base URL for from where relative URLs will be loaded.
+ *
+ * * In browser, it resolves to `baseUrl(location.href)` i.e document's base URL
+ * (see: https://www.w3.org/TR/WD-html40-970917/htmlweb.html#h-5.1.2).
+ *
+ * * In node, it resolves to `file://${process.cwd()}`.
+ */
+export function getAppBaseUrl() {
+    return `file://${process.cwd()}/`;
+}

--- a/@here/harp-utils/lib/UrlPlatformUtils.web.ts
+++ b/@here/harp-utils/lib/UrlPlatformUtils.web.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { baseUrl } from "./UrlUtils";
+
+/**
+ * Get base URL for from where relative URLs will be loaded.
+ *
+ * * In browser, it resolves to `baseUrl(location.href)` i.e document's base URL
+ * (see: https://www.w3.org/TR/WD-html40-970917/htmlweb.html#h-5.1.2).
+ *
+ * * In node, it resolves to `file://${process.cwd()}`.
+ */
+export function getAppBaseUrl() {
+    return baseUrl(window.location.href);
+}


### PR DESCRIPTION
Fix double problems with double theme loading by resolving theme `url`
property to absolute url at first load.

Extra: for inline themes, assign page base url on initial load.

