### PR TITLE
HARP-7356: Fix textIsOptional property

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1762,7 +1762,7 @@ export class TextElementsRenderer {
         let iconSpaceAvailable = true;
 
         // Check if icon should be rendered at this zoomLevel
-        const renderIcon =
+        let renderIcon =
             poiInfo === undefined ||
             MathUtils.isClamped(
                 mapViewState.zoomLevel,
@@ -1981,6 +1981,7 @@ export class TextElementsRenderer {
 
             // If the text is not visible nor optional, we won't render the icon neither.
             else if (!renderIcon || !textIsOptional) {
+                renderIcon = false;
                 if (pointLabel.poiInfo === undefined || iconRenderState.isVisible()) {
                     if (pointLabel.poiInfo !== undefined) {
                         this.startFadeOut(


### PR DESCRIPTION
textIsOptional = false was not handled properly (i.e. the icon was rendered without text).
In addition the rendering was never finished (infinite animation loop)