### PR TITLE
HARP-7579 Add pre-dist-tag to publish

### DIFF
--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -6,4 +6,4 @@
 #
 
 echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
-npx lerna publish -y from-git
+npx lerna publish -y from-git --pre-dist-tag alpha


### PR DESCRIPTION
We need to tell `lerna` to tag as latest only the non-alpha packages.

Using [verdaccio](https://github.com/verdaccio/verdaccio) locally I was able to test and verify the following behavior with [this sample project](https://github.com/musculman/yarn-workspaces-example)

1. do changes
2. run `lerna version preminor` to create a _minor alpha_ version
3. `lerna publish -y from-git --pre-dist-tag alpha` publishes the expected _minor alpha_ packages
4. do some more changes
5. run `lerna version minor` to create a _minor_ version
6. `lerna publish -y from-git --pre-dist-tag alpha` publishes the expected _minor_ packages


Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>
