### PR TITLE
HARP-5644: Support for Political Views via FeatureModfier.

### DIFF
--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -399,6 +399,17 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
+     * Used to express different country point of view (political view).
+     *
+     * @note Set to null if you want to reset to default point of view.
+     * @param pov The country code which point of view should be presented in ISO 3166-1 alpha-2
+     * format.
+     */
+    setPoliticalView(pov?: string): void {
+        // to be overloaded by subclasses
+    }
+
+    /**
      * This method is called when [[MapView]] needs to visualize or preload the content of a
      * [[TileKey]].
      *

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -549,6 +549,18 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
     languages?: string[];
 
     /**
+     * Sets the data sources to use specific country point of view (political view).
+     *
+     * This option may result in rendering different country borders then commonly accepted for
+     * some regions and it mainly regards to so called __disputed borders__. Although not all
+     * data sources or themes may support it.
+     *
+     * @note Country code should be coded in ISO 3166-1 alpha-2 standard, if this option
+     * is `undefined` the majority point of view will be used.
+     */
+    politicalView?: string;
+
+    /**
      * Set fixed pixel ratio for rendering. Useful when rendering on high resolution displays with
      * low performance GPUs that may be fill-rate limited.
      * @default `window.devicePixelRatio`
@@ -900,6 +912,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_thisFrameTilesChanged: boolean | undefined;
     private m_lastTileIds: string = "";
     private m_languages: string[] | undefined;
+    private m_politicalView: string | undefined;
     private m_copyrightInfo: CopyrightInfo[] = [];
     private m_animatedExtrusionHandler: AnimatedExtrusionHandler;
 
@@ -991,6 +1004,7 @@ export class MapView extends THREE.EventDispatcher {
         this.m_options.enableStatistics = this.m_options.enableStatistics === true;
 
         this.m_languages = this.m_options.languages;
+        this.m_politicalView = this.m_options.politicalView;
 
         if (
             !isProduction &&
@@ -1460,6 +1474,36 @@ export class MapView extends THREE.EventDispatcher {
         this.m_tileDataSources.forEach((dataSource: DataSource) => {
             dataSource.setLanguages(this.m_languages);
         });
+        this.update();
+    }
+
+    /**
+     * Get currently presented political point of view - the country code.
+     *
+     * @note Country code is stored in ISO 3166-1 alpha-2 standard.
+     * @return Country code or undefined if default
+     * (majorly accepted) point of view is used.
+     */
+    get politicalView(): string | undefined {
+        return this.m_politicalView;
+    }
+
+    /**
+     * Set the political view (country code) to be used when rendering disputed features (borders).
+     *
+     * @note Country code should be encoded in ISO 3166-1 alpha-2 standard.
+     * @param pov The code of the country which point of view should be presented,
+     * `undefined` if default (commonly accepted) political view should be used.
+     */
+    set politicalView(pov: string | undefined) {
+        if (this.m_politicalView === pov) {
+            return;
+        }
+        this.m_politicalView = pov;
+        this.m_tileDataSources.forEach((dataSource: DataSource) => {
+            dataSource.setPoliticalView(pov);
+        });
+        this.clearTileCache();
         this.update();
     }
 

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -119,10 +119,20 @@ export interface OmvDataSourceParameters extends DataSourceOptions {
 
     /**
      * Identifier used to choose OmvFeatureModifier, if undefined [[OmvGenericFeatureModifier]] is
-     * used. This parameter gets applied to the decoder used in the [[OmvDataSource]] which might
+     * used only if [[politicalView]] is undefined, otherwise [[OmvPoliticalViewFeatureModifier]]
+     * will be used.
+     * This parameter gets applied to the decoder used in the [[OmvDataSource]] which might
      * be shared between various [[OmvDataSource]]s.
      */
     featureModifierId?: FeatureModifierId;
+
+    /**
+     * Expresses specific country point of view that is used when rendering disputed features,
+     * like borders, names, etc. If undefined "defacto" or most widely accepted political view
+     * will be presented.
+     * @see featureModifierId
+     */
+    politicalView?: string;
 
     /**
      * Optional, default copyright information of tiles provided by this data source.
@@ -204,6 +214,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
             filterDescription: this.m_params.filterDescr,
             gatherFeatureAttributes: this.m_params.gatherFeatureAttributes === true,
             featureModifierId: this.m_params.featureModifierId,
+            politicalView: this.m_params.politicalView,
             skipShortLabels: this.m_params.skipShortLabels,
             storageLevelOffset: getOptionValue(m_params.storageLevelOffset, -1),
             enableElevationOverlay: this.m_params.enableElevationOverlay === true
@@ -270,6 +281,18 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
     setLanguages(languages?: string[]): void {
         if (languages !== undefined) {
             this.configureDecoder(undefined, undefined, languages, undefined);
+        }
+    }
+
+    /** @override */
+    setPoliticalView(pointOfView?: string): void {
+        if (this.m_decoderOptions.politicalView !== pointOfView) {
+            this.m_decoderOptions.politicalView = pointOfView;
+            this.configureDecoder(undefined, undefined, undefined, {
+                filterDescription: this.m_decoderOptions.filterDescription,
+                featureModifierId: FeatureModifierId.pointOfView,
+                politicalView: pointOfView
+            });
         }
     }
 

--- a/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
@@ -12,7 +12,11 @@ export enum FeatureModifierId {
     /**
      * Identifier to use the OmvTomTomFeatureModifier in the OmvDecoder.
      */
-    tomTom
+    tomTom,
+    /**
+     * Identifies modifier used to support different political points of view.
+     */
+    pointOfView
 }
 
 /**
@@ -187,6 +191,12 @@ export interface OmvDecoderOptions {
      * used.
      */
     featureModifierId?: FeatureModifierId;
+
+    /**
+     * Country code in ISO 3166-1 alpha-2 format defining optional point of view to be used.
+     * Set to null if you want to revert to default point of view.
+     */
+    politicalView?: string | null;
 
     enableElevationOverlay?: boolean;
 }

--- a/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
@@ -194,7 +194,7 @@ export interface OmvDecoderOptions {
 
     /**
      * Country code in ISO 3166-1 alpha-2 format defining optional point of view to be used.
-     * Set to null if you want to revert to default point of view.
+     * Set to `null` if you want to use default (commonly accepted) point of view.
      */
     politicalView?: string | null;
 

--- a/@here/harp-omv-datasource/lib/OmvPoliticalViewFeatureModifier.ts
+++ b/@here/harp-omv-datasource/lib/OmvPoliticalViewFeatureModifier.ts
@@ -23,19 +23,18 @@ const logger = LoggerManager.instance.create("OmvPoliticalViewFeatureModifier");
  * may be visible or not for certain regions and different users (clients).
  */
 export class OmvPoliticalViewFeatureModifier extends OmvGenericFeatureModifier {
-    private readonly m_countriesPov: string[];
+    private readonly m_countryCode: string;
 
     /**
      * C-tor.
      *
      * @param description Contains layers and features filtering rules.
-     * @param respectedPov The codes (in ISO 3166-1 alpha-2 format) of countries which
-     * point of view should be taken firstly into account. The position on the lists
-     * relates to priority, so the first entries have precedence before the later.
+     * @param respectedPov The code of the country (in ISO 3166-1 alpha-2 format) which
+     * point of view should be taken firstly into account.
      */
-    constructor(description: OmvFeatureFilterDescription, respectedPov: string[]) {
+    constructor(description: OmvFeatureFilterDescription, respectedPov: string) {
         super(description);
-        this.m_countriesPov = respectedPov;
+        this.m_countryCode = respectedPov;
     }
 
     /**
@@ -59,32 +58,32 @@ export class OmvPoliticalViewFeatureModifier extends OmvGenericFeatureModifier {
      */
     private rewriteEnvironment(layer: string, env: MapEnv) {
         // For now we need to rewrite "boundaries" layer only.
-        if (this.isBoundary(layer)) {
-            this.updateEnvironment(env, this.m_countriesPov, "kind");
+        if (this.isPoliticalViewLayer(layer)) {
+            this.updateEnvironment(env, this.m_countryCode, "kind");
         }
     }
 
-    private updateEnvironment(env: MapEnv, countryCodes: string[], propName: string): void {
-        const value = this.getAlternativePov(env, countryCodes, propName);
+    private updateEnvironment(env: MapEnv, countryCode: string, propName: string): void {
+        const value = this.getAlternativePov(env, countryCode, propName);
         if (value !== undefined) {
             env.entries[propName] = value;
         }
     }
 
-    private getAlternativePov(env: MapEnv, countryCodes: string[], propName: string) {
+    private getAlternativePov(env: MapEnv, countryCode: string, propName: string) {
         logger.log("Get alternate POV: ", JSON.stringify(env));
-        for (const cc of countryCodes) {
-            const value = env.lookup(`${propName}:${cc}`);
-            logger.log("Lookup POV: ", `${propName}:${cc}`, value);
-            if (typeof value === "string" && value.length > 0) {
-                logger.log("Found POV: ", `${propName}:${cc}`, value);
-                return value;
-            }
+        const cc = countryCode;
+        const value = env.lookup(`${propName}:${cc}`);
+        logger.log("Lookup POV: ", `${propName}:${cc}`, value);
+        if (typeof value === "string" && value.length > 0) {
+            logger.log("Found POV: ", `${propName}:${cc}`, value);
+            return value;
+        } else {
+            return undefined;
         }
-        return undefined;
     }
 
-    private isBoundary(layer: string): boolean {
+    private isPoliticalViewLayer(layer: string): boolean {
         return layer === "boundaries";
     }
 }

--- a/@here/harp-omv-datasource/lib/OmvPoliticalViewFeatureModifier.ts
+++ b/@here/harp-omv-datasource/lib/OmvPoliticalViewFeatureModifier.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { LoggerManager } from "@here/harp-utils";
+import { OmvGenericFeatureModifier } from "./OmvDataFilter";
+import { OmvFeatureFilterDescription } from "./OmvDecoderDefs";
+
+const logger = LoggerManager.instance.create("OmvPoliticalViewFeatureModifier");
+
+/**
+ * Modifies the MapEnv of the Vector Tiles in Tilezen format with different POV.
+ *
+ * This feature modifier updates feature properties according to different political
+ * point of view.
+ * Political views (or alternate point of views) are supported in Tilezen by adding
+ * additional property with ISO 3166-1 alpha-2 compliant country posix to __default__ property name.
+ * For example country borders (__boundaries__ layer) may have both __kind__ property for
+ * default (major POV) and __kind:xx__ for alternate points of view. This way disputed borders
+ * may be visible or not for certain regions and different users (clients).
+ */
+export class OmvPoliticalViewFeatureModifier extends OmvGenericFeatureModifier {
+    private readonly m_countriesPov: string[];
+
+    /**
+     * C-tor.
+     *
+     * @param description Contains layers and features filtering rules.
+     * @param respectedPov The codes (in ISO 3166-1 alpha-2 format) of countries which
+     * point of view should be taken firstly into account. The position on the lists
+     * relates to priority, so the first entries have precedence before the later.
+     */
+    constructor(description: OmvFeatureFilterDescription, respectedPov: string[]) {
+        super(description);
+        this.m_countriesPov = respectedPov;
+    }
+
+    /**
+     * Overrides line features processing.
+     *
+     * Currently only line features support different point of view.
+     * @param layer The name of the layer.
+     * @param env The environment to use.
+     * @override
+     */
+    doProcessLineFeature(layer: string, env: MapEnv): boolean {
+        this.rewriteEnvironment(layer, env);
+        return super.doProcessLineFeature(layer, env);
+    }
+
+    /**
+     * Rewrites the Environment to match the different points of view.
+     *
+     * @param layer The layer name.
+     * @param env The environment to use.
+     */
+    private rewriteEnvironment(layer: string, env: MapEnv) {
+        // For now we need to rewrite "boundaries" layer only.
+        if (this.isBoundary(layer)) {
+            this.updateEnvironment(env, this.m_countriesPov, "kind");
+        }
+    }
+
+    private updateEnvironment(env: MapEnv, countryCodes: string[], propName: string): void {
+        const value = this.getAlternativePov(env, countryCodes, propName);
+        if (value !== undefined) {
+            env.entries[propName] = value;
+        }
+    }
+
+    private getAlternativePov(env: MapEnv, countryCodes: string[], propName: string) {
+        logger.log("Get alternate POV: ", JSON.stringify(env));
+        for (const cc of countryCodes) {
+            const value = env.lookup(`${propName}:${cc}`);
+            logger.log("Lookup POV: ", `${propName}:${cc}`, value);
+            if (typeof value === "string" && value.length > 0) {
+                logger.log("Found POV: ", `${propName}:${cc}`, value);
+                return value;
+            }
+        }
+        return undefined;
+    }
+
+    private isBoundary(layer: string): boolean {
+        return layer === "boundaries";
+    }
+}


### PR DESCRIPTION
When different political view is requested, special implementation of
FeatureModifier is initialized that converts border lines "kind"
attributes according to different point of view, i.e. re-writing generic
"kind" with a contents of "kind:xx", where "xx" denotes country code.
This results in assigning new kinds'v values:
- unrecognized_disputed,
- unrecognized_country,
to generic "kind". Of course this kinds require separate/unique styling
policy, because current themes does not define any styling for it.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
