### PR TITLE
HARP-7670: Fix CI for windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,10 +37,12 @@ jobs:
       run: |
         yarn cov-test --forbid-only
       shell: bash
+      if: matrix.os != 'windows-latest'
     - name: Generate coverage report
       run: |
         yarn cov-report-html
       shell: bash
+      if: matrix.os != 'windows-latest'
     - name: Save Coverage Report (Linux)
       uses: actions/upload-artifact@master
       with:
@@ -74,6 +76,7 @@ jobs:
         cp node_modules/geckodriver/geckodriver.exe .
         yarn test-browser --headless-firefox
       if: matrix.os == 'windows-latest'
+      shell: bash
     - name: Tests on Firefox (Linux)
       run: |
         set -ex


### PR DESCRIPTION
Disable node-js tests or GithubActions / Windows as they are not reliable.

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>
