### PR TITLE
Test related tweaks.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,33 +29,12 @@ jobs:
       with:
         version: ${{ matrix.node_version }}
     - name: Install dependencies
-      run: |
-        npm install -g chromedriver geckodriver
-      if: matrix.os != 'windows-latest'
-    - name: Install dependencies (Windows)
-      shell: bash
-      run: |
-        set -ex
-        # This is arbitrary version that happens to be installed in github CI env atm.
-        # As for now `chromedriver` supports only exact version, so this version have to be
-        # updated with Github CI windows infra.
-        #
-        # See
-        #  https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#windows-server-2019
-        #  https://github.com/giggio/node-chromedriver - explanation
-        #  https://sites.google.com/a/chromium.org/chromedriver/downloads - available versions
-        export CHROMEDRIVER_VERSION=75.0.3770.140
-      if: matrix.os == 'windows-latest'
+      run: yarn
     - name: Pretest
-      run: |
-        set -ex
-        yarn
-        npx ts-mocha -r tsconfig-paths/register ./test/*.ts
-        yarn run tslint
-        yarn run prettier
+      run: yarn run pre-test
       shell: bash
     - name: Test on Node.js
-      run: npx ts-mocha -r tsconfig-paths/register ./@here/*/test/*.ts
+      run: yarn test
       shell: bash
     - name: Build test bundle
       run: yarn run build-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,9 @@ jobs:
     - name: "Test"
       script: |
         set -ex
-        npx ts-mocha -r tsconfig-paths/register ./test/*.ts
-        yarn run tslint
-        yarn run prettier
-        yarn run build-tests
-        npx ts-mocha -r tsconfig-paths/register ./@here/*/test/*.ts
+        yarn pre-test
+        yarn test
+        yarn build-tests
         yarn test-browser --headless-firefox
         yarn test-browser --headless-chrome
         #./scripts/test-npm-packages.sh

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
         "webpack-dev-server": "^3.7.2"
     },
     "scripts": {
-        "test": "ts-mocha -r tsconfig-paths/register ./test/*.ts ./@here/*/test/*.ts",
+        "pre-test": "yarn run code-pre-tests && yarn run prettier && yarn run tslint",
+        "code-pre-tests": "ts-mocha --forbid-only --no-timeouts ./test/*.ts",
+        "test": "ts-mocha --forbid-only ./@here/*/test/*.ts",
         "start": "ts-node ./scripts/credentials.ts -- . && webpack-dev-server -d --config @here/harp-examples/webpack.config.js",
         "build": "npm run build-bundle && npm run build-examples",
         "build-examples": "ts-node ./scripts/credentials.ts -- dist/examples && webpack -d --config @here/harp-examples/webpack.config.js",

--- a/test/ImportTest.ts
+++ b/test/ImportTest.ts
@@ -247,7 +247,6 @@ function checkImports() {
 }
 
 describe("ImportCheck", function() {
-    this.timeout(4000);
     it("Uses correct imports", function() {
         assert.deepEqual(checkImports(), []);
     });

--- a/test/LicenseHeaderTest.ts
+++ b/test/LicenseHeaderTest.ts
@@ -20,7 +20,6 @@ const license = `/*
 `;
 
 describe("LicenseHeaderCheck", function() {
-    this.timeout(4000);
     let sourceFiles: string[];
 
     before(function() {


### PR DESCRIPTION
* alias `yarn code-rules-tests` for code quality tests in `test/* folder`
* alias `pre-check` for them and `tslint` and `prettier` to align
  experience with CI `Pre check` step
* remove timeouts from code quality check, as they are sometimes very
  heavy and timeout is not a failure, run them with `--no-timeouts`
* add `--forbid-only` to `mocha` test runs to prevent accidental green,
  but actually not ran tests
