### PR TITLE
HARP-5644: Support for Political Views via features environment map.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Env.ts
+++ b/@here/harp-datasource-protocol/lib/Env.ts
@@ -20,6 +20,7 @@ export interface ValueMap {
  * @hidden
  */
 export class Env {
+    constructor(readonly entries: ValueMap) {}
     /**
      * Returns property in [[Env]] by name.
      *
@@ -28,6 +29,7 @@ export class Env {
     lookup(_name: string): Value | undefined {
         return undefined;
     }
+
     /**
      * Return an object containing all properties of this environment. (Here: empty object).
      */
@@ -41,8 +43,9 @@ export class Env {
  */
 export class MapEnv extends Env {
     constructor(readonly entries: ValueMap, private readonly parent?: Env) {
-        super();
+        super(entries);
     }
+
     /**
      * Returns property in [[Env]] by name.
      *
@@ -69,5 +72,94 @@ export class MapEnv extends Env {
             }
         }
         return obj;
+    }
+}
+
+export type LocaleMap = Map<string, string>;
+
+/**
+ * Allows access to map specific environment properties with support for localization.
+ */
+export class MapLocalEnv extends MapEnv {
+    /**
+     * Map that contains localized properties names with requested localization (country code).
+     */
+    private readonly m_locale: LocaleMap;
+
+    constructor(entries: ValueMap, parent?: Env | undefined, locale?: LocaleMap | undefined) {
+        super(entries, parent);
+        this.m_locale = locale === undefined ? new Map<string, string>() : locale;
+    }
+
+    /**
+     * Setup environment to prioritize localized properties before generic ones.
+     *
+     * @note Some map features may have properties defined in _localized_ and _generic_
+     * version. The _localized_ attribute may hold for example name of the place in
+     * country specific language, but it may be also the variable property that is
+     * specific only for certain country point of view.
+     * For example some country borders may be disputed by general community, while totally
+     * accepted or claimed by some certain countries, depending on their political point of
+     * view.
+     * @see [ISO_3166-1_alfa-2|https://pl.wikipedia.org/wiki/ISO_3166-1_alfa-2] for more
+     * info about supported country codes.
+     * @param propertyName The name of property to be localized.
+     * @param countryCode The country code in ISO 3166-1 alfa-2 format (two letters).
+     */
+    setLocale(propertyName: string, countryCode: string): void {
+        // TODO: Hold compound property in form `${name}:${country}`,
+        // which may greatly improve performance - no string object
+        // creation at each lookup.
+        this.m_locale.set(propertyName, countryCode);
+    }
+
+    /**
+     * Unset localization for certain property name.
+     *
+     * @param propertyName The name of property that was localized.
+     * @return [[true]] if property was localized, false if not.
+     */
+    unsetLocale(propertyName: string): boolean {
+        return this.m_locale.delete(propertyName);
+    }
+
+    /**
+     * Remove all properties localization.
+     *
+     * Only generic values of properties will be returned on [[lookup]], thus
+     * from now on class will behave like simple [[MapEnv]] object.
+     */
+    clearLocale(): void {
+        this.m_locale.clear();
+    }
+
+    /**
+     * Returns localized property in [[Env]] using its name and optional country posix.
+     *
+     * This method supports properties localization via optional country posix that may
+     * be added to property in format [[name]]:__country__. If localized property
+     * is not available or property is not requested for localization returns its generic
+     * value identified simply by [[name]].
+     *
+     * @param name Name of property.
+     */
+    lookup(name: string): Value | undefined {
+        const country: string | undefined = this.m_locale.get(name);
+        if (country !== undefined) {
+            const localProp = super.lookup(`${name}:${country}`);
+            if (localProp !== undefined) {
+                return localProp;
+            }
+        }
+        return super.lookup(name);
+    }
+
+    /**
+     * Return an object containing all properties of this environment, takes care of the parent
+     * object.
+     */
+    unmap(): ValueMap {
+        // TODO: Consider replacing localized properties
+        return super.unmap();
     }
 }

--- a/@here/harp-datasource-protocol/lib/ITileDecoder.ts
+++ b/@here/harp-datasource-protocol/lib/ITileDecoder.ts
@@ -60,12 +60,14 @@ export interface ITileDecoder {
      * @param styleSet optional, new style set.
      * @param definitions optional, definitions used to resolve references in `styleSet`
      * @param languages optional, language list
+     * @param politicalView optional, political point of view (country code in ISO 3166-1 alfa-2)
      * @param options optional, new options - shape is specific for each decoder
      */
     configure(
         styleSet?: StyleSet,
         definitions?: Definitions,
         languages?: string[],
+        politicalView?: string,
         options?: OptionsMap
     ): void;
 

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -317,7 +317,7 @@ export class StyleSetEvaluator {
     private readonly m_definitions?: Definitions;
     private readonly m_definitionExprCache = new Map<string, Expr>();
     private readonly m_tmpOptimizedSubSetKey: OptimizedSubSetKey = new OptimizedSubSetKey();
-    private readonly m_emptyEnv = new Env();
+    private readonly m_emptyEnv = new Env({});
     private m_layer: string | undefined;
     private m_geometryType: string | undefined;
 

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -5,7 +5,7 @@
  */
 
 import { LoggerManager } from "@here/harp-utils";
-import { Env, Expr, ExprScope, MapEnv, Value } from "./Expr";
+import { Env, Expr, ExprScope, Value } from "./Expr";
 import { getPropertyValue, isInterpolatedProperty } from "./InterpolatedProperty";
 import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
 
@@ -15,7 +15,7 @@ export interface AttrEvaluationContext {
     /**
      * Expression evaluation environment containing variable bindings.
      */
-    env: MapEnv;
+    env: Env;
 
     /**
      * Storage level of tile containing this feature.

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -1088,7 +1088,7 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
 
     /**
      * Default color used if feature doesn't provide color attribute
-     * and [[MapEnv]] did not return it too.
+     * and [[Env]] did not return it too.
      * @format color-hex
      */
     defaultColor?: DynamicProperty<StyleColor>;

--- a/@here/harp-datasource-protocol/lib/TileInfo.ts
+++ b/@here/harp-datasource-protocol/lib/TileInfo.ts
@@ -6,7 +6,7 @@
 import { TileKey } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 
-import { Env, MapEnv, Value } from "./Expr";
+import { Env, Value } from "./Expr";
 import { makeDecodedTechnique } from "./StyleSetEvaluator";
 import { AttrEvaluationContext, evaluateTechniqueAttr } from "./TechniqueAttr";
 import {
@@ -560,7 +560,7 @@ export class ExtendedTileInfoWriter {
      */
     addFeature(
         featureGroup: FeatureGroup,
-        env: MapEnv,
+        env: Env,
         featureId: number | undefined,
         featureText: string | undefined,
         infoTileTechniqueIndex: number,

--- a/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
@@ -75,6 +75,7 @@ export namespace WorkerDecoderProtocol {
         definitions?: Definitions;
         options?: OptionsMap;
         languages?: string[];
+        politicalView?: string;
     }
 
     /**

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -20,7 +20,7 @@ function evaluate(expr: string | JsonExpr | Expr, env?: Env | ValueMap): Value {
         : typeof expr === "string"
         ? Expr.parse(expr)
         : Expr.fromJSON(expr)
-    ).evaluate(env || new Env());
+    ).evaluate(env || new Env({}));
 }
 
 describe("Expr", function() {

--- a/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
+++ b/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
@@ -24,6 +24,7 @@ import { Projection, TileKey } from "@here/harp-geoutils";
  */
 export abstract class ThemedTileDecoder implements ITileDecoder {
     languages?: string[];
+    politicalView?: string;
     m_storageLevelOffset: number = 0;
 
     protected m_styleSetEvaluator?: StyleSetEvaluator;
@@ -59,6 +60,7 @@ export abstract class ThemedTileDecoder implements ITileDecoder {
         styleSet?: StyleSet,
         definitions?: Definitions,
         languages?: string[],
+        politicalView?: string,
         options?: OptionsMap
     ): void {
         if (styleSet !== undefined) {
@@ -66,6 +68,9 @@ export abstract class ThemedTileDecoder implements ITileDecoder {
         }
         if (languages !== undefined) {
             this.languages = languages;
+        }
+        if (politicalView !== undefined) {
+            this.politicalView = politicalView;
         }
         if (options !== undefined && options.storageLevelOffset !== undefined) {
             this.m_storageLevelOffset = options.storageLevelOffset;

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -198,7 +198,7 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
         await Promise.all([this.m_options.dataProvider.connect(), this.m_decoder.connect()]);
         this.m_isReady = true;
 
-        this.m_decoder.configure(undefined, undefined, undefined, {
+        this.m_decoder.configure(undefined, undefined, undefined, undefined, {
             storageLevelOffset: this.m_options.storageLevelOffset
         });
     }

--- a/@here/harp-mapview-decoder/lib/TileDecoderService.ts
+++ b/@here/harp-mapview-decoder/lib/TileDecoderService.ts
@@ -141,6 +141,7 @@ export class TileDecoderService extends WorkerService {
             message.styleSet,
             message.definitions,
             message.languages,
+            message.politicalView,
             message.options
         );
     }

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -240,6 +240,17 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
+     * Used to express different country point of view (political view).
+     *
+     * @note Set to __undefined__ if you want to reset to default point of view.
+     * @param pov The country code which point of view should be presented in ISO 3166-1 alpha-2
+     * format.
+     */
+    setPoliticalView(pov?: string): void {
+        // to be overloaded by subclasses
+    }
+
+    /**
      * This method is called when [[MapView]] needs to visualize or preload the content of a
      * [[TileKey]].
      *

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -769,6 +769,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_thisFrameTilesChanged: boolean | undefined;
     private m_lastTileIds: string = "";
     private m_languages: string[] | undefined;
+    private m_politicalView: string | undefined;
     private m_copyrightInfo: CopyrightInfo[] = [];
     private m_animatedExtrusionHandler: AnimatedExtrusionHandler;
 
@@ -857,6 +858,7 @@ export class MapView extends THREE.EventDispatcher {
         this.m_options.enableStatistics = this.m_options.enableStatistics === true;
 
         this.m_languages = this.m_options.languages;
+        this.m_politicalView = undefined;
 
         if (
             !isProduction &&
@@ -1303,6 +1305,31 @@ export class MapView extends THREE.EventDispatcher {
         this.m_tileDataSources.forEach((dataSource: DataSource) => {
             dataSource.setLanguages(this.m_languages);
         });
+        this.update();
+    }
+
+    /**
+     * Get currently presented political point of view - the country code.
+     *
+     * @return Country code in ISO 3166-1 alpha-2 standard or null if majorly
+     * accepted (default) point of view is used.
+     */
+    get politicalView(): string | undefined {
+        return this.m_politicalView;
+    }
+
+    /**
+     * Set the point of view to be used when rendering disputed features.
+     *
+     * @param pov The code of country which point of view should be presented or
+     * null if default (commonly accepted) point of view should be set.
+     */
+    set politicalView(pov: string | undefined) {
+        this.m_politicalView = pov;
+        this.m_tileDataSources.forEach((dataSource: DataSource) => {
+            dataSource.setPoliticalView(pov);
+        });
+        this.clearTileCache();
         this.update();
     }
 

--- a/@here/harp-mapview/lib/WorkerBasedDecoder.ts
+++ b/@here/harp-mapview/lib/WorkerBasedDecoder.ts
@@ -161,6 +161,7 @@ export class WorkerBasedDecoder implements ITileDecoder {
         styleSet?: StyleSet,
         definitions?: Definitions,
         languages?: string[],
+        politicalView?: string,
         options?: OptionsMap
     ): void {
         const message: WorkerDecoderProtocol.ConfigurationMessage = {
@@ -169,7 +170,8 @@ export class WorkerBasedDecoder implements ITileDecoder {
             styleSet,
             definitions,
             options,
-            languages
+            languages,
+            politicalView
         };
 
         this.workerSet.broadcastMessage(message);

--- a/@here/harp-omv-datasource/lib/IEnvironmentProcessor.ts
+++ b/@here/harp-omv-datasource/lib/IEnvironmentProcessor.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Env, ValueMap } from "@here/harp-datasource-protocol/index-decoder";
+
+/**
+ * The [[IEnvironmentProcessor]] is used to create features environment (attributes set) encoded in
+ * OMV tiles.
+ *
+ * [[OmvDecoder]] will pass to the factory methods of the concrete implementations
+ * of this interface.
+ *
+ * The methods of concrete implementations of [[IEnvironmentProcessor]] are called to process point,
+ * line and polygon geometries, see [[OmvDecoder]].
+ */
+export interface IEnvironmentProcessor {
+    createFeatureEnvironment(attributes: ValueMap, parent?: Env): Env;
+}

--- a/@here/harp-omv-datasource/lib/IGeometryProcessor.ts
+++ b/@here/harp-omv-datasource/lib/IGeometryProcessor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { Env } from "@here/harp-datasource-protocol/index-decoder";
 import { Vector2 } from "three";
 
 /**
@@ -71,7 +71,7 @@ export interface IGeometryProcessor {
         layerName: string,
         layerExtents: number,
         geometry: Vector2[],
-        env: MapEnv,
+        env: Env,
         storageLevel: number
     ): void;
 
@@ -90,7 +90,7 @@ export interface IGeometryProcessor {
         layerName: string,
         layerExtents: number,
         geometry: ILineGeometry[],
-        env: MapEnv,
+        env: Env,
         storageLevel: number
     ): void;
 
@@ -109,7 +109,7 @@ export interface IGeometryProcessor {
         layerName: string,
         layerExtents: number,
         geometry: IPolygonGeometry[],
-        env: MapEnv,
+        env: Env,
         storageLevel: number
     ): void;
 }

--- a/@here/harp-omv-datasource/lib/OmvDataFilter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataFilter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { GeometryKind, GeometryKindSet } from "@here/harp-datasource-protocol";
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { Env } from "@here/harp-datasource-protocol/index-decoder";
 import {
     OmvFeatureFilterDescription,
     OmvFilterDescription,
@@ -93,7 +93,7 @@ export interface OmvFeatureModifier {
      * @param level Level of tile.
      * @returns `false` to ignore feature.
      */
-    doProcessPointFeature(layer: string, env: MapEnv, level: number): boolean;
+    doProcessPointFeature(layer: string, env: Env, level: number): boolean;
 
     /**
      * Check if the line feature described by `env` should be processed. The properties can be
@@ -104,7 +104,7 @@ export interface OmvFeatureModifier {
      * @param level Level of tile.
      * @returns `false` to ignore feature.
      */
-    doProcessLineFeature(layer: string, env: MapEnv, level: number): boolean;
+    doProcessLineFeature(layer: string, env: Env, level: number): boolean;
 
     /**
      * Check if the polygon feature described by `env` should be processed. The properties can be
@@ -115,7 +115,7 @@ export interface OmvFeatureModifier {
      * @param level Level of tile.
      * @returns `false` to ignore feature.
      */
-    doProcessPolygonFeature(layer: string, env: MapEnv, level: number): boolean;
+    doProcessPolygonFeature(layer: string, env: Env, level: number): boolean;
 }
 
 /**
@@ -752,7 +752,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         return false;
     }
 
-    static matchAttribute(layerName: string, env: MapEnv, items: OmvFilterDescription[]): boolean {
+    static matchAttribute(layerName: string, env: Env, items: OmvFilterDescription[]): boolean {
         for (const item of items) {
             if (item.featureAttribute !== undefined) {
                 if (
@@ -768,7 +768,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
 
     constructor(private description: OmvFeatureFilterDescription) {}
 
-    doProcessPointFeature(layer: string, env: MapEnv): boolean {
+    doProcessPointFeature(layer: string, env: Env): boolean {
         return this.doProcessFeature(
             this.description.pointsToProcess,
             this.description.pointsToIgnore,
@@ -778,7 +778,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         );
     }
 
-    doProcessLineFeature(layer: string, env: MapEnv): boolean {
+    doProcessLineFeature(layer: string, env: Env): boolean {
         return this.doProcessFeature(
             this.description.linesToProcess,
             this.description.linesToIgnore,
@@ -788,7 +788,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         );
     }
 
-    doProcessPolygonFeature(layer: string, env: MapEnv): boolean {
+    doProcessPolygonFeature(layer: string, env: Env): boolean {
         return this.doProcessFeature(
             this.description.polygonsToProcess,
             this.description.polygonsToIgnore,
@@ -802,7 +802,7 @@ export class OmvGenericFeatureModifier implements OmvFeatureModifier {
         itemsToProcess: OmvFilterDescription[],
         itemsToIgnore: OmvFilterDescription[],
         layer: string,
-        env: MapEnv,
+        env: Env,
         defaultResult: boolean
     ): boolean {
         if (layer === undefined || (itemsToProcess.length === 0 && itemsToIgnore.length === 0)) {

--- a/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
@@ -12,7 +12,11 @@ export enum FeatureModifierId {
     /**
      * Identifier to use the OmvTomTomFeatureModifier in the OmvDecoder.
      */
-    tomTom
+    tomTom,
+    /**
+     * Identifies modifier used to support different political points of view.
+     */
+    pointOfView
 }
 
 /**
@@ -175,6 +179,12 @@ export interface OmvDecoderOptions {
      * used.
      */
     featureModifierId?: FeatureModifierId;
+
+    /**
+     * Country code in ISO 3166-1 alpha-2 format defining optional point of view to be used.
+     * Set to __undefined__ if you want to revert to default point of view.
+     */
+    politicalView?: string;
 
     enableElevationOverlay?: boolean;
 }

--- a/@here/harp-omv-datasource/lib/OmvTomTomFeatureModifier.ts
+++ b/@here/harp-omv-datasource/lib/OmvTomTomFeatureModifier.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+import { Env } from "@here/harp-datasource-protocol/index-decoder";
 import { LoggerManager } from "@here/harp-utils";
 import { OmvGenericFeatureModifier } from "./OmvDataFilter";
 import { OmvFeatureFilterDescription, OmvFilterDescription } from "./OmvDecoderDefs";
@@ -17,7 +17,7 @@ const DEFAULT_BUILDING_MIN_HEIGHT = "2";
 const DEFAULT_BUILDING_HEIGHT = "20";
 
 /**
- * Modifies the MapEnv of the TomTom Vector Tiles to be similar to the OMV format, so that the same
+ * Modifies the Env of the TomTom Vector Tiles to be similar to the OMV format, so that the same
  * theme files can be used.
  */
 export class OmvTomTomFeatureModifier extends OmvGenericFeatureModifier {
@@ -29,7 +29,7 @@ export class OmvTomTomFeatureModifier extends OmvGenericFeatureModifier {
         itemsToProcess: OmvFilterDescription[],
         itemsToIgnore: OmvFilterDescription[],
         layer: string,
-        env: MapEnv,
+        env: Env,
         defaultResult: boolean
     ): boolean {
         this.rewriteEnvironment(layer, env);
@@ -46,7 +46,7 @@ export class OmvTomTomFeatureModifier extends OmvGenericFeatureModifier {
      * @param layer
      * @param env
      */
-    private rewriteEnvironment(layer: string, env: MapEnv) {
+    private rewriteEnvironment(layer: string, env: Env) {
         // Rewriting landuse layers
         if (this.isWood(layer)) {
             this.updateEnvironment(env, "landuse", "wood");
@@ -125,7 +125,7 @@ export class OmvTomTomFeatureModifier extends OmvGenericFeatureModifier {
     }
 
     private updateEnvironment(
-        env: MapEnv,
+        env: Env,
         layer: string,
         newClass?: string,
         structure?: string

--- a/@here/harp-omv-datasource/test/OmvTest.ts
+++ b/@here/harp-omv-datasource/test/OmvTest.ts
@@ -17,7 +17,7 @@ import {
     OmvGeometryType
 } from "../index";
 
-import { MapEnv, Value } from "@here/harp-datasource-protocol/index-decoder";
+import { Env, MapEnv, Value } from "@here/harp-datasource-protocol/index-decoder";
 import { assert } from "chai";
 
 /**
@@ -57,11 +57,11 @@ export class RoadFilter implements OmvFeatureFilter {
 }
 
 export class RoadFeatureFilter implements OmvFeatureModifier {
-    doProcessPointFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPointFeature(_layer: string, _env: Env): boolean {
         return false;
     }
 
-    doProcessLineFeature(_layer: string, env: MapEnv): boolean {
+    doProcessLineFeature(_layer: string, env: Env): boolean {
         const roadClass = env.lookup("class");
         const isRoad =
             roadClass !== undefined &&
@@ -70,23 +70,23 @@ export class RoadFeatureFilter implements OmvFeatureModifier {
         return isRoad;
     }
 
-    doProcessPolygonFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPolygonFeature(_layer: string, _env: Env): boolean {
         return false;
     }
 }
 
 export class RoadsToRailroads implements OmvFeatureModifier {
-    doProcessPointFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPointFeature(_layer: string, _env: Env): boolean {
         return false;
     }
 
-    doProcessLineFeature(_layer: string, env: MapEnv): boolean {
+    doProcessLineFeature(_layer: string, env: Env): boolean {
         // turn all roads into railroads
         env.entries.class = "major_rail";
         return true;
     }
 
-    doProcessPolygonFeature(_layer: string, _env: MapEnv): boolean {
+    doProcessPolygonFeature(_layer: string, _env: Env): boolean {
         return false;
     }
 }

--- a/test/performance/OmvDecoderPerformanceTest.ts
+++ b/test/performance/OmvDecoderPerformanceTest.ts
@@ -9,11 +9,17 @@
 import { assert } from "chai";
 
 import { Theme } from "@here/harp-datasource-protocol";
-import { MapEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+import {
+    Env,
+    MapEnv,
+    StyleSetEvaluator,
+    ValueMap
+} from "@here/harp-datasource-protocol/index-decoder";
 import { accessToken } from "@here/harp-examples/config";
 import { sphereProjection, TileKey, webMercatorProjection } from "@here/harp-geoutils";
 import { ThemeLoader } from "@here/harp-mapview";
 import { APIFormat, OmvRestClient, OmvRestClientParameters } from "@here/harp-omv-datasource";
+import { IEnvironmentProcessor } from "@here/harp-omv-datasource/lib/IEnvironmentProcessor";
 import {
     IGeometryProcessor,
     ILineGeometry,
@@ -128,9 +134,19 @@ export function createOMVDecoderPerformanceTest(
                 }
             };
 
+            const environmentProcessor: IEnvironmentProcessor = {
+                createFeatureEnvironment(attributes: ValueMap, parent?: Env): Env {
+                    return new MapEnv(attributes, parent);
+                }
+            };
+
             await measurePerformanceSync(counterName, repeats, function() {
                 for (const [tileKey, tileData] of omvTiles) {
-                    const decoder = new OmvProtobufDataAdapter(geometryProcessor, undefined);
+                    const decoder = new OmvProtobufDataAdapter(
+                        geometryProcessor,
+                        environmentProcessor,
+                        undefined
+                    );
                     decoder.process(tileData, tileKey);
                 }
             });


### PR DESCRIPTION
When different political view is requested, special implementation of
Feature Env (environment) is initialized that allows to access localized
attributes - attributes with posix in from of ":xx", where "xx" denotes
country code. The special (localized) environment exposes such local
attributes instead of general ones, for example:
- border lines with "kind" attributes are accessed according to different
point of view (by country), i.e. replacing generic "kind" with a contents
of "kind:xx" with a given point of view.
- features "name" atributes may be translated according to localized name
with "name:xx".

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
