### PR TITLE
MINOR: Initial view is not Berlin.

### DIFF
--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -10,7 +10,7 @@ import {
     MapViewFeature,
     MapViewMultiPolygonFeature
 } from "@here/harp-features-datasource";
-import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
+import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
 import { TopViewClipPlanesEvaluator } from "@here/harp-mapview/lib/ClipPlanesEvaluator";
@@ -318,7 +318,6 @@ export namespace PolygonsFeaturesExample {
                 }
             }
         });
-        mapView.setCameraGeolocationAndZoom(new GeoCoordinates(30, 10), 3.2);
         mapView.renderLabels = false;
 
         const controls = new MapControls(mapView);

--- a/@here/harp-examples/src/datasource_satellite-tile.ts
+++ b/@here/harp-examples/src/datasource_satellite-tile.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { WebTileDataSource } from "@here/harp-webtile-datasource";
@@ -66,9 +65,6 @@ export namespace SatelliteDataSourceExample {
         tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE
     });
     // end:harp_gl_datasource_satellitetile_1.ts
-
-    const NY = new GeoCoordinates(40.707, -74.01);
-    mapView.lookAt(NY, 4000, 40);
 
     // snippet:harp_gl_datasource_satellitetile_2.ts
     mapView.addDataSource(webTileDataSource);

--- a/@here/harp-examples/src/datasource_satellite-tile_globe.ts
+++ b/@here/harp-examples/src/datasource_satellite-tile_globe.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
+import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { WebTileDataSource } from "@here/harp-webtile-datasource";
@@ -79,8 +79,6 @@ export namespace SatelliteTileDataSourceGlobeExample {
             tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE
         });
         // end:harp_gl_datasource_satellitetile_globe_1.ts
-
-        mapView.setCameraGeolocationAndZoom(new GeoCoordinates(40.702, -74.01154), 3.6);
 
         // snippet:harp_gl_datasource_satellitetile_globe_2.ts
         mapView.addDataSource(webTileDataSource);

--- a/@here/harp-examples/src/datasource_webtile.ts
+++ b/@here/harp-examples/src/datasource_webtile.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { WebTileDataSource } from "@here/harp-webtile-datasource";
@@ -66,9 +65,6 @@ export namespace WebTileDataSourceExample {
         ppi: WebTileDataSource.ppiValue.ppi320
     });
     // end:harp_gl_datasource_webtile_1.ts
-
-    const NY = new GeoCoordinates(40.707, -74.01);
-    mapView.lookAt(NY, 4000, 40);
 
     // snippet:harp_gl_datasource_webtile_2.ts
     mapView.addDataSource(webTileDataSource);

--- a/@here/harp-examples/src/datasource_webtile_globe.ts
+++ b/@here/harp-examples/src/datasource_webtile_globe.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
+import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { WebTileDataSource } from "@here/harp-webtile-datasource";
@@ -79,8 +79,6 @@ export namespace WebTileDataSourceGlobeExample {
             ppi: WebTileDataSource.ppiValue.ppi320
         });
         // end:harp_gl_datasource_webtile_globe_1.ts
-
-        mapView.setCameraGeolocationAndZoom(new GeoCoordinates(40.702, -74.01154), 3.6);
 
         // snippet:harp_gl_datasource_webtile_globe_2.ts
         mapView.addDataSource(webTileDataSource);

--- a/@here/harp-examples/src/datasource_xyzmvt.ts
+++ b/@here/harp-examples/src/datasource_xyzmvt.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
@@ -86,8 +85,6 @@ export namespace DatasourceXYZMVTExample {
         mapControls.maxTiltAngle = 50;
         const ui = new MapControlsUI(mapControls, { zoomLevel: "input" });
         canvas.parentElement!.appendChild(ui.domElement);
-        const NY = new GeoCoordinates(40.707, -74.01);
-        map.lookAt(NY, 3500, 50);
         // end:harp_gl_datasource_xyzmvt_example_2.ts
 
         // snippet:harp_gl_datasource_xyzmvt_example_3.ts

--- a/@here/harp-examples/src/getting-started_globe-projection.ts
+++ b/@here/harp-examples/src/getting-started_globe-projection.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
+import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
@@ -49,9 +49,6 @@ export namespace GlobeExample {
         const mapControls = new MapControls(map);
         const ui = new MapControlsUI(mapControls, { zoomLevel: "input" });
         map.canvas.parentElement!.appendChild(ui.domElement);
-
-        const NY = new GeoCoordinates(40.71, -74.007);
-        map.setCameraGeolocationAndZoom(NY, 3.2);
     }
 
     main();

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2919,7 +2919,7 @@ export class MapView extends THREE.EventDispatcher {
     private setupCamera() {
         const { width, height } = this.getCanvasClientSize();
 
-        const defaultGeoCenter = new GeoCoordinates(52.518611, 13.376111, 3000);
+        const defaultGeoCenter = new GeoCoordinates(25, 0, 30000000);
 
         this.projection.projectPoint(defaultGeoCenter, this.m_camera.position);
 


### PR DESCRIPTION
If `lookAt`, `setCameraGeolocationAndZoom` or `geoCenter` are not specified in the client code, MapView currently sets the camera above Berlin. This PR makes the initial view a wide world view from afar that fits both planar and globe instead.