### PR TITLE
MINOR: Fix the building animation going through ground.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -1507,8 +1507,7 @@ export class TileGeometryCreator {
         // TODO cache the material HARP-4207
         const material = new MapMeshBasicMaterial({
             color: colorHex,
-            visible: isVisible,
-            depthWrite: false
+            visible: isVisible
         });
         const plane = new THREE.Mesh(geometry, material);
         plane.position.copy(planeCenter);

--- a/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
@@ -12,7 +12,10 @@ uniform float extrusionRatio;
 varying vec4 vExtrusionAxis;
 `,
     extrusion_vertex: `
-transformed = transformed - extrusionAxis.xyz + extrusionAxis.xyz * extrusionRatio;
+// animate only if the point is above the ground
+if(dot(position,vec3(extrusionAxis))>0.0){
+    transformed = transformed + extrusionAxis.xyz * (extrusionRatio - 1.0);
+}
 vExtrusionAxis = vec4(normalMatrix * extrusionAxis.xyz, extrusionAxis.w);
 `,
     // Modified version of THREE <normal_fragment_begin> shader chunk which, for flat shaded


### PR DESCRIPTION
This PR fixes the building animation going through the ground. It was not visible at implementation time because the background plane was writing depth, then the style handling broke the animation while the `depthWrite: false` was implemented. 

Now, first the `depthWrite: false` is not necessary for the webtiles and the satellite tiles apparently, this PR removes it. It also computes the `altitude` of the vertices of extruded polygons and animates the extrusion only if the altitude is not `0`, that is, if it is the top of the shape being rendered. This way the bottom of the polygons isn't animated.