### PR TITLE
MINOR: Fix buildings outlines (edges) rendering.

### DIFF
--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -273,7 +273,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
     constructor(
         maxElevation: number = EarthConstants.MAX_BUILDING_HEIGHT,
         minElevation: number = 0,
-        readonly nearMin: number = 0.1,
+        readonly nearMin: number = 1.0,
         readonly nearFarMargin: number = 10.0,
         readonly farMaxRatio = 1.8
     ) {


### PR DESCRIPTION
Depth offset was multiplied by homogeneous 'w' coordinate, which results
in constant offset in NDC space, although it seems to be correct,
because of depth buffer non-linear nature, this may promote some occluded
edges before their buildings geometry. This comes from fact that varying
offset (dependent on homogeneous w) applied in clip space provides huge
depth differences, thus resulting in z-fight (and win) of buildings
outlines rendered behind the actual geometry (in certeain frustum settings)

Second problem solved in this PR was promoting clipped geometry (outlines)
from outside the clip range -1 < z < 1 to inside of it, resulting in
rendering outlines of clipped buildings, this requires conditional
offseting - only if vertexes are not to be clipped in the next phase.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
