### PR TITLE
Performance test infrastructure and sample decoding test

### DIFF
--- a/@here/harp-test-utils/lib/ProfileHelper.ts
+++ b/@here/harp-test-utils/lib/ProfileHelper.ts
@@ -1,0 +1,638 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from "fs";
+
+//
+// `performance`, `PerformanceObserver`, ... are global in Browser environment, but only available
+// from `perf_hooks` in node env.
+//
+if (typeof window === "undefined") {
+    // tslint:disable-next-line:no-var-requires
+    const perfHooks = require("perf_hooks");
+
+    (global as any).performance = perfHooks.performance;
+    (global as any).PerformanceObserver = perfHooks.PerformanceObserver;
+    (global as any).PerformanceEntry = perfHooks.PerformanceEntry;
+}
+
+export interface PerformanceTestStats {
+    min: number;
+    sum: number;
+    avg: number;
+    med: number;
+    med95: number;
+    repeats: number;
+    gcTime?: number;
+}
+
+export interface PerformanceTestResultEntry {
+    name: string;
+    stats: PerformanceTestStats;
+}
+
+export type PerformanceTestResults = PerformanceTestResultEntry[];
+
+export interface PerformanceTestSample {
+    name: string;
+    time: number;
+}
+
+/**
+ * More or less portable way to get best performance counter.
+ *
+ * Somehow, it appears that `process.hrtime()` has better real resolution
+ * than `performance.now()`, or i can't into math ;)
+ *
+ * @returns function that gets current time in milliseconds
+ */
+function getNowFunc() {
+    if (typeof performance !== "undefined" && typeof performance.now === "function") {
+        return () => performance.now();
+    }
+
+    if (typeof process !== "undefined" && typeof process.hrtime === "function") {
+        return () => {
+            const t = process.hrtime();
+            return t[0] * 1000 + t[1] / 1000000;
+        };
+    }
+
+    // fall back to Date.getTime()
+    return () => {
+        return new Date().getTime();
+    };
+}
+
+export function calculateStats(samples: number[], gcTime?: number): PerformanceTestStats {
+    const repeats = samples.length;
+    let sum = 0;
+    let min = Number.MAX_VALUE;
+    for (const sample of samples) {
+        sum += sample;
+        min = Math.min(sample, min);
+    }
+
+    const avg = sum / repeats;
+
+    samples.sort();
+    const middle = (repeats - 1) / 2;
+    const med = (samples[Math.floor(middle)] + samples[Math.ceil(middle)]) / 2;
+
+    const mid95 = Math.floor(samples.length * 0.95);
+    const med95 = samples[mid95];
+
+    return { min, sum, gcTime, avg, med, med95, repeats };
+}
+
+/**
+ * Get current time in milliseconds.
+ */
+export const getCurrentTime = getNowFunc();
+
+/**
+ * Measure time performance of code.
+ *
+ * Executes `test` code `repeats` times and measures: `min`, `med` (median), `sum` and `avg`
+ * (average) execution times.
+ *
+ * [[performance.now]] is used as time provider, with fallback to `new Date().getTime()`.
+ *
+ * Measurement reports are saved for later and logged after all tests (if in Mocha environment). See
+ * [[reportPerformanceAndReset]].
+ *
+ * Example:
+ *
+ *     it('performance test', async () => {
+ *         await measurePerformanceSync("Array/grow", 50, () => {
+ *             // the code under test
+ *             // will be executed 50 times ----^^
+ *         });
+ *     });
+ *
+ * Will print report like this after all tests:
+ *
+ *     #performance: Array/grow: min=1 med=2 avg=1.8 sum=72 (50 repeats)
+ *
+ * @param name name of performance test
+ * @param repeats number of test repeats
+ * @param test tested code
+ */
+
+export async function measurePerformanceSync(name: string, repeats: number, test: () => void) {
+    if (repeats < 1) {
+        throw new Error("measurePerformanceSync: repeats must be positive number");
+    }
+
+    // warmup
+    for (let i = 0; i < repeats / 2; i++) {
+        test();
+    }
+
+    // actual test
+    const samples = new Array(repeats);
+    const testFun = () => {
+        for (let i = 0; i < repeats; i++) {
+            const sampleStart = getCurrentTime();
+            test();
+            const sampleEnd = getCurrentTime();
+            const sample = sampleEnd - sampleStart;
+            samples[i] = sample;
+        }
+    };
+
+    const { gcTime } = await runAndMeasureGc(testFun);
+
+    const entry = { name, stats: calculateStats(samples, gcTime) };
+    measurePerformanceResults.push(entry);
+}
+
+/**
+ * Measure throughput performance of code.
+ *
+ * Executes `test` code for `timeout` milliseconds and reports throughput and aggregated times:
+ * `min`, `med` (median), `sum` and `avg` (average) execution times.
+ *
+ * [[performance.now]] is used as time provider, with fallback to `new Date().getTime()`.
+ *
+ * Measurement reports are saved for later and logged after all tests (if in Mocha environment). See
+ * [[reportPerformanceAndReset]].
+ *
+ * Example:
+ *
+ *     it('throughput test', async () => {
+ *         await measureThroughputSync("Array/grow", 100, () => {
+ *             // the code under test
+ *             // will be executed for 100 milliseconds ----^^
+ *         });
+ *     });
+ *
+ * Will print report like this after all tests:
+ *
+ *     #performance: Array/grow: min=1 med=2 avg=1.8 sum=72 repeats=123 throughput=1242/s
+ *
+ * @param name name of performance test
+ * @param repeats number of test repeats
+ * @param test tested code
+ */
+export async function measureThroughputSync(name: string, testDuration: number, test: () => void) {
+    if (testDuration < 10) {
+        throw new Error("measureThroughputSync: invalid testDuration");
+    }
+
+    let now = getCurrentTime();
+
+    // warmup
+    const warmUpTimeout = now + testDuration / 2;
+    while (now < warmUpTimeout) {
+        test();
+        now = getCurrentTime();
+    }
+
+    // actual test
+    const samples: number[] = [];
+    const testStart = getCurrentTime();
+    const testTimeout = testStart + testDuration;
+    const testFun = async () => {
+        let samplesCount = 1;
+        let lastSampleStart = (now = getCurrentTime());
+        while (now < testTimeout) {
+            test();
+            const sampleEnd = (now = getCurrentTime());
+            if (lastSampleStart === sampleEnd) {
+                samplesCount++;
+                continue;
+            }
+            if (samplesCount > 1) {
+                const avgSampleDuration = (sampleEnd - lastSampleStart) / samplesCount;
+                for (let i = 0; i < samplesCount; ++i) {
+                    samples.push(avgSampleDuration);
+                }
+                samplesCount = 1;
+            } else {
+                const sampleDuration = sampleEnd - lastSampleStart;
+                samples.push(sampleDuration);
+            }
+            lastSampleStart = sampleEnd;
+        }
+    };
+    const { gcTime } = await runAndMeasureGc(testFun);
+
+    const entry = { name, stats: calculateStats(samples, gcTime) };
+    measurePerformanceResults.push(entry);
+}
+
+async function runAndMeasureGc(testFun: () => void): Promise<{ gcTime: number | undefined }> {
+    if (typeof window !== "undefined") {
+        return { gcTime: undefined };
+    }
+    let gcTime = 0;
+    let obs: PerformanceObserver;
+
+    let perfStartEntry: PerformanceEntry | undefined;
+    let perfEndEntry: PerformanceEntry | undefined;
+
+    let perfCountersCollected = false;
+    obs = new PerformanceObserver((list, observer) => {
+        if (perfStartEntry === undefined || perfEndEntry === undefined) {
+            const markedEntries = list.getEntriesByType("mark");
+            if (perfStartEntry === undefined) {
+                perfStartEntry = markedEntries.find(e => e.name === "#test-start");
+            }
+            if (perfEndEntry === undefined) {
+                perfEndEntry = markedEntries.find(e => e.name === "#test-end");
+            }
+            if (perfStartEntry === undefined || perfEndEntry === undefined) {
+                return;
+            }
+        }
+        const testStartMark = perfStartEntry.startTime;
+        const testEndMark = perfEndEntry.startTime;
+
+        const gcEntries = list.getEntriesByType("gc");
+        for (const gcEntry of gcEntries) {
+            if (gcEntry.startTime > testStartMark && gcEntry.startTime < testEndMark) {
+                gcTime += gcEntry.duration;
+            }
+        }
+
+        if (perfEndEntry) {
+            perfCountersCollected = true;
+        }
+    });
+
+    obs!.observe({ entryTypes: ["gc", "mark", "node"], buffered: true });
+
+    performance.mark("#test-start");
+    testFun();
+    performance.mark("#test-end");
+
+    // For some reason, in order to get `gc` entries, we need to force async flow before
+    // disconnecting ...
+    // ... and doesn't work with manually created promises, so we need to poll.
+    await new Promise(resolve => {
+        const poll = () => {
+            if (perfCountersCollected) {
+                resolve();
+            } else {
+                setTimeout(poll, 1);
+            }
+        };
+        poll();
+    });
+    obs!.disconnect();
+
+    return { gcTime };
+}
+
+export function addPerformanceResultsSample(name: string, time: number) {
+    measurePerformanceSamples.push({ name, time });
+}
+
+/**
+ *
+ */
+export function reportPerformanceResults(
+    results: PerformanceTestResults,
+    baseline?: PerformanceTestResults
+) {
+    for (const entry of results) {
+        const name = entry.name;
+
+        const baseLineEntry =
+            baseline !== undefined ? baseline.find(e => e.name === name) : undefined;
+        if (baseLineEntry) {
+            reportPerformanceEntryWithBaseline(entry, baseLineEntry);
+        } else {
+            reportPerformanceEntry(entry);
+        }
+    }
+}
+
+function readableNum(b: number | undefined, unit: string = "ms") {
+    if (b === undefined) {
+        return "n/a";
+    }
+    if (Math.abs(b) > 100) {
+        return b.toFixed(2) + unit;
+    } else {
+        return (
+            Number(b)
+                .toFixed(4)
+                .replace(/(\.?)0+$/, "") + unit
+        );
+    }
+}
+
+function tagsToString(tags: { [name: string]: string | number }) {
+    return Object.keys(tags)
+        .map(key => `${key}=${tags[key]}`)
+        .join(" ");
+}
+
+function calculateThroughPutPerSeconds(repeats: number, sum: number) {
+    return repeats / (sum / 1000);
+}
+export function reportPerformanceEntry(entry: PerformanceTestResultEntry) {
+    const name = entry.name;
+    const stats = entry.stats;
+    const mainTags: { [name: string]: string | number } = {
+        min: readableNum(stats.min),
+        sum: readableNum(stats.sum),
+        throughput: readableNum(calculateThroughPutPerSeconds(stats.repeats, stats.sum), "/s"),
+        repeats: stats.repeats
+    };
+    // tslint:disable-next-line:no-console
+    console.log(`#performance ${name}`);
+    // tslint:disable-next-line:no-console
+    console.log(`  ${tagsToString(mainTags)}`);
+    const averages = {
+        avg: readableNum(stats.avg),
+        med: readableNum(stats.med),
+        med95: readableNum(stats.med95)
+    };
+    // tslint:disable-next-line:no-console
+    console.log(`  ${tagsToString(averages)}`);
+    if (stats.gcTime !== undefined) {
+        const gcAdjusted = {
+            gcTime: readableNum(stats.gcTime),
+            sumNoGc: readableNum(stats.sum - stats.gcTime),
+            throughputNoGc: readableNum(
+                calculateThroughPutPerSeconds(stats.repeats, stats.sum - stats.gcTime)
+            )
+        };
+        // tslint:disable-next-line:no-console
+        console.log(`  ${tagsToString(gcAdjusted)}`);
+    }
+    // tslint:disable-next-line:no-console
+    console.log(``);
+}
+
+export function reportPerformanceEntryWithBaseline(
+    entry: PerformanceTestResultEntry,
+    baseLineEntry: PerformanceTestResultEntry
+) {
+    const currentStats = entry.stats;
+    const baseseLineStats = baseLineEntry.stats;
+
+    function compare(current: number, baseline: number, unit: string = "ms") {
+        const ratio = Math.round((current / baseline) * 10000 - 10000) / 100;
+
+        if (current === baseline) {
+            return `${readableNum(current, unit)}`;
+        }
+
+        return (
+            `${readableNum(current, unit)} ` +
+            `(${readableNum(ratio, "%")} vs ${readableNum(baseline, unit)})`
+        );
+    }
+
+    const name = entry.name;
+    const mainTags: { [name: string]: string | number } = {
+        min: compare(currentStats.min, baseseLineStats.min),
+        sum: compare(currentStats.sum, baseseLineStats.sum),
+        repeats: compare(currentStats.repeats, baseseLineStats.repeats, ""),
+        throughput: compare(
+            calculateThroughPutPerSeconds(currentStats.repeats, currentStats.sum),
+            calculateThroughPutPerSeconds(baseseLineStats.repeats, baseseLineStats.sum),
+            "/s"
+        )
+    };
+    const averages = {
+        avg: compare(currentStats.avg, baseseLineStats.avg),
+        med: compare(currentStats.med, baseseLineStats.med),
+        med95: compare(currentStats.med95, baseseLineStats.med95)
+    };
+
+    // tslint:disable-next-line:no-console
+    console.log(`#performance ${name}`);
+    // tslint:disable-next-line:no-console
+    console.log(`  ${tagsToString(mainTags)}`);
+    // tslint:disable-next-line:no-console
+    console.log(`  ${tagsToString(averages)}`);
+
+    if (currentStats.gcTime !== undefined && baseseLineStats.gcTime !== undefined) {
+        const gcAdjusted = {
+            gcTime: compare(currentStats.gcTime, baseseLineStats.gcTime),
+            sumNoGc: compare(
+                currentStats.sum - currentStats.gcTime,
+                baseseLineStats.sum - baseseLineStats.gcTime
+            ),
+            throughputNoGc: compare(
+                calculateThroughPutPerSeconds(
+                    currentStats.repeats,
+                    currentStats.sum - currentStats.gcTime
+                ),
+                calculateThroughPutPerSeconds(
+                    baseseLineStats.repeats,
+                    currentStats.sum - baseseLineStats.gcTime
+                ),
+                "/s"
+            )
+        };
+        // tslint:disable-next-line:no-console
+        console.log(`  ${tagsToString(gcAdjusted)}`);
+    }
+    // tslint:disable-next-line:no-console
+    console.log("");
+}
+
+export function getPerformanceTestResults(): PerformanceTestResults {
+    const mergedSamplesMap = measurePerformanceSamples.reduce((results, sample) => {
+        let sampleArray = results.get(sample.name);
+        if (sampleArray === undefined) {
+            sampleArray = [];
+            results.set(sample.name, sampleArray);
+        }
+        sampleArray.push(sample.time);
+        return results;
+    }, new Map<string, number[]>());
+
+    const mergedSamplesResults = Array.from(mergedSamplesMap.entries()).map(entry => {
+        const [name, samples] = entry;
+        return { name, stats: calculateStats(samples) };
+    });
+
+    return [...measurePerformanceResults, ...mergedSamplesResults];
+}
+
+/**
+ * Report and reset performance measurement results.
+ *
+ * Designed to be called after round of tests. Shows results of all performance tests executed by
+ * [[measurePerformanceSync]] and [[measureThroughputSync]].
+ *
+ * It resets results afterwards.
+ *
+ * If baseline is available (`.profile-helper-baseline.json`, customized by `PROFILEHELPER_OUTPUT`_)
+ * then this run results are compared to baseline
+ *
+ * If `PROFILEHELPER_COMMAND=baseline` resutls are saved as baseline.
+ *
+ * In `Mocha` runtime it is called automatically in global `after` callback.
+ */
+export function reportPerformanceAndReset() {
+    const results = getPerformanceTestResults();
+    const baseLine = loadBaseLineIfAvailable();
+    reportPerformanceResults(results, baseLine);
+
+    measurePerformanceSamples = [];
+    measurePerformanceResults = [];
+
+    saveBaselineIfRequested(results);
+}
+
+function saveBaselineIfRequested(results: PerformanceTestResults) {
+    if (typeof window === "undefined" && process.env.PROFILEHELPER_COMMAND === "baseline") {
+        const baselineFileName =
+            process.env.PROFILEHELPER_OUTPUT || ".profile-helper-baseline.json";
+        if (!baselineFileName) {
+            return;
+        }
+        // tslint:disable-next-line:no-console
+        console.log(`#performance saving baseline to ${baselineFileName}`);
+        fs.writeFileSync(baselineFileName, JSON.stringify(results, null, 2), "utf-8");
+    }
+}
+
+function loadBaseLineIfAvailable() {
+    if (typeof window === "undefined") {
+        const baselineFileName =
+            process.env.PROFILEHELPER_OUTPUT || ".profile-helper-baseline.json";
+        if (!baselineFileName || !fs.existsSync(baselineFileName)) {
+            return undefined;
+        }
+        // tslint:disable-next-line:no-console
+        console.log(`#performance loading baseline from ${baselineFileName}`);
+        return JSON.parse(fs.readFileSync(baselineFileName, "utf-8"));
+    }
+}
+
+/**
+ * Report call.
+ *
+ * Convenience utility to be used temporarily in development to confirm expectations about number
+ * of calls when measuring performance.
+ *
+ * Call counts are logged after all tests (if in Mocha environment). See
+ * [[reportCallCountsAndReset]].
+ *
+ * Usage:
+ *
+ *     class Foo {
+ *         push() {
+ *             countCall("Foo#bar")
+ *         }
+ *     }
+ *
+ * It reports following after all tests:
+ *
+ *     #countCall: Foo#push called=123
+ */
+export function countCall(name: string, delta = 1) {
+    let current = occurenceResults.get(name) || 0;
+    current += delta;
+    occurenceResults.set(name, current);
+}
+
+/**
+ * Count function/method calls decorator.
+ *
+ * Convenience utility to be used temporarily in development to confirm expectations about number
+ * of calls when measuring performance.
+ *
+ * Call counts are logged after all tests (if in Mocha environment). See
+ * [[reportCallCountsAndReset]].
+ *
+ * Usage - basic functional composition:
+ *
+ *     const bar = countCalls("bar",  () => { ... })
+ *
+ * Usage - experimental TypeScript decorators:
+ *
+ *     class Foo {
+ *         @countCalls()
+ *         push() {}
+ *     }
+ *
+ * It reports following after execution of all tests:
+ *
+ *     ProfileHelper: Foo#push called=123
+ *     ProfileHelper: bar called=1111
+ */
+export function countCalls<T extends (...args: any[]) => any>(name: string, fun?: T): T;
+export function countCalls<T extends (...args: any[]) => any>(fun?: T): T;
+export function countCalls(): MethodDecorator;
+
+export function countCalls(): any {
+    let fun: ((...args: any[]) => any) | undefined;
+    let name: string;
+    if (arguments.length === 1 && typeof arguments[0] === "function") {
+        fun = arguments[0] as () => any;
+        name = fun.name;
+    } else if (
+        arguments.length === 2 &&
+        typeof arguments[0] === "string" &&
+        typeof arguments[1] === "function"
+    ) {
+        name = arguments[0];
+        fun = arguments[1] as (...args: any[]) => any;
+    }
+
+    if (fun !== undefined) {
+        // classic functional composition
+        // const foo = countCalls(function foo() { })
+        return function(this: any, ...args: any[]) {
+            countCall(name);
+            return fun!.call(this, args);
+        };
+    }
+
+    // typescript member function decorator
+    return function(this: any, target: any, key: string, descriptor: PropertyDescriptor) {
+        if (descriptor === undefined) {
+            descriptor = Object.getOwnPropertyDescriptor(target, key)!;
+        }
+        const originalMethod = descriptor.value;
+        const methodName = target.constructor.name + "#" + originalMethod.name;
+
+        descriptor.value = countCalls(methodName, originalMethod);
+        return descriptor;
+    };
+}
+
+/**
+ * Report and reset [[countCall]] results.
+ *
+ * Designed to be called after round of tests. Shows counters from all [[countCall]] calls.
+ *
+ * It resets results afterwards.
+ *
+ * In `Mocha` runtime it is called automatically in global `after` callback.
+ */
+export function reportCallCountsAndReset() {
+    occurenceResults.forEach((value, name) => {
+        // tslint:disable-next-line:no-console
+        console.log(`#countCall ${name}: called=${value}`);
+    });
+    occurenceResults.clear();
+}
+
+const occurenceResults = new Map<string, number>();
+
+let measurePerformanceResults: PerformanceTestResultEntry[] = [];
+let measurePerformanceSamples: PerformanceTestSample[] = [];
+
+//
+// in Mocha environment log all profile results after each test
+//
+if (typeof after === "function") {
+    afterEach(() => {
+        reportPerformanceAndReset();
+        reportCallCountsAndReset();
+    });
+}

--- a/@here/harp-test-utils/lib/ProfileHelper.ts
+++ b/@here/harp-test-utils/lib/ProfileHelper.ts
@@ -631,7 +631,7 @@ let measurePerformanceSamples: PerformanceTestSample[] = [];
 // in Mocha environment log all profile results after each test
 //
 if (typeof after === "function") {
-    afterEach(() => {
+    after(() => {
         reportPerformanceAndReset();
         reportCallCountsAndReset();
     });

--- a/README.md
+++ b/README.md
@@ -161,6 +161,44 @@ npx mocha-webdriver-runner http://localhost:8081/ --chrome
 npx mocha-webdriver-runner http://localhost:8081/ --headless-firefox
 ```
 
+### Run performance tests in Node.js environment
+
+As for now, there is no baseline for performance tests results, so before examining performance one
+have to establish baseline:
+
+Performance test steps
+
+1) Establish baseline results.
+
+```
+$ git checkout master
+PROFILEHELPER_COMMAND=baseline yarn performance-test-node # create baseline of measurements for your particular platform
+```
+
+> Note, that performance test suite is very limited, so it is highly possible that you
+> have to write new dedicated performance test for code that is about to be optimized.
+> See `tests/performance` for examples.
+
+2) Go back to your branch, change stuff and
+
+3) Rerun tests with your changes
+
+```
+yarn performance-test-node --grep lines # assuming you're playing with lines
+```
+
+4) Examine output:
+
+```
+...
+
+performance createLineGeometry segments=2
+  min=0.0014ms (-2.44% vs 0.0014ms) sum=999.16ms (0% vs 999.12ms) repeats=499568.00 (-6.47% vs 534131.00) throughput=499988.43/s (-6.47% vs 534600.13/s)
+  avg=0.002ms (6.92% vs 0.0019ms) med=0.0015ms (0.2% vs 0.0015ms) med95=0.0031ms (17.6% vs 0.0026ms)
+  gcTime=39.6195ms (-3.39% vs 41.011ms) sumNoGc=959.54ms (0.15% vs 958.11ms) throughputNoGc=520633.00/s (-6.61% vs 557461.83/s)
+```
+
+
 ### Generate documentation
 
 Run:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "version": "1.0.0",
     "description": "Core render components of harp.gl, an open-source 3D map rendering engine.",
     "workspaces": [
-        "@here/*"
+        "@here/*",
+        "test/performance"
     ],
     "devDependencies": {
         "@strictsoftware/typedoc-plugin-monorepo": "^0.2.1",
@@ -36,6 +37,7 @@
         "pre-test": "yarn run code-pre-tests --forbid-only && yarn run prettier && yarn run tslint",
         "code-pre-tests": "ts-mocha --no-timeouts ./test/*.ts",
         "test": "ts-mocha ./@here/*/test/*.ts",
+        "performance-test-node": "ts-mocha ./test/performance/**/*.ts",
         "cov-test": "nyc mocha -r ts-node/register ./@here/*/test/*.ts",
         "cov-report-html": "nyc report --reporter=html",
         "start": "ts-node ./scripts/credentials.ts -- . && webpack-dev-server -d --config @here/harp-examples/webpack.config.js",

--- a/test/performance/LinesPerformanceTest.ts
+++ b/test/performance/LinesPerformanceTest.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+
+import { MathUtils } from "@here/harp-geoutils";
+import { createLineGeometry } from "@here/harp-lines";
+import { measureThroughputSync } from "@here/harp-test-utils/lib/ProfileHelper";
+import * as THREE from "three";
+
+describe(`lines`, function() {
+    this.timeout(0);
+    const center = new THREE.Vector3();
+
+    const tests: Array<{ segments: number; points?: number[] }> = [
+        { segments: 2 },
+        { segments: 4 },
+        { segments: 16 },
+        { segments: 64 },
+        { segments: 256 }
+    ];
+
+    before(function() {
+        this.timeout(0);
+        tests.forEach(test => {
+            const segments = test.segments;
+            test.points = [];
+            const radius = 100;
+            for (let i = 0; i < segments; i++) {
+                const angle = (i * 360) / segments;
+                test.points.push(
+                    Math.cos(MathUtils.degToRad(angle) * radius),
+                    Math.cos(MathUtils.degToRad(angle) * radius),
+                    0
+                );
+            }
+        });
+    });
+
+    tests.forEach(test => {
+        it(`createLineGeometry segments=${test.segments}`, async function() {
+            this.timeout(0);
+            await measureThroughputSync(
+                `createLineGeometry segments=${test.segments}`,
+                1000,
+                function() {
+                    createLineGeometry(center, test.points!);
+                }
+            );
+        });
+    });
+});

--- a/test/performance/OmvDecoderPerformanceTest.ts
+++ b/test/performance/OmvDecoderPerformanceTest.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+
+import { assert } from "chai";
+
+import { getProjection, Theme } from "@here/harp-datasource-protocol";
+import { StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+import { accessToken } from "@here/harp-examples/config";
+import { TileKey } from "@here/harp-geoutils";
+import { ThemeLoader } from "@here/harp-mapview";
+import { APIFormat, OmvRestClient, OmvRestClientParameters } from "@here/harp-omv-datasource";
+import { OmvDecoder } from "@here/harp-omv-datasource/lib/OmvDecoder";
+import { getTestResourceUrl } from "@here/harp-test-utils/index.web";
+import { measurePerformanceSync } from "@here/harp-test-utils/lib/ProfileHelper";
+
+export interface OMVDecoderPerformanceTestOptions {
+    /**
+     *
+     */
+    repeats?: number;
+    /**
+     * Theme url or object.
+     *
+     * Will be resolved using [[ThemeLoader.load]].
+     */
+    theme: Theme | string;
+
+    /**
+     * Styleset name, defaults to `tilezen`.
+     */
+    styleSetName?: string;
+
+    /**
+     * Morton codes of tiles.
+     */
+    tiles: number[];
+
+    /**
+     * Requires settings for [[OmvRestClient]] to download tiles.
+     */
+    omvRestClientOptions: OmvRestClientParameters;
+}
+
+/**
+ * Create tests that downloads some OMV tiles from real datasource, then decodes them using
+ * particular style.
+ *
+ * @see OMVDecoderPerformanceTestOptions
+ */
+export function createOMVDecoderPerformanceTest(
+    name: string,
+    options: OMVDecoderPerformanceTestOptions
+) {
+    const repeats = options.repeats || 10;
+    const styleSetName = options.styleSetName || "tilezen";
+    describe(`OMVDecoderPerformanceTest - ${name}`, function() {
+        this.timeout(0);
+        let omvTiles: Array<[TileKey, ArrayBuffer]>;
+        let theme: Theme;
+
+        const counterName = `OMVDecoderPerformanceTest-${name}`;
+        before(async function() {
+            this.timeout(10000);
+            const omvDataProvider = new OmvRestClient(options.omvRestClientOptions);
+
+            await omvDataProvider.connect();
+            assert(omvDataProvider.ready());
+            omvTiles = await Promise.all(
+                options.tiles.map(async mortonCode => {
+                    const tileKey = TileKey.fromMortonCode(mortonCode);
+                    const tile = await omvDataProvider.getTile(tileKey);
+                    assert(tile instanceof ArrayBuffer);
+                    return [tileKey, tile as ArrayBuffer] as [TileKey, ArrayBuffer];
+                })
+            );
+
+            theme = await ThemeLoader.load(options.theme);
+            assert.isObject(theme.styles);
+            assert.isArray(theme.styles![styleSetName]);
+        });
+
+        it(`measure decode time`, async () => {
+            this.timeout(0);
+            const projection = getProjection("mercator");
+
+            const styleSetEvaluator = new StyleSetEvaluator(
+                theme.styles![styleSetName],
+                theme.definitions
+            );
+
+            await measurePerformanceSync(counterName, repeats, function() {
+                for (const [tileKey, tileData] of omvTiles) {
+                    const decoder = new OmvDecoder(projection, styleSetEvaluator, false);
+                    decoder.getDecodedTile(tileKey, tileData);
+                }
+            });
+        });
+    });
+}
+
+const BERLIN_CENTER_TILES = [371506851, 371506850, 371506849, 371506848];
+
+createOMVDecoderPerformanceTest("theme=berlin tiles=4 region=berlin data=herebase", {
+    theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
+    tiles: BERLIN_CENTER_TILES,
+    omvRestClientOptions: {
+        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        apiFormat: APIFormat.XYZOMV,
+        authenticationCode: accessToken
+    }
+});
+
+createOMVDecoderPerformanceTest("theme=berlin tiles=4 region=berlin data=osmbase", {
+    theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
+    tiles: BERLIN_CENTER_TILES,
+    omvRestClientOptions: {
+        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
+        apiFormat: APIFormat.XYZMVT,
+        authenticationCode: accessToken
+    }
+});
+
+const NEW_YORK_TILES = [
+    327439127,
+    327439124,
+    327439125,
+    327439168,
+    327439170,
+
+    327438781,
+    327438783,
+    327438826,
+    327438782,
+    327438824
+];
+
+createOMVDecoderPerformanceTest("theme=berlin tiles=10 region=ny data=herebase", {
+    theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
+    tiles: NEW_YORK_TILES,
+    omvRestClientOptions: {
+        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        apiFormat: APIFormat.XYZOMV,
+        authenticationCode: accessToken
+    }
+});
+
+createOMVDecoderPerformanceTest("theme=berlin tiles=10 region=ny data=osmbase", {
+    theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
+    tiles: NEW_YORK_TILES,
+    omvRestClientOptions: {
+        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
+        apiFormat: APIFormat.XYZMVT,
+        authenticationCode: accessToken
+    }
+});

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -9,12 +9,14 @@
     "devDependencies": {
         "@here/harp-datasource-protocol": "^0.10.0",
         "@here/harp-geoutils": "^0.10.0",
+        "@here/harp-lines": "^0.10.0",
         "@here/harp-omv-datasource": "^0.10.0",
         "@here/harp-mapview": "^0.10.0",
         "@here/harp-test-utils": "^0.10.0",
         "@here/harp-examples": "^0.10.0",
         "@types/chai": "^4.2.2",
-        "chai": "^4.2.0"
+        "chai": "^4.2.0",
+        "three": "^0.108.0"
     },
     "license": "Apache-2.0"
 }

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@here/harp-integration-tests",
+    "version": "0.1.0",
+    "private": true,
+    "author": {
+        "name": "HERE Europe B.V.",
+        "url": "https://here.com"
+    },
+    "devDependencies": {
+        "@here/harp-datasource-protocol": "^0.10.0",
+        "@here/harp-geoutils": "^0.10.0",
+        "@here/harp-omv-datasource": "^0.10.0",
+        "@here/harp-mapview": "^0.10.0",
+        "@here/harp-test-utils": "^0.10.0",
+        "@here/harp-examples": "^0.10.0",
+        "@types/chai": "^4.2.2",
+        "chai": "^4.2.0"
+    },
+    "license": "Apache-2.0"
+}

--- a/webpack.tests.config.js
+++ b/webpack.tests.config.js
@@ -39,7 +39,8 @@ const browserTestsConfig = {
         ]
     },
     entry: {
-        test: glob.sync("@here/*/test/**/*.ts")
+        test: glob.sync("@here/*/test/**/*.ts"),
+        "performance-test": glob.sync("test/performance/**/*.ts")
     },
     output: {
         path: path.join(__dirname, "dist/test"),
@@ -53,6 +54,7 @@ const browserTestsConfig = {
         }),
         new CopyWebpackPlugin([
             path.join(__dirname, "test/index.html"),
+            path.join(__dirname, "test/performance.html"),
             require.resolve("three/build/three.min.js"),
             require.resolve("mocha/mocha.js"),
             require.resolve("mocha/mocha.css"),
@@ -73,6 +75,7 @@ const browserTestsConfig = {
     externals: [
         {
             fs: "undefined",
+            perf_hooks: "undefined",
             three: "THREE",
             typestring: "undefined"
         },


### PR DESCRIPTION
Infrastructure and example test for measuring performance in repeatable way (part of #853 and #852)

* OMVDecoder performance test added. 
* ProfileHelper added

Yes, this is _only_ for nodejs, but CPU-bound performance critical code will behave in similar way as in real browser and if we want to test this in real browsers too, this may be good first step ...

New workflow (also in `README`):

Example usage:
1) `git checkout master`
2)  `PROFILEHELPER_COMMAND=baseline yarn performance-test-node` - create baseline of measurements for your particular platform

3) checkout your branch
4) ~break~ ... improve some things
5) `yarn performance-test-node`

Output something like this:
```
agorski@zagorski-dev-mee:~/here/harp.gl/mapsdk/coresdk$ yarn performance-test-node
yarn run v1.15.2
$ ts-mocha ./test/performance-tests**/*.ts

...

#performance loading baseline from .profile-helper-baseline.json
#performance OMVDecoderPerformanceTest-theme=berlin tiles=4 region=berlin data=herebase
  min=144.21ms (-7.27% vs 155.51ms) sum=1659.32ms (-5.41% vs 1754.29ms) avg=165.93ms (-5.41% vs 175.43ms) med=156.13ms (-8.99% vs 171.55ms) med95=227.38ms (+8.04% vs 210.46ms) repeats=10 throughput=6.0266/s (+5.72% vs 5.7003/s)**==
#performance OMVDecoderPerformanceTest-theme=berlin tiles=4 region=berlin data=osmbase
  min=148.95ms (-10.22% vs 165.90ms) sum=1645.42ms (-18.23% vs 2012.35ms) avg=164.54ms (-18.23% vs 201.23ms) med=167.10ms (-19.04% vs 206.40ms) med95=182.25ms (-17.31% vs 220.39ms) repeats=10 throughput=6.0775/s (+22.3% vs 4.9693/s)
#performance OMVDecoderPerformanceTest-theme=berlin tiles=10 region=ny data=herebase
  min=590.20ms (-23.5% vs 771.48ms) sum=6643.38ms (-23.44% vs 8677.49ms) avg=664.34ms (-23.44% vs 867.75ms) med=671.41ms (-18.65% vs 825.34ms) med95=714.40ms (-24.75% vs 949.33ms) repeats=10 throughput=1.5053/s (+30.62% vs 1.1524/s)
#performance OMVDecoderPerformanceTest-theme=berlin tiles=10 region=ny data=osmbase
  min=210.74ms (-10.4% vs 235.21ms) sum=2312.38ms (-8.27% vs 2520.75ms) avg=231.24ms (-8.27% vs 252.07ms) med=229.11ms (-7.07% vs 246.54ms) med95=261.45ms (-11.28% vs 294.70ms) repeats=10 throughput=4.3246/s (+9.01% vs 3.9671/s)


```