### PR TITLE
Typings for harp.js bundle.

### DIFF
--- a/@here/harp.gl/package.json
+++ b/@here/harp.gl/package.json
@@ -13,11 +13,13 @@
     ],
     "main": "dist/harp.js",
     "scripts": {
-        "prepare": "webpack && NODE_ENV=production webpack",
+        "prepare": "webpack && NODE_ENV=production webpack -p && yarn build-typings",
+        "build-typings": "tsc -p tsconfig-bundle.json && ts-node ./scripts/resolve-absolute-imports.ts dist/types/",
         "profile-min": "NODE_ENV=production webpack --profile --json > webpack-stats-production.json",
         "profile-dev": "webpack --profile --json > webpack-stats-dev.json",
         "test": "true"
     },
+    "typings": "dist/types/harp.gl/lib/",
     "repository": {
         "type": "git",
         "url": "https://github.com/heremaps/harp.gl.git"
@@ -46,7 +48,10 @@
         "@here/harp-text-canvas": "^0.10.0",
         "@here/harp-utils": "^0.10.0",
         "@here/harp-webtile-datasource": "^0.10.0",
+        "@types/glob": "^7.1.1",
+        "glob": "^7.1.4",
         "ts-loader": "^6.0.3",
+        "ts-node": "^8.4.1",
         "typescript": "^3.5.2",
         "webpack": "^4.34.0",
         "webpack-cli": "^3.3.4",

--- a/@here/harp.gl/scripts/resolve-absolute-imports.ts
+++ b/@here/harp.gl/scripts/resolve-absolute-imports.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Resolve references in `.d.ts` files generated to `dist/types`.
+ *
+ * Types are generated to
+ *   `root/harp-foobar/.../Module.d.ts`
+ *
+ * and in `d.ts` files are referenced as relative, CommonJS like paths:
+ *
+ *    `@here/harp-foobar/...`
+ *
+ * This script resolves actual path of "@here/harp*" imports, so they can
+ * be packaged with `harp.js`.
+ *
+ * Usage:
+ *    ts-node ./scripts/resolve-absolute-imports.ts dist/types
+ */
+import * as fs from "fs";
+import * as glob from "glob";
+import * as path from "path";
+
+interface RemapConfig {
+    rootDir: string;
+}
+
+function replaceWithMatch(
+    regexp: RegExp,
+    input: string,
+    replacer: (match: RegExpExecArray) => string
+) {
+    let somethingReplaced = false;
+    let prevIndex = 0;
+    let result = "";
+    const regexpCopy = new RegExp(regexp);
+    while (true) {
+        const match = regexpCopy.exec(input);
+        if (!match) {
+            break;
+        }
+        somethingReplaced = true;
+        result += input.substr(prevIndex, match.index - prevIndex);
+        const replaced = replacer(match);
+        result += replaced;
+        prevIndex = regexpCopy.lastIndex;
+    }
+    if (!somethingReplaced) {
+        return input;
+    }
+    if (prevIndex !== input.length) {
+        result += input.substr(prevIndex);
+    }
+    return result;
+}
+
+function remapImportsSource(source: string, sourceDir: string, remapingConfig: RemapConfig) {
+    const importRE = new RegExp(/(import|export)\s*({[\s\S]*?}|\*)\s*from\s+["'](.*)["']/, "g");
+    return replaceWithMatch(importRE, source, match => {
+        const statement = match[1];
+        const importSymbols = match[2];
+        const importModuleOriginal = match[3];
+        let importModule = importModuleOriginal;
+
+        if (importModule.startsWith("@here/harp-")) {
+            const relativeToRoot = importModule.substr(6);
+            importModule = path.relative(
+                sourceDir,
+                path.join(remapingConfig.rootDir, relativeToRoot)
+            );
+        }
+        return `${statement} ${importSymbols} from "${importModule}"`;
+    });
+}
+
+function remapImportsFile(filePath: string, remapingConfig: RemapConfig) {
+    const contents = fs.readFileSync(filePath, "utf-8");
+
+    // tslint:disable-next-line:no-console
+    console.log(`${filePath} ...`);
+    const newContents = remapImportsSource(contents, path.dirname(filePath), remapingConfig);
+    if (contents === newContents) {
+        return;
+    }
+    fs.writeFileSync(filePath, newContents, "utf-8");
+}
+
+async function remapImportFiles(rootDir: string) {
+    // now, iterate all typescript source files
+    const sourceFiles = glob.sync(path.join(rootDir, "/**/*.ts"));
+
+    let failed = false;
+
+    for (const sourceFile of sourceFiles) {
+        try {
+            remapImportsFile(sourceFile, { rootDir });
+        } catch (error) {
+            // tslint:disable-next-line:no-console
+            console.error(`resolve-absolute-imports: error processing ${sourceFile}: ${error}`);
+            failed = false;
+        }
+    }
+    process.exit(failed ? 1 : 0);
+}
+
+const root = process.argv.length === 3 ? process.argv[2] : "dist/types";
+
+remapImportFiles(root).catch(error => {
+    // tslint:disable-next-line:no-console
+    console.error(`resolve-absolute-imports: unhandled exception: ${error}`, error);
+    process.exit(2);
+});

--- a/@here/harp.gl/tsconfig-bundle.json
+++ b/@here/harp.gl/tsconfig-bundle.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "emitDeclarationOnly": true,
+        "declaration": true,
+        "declarationDir": "dist/types"
+    },
+    "files": ["lib/index.ts", "lib/DecoderBootstrap.ts"],
+    "include": ["../../@here/*/index*.ts", "../../@here/*/lib/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7931,6 +7931,17 @@ ts-node@^8.3.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+ts-node@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.4.1.tgz#270b0dba16e8723c9fa4f9b4775d3810fd994b4f"
+  integrity sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
+
 tsconfig-paths@^3.5.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
Experiment
Build typings for all modules bundled in `harp.js` and distribute
them in `harp.gl` npm package.

Very raw approach, but works. Afair there are no working solutions for bundling typings such big typescript codebase into module.
