### PR TITLE
HARP-6638: Fix MapView.FrameComplete event.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -3226,7 +3226,10 @@ export class MapView extends THREE.EventDispatcher {
         this.poiTableManager.clear();
 
         // Add the POI tables defined in the theme.
-        this.poiTableManager.loadPoiTables(this.m_theme as Theme);
+        this.poiTableManager
+            .loadPoiTables(this.m_theme as Theme)
+            .then(() => this.update())
+            .catch(() => this.update());
     }
 
     private setupStats(enable: boolean) {


### PR DESCRIPTION
Fix condition, where PoiTableManager is last one to be ready.
Before fix, finish of PoiTableManager didn't trigger update and thus
there was no change to observer, first complete frame.

Followup of #917

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>
