### PR TITLE
HARP-6527: Support discrete interpolators of arbitrary types.

### DIFF
--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -45,11 +45,12 @@ export function isInterpolatedPropertyDefinition<T>(
     p: any
 ): p is InterpolatedPropertyDefinition<T> {
     if (
-        p !== undefined &&
-        p.values instanceof Array &&
+        p &&
+        p.interpolationMode === undefined &&
+        Array.isArray(p.values) &&
         p.values.length > 0 &&
         p.values[0] !== undefined &&
-        p.zoomLevels instanceof Array &&
+        Array.isArray(p.zoomLevels) &&
         p.zoomLevels.length > 0 &&
         p.zoomLevels[0] !== undefined &&
         p.values.length === p.zoomLevels.length
@@ -77,7 +78,7 @@ export function isInterpolatedProperty<T>(p: any): p is InterpolatedProperty<T> 
 }
 
 /**
- * Get the value of the specified property at the given zoom level, represented as a `number` value.
+ * Get the value of the specified property at the given zoom level.
  *
  * @param property Property of a technique.
  * @param level Display level the property should be rendered at.
@@ -89,12 +90,12 @@ export function getPropertyValue<T>(
     property: Value | Expr | InterpolatedProperty<T> | undefined,
     level: number,
     pixelToMeters: number = 1.0
-): number {
+): any {
     if (isInterpolatedPropertyDefinition<T>(property)) {
         throw new Error("Cannot interpolate a InterpolatedPropertyDefinition.");
     } else if (!isInterpolatedProperty(property)) {
         if (typeof property !== "string") {
-            return (property as unknown) as number;
+            return property;
         } else {
             const matchedFormat = StringEncodedNumeralFormats.find(format =>
                 format.regExp.test(property)
@@ -204,32 +205,37 @@ export function createInterpolatedProperty(
     prop: InterpolatedPropertyDefinition<unknown>
 ): InterpolatedProperty<unknown> | undefined {
     removeDuplicatePropertyValues(prop);
-    const propKeys = new Float32Array(prop.zoomLevels);
-    let propValues;
-    let maskValues;
+
+    const interpolationMode =
+        prop.interpolation !== undefined
+            ? InterpolationMode[prop.interpolation]
+            : InterpolationMode.Discrete;
+
+    const zoomLevels = prop.zoomLevels;
+
+    if (interpolationMode === InterpolationMode.Discrete) {
+        return {
+            interpolationMode,
+            zoomLevels,
+            values: prop.values
+        };
+    }
+
     const firstValue = prop.values[0];
     switch (typeof firstValue) {
         default:
         case "number":
-            propValues = new Float32Array((prop.values as any[]) as number[]);
             return {
-                interpolationMode:
-                    prop.interpolation !== undefined
-                        ? InterpolationMode[prop.interpolation]
-                        : InterpolationMode.Discrete,
-                zoomLevels: propKeys,
-                values: propValues,
+                interpolationMode,
+                zoomLevels,
+                values: prop.values,
                 exponent: prop.exponent
             };
         case "boolean":
-            propValues = new Float32Array(prop.values.length);
-            for (let i = 0; i < prop.values.length; ++i) {
-                propValues[i] = ((prop.values[i] as unknown) as boolean) ? 1 : 0;
-            }
             return {
-                interpolationMode: InterpolationMode.Discrete,
-                zoomLevels: propKeys,
-                values: propValues,
+                interpolationMode,
+                zoomLevels,
+                values: prop.values.map(value => Number(value)),
                 exponent: prop.exponent
             };
         case "string":
@@ -242,8 +248,8 @@ export function createInterpolatedProperty(
                 logger.error(`No StringEncodedNumeralFormat matched ${firstValue}.`);
                 return undefined;
             }
-            propValues = new Float32Array(prop.values.length * matchedFormat.size);
-            maskValues = new Float32Array(prop.values.length);
+            const propValues = new Float32Array(prop.values.length * matchedFormat.size);
+            const maskValues = new Float32Array(prop.values.length);
             needsMask = procesStringEnocodedNumeralInterpolatedProperty(
                 matchedFormat,
                 prop as InterpolatedPropertyDefinition<string>,
@@ -252,11 +258,8 @@ export function createInterpolatedProperty(
             );
 
             return {
-                interpolationMode:
-                    prop.interpolation !== undefined
-                        ? InterpolationMode[prop.interpolation]
-                        : InterpolationMode.Discrete,
-                zoomLevels: propKeys,
+                interpolationMode,
+                zoomLevels,
                 values: propValues,
                 exponent: prop.exponent,
                 _stringEncodedNumeralType: matchedFormat.type,

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -46,12 +46,12 @@ export interface InterpolatedProperty<T> {
     /**
      * Zoom level keys array.
      */
-    zoomLevels: Float32Array;
+    zoomLevels: ArrayLike<number>;
 
     /**
      * Property values array.
      */
-    values: Float32Array;
+    values: ArrayLike<any>;
 
     /**
      * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -74,7 +74,7 @@ export function evaluateTechniqueAttr<T = Value>(
     } else if (isInterpolatedProperty(attrValue)) {
         const storageLevel =
             context instanceof Env ? (context.lookup("$level") as number) : context.storageLevel;
-        evaluated = getPropertyValue(attrValue, storageLevel);
+        evaluated = getPropertyValue(attrValue, storageLevel) as any;
     } else {
         evaluated = (attrValue as unknown) as Value;
     }

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -12,49 +12,66 @@ import { getPropertyValue } from "../lib/InterpolatedProperty";
 import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
-const levels = new Float32Array([0, 5, 10]);
+const levels = [0, 5, 10];
+
 const numberProperty: InterpolatedProperty<number> = {
     interpolationMode: InterpolationMode.Discrete,
     zoomLevels: levels,
-    values: new Float32Array([0, 100, 500])
+    values: [0, 100, 500]
 };
+
 const booleanProperty: InterpolatedProperty<boolean> = {
     interpolationMode: InterpolationMode.Discrete,
     zoomLevels: levels,
-    values: new Float32Array([1.0, 0.0, 1.0])
+    values: [true, false, true]
 };
-const colorProperty: InterpolatedProperty<string> = {
+
+const colorProperty: InterpolatedProperty<number> = {
     interpolationMode: InterpolationMode.Discrete,
     zoomLevels: levels,
-    values: new Float32Array([0, 1, 0.5, 120 / 360, 1, 0.5, 240 / 360, 1, 0.5]),
+    values: [0, 1, 0.5, 120 / 360, 1, 0.5, 240 / 360, 1, 0.5],
     _stringEncodedNumeralType: StringEncodedNumeralType.Hex
+};
+
+const enumProperty: InterpolatedProperty<string> = {
+    interpolationMode: InterpolationMode.Discrete,
+    zoomLevels: levels,
+    values: ["Enum0", "Enum1", "Enum2"]
 };
 
 describe("Interpolation", function() {
     it("Discrete", () => {
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 0);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 100);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.strictEqual(getPropertyValue(numberProperty, -Infinity), 0);
+        assert.strictEqual(getPropertyValue(numberProperty, 0), 0);
+        assert.strictEqual(getPropertyValue(numberProperty, 2.5), 0);
+        assert.strictEqual(getPropertyValue(numberProperty, 5), 100);
+        assert.strictEqual(getPropertyValue(numberProperty, 7.5), 100);
+        assert.strictEqual(getPropertyValue(numberProperty, 10), 500);
+        assert.strictEqual(getPropertyValue(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(booleanProperty, -Infinity), 1);
-        assert.equal(getPropertyValue(booleanProperty, 0), 1);
-        assert.equal(getPropertyValue(booleanProperty, 2.5), 1);
-        assert.equal(getPropertyValue(booleanProperty, 5), 0);
-        assert.equal(getPropertyValue(booleanProperty, 7.5), 0);
-        assert.equal(getPropertyValue(booleanProperty, 10), 1);
-        assert.equal(getPropertyValue(booleanProperty, Infinity), 1);
+        assert.strictEqual(getPropertyValue(booleanProperty, -Infinity), true);
+        assert.strictEqual(getPropertyValue(booleanProperty, 0), true);
+        assert.strictEqual(getPropertyValue(booleanProperty, 2.5), true);
+        assert.strictEqual(getPropertyValue(booleanProperty, 5), false);
+        assert.strictEqual(getPropertyValue(booleanProperty, 7.5), false);
+        assert.strictEqual(getPropertyValue(booleanProperty, 10), true);
+        assert.strictEqual(getPropertyValue(booleanProperty, Infinity), true);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.strictEqual(getPropertyValue(colorProperty, -Infinity), 0xff0000);
+        assert.strictEqual(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.strictEqual(getPropertyValue(colorProperty, 2.5), 0xff0000);
+        assert.strictEqual(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.strictEqual(getPropertyValue(colorProperty, 7.5), 0x00ff00);
+        assert.strictEqual(getPropertyValue(colorProperty, 10), 0x0000ff);
+        assert.strictEqual(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+
+        assert.strictEqual(getPropertyValue(enumProperty, -Infinity), "Enum0");
+        assert.strictEqual(getPropertyValue(enumProperty, 0), "Enum0");
+        assert.strictEqual(getPropertyValue(enumProperty, 2.5), "Enum0");
+        assert.strictEqual(getPropertyValue(enumProperty, 5), "Enum1");
+        assert.strictEqual(getPropertyValue(enumProperty, 7.5), "Enum1");
+        assert.strictEqual(getPropertyValue(enumProperty, 10), "Enum2");
+        assert.strictEqual(getPropertyValue(enumProperty, Infinity), "Enum2");
     });
     it("Linear", () => {
         numberProperty.interpolationMode = InterpolationMode.Linear;


### PR DESCRIPTION
Also, remove the requirement of InterpolatedProperty to store
zoomLevels and values as Float32Array.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
