### PR TITLE
Re-enable Node.js tests on GHCI/Windows.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,10 @@ jobs:
       run: |
         yarn cov-test --forbid-only
       shell: bash
-      if: matrix.os != 'windows-latest'
     - name: Generate coverage report
       run: |
         yarn cov-report-html
       shell: bash
-      if: matrix.os != 'windows-latest'
     - name: Save Coverage Report (Linux)
       uses: actions/upload-artifact@master
       with:


### PR DESCRIPTION
Attempt to make test enviromnet stable for tests ran in
Node.js env on Windows.

Attempt to find clean way for "magic" fix found in #955 

Followup of #959.

