### PR TITLE
Remove circular dependency between material & mapview packages.

### DIFF
--- a/@here/harp-datasource-protocol/lib/ViewRanges.ts
+++ b/@here/harp-datasource-protocol/lib/ViewRanges.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Structure that holds near, far planes distances and maximum visibility range.
+ */
+export interface ViewRanges {
+    /**
+     * Distance from camera to near clipping plane along camera eye vector.
+     * @note This value is always positive and in camera space, should be bigger then zero.
+     */
+    near: number;
+    /**
+     * Far clipping plane distance in camera space, along its eye vector.
+     * @note Should be always positive and bigger then [[near]] plane distance.
+     */
+    far: number;
+    /**
+     * Minimum distance that may be applied to near plane.
+     *
+     * Reflects minimum possible near plane distance regardless of camera orientation.
+     *
+     * @note Such constraint is always required because near plane can not be placed at zero
+     * distance from camera (regardless of rendering Api used). Moreover this value may be
+     * used as input for algorighms related to frustum planes, but rather based on visibility
+     * ranges such as it does not change during tilt. Frustum planes may change dynamically with
+     * camera orientation changes, while this value preserve constness for certain camera
+     * position and may be used for effects like near geometry fading.
+     */
+    minimum: number;
+    /**
+     * Maximum possible distance for far plane placement.
+     *
+     * This accounts for maximum visibility range in camera space, regardless of camera
+     * orientation. Far plane will never be placed beyond that distance, this value says
+     * about viewing distance limit, thus it is constrained for performance reasons and
+     * allows to compute effects applied at the end of viewing range such as fog or
+     * geometry fading.
+     *
+     * @note Holds the maximum distance that may be applied for [[far]] plane at
+     * certain camera position, it is const in between orientation changes. You may use this
+     * value to calculate fog or other depth effects that are related to frustum planes,
+     * but should not change as dynamically as current near/far planes distances.
+     */
+    maximum: number;
+}

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -164,17 +164,8 @@ export class AnimatedExtrusionHandler {
  * Implements animated extrusion effect for the extruded objects in the [[Tile]]
  */
 export class AnimatedExtrusionTileHandler {
-    /**
-     * Minimum ratio value for extrusion effect
-     */
-    static DEFAULT_RATIO_MIN: number = 0.001;
-    /**
-     * Maximum ratio value for extrusion effect
-     */
-    static DEFAULT_RATIO_MAX: number = 1;
-
     private m_extrudedObjects: THREE.Object3D[] = [];
-    private m_animatedExtrusionRatio: number = AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX;
+    private m_animatedExtrusionRatio: number = ExtrusionFeature.DEFAULT_RATIO_MAX;
     private m_animatedExtrusionState: AnimatedExtrusionState = AnimatedExtrusionState.None;
     private m_animatedExtrusionStartTime: number | undefined = undefined;
     private m_mapView: MapView;
@@ -364,8 +355,8 @@ export class AnimatedExtrusionTileHandler {
         );
 
         this.extrusionRatio = MathUtils.easeInOutCubic(
-            AnimatedExtrusionTileHandler.DEFAULT_RATIO_MIN,
-            AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX,
+            ExtrusionFeature.DEFAULT_RATIO_MIN,
+            ExtrusionFeature.DEFAULT_RATIO_MAX,
             timeProgress / this.m_animatedExtrusionDuration
         );
 

--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -4,56 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import { EarthConstants, Projection, ProjectionType } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
 import { MapViewUtils } from "./Utils";
 
 const epsilon = 0.000001;
-
-/**
- * Structure that holds near, far planes distances and maximum visibility range.
- */
-export interface ViewRanges {
-    /**
-     * Distance from camera to near clipping plane along camera eye vector.
-     * @note This value is always positive and in camera space, should be bigger then zero.
-     */
-    near: number;
-    /**
-     * Far clipping plane distance in camera space, along its eye vector.
-     * @note Should be always positive and bigger then [[near]] plane distance.
-     */
-    far: number;
-    /**
-     * Minimum distance that may be applied to near plane.
-     *
-     * Reflects minimum possible near plane distance regardless of camera orientation.
-     *
-     * @note Such constraint is always required because near plane can not be placed at zero
-     * distance from camera (regardless of rendering Api used). Moreover this value may be
-     * used as input for algorighms related to frustum planes, but rather based on visibility
-     * ranges such as it does not change during tilt. Frustum planes may change dynamically with
-     * camera orientation changes, while this value preserve constness for certain camera
-     * position and may be used for effects like near geometry fading.
-     */
-    minimum: number;
-    /**
-     * Maximum possible distance for far plane placement.
-     *
-     * This accounts for maximum visibility range in camera space, regardless of camera
-     * orientation. Far plane will never be placed beyond that distance, this value says
-     * about viewing distance limit, thus it is constrained for performance reasons and
-     * allows to compute effects applied at the end of viewing range such as fog or
-     * geometry fading.
-     *
-     * @note Holds the maximum distance that may be applied for [[far]] plane at
-     * certain camera position, it is const in between orientation changes. You may use this
-     * value to calculate fog or other depth effects that are related to frustum planes,
-     * but should not change as dynamically as current near/far planes distances.
-     */
-    maximum: number;
-}
 
 export interface ClipPlanesEvaluator {
     /**

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -22,10 +22,11 @@ import {
 import { assert, getOptionValue, LoggerManager, Math2D, PerformanceTimer } from "@here/harp-utils";
 import * as THREE from "three";
 
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import { AnimatedExtrusionHandler } from "./AnimatedExtrusionHandler";
 import { BackgroundDataSource } from "./BackgroundDataSource";
 import { CameraMovementDetector } from "./CameraMovementDetector";
-import { ClipPlanesEvaluator, defaultClipPlanesEvaluator, ViewRanges } from "./ClipPlanesEvaluator";
+import { ClipPlanesEvaluator, defaultClipPlanesEvaluator } from "./ClipPlanesEvaluator";
 import { IMapAntialiasSettings, IMapRenderingManager, MapRenderingManager } from "./composing";
 import { ConcurrentDecoderFacade } from "./ConcurrentDecoderFacade";
 import { CopyrightInfo } from "./CopyrightInfo";

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -3,6 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import {
     EarthConstants,
     GeoCoordinates,
@@ -14,7 +15,7 @@ import {
 import { LRUCache } from "@here/harp-lrucache";
 import { assert } from "@here/harp-utils";
 import THREE = require("three");
-import { ClipPlanesEvaluator, ViewRanges } from "./ClipPlanesEvaluator";
+import { ClipPlanesEvaluator } from "./ClipPlanesEvaluator";
 import { DataSource } from "./DataSource";
 import { CalculationStatus, ElevationRange, ElevationRangeSource } from "./ElevationRangeSource";
 import { FrustumIntersection, TileKeyEntry } from "./FrustumIntersection";

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -6,7 +6,6 @@
 
 import * as THREE from "three";
 
-import { AnimatedExtrusionTileHandler } from "../../harp-mapview/lib/AnimatedExtrusionHandler";
 import {
     DisplacementFeature,
     DisplacementFeatureParameters,
@@ -145,7 +144,7 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
                 edgeColorMix: new THREE.Uniform(EdgeMaterial.DEFAULT_COLOR_MIX),
                 fadeNear: new THREE.Uniform(FadingFeature.DEFAULT_FADE_NEAR),
                 fadeFar: new THREE.Uniform(FadingFeature.DEFAULT_FADE_FAR),
-                extrusionRatio: new THREE.Uniform(AnimatedExtrusionTileHandler.DEFAULT_RATIO_MIN),
+                extrusionRatio: new THREE.Uniform(ExtrusionFeature.DEFAULT_RATIO_MIN),
                 displacementMap: new THREE.Uniform(
                     hasDisplacementMap ? params!.displacementMap : new THREE.Texture()
                 )
@@ -232,8 +231,7 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
     }
     set extrusionRatio(value: number) {
         this.uniforms.extrusionRatio.value = value;
-        const doExtrusion =
-            value !== undefined && value >= AnimatedExtrusionTileHandler.DEFAULT_RATIO_MIN;
+        const doExtrusion = value !== undefined && value >= ExtrusionFeature.DEFAULT_RATIO_MIN;
         if (doExtrusion) {
             this.needsUpdate = this.needsUpdate || this.defines.USE_EXTRUSION === undefined;
             this.defines.USE_EXTRUSION = "";

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import { applyMixinsWithoutProperties, chainCallbacks } from "@here/harp-utils";
-import { AnimatedExtrusionTileHandler } from "../../harp-mapview/lib/AnimatedExtrusionHandler";
 import { insertShaderInclude } from "./Utils";
 
 import * as THREE from "three";
 
-import { ViewRanges } from "../../harp-mapview/lib/ClipPlanesEvaluator";
 import extrusionShaderChunk from "./ShaderChunks/ExtrusionChunks";
 import fadingShaderChunk from "./ShaderChunks/FadingChunks";
 
@@ -559,6 +558,15 @@ export class FadingFeatureMixin implements FadingFeature {
 
 export namespace ExtrusionFeature {
     /**
+     * Minimum ratio value for extrusion effect
+     */
+    export const DEFAULT_RATIO_MIN: number = 0.001;
+    /**
+     * Maximum ratio value for extrusion effect
+     */
+    export const DEFAULT_RATIO_MAX: number = 1;
+
+    /**
      * Patch the THREE.ShaderChunk on first call with some extra shader chunks.
      */
     export function patchGlobalShaderChunks() {
@@ -581,7 +589,7 @@ export namespace ExtrusionFeature {
 
         if (
             extrusionMaterial.extrusionRatio !== undefined &&
-            extrusionMaterial.extrusionRatio >= AnimatedExtrusionTileHandler.DEFAULT_RATIO_MIN
+            extrusionMaterial.extrusionRatio >= ExtrusionFeature.DEFAULT_RATIO_MIN
         ) {
             // Add this define to differentiate it internally from other MeshBasicMaterial
             extrusionMaterial.defines.EXTRUSION_MATERIAL = "";
@@ -668,7 +676,7 @@ export namespace ExtrusionFeature {
             properties.shader.uniforms.extrusionRatio !== undefined
         ) {
             properties.shader.uniforms.extrusionRatio.value =
-                extrusionMaterial.extrusionRatio || AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX;
+                extrusionMaterial.extrusionRatio || ExtrusionFeature.DEFAULT_RATIO_MAX;
             extrusionMaterial.uniformsNeedUpdate = true;
         }
     }
@@ -684,7 +692,7 @@ export namespace ExtrusionFeature {
 export class ExtrusionFeatureMixin implements ExtrusionFeature {
     needsUpdate?: boolean;
     uniformsNeedUpdate?: boolean;
-    private m_extrusion: number = AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX;
+    private m_extrusion: number = ExtrusionFeature.DEFAULT_RATIO_MAX;
 
     /**
      * @see [[ExtrusionFeature#extrusion]]
@@ -821,7 +829,7 @@ export class MapMeshBasicMaterial extends THREE.MeshBasicMaterial
     }
 
     get extrusionRatio(): number {
-        return AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX;
+        return ExtrusionFeature.DEFAULT_RATIO_MAX;
     }
     // tslint:disable-next-line:no-unused-variable
     set extrusionRatio(value: number) {
@@ -953,7 +961,7 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
     }
 
     get extrusionRatio(): number {
-        return AnimatedExtrusionTileHandler.DEFAULT_RATIO_MAX;
+        return ExtrusionFeature.DEFAULT_RATIO_MAX;
     }
     // tslint:disable-next-line:no-unused-variable
     set extrusionRatio(value: number) {

--- a/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
+++ b/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
@@ -15,7 +15,7 @@ import {
 } from "@here/harp-text-canvas";
 import * as THREE from "three";
 
-import { TileGeometryCreator } from "../../harp-mapview/lib/geometry/TileGeometryCreator";
+import { TileGeometryCreator } from "@here/harp-mapview/lib/geometry/TileGeometryCreator";
 import { OmvTile } from "./OmvTile";
 
 const debugMaterial = new THREE.LineBasicMaterial({

--- a/test/ImportTest.ts
+++ b/test/ImportTest.ts
@@ -89,6 +89,7 @@ function checkImports() {
         let env = "browser";
         const relativePath = path.relative(__dirname + "/../@here", sourceFile);
         const moduleName = "@here/" + relativePath.split(path.sep)[0];
+        const modulePath = path.resolve(__dirname + "/../", moduleName);
 
         const environmentMatch = environmentRE.exec(contents);
         if (environmentMatch) {
@@ -155,12 +156,9 @@ function checkImports() {
                     importedModule
                 );
 
-                if (
-                    path.dirname(resolvedImportedModule) === path.resolve(__dirname + "/../@here")
-                ) {
-                    const importedModuleName = importedModule.split("/").slice(-1)[0];
+                if (!path.dirname(resolvedImportedModule).startsWith(modulePath)) {
                     errors.push(
-                        `Error: the module @here/${importedModuleName} is imported via a relative path in ${moduleName}`
+                        `Error: the module ${importedModule} is imported via a relative path in ${sourceFile}`
                     );
                 }
             }


### PR DESCRIPTION
Remove circular dependency between material & mapview packages.

Fix `ImportCheck` tests, so bogus imports from `../../` are marked as errors.