### PR TITLE
Change signatures of the style operator descriptors.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -90,10 +90,10 @@ class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
     }
 
     visitCallExpr(expr: CallExpr, context: ExprDependencies): void {
-        if (expr.op === "zoom" && expr.children.length === 0) {
+        if (expr.op === "zoom" && expr.args.length === 0) {
             context.zoom = true;
         } else {
-            expr.children.forEach(childExpr => childExpr.accept(this, context));
+            expr.args.forEach(childExpr => childExpr.accept(this, context));
         }
     }
 
@@ -696,8 +696,16 @@ export class ContainsExpr extends Expr {
 export class CallExpr extends Expr {
     descriptor?: OperatorDescriptor;
 
-    constructor(readonly op: string, readonly children: Expr[]) {
+    constructor(readonly op: string, readonly args: Expr[]) {
         super();
+    }
+
+    /**
+     * Returns the child nodes of this [[Expr]].
+     * @deprecated
+     */
+    get children() {
+        return this.args;
     }
 
     accept<Result, Context>(visitor: ExprVisitor<Result, Context>, context: Context): Result {
@@ -802,7 +810,7 @@ class ExprSerializer implements ExprVisitor<JsonValue, void> {
     }
 
     visitCallExpr(expr: CallExpr, context: void): JsonValue {
-        return [expr.op, ...expr.children.map(childExpr => this.serialize(childExpr))];
+        return [expr.op, ...expr.args.map(childExpr => this.serialize(childExpr))];
     }
 
     visitMatchExpr(expr: MatchExpr, context: void): JsonValue {

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -37,7 +37,7 @@ import { StringOperators } from "./operators/StringOperators";
 import { TypeOperators } from "./operators/TypeOperators";
 
 export interface OperatorDescriptor {
-    call: (context: ExprEvaluatorContext, args: Expr[]) => Value;
+    call: (context: ExprEvaluatorContext, call: CallExpr) => Value;
 }
 
 export interface OperatorDescriptorMap {
@@ -146,7 +146,7 @@ export class ExprEvaluator implements ExprVisitor<Value, ExprEvaluatorContext> {
     visitCallExpr(expr: CallExpr, context: ExprEvaluatorContext): Value {
         switch (expr.op) {
             case "all":
-                for (const childExpr of expr.children) {
+                for (const childExpr of expr.args) {
                     if (!childExpr.accept(this, context)) {
                         return false;
                     }
@@ -154,7 +154,7 @@ export class ExprEvaluator implements ExprVisitor<Value, ExprEvaluatorContext> {
                 return true;
 
             case "any":
-                for (const childExpr of expr.children) {
+                for (const childExpr of expr.args) {
                     if (childExpr.accept(this, context)) {
                         return true;
                     }
@@ -162,7 +162,7 @@ export class ExprEvaluator implements ExprVisitor<Value, ExprEvaluatorContext> {
                 return false;
 
             case "none":
-                for (const childExpr of expr.children) {
+                for (const childExpr of expr.args) {
                     if (childExpr.accept(this, context)) {
                         return false;
                     }
@@ -182,7 +182,7 @@ export class ExprEvaluator implements ExprVisitor<Value, ExprEvaluatorContext> {
                 if (descriptor) {
                     expr.descriptor = descriptor;
 
-                    const result = descriptor.call(context, expr.children);
+                    const result = descriptor.call(context, expr);
 
                     if (context.cache) {
                         context.cache.set(expr, result);

--- a/@here/harp-datasource-protocol/lib/ExprPool.ts
+++ b/@here/harp-datasource-protocol/lib/ExprPool.ts
@@ -147,7 +147,7 @@ export class ExprPool implements ExprVisitor<Expr, void> {
 
     visitCallExpr(expr: CallExpr, context: void): Expr {
         // rewrite the actual arguments
-        const expressions = expr.children.map(childExpr => childExpr.accept(this, context));
+        const expressions = expr.args.map(childExpr => childExpr.accept(this, context));
         // ensure we have a valid set of interned expressions for the calls
         if (!this.m_callExprs.has(expr.op)) {
             this.m_callExprs.set(expr.op, []);
@@ -156,17 +156,17 @@ export class ExprPool implements ExprVisitor<Expr, void> {
         const calls = this.m_callExprs.get(expr.op)!;
         for (const call of calls) {
             // check the number of arguments
-            if (call.children.length !== expressions.length) {
+            if (call.args.length !== expressions.length) {
                 continue;
             }
             // find the index of the first mismatch.
             let index = 0;
-            for (; index < call.children.length; ++index) {
-                if (call.children[index] !== expressions[index]) {
+            for (; index < call.args.length; ++index) {
+                if (call.args[index] !== expressions[index]) {
                     break;
                 }
             }
-            if (index === call.children.length) {
+            if (index === call.args.length) {
                 // no mismatch found, return the 'interned' call.
                 return call;
             }

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -169,7 +169,7 @@ class StyleConditionClassifier implements ExprVisitor<Expr | undefined, Expr | u
             // processing of an `["all", e1, e2, ... eN]` expression. In this case
             // search for expressions matching comparison of `$layer` and string literals
             // in the sub expressions.
-            const children = call.children
+            const children = call.args
                 .map(childExpr => childExpr.accept(this, call))
                 .filter(childExpr => childExpr !== undefined) as Expr[];
 
@@ -217,8 +217,8 @@ class StyleConditionClassifier implements ExprVisitor<Expr | undefined, Expr | u
      */
     private matchVarStringComparison(call: CallExpr) {
         if (call.op === "==") {
-            const left = call.children[0];
-            const right = call.children[1];
+            const left = call.args[0];
+            const right = call.args[1];
 
             if (left instanceof VarExpr && right instanceof StringLiteralExpr) {
                 return { name: left.name, value: right.value };

--- a/@here/harp-datasource-protocol/lib/operators/ArrayOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ArrayOperators.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
     at: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const args = call.args;
             const index = context.evaluate(args[0]);
             if (typeof index !== "number") {
                 throw new Error(`expected the index of the element to retrieve`);

--- a/@here/harp-datasource-protocol/lib/operators/CastOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/CastOperators.ts
@@ -4,25 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
     "to-boolean": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return Boolean(context.evaluate(args[0]));
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return Boolean(context.evaluate(call.args[0]));
         }
     },
 
     "to-string": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return String(context.evaluate(args[0]));
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return String(context.evaluate(call.args[0]));
         }
     },
 
     "to-number": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            for (const arg of args) {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            for (const arg of call.args) {
                 const value = Number(context.evaluate(arg));
                 if (!isNaN(value)) {
                     return value;

--- a/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
@@ -6,17 +6,17 @@
 
 import * as THREE from "three";
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const tmpColor = new THREE.Color();
 const operators = {
     rgb: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const r = context.evaluate(args[0]);
-            const g = context.evaluate(args[1]);
-            const b = context.evaluate(args[2]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const r = context.evaluate(call.args[0]);
+            const g = context.evaluate(call.args[1]);
+            const b = context.evaluate(call.args[2]);
             if (typeof r === "number" && typeof g === "number" && typeof b === "number") {
                 return (
                     "#" +
@@ -33,10 +33,10 @@ const operators = {
         }
     },
     hsl: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const h = context.evaluate(args[0]);
-            const s = context.evaluate(args[1]);
-            const l = context.evaluate(args[2]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const h = context.evaluate(call.args[0]);
+            const s = context.evaluate(call.args[1]);
+            const l = context.evaluate(call.args[2]);
             if (
                 typeof h === "number" &&
                 typeof s === "number" &&

--- a/@here/harp-datasource-protocol/lib/operators/ComparisonOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ComparisonOperators.ts
@@ -4,19 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
-type RelOp = "<" | ">" | "<=" | ">=";
-
-function compare(
-    context: ExprEvaluatorContext,
-    op: RelOp,
-    actuals: Expr[],
-    strict: boolean = false
-) {
-    const left = context.evaluate(actuals[0]) as any;
-    const right = context.evaluate(actuals[1]) as any;
+function compare(context: ExprEvaluatorContext, call: CallExpr, strict: boolean = false) {
+    const left = context.evaluate(call.args[0]) as any;
+    const right = context.evaluate(call.args[1]) as any;
 
     if (
         !(
@@ -25,11 +18,11 @@ function compare(
         )
     ) {
         if (strict) {
-            throw new Error(`invalid operands '${left}' and '${right}' for operator '${op}'`);
+            throw new Error(`invalid operands '${left}' and '${right}' for operator '${call.op}'`);
         }
     }
 
-    switch (op) {
+    switch (call.op) {
         case "<":
             return left < right;
         case ">":
@@ -39,37 +32,37 @@ function compare(
         case ">=":
             return left >= right;
         default:
-            throw new Error(`invalid comparison operator '${op}'`);
+            throw new Error(`invalid comparison operator '${call.op}'`);
     }
 }
 
 const operators = {
     "!": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return !context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return !context.evaluate(call.args[0]);
         }
     },
 
     "==": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const left = context.evaluate(args[0]);
-            const right = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const left = context.evaluate(call.args[0]);
+            const right = context.evaluate(call.args[1]);
             return left === right;
         }
     },
 
     "!=": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const left = context.evaluate(args[0]);
-            const right = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const left = context.evaluate(call.args[0]);
+            const right = context.evaluate(call.args[1]);
             return left !== right;
         }
     },
 
-    "<": { call: (context: ExprEvaluatorContext, args: Expr[]) => compare(context, "<", args) },
-    ">": { call: (context: ExprEvaluatorContext, args: Expr[]) => compare(context, ">", args) },
-    "<=": { call: (context: ExprEvaluatorContext, args: Expr[]) => compare(context, "<=", args) },
-    ">=": { call: (context: ExprEvaluatorContext, args: Expr[]) => compare(context, ">=", args) }
+    "<": { call: (context: ExprEvaluatorContext, call: CallExpr) => compare(context, call) },
+    ">": { call: (context: ExprEvaluatorContext, call: CallExpr) => compare(context, call) },
+    "<=": { call: (context: ExprEvaluatorContext, call: CallExpr) => compare(context, call) },
+    ">=": { call: (context: ExprEvaluatorContext, call: CallExpr) => compare(context, call) }
 };
 
 export const ComparisonOperators: OperatorDescriptorMap = operators;

--- a/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
     "geometry-type": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
             const geometryType = context.env.lookup("$geometryType");
             switch (geometryType) {
                 case "point":

--- a/@here/harp-datasource-protocol/lib/operators/FlowOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FlowOperators.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr, Expr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 function conditionalCast(context: ExprEvaluatorContext, type: string, args: Expr[]) {
@@ -26,20 +26,20 @@ function conditionalCast(context: ExprEvaluatorContext, type: string, args: Expr
 
 const operators = {
     boolean: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return conditionalCast(context, "boolean", args);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return conditionalCast(context, "boolean", call.args);
         }
     },
 
     number: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return conditionalCast(context, "number", args);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return conditionalCast(context, "number", call.args);
         }
     },
 
     string: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return conditionalCast(context, "string", args);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return conditionalCast(context, "string", call.args);
         }
     }
 };

--- a/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 import * as THREE from "three";
 
 const operators = {
     "^": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const a = context.evaluate(args[0]);
-            const b = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const a = context.evaluate(call.args[0]);
+            const b = context.evaluate(call.args[1]);
             if (typeof a !== "number" || typeof b !== "number") {
                 // tslint:disable-next-line: max-line-length
                 throw new Error(
@@ -25,9 +25,9 @@ const operators = {
     },
 
     "-": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const a = context.evaluate(args[0]);
-            const b = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const a = context.evaluate(call.args[0]);
+            const b = context.evaluate(call.args[1]);
             if (typeof a !== "number" || typeof b !== "number") {
                 throw new Error(
                     `invalid operands '${typeof a}' and '${typeof b}' for operator '-'`
@@ -38,9 +38,9 @@ const operators = {
     },
 
     "/": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const a = context.evaluate(args[0]);
-            const b = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const a = context.evaluate(call.args[0]);
+            const b = context.evaluate(call.args[1]);
             if (typeof a !== "number" || typeof b !== "number") {
                 // tslint:disable-next-line: max-line-length
                 throw new Error(
@@ -52,9 +52,9 @@ const operators = {
     },
 
     "%": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const a = context.evaluate(args[0]);
-            const b = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const a = context.evaluate(call.args[0]);
+            const b = context.evaluate(call.args[1]);
             if (typeof a !== "number" || typeof b !== "number") {
                 // tslint:disable-next-line: max-line-length
                 throw new Error(
@@ -66,20 +66,20 @@ const operators = {
     },
 
     "+": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return args.reduce((a, b) => Number(a) + Number(context.evaluate(b)), 0);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return call.args.reduce((a, b) => Number(a) + Number(context.evaluate(b)), 0);
         }
     },
 
     "*": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return args.reduce((a, b) => Number(a) * Number(context.evaluate(b)), 1);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return call.args.reduce((a, b) => Number(a) * Number(context.evaluate(b)), 1);
         }
     },
 
     abs: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'abs'`);
             }
@@ -88,8 +88,8 @@ const operators = {
     },
 
     acos: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'acos'`);
             }
@@ -98,8 +98,8 @@ const operators = {
     },
 
     asin: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'asin'`);
             }
@@ -108,8 +108,8 @@ const operators = {
     },
 
     atan: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'atan'`);
             }
@@ -118,8 +118,8 @@ const operators = {
     },
 
     ceil: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'ceil'`);
             }
@@ -128,8 +128,8 @@ const operators = {
     },
 
     cos: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'cos'`);
             }
@@ -144,8 +144,8 @@ const operators = {
     },
 
     floor: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'floor'`);
             }
@@ -154,8 +154,8 @@ const operators = {
     },
 
     ln: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'ln'`);
             }
@@ -164,8 +164,8 @@ const operators = {
     },
 
     ln2: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'ln2'`);
             }
@@ -174,8 +174,8 @@ const operators = {
     },
 
     log10: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'log10'`);
             }
@@ -184,14 +184,14 @@ const operators = {
     },
 
     max: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return Math.max(...args.map(v => Number(context.evaluate(v))));
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return Math.max(...call.args.map(v => Number(context.evaluate(v))));
         }
     },
 
     min: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return Math.min(...args.map(v => Number(context.evaluate(v))));
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return Math.min(...call.args.map(v => Number(context.evaluate(v))));
         }
     },
 
@@ -204,10 +204,10 @@ const operators = {
      * ```
      */
     clamp: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const v = context.evaluate(args[0]);
-            const min = context.evaluate(args[1]);
-            const max = context.evaluate(args[2]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const v = context.evaluate(call.args[0]);
+            const min = context.evaluate(call.args[1]);
+            const max = context.evaluate(call.args[2]);
 
             if (typeof v !== "number" || typeof min !== "number" || typeof max !== "number") {
                 throw new Error(`invalid operands '${v}', ${min}, ${max} for operator 'clamp'`);
@@ -223,8 +223,8 @@ const operators = {
     },
 
     round: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'round'`);
             }
@@ -233,8 +233,8 @@ const operators = {
     },
 
     sin: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'sin'`);
             }
@@ -243,8 +243,8 @@ const operators = {
     },
 
     sqrt: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'sqrt'`);
             }
@@ -253,8 +253,8 @@ const operators = {
     },
 
     tan: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (typeof value !== "number") {
                 throw new Error(`invalid operand '${value}' for operator 'tan'`);
             }

--- a/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
     length: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const value = context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]);
             if (Array.isArray(value) || typeof value === "string") {
                 return value.length;
             }
@@ -18,8 +18,8 @@ const operators = {
         }
     },
     coalesce: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            for (const childExpr of args) {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            for (const childExpr of call.args) {
                 const value = context.evaluate(childExpr);
                 if (value !== null) {
                     return value;

--- a/@here/harp-datasource-protocol/lib/operators/ObjectOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ObjectOperators.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr, Expr } from "../Expr";
 
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
@@ -33,13 +33,13 @@ function lookupMember(context: ExprEvaluatorContext, args: Expr[], lookupMode: L
 
 const operators = {
     get: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) =>
-            lookupMember(context, args, LookupMode.get)
+        call: (context: ExprEvaluatorContext, call: CallExpr) =>
+            lookupMember(context, call.args, LookupMode.get)
     },
 
     has: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) =>
-            lookupMember(context, args, LookupMode.has)
+        call: (context: ExprEvaluatorContext, call: CallExpr) =>
+            lookupMember(context, call.args, LookupMode.has)
     }
 };
 

--- a/@here/harp-datasource-protocol/lib/operators/StringOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/StringOperators.ts
@@ -4,32 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
     concat: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return "".concat(...args.map(a => String(context.evaluate(a))));
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return "".concat(...call.args.map(a => String(context.evaluate(a))));
         }
     },
 
     downcase: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return String(context.evaluate(args[0])).toLocaleLowerCase();
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return String(context.evaluate(call.args[0])).toLocaleLowerCase();
         }
     },
 
     upcase: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return String(context.evaluate(args[0])).toLocaleUpperCase();
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return String(context.evaluate(call.args[0])).toLocaleUpperCase();
         }
     },
 
     "~=": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const left = context.evaluate(args[0]);
-            const right = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const left = context.evaluate(call.args[0]);
+            const right = context.evaluate(call.args[1]);
             if (typeof left === "string" && typeof right === "string") {
                 return left.indexOf(right) !== -1;
             }
@@ -38,9 +38,9 @@ const operators = {
     },
 
     "^=": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const left = context.evaluate(args[0]);
-            const right = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const left = context.evaluate(call.args[0]);
+            const right = context.evaluate(call.args[1]);
             if (typeof left === "string" && typeof right === "string") {
                 return left.startsWith(right);
             }
@@ -49,9 +49,9 @@ const operators = {
     },
 
     "$=": {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            const left = context.evaluate(args[0]);
-            const right = context.evaluate(args[1]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const left = context.evaluate(call.args[0]);
+            const right = context.evaluate(call.args[1]);
             if (typeof left === "string" && typeof right === "string") {
                 return left.endsWith(right);
             }

--- a/@here/harp-datasource-protocol/lib/operators/TypeOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/TypeOperators.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Expr } from "../Expr";
+import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
     typeof: {
-        call: (context: ExprEvaluatorContext, args: Expr[]) => {
-            return typeof context.evaluate(args[0]);
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return typeof context.evaluate(call.args[0]);
         }
     }
 };

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -143,10 +143,10 @@ describe("Expr", function() {
                 const expr = Expr.fromJSON(["ref", "topExpr"], definitions);
                 assert.instanceOf(expr, CallExpr);
                 const callExpr = expr as CallExpr;
-                assert.equal(callExpr.children.length, 2);
+                assert.equal(callExpr.args.length, 2);
 
                 // Assert that both children of both exprs refer to exactly same expr instance.
-                assert.strictEqual(callExpr.children[0], callExpr.children[1]);
+                assert.strictEqual(callExpr.args[0], callExpr.args[1]);
             });
             it("uses definitionExprCache across calls", function() {
                 const definitions: Definitions = {


### PR DESCRIPTION
Prefer to pass the CallExpr instead of just the list of actual
arguments. This change will allow the operators to use properties
stored together with the CallExpr node. Also, it makes it possible
for evaluators to return the CallExpr node when partially evaluating
expressions.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
