### PR TITLE
MINOR: Check the number of arguments before evaluating 'step'.

### DIFF
--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -13,14 +13,19 @@ import { InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
  * Evaluates the given piecewise function.
  */
 function step(context: ExprEvaluatorContext, args: Expr[]) {
+    if (args.length < 3 || args.length % 2) {
+        throw new Error("not enough arguments");
+    }
+
     const value = context.evaluate(args[0]) as number;
+
+    if (value === null) {
+        // returns the default value of step.
+        return context.evaluate(args[1]);
+    }
 
     if (typeof value !== "number") {
         throw new Error(`the input of a 'step' operator must have type 'number'`);
-    }
-
-    if (args.length < 3 || args.length % 2) {
-        throw new Error("not enough arguments");
     }
 
     let first = 1;

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -566,7 +566,7 @@ describe("ExprEvaluator", function() {
 
             assert.throws(
                 () => evaluate(["step", ["get", "x"]], { x: "text" }, ExprScope.Condition),
-                "the input of a 'step' operator must have type 'number'"
+                "not enough arguments"
             );
 
             assert.throws(
@@ -753,5 +753,14 @@ describe("ExprEvaluator", function() {
                 }
             });
         }
+
+        it("default value of a step", function() {
+            assert.strictEqual(
+                evaluate(["step", ["get", "x"], "default value", 0, "value"], {
+                    x: null
+                }),
+                "default value"
+            );
+        });
     });
 });


### PR DESCRIPTION
Also, returns the default value of the 'step' when the input evaluates
to 'null'.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
