### PR TITLE
MINOR: Fixed Github CI warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node_version }}
       uses: actions/setup-node@v1
       with:
-        version: ${{ matrix.node_version }}
+        node-version: ${{ matrix.node_version }}
     - name: Install dependencies
       run: yarn
     - name: Pretest


### PR DESCRIPTION
Following warning will be fixed with this change:

> Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead
