### PR TITLE
HARP-7356: Fixed wrong handling of tiles that only contain text eleme…

### DIFF
--- a/@here/harp-mapview/test/TileTest.ts
+++ b/@here/harp-mapview/test/TileTest.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { assert, expect } from "chai";
+
+import { DecodedTile } from "@here/harp-datasource-protocol";
+import { mercatorProjection, TileKey, webMercatorTilingScheme } from "@here/harp-geoutils";
+import { DataSource } from "../lib/DataSource";
+import { MapView } from "../lib/MapView";
+import { Tile } from "../lib/Tile";
+
+class TileTestStubDataSource extends DataSource {
+    getTile(tileKey: TileKey) {
+        return undefined;
+    }
+
+    getTilingScheme() {
+        return webMercatorTilingScheme;
+    }
+}
+
+describe("Tile", function() {
+    const tileKey = TileKey.fromRowColumnLevel(0, 0, 0);
+    const stubDataSource = new TileTestStubDataSource("test-data-source");
+    const mapView = { projection: mercatorProjection };
+    stubDataSource.attach(mapView as MapView);
+
+    it("set empty decoded tile forces hasGeometry to be true", function() {
+        const tile = new Tile(stubDataSource, tileKey);
+        const decodedTile: DecodedTile = {
+            techniques: [],
+            geometries: []
+        };
+        tile.decodedTile = decodedTile;
+        assert(tile.hasGeometry);
+        expect(tile.decodedTile).to.be.equal(decodedTile);
+    });
+    it("set decoded tile with text only forces hasGeometry to be true", function() {
+        const tile = new Tile(stubDataSource, tileKey);
+        const decodedTile: DecodedTile = {
+            techniques: [],
+            geometries: [],
+            textGeometries: [
+                {
+                    positions: {
+                        name: "positions",
+                        buffer: new Float32Array(),
+                        type: "float",
+                        itemCount: 1000
+                    },
+                    texts: new Array<number>(1000)
+                }
+            ]
+        };
+        tile.decodedTile = decodedTile;
+        assert(tile.hasGeometry);
+        expect(tile.decodedTile).to.be.equal(decodedTile);
+    });
+});


### PR DESCRIPTION
…nts but no geometry.

If a tile contains no geometry but just text the Tile.hasGeometry flag was set to false (b/c Tile.forceGeometry was not called). Since hasGeometry is used in the VisibleTileSet computation to deduce if a tile is loaded(what is also totally wrong but will be adressed in a separate PR) no tile was rendered.
With this change forceGeometry will be called if the tile has no geometry but text.
Additionally the original decodedTile will be kept and it will not be replaced with a dummy empty decodedTile (this was also requested by OLP)