### PR TITLE
HARP-7270: Change maxVisibleDataSourceTiles use from MapViewOptions.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -609,7 +609,7 @@ export const MapViewDefaults = {
     projection: mercatorProjection,
     clipPlanesEvaluator: defaultClipPlanesEvaluator,
 
-    maxVisibleDataSourceTiles: 120,
+    maxVisibleDataSourceTiles: 500,
     extendedFrustumCulling: true,
 
     tileCacheSize: 200,
@@ -1091,21 +1091,30 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Returns the cache size.
+     *
+     * @see setCacheSize.
      */
     getCacheSize(): number {
         return this.m_visibleTiles.getDataSourceCacheSize();
     }
 
     /**
-     * Sets the cache size in number of tiles.
+     * Sets the cache size as number of tiles or memory consumed in total.
+     *
+     * The meaning of cache size depends on [[resourceComputationType]], if its set to
+     * [[ResourceComputationType.EstimationInMb]] then cache size is measured in megabytes,
+     * otherwise - [[ResourceComputationType.NumberOfTiles]] accounts simply for number of tiles
+     * cached. This function also allows to set new strategy for [[resourceComputationType]] via
+     * optional parameter.
      *
      * @param size The cache size in tiles.
-     * @param numVisibleTiles The number of tiles visible, which is size/2 by default.
+     * @param rct The optional parameter that defines how cache size is measured.
      */
-    setCacheSize(size: number, numVisibleTiles?: number): void {
+    setCacheSize(size: number, rct?: ResourceComputationType): void {
+        if (rct !== undefined) {
+            this.m_visibleTiles.resourceComputationType = rct;
+        }
         this.m_visibleTiles.setDataSourceCacheSize(size);
-        numVisibleTiles = numVisibleTiles !== undefined ? numVisibleTiles : size / 2;
-        this.m_visibleTiles.setNumberOfVisibleTiles(Math.floor(numVisibleTiles));
         this.updateImages();
         this.updateLighting();
 

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -404,18 +404,18 @@ export class VisibleTileSet {
     }
 
     /**
-     * Retrieves maximum number of visible tiles.
+     * Retrieves maximum number of visible tiles per data source.
      */
-    getNumberOfVisibleTiles() {
+    get maxVisibleDataSourceTiles() {
         return this.options.maxVisibleDataSourceTiles;
     }
 
     /**
-     * Sets maximum number of visible tiles.
+     * Sets maximum number of visible tiles per data source.
      *
-     * @param size size of visible tiles array
+     * @param size maximum number of tiles rendered.
      */
-    setNumberOfVisibleTiles(size: number) {
+    set maxVisibleDataSourceTiles(size: number) {
         this.options.maxVisibleDataSourceTiles = size;
     }
 
@@ -505,7 +505,7 @@ export class VisibleTileSet {
             for (
                 let i = 0;
                 i < visibleTileKeys.length &&
-                actuallyVisibleTiles.length < this.options.maxVisibleDataSourceTiles;
+                actuallyVisibleTiles.length < this.maxVisibleDataSourceTiles;
                 i++
             ) {
                 const tileEntry = visibleTileKeys[i];


### PR DESCRIPTION
Since it is difficult to predict the number of tiles to be displayed cause
it depends on geo-projection used and camera pose, we decided to set this
constraint (limit of tiles) to extreme value and not relate it to cache
size.
The number of tiles should be anyway limited by proper frustum culling and
correct near/far frustum planes calculation (see ClipPlanesEvaluator).

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
