### PR TITLE
Fix flickering when updating style.

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -869,7 +869,6 @@ export class Tile implements CachedResource {
         tileLoader
             .loadAndDecode()
             .then(tileLoaderState => {
-                this.clear();
                 assert(tileLoaderState === TileLoaderState.Ready);
                 const decodedTile = tileLoader.decodedTile;
                 this.decodedTile = decodedTile;

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -1062,7 +1062,7 @@ export class VisibleTileSet {
                 dataSourceCache.deleteByKey(key);
                 tile.dispose();
             }
-        });
+        }, renderListEntry.dataSource);
     }
 
     // Computes the visible tile keys for each supplied datasource.

--- a/@here/harp-mapview/lib/geometry/PhasedTileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/PhasedTileGeometryLoader.ts
@@ -207,6 +207,7 @@ export class PhasedTileGeometryLoader implements TileGeometryLoader {
                 enabledKinds,
                 disabledKinds
             );
+            tile.clear();
         }
 
         if (decodedTile === undefined || currentPhase >= this.numberOfPhases) {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -204,8 +204,6 @@ export class TileGeometryCreator {
      * @param decodedTile The decodedTile containing the actual tile map data.
      */
     createAllGeometries(tile: Tile, decodedTile: DecodedTile) {
-        tile.clear();
-
         const filter = (technique: Technique): boolean => {
             return technique.enabled !== false;
         };

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -283,6 +283,7 @@ export class SimpleTileGeometryLoader implements TileGeometryLoader {
 
             const geometryCreator = TileGeometryCreator.instance;
 
+            tile.clear();
             geometryCreator.initDecodedTile(decodedTile, enabledKinds, disabledKinds);
 
             geometryCreator.createAllGeometries(tile, decodedTile);


### PR DESCRIPTION
* In tile update scenario, ensure that we clear and create geometry in very same frame to prevent flickering in scenarios like style update.

* Fix regression which caused `MapView.markTilesDirty` to clear cache from tiles owned other datasources.