### PR TITLE
HARP-7373: Move text element render state to TextElementState.

### DIFF
--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * State of fading.
+ */
+export enum FadingState {
+    Undefined = 0,
+    FadingIn = 1,
+    FadedIn = 2,
+    FadingOut = -1,
+    FadedOut = -2
+}
+
+/**
+ * Time to fade in/fade out the labels in milliseconds.
+ */
+export const DEFAULT_FADE_TIME = 800;
+
+/**
+ * State of rendering of the icon and text part of the `TextElement`. Mainly for fading the elements
+ * in and out, to compute the opacity.
+ *
+ * @hidden
+ */
+export class RenderState {
+    /**
+     * Create a `RenderState`.
+     *
+     * @param state Fading state.
+     * @param value Current fading value [0..1].
+     * @param startTime Time stamp the fading started.
+     * @param opacity Computed opacity depending on value.
+     * @param lastFrameNumber Latest frame the elements was rendered, allows to detect some less
+     *                        obvious states, like popping up after being hidden.
+     * @param fadingTime Time used to fade in or out.
+     */
+    constructor(
+        public state = FadingState.Undefined,
+        public value = 0.0,
+        public startTime = 0,
+        public opacity = 1.0,
+        public lastFrameNumber = Number.MIN_SAFE_INTEGER,
+        public fadingTime: number = DEFAULT_FADE_TIME
+    ) {}
+    /**
+     * Reset existing `RenderState` to appear like a fresh state.
+     */
+    reset() {
+        this.state = FadingState.Undefined;
+        this.value = 0.0;
+        this.startTime = 0.0;
+        this.opacity = 1.0;
+        this.lastFrameNumber = Number.MIN_SAFE_INTEGER;
+    }
+    /**
+     * @returns `true` if element is either fading in or fading out.
+     */
+    isFading(): boolean {
+        const fading = this.state === FadingState.FadingIn || this.state === FadingState.FadingOut;
+        return fading;
+    }
+    /**
+     * @returns `true` if element is fading in.
+     */
+    isFadingIn(): boolean {
+        const fadingIn = this.state === FadingState.FadingIn;
+        return fadingIn;
+    }
+    /**
+     * @returns `true` if element is fading out.
+     */
+    isFadingOut(): boolean {
+        const fadingOut = this.state === FadingState.FadingOut;
+        return fadingOut;
+    }
+    /**
+     * @returns `true` if element is done with fading in.
+     */
+    isFadedIn(): boolean {
+        const fadedIn = this.state === FadingState.FadedIn;
+        return fadedIn;
+    }
+    /**
+     * @returns `true` if element is done with fading out.
+     */
+    isFadedOut(): boolean {
+        const fadedOut = this.state === FadingState.FadedOut;
+        return fadedOut;
+    }
+    /**
+     * @returns `true` if element is either faded in, is fading in or is fading out.
+     */
+    isVisible(): boolean {
+        const visible =
+            this.state === FadingState.FadingIn ||
+            this.state === FadingState.FadedIn ||
+            this.state === FadingState.FadingOut;
+        return visible;
+    }
+}

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_FADE_TIME, FadingState, RenderState } from "./RenderState";
+import { TextElementType } from "./TextElementType";
+
+/**
+ * `TextElementState` keeps the current state of a text element while it's being rendered.
+ */
+export class TextElementState {
+    /**
+     * @hidden
+     * Used during label placement to reserve space from front to back.
+     */
+    m_viewDistance?: number;
+
+    /**
+     * @hidden
+     * Used during rendering. The array type is used for line markers only, which have a points
+     * array and multiple icon positions to render. Since line markers use the same renderState
+     * for text part and icon, there is no separate array of [[RenderState]]s for the text parts
+     * of the line markers.
+     */
+    m_iconRenderStates?: RenderState | RenderState[];
+
+    /**
+     * @hidden
+     * Used during rendering.
+     */
+    m_textRenderState?: RenderState;
+
+    /**
+     * Initializes the state.
+     * @param textElementType The text element type.
+     * @param disableFading True if fading is disabled, false otherwise.
+     * @param textElementPointCount Number of points the text element has.
+     */
+    initialize(
+        textElementType: TextElementType,
+        disableFading: boolean,
+        textElementPointCount: number = 1
+    ) {
+        const fadingTime = disableFading === true ? 0 : DEFAULT_FADE_TIME;
+
+        if (textElementType === TextElementType.LineMarker) {
+            this.m_iconRenderStates = new Array<RenderState>();
+            for (let i = 0; i < textElementPointCount; ++i) {
+                const iconRenderStates = this.m_iconRenderStates as RenderState[];
+                const renderState = new RenderState();
+                renderState.state = FadingState.FadingIn;
+                renderState.fadingTime = fadingTime;
+                iconRenderStates.push(renderState);
+            }
+            return;
+        }
+
+        this.m_textRenderState = new RenderState();
+        this.m_textRenderState.fadingTime = fadingTime;
+
+        if (textElementType === TextElementType.PoiLabel) {
+            this.m_iconRenderStates = new RenderState();
+            this.m_iconRenderStates.fadingTime = fadingTime;
+        }
+    }
+
+    get initialized(): boolean {
+        return this.m_textRenderState !== undefined || this.m_iconRenderStates !== undefined;
+    }
+
+    /**
+     * Clears the state.
+     */
+    clear() {
+        this.m_iconRenderStates = undefined;
+        this.m_textRenderState = undefined;
+    }
+
+    /**
+     * Returns the last computed distance of the text element to the camera.
+     * @returns Distance to camera.
+     */
+    get viewDistance(): number | undefined {
+        return this.m_viewDistance;
+    }
+
+    set viewDistance(distance: number | undefined) {
+        this.m_viewDistance = distance;
+    }
+
+    /**
+     * @returns The text render state.
+     */
+    get textRenderState(): RenderState | undefined {
+        return this.m_textRenderState;
+    }
+
+    /**
+     * Returns the icon render state for the case where the text element has only one icon.
+     * @returns The icon render state if the text element has a single icon, otherwise undefined.
+     */
+    get iconRenderState(): RenderState | undefined {
+        if (this.m_iconRenderStates === undefined) {
+            return undefined;
+        }
+
+        return this.m_iconRenderStates instanceof RenderState ? this.m_iconRenderStates : undefined;
+    }
+
+    /**
+     * Returns the icon render states for text elements with multiple icons.
+     * @returns The icon render states if the text element has multiple icons, otherwise undefined.
+     */
+    get iconRenderStates(): RenderState[] | undefined {
+        if (this.m_iconRenderStates === undefined) {
+            return undefined;
+        }
+
+        return this.m_iconRenderStates instanceof RenderState
+            ? undefined
+            : (this.m_iconRenderStates as RenderState[]);
+    }
+}

--- a/@here/harp-mapview/lib/text/TextElementType.ts
+++ b/@here/harp-mapview/lib/text/TextElementType.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Types of text elements.
+ */
+export enum TextElementType {
+    PoiLabel,
+    PathLabel,
+    LineMarker
+}

--- a/@here/harp-mapview/test/TextElementsRendererTest.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTest.ts
@@ -25,7 +25,8 @@ import * as THREE from "three";
 import { MapView } from "../lib/MapView";
 import { ScreenCollisions } from "../lib/ScreenCollisions";
 import { ScreenProjector } from "../lib/ScreenProjector";
-import { DEFAULT_FADE_TIME, TextElement } from "../lib/text/TextElement";
+import { DEFAULT_FADE_TIME } from "../lib/text/RenderState";
+import { TextElement } from "../lib/text/TextElement";
 import { TextElementsRenderer } from "../lib/text/TextElementsRenderer";
 import { TextLayoutStyleCache, TextRenderStyleCache } from "../lib/text/TextStyleCache";
 import { MapViewUtils } from "../lib/Utils";
@@ -221,9 +222,11 @@ describe("TextElementsRenderer", function() {
 
         expect(numRenderedTextElements).to.be.equal(1);
         expect(renderedTextElements.length).to.be.equal(1);
-        expect(renderedTextElements[0].textRenderState!.startTime).to.be.equal(startTime);
-        expect(renderedTextElements[0].textRenderState!.opacity).to.be.equal(0);
-        assert(renderedTextElements[0].textRenderState!.isFadingIn());
+        expect(renderedTextElements[0].renderState.textRenderState!.startTime).to.be.equal(
+            startTime
+        );
+        expect(renderedTextElements[0].renderState.textRenderState!.opacity).to.be.equal(0);
+        assert(renderedTextElements[0].renderState.textRenderState!.isFadingIn());
 
         // Second frame. Label should be semi-transparent and fading in.
         renderedTextElements.splice(0);
@@ -238,12 +241,12 @@ describe("TextElementsRenderer", function() {
 
         expect(numRenderedTextElements).to.be.equal(1);
         expect(renderedTextElements.length).to.be.equal(1);
-        expect(renderedTextElements[0].textRenderState!.opacity)
+        expect(renderedTextElements[0].renderState.textRenderState!.opacity)
             .to.be.greaterThan(0)
             .to.be.lessThan(1);
-        assert(renderedTextElements[0].textRenderState!.isFadingIn());
+        assert(renderedTextElements[0].renderState.textRenderState!.isFadingIn());
 
-        const lastOpacity = renderedTextElements[0].textRenderState!.opacity;
+        const lastOpacity = renderedTextElements[0].renderState.textRenderState!.opacity;
 
         // Third frame. Label should be semi-transparent and still fading in.
         renderedTextElements.splice(0);
@@ -257,10 +260,10 @@ describe("TextElementsRenderer", function() {
         );
         expect(numRenderedTextElements).to.be.equal(1);
         expect(renderedTextElements.length).to.be.equal(1);
-        expect(renderedTextElements[0].textRenderState!.opacity)
+        expect(renderedTextElements[0].renderState.textRenderState!.opacity)
             .to.be.greaterThan(lastOpacity)
             .to.be.lessThan(1);
-        assert(renderedTextElements[0].textRenderState!.isFadingIn());
+        assert(renderedTextElements[0].renderState.textRenderState!.isFadingIn());
 
         // Forth frame. Label should be visible and fading should be finished.
         renderedTextElements.splice(0);
@@ -275,8 +278,8 @@ describe("TextElementsRenderer", function() {
 
         expect(numRenderedTextElements).to.be.equal(1);
         expect(renderedTextElements.length).to.be.equal(1);
-        expect(renderedTextElements[0].textRenderState!.opacity).to.be.equal(1);
-        assert(renderedTextElements[0].textRenderState!.isFadedIn());
+        expect(renderedTextElements[0].renderState.textRenderState!.opacity).to.be.equal(1);
+        assert(renderedTextElements[0].renderState.textRenderState!.isFadedIn());
 
         return Promise.resolve();
     });


### PR DESCRIPTION
So far the state of a text element was held in the Tile. This is generally wrong from the design point of view, a tile shouldn't hold any state related to rendering.

Furthermore, this meant that the state of a label was not reachable once the tile was not in the visible tile list anymore (e.g. during zoom level changes). This made impossible reusing a label state when a new label corresponding to the same map object in a different zoom level is rendered.
