### PR TITLE
MINOR: ClipPlanesEvaluators uses relative margin between planes.

### DIFF
--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -20,7 +20,7 @@ export interface ClipPlanesEvaluator {
     minElevation: number;
 
     /**
-     * Set maximum elevation to be rendered, values above sea level are possitive.
+     * Set maximum elevation to be rendered, values above sea level are positive.
      */
     maxElevation: number;
 
@@ -31,7 +31,7 @@ export interface ClipPlanesEvaluator {
      * This is related to evaluator implementation and its input data, that may suddenly change
      * such as camera position or angle, projection type or so.
      * Some evaluators may not depend on all or even any of input objects, but to preserve
-     * compatibility with any evaluator type it is strongly reccomended to update on every frame.
+     * compatibility with any evaluator type it is strongly recommended to update on every frame.
      * @param mapView The [[MapView]] in use.
      * @note Camera clipping planes aren't automatically updated via #evaluateClipPlanes()
      * call, user should do it manually if needed.
@@ -43,15 +43,15 @@ export interface ClipPlanesEvaluator {
  * Simplest camera clip planes evaluator, interpolates near/far planes based on ground distance.
  *
  * At general ground distance to camera along the surface normal is used as reference point for
- * planes evaluation, where near plane distance is set as fraction of this distance refered as
+ * planes evaluation, where near plane distance is set as fraction of this distance refereed as
  * [[nearMultiplier]]. Far plane equation has its own multiplier - [[nearFarMultiplier]],
  * which is applied to near plane and offset giving finally far plane distance.
- * This evaluator supports both planar and spherical projections, although it's behaviour is
+ * This evaluator supports both planar and spherical projections, although it's behavior is
  * slightly different in each case. General algorithm sets near plane between camera and
  * ground level, while far plane is just calculated using scale and bias approach with far offset
  * and multiplier.
  * @deprecated Class contains the legacy (first and original) clip planes evaluation method, which
- * is widelly used in examples thus is still kept for backward compatibility and comparisons.
+ * is widely used in examples thus is still kept for backward compatibility and comparisons.
  */
 export class InterpolatedClipPlanesEvaluator implements ClipPlanesEvaluator {
     readonly farMin: number;
@@ -108,7 +108,7 @@ export class InterpolatedClipPlanesEvaluator implements ClipPlanesEvaluator {
             );
             // Setup quaternion based on X axis.
             this.m_tmpQuaternion.setFromAxisAngle(this.m_tmpVectors[0], alpha);
-            // Aquire forward vector based on Z axis reversed (keep it in tmpVectors[2]).
+            // Acquire forward vector based on Z axis reversed (keep it in tmpVectors[2]).
             const fwd = this.m_tmpVectors[2].negate();
             // Apply quaternion rotation to forward vector, store it in tmpVectors[1].
             const fwdRot = this.m_tmpVectors[1].copy(fwd).applyQuaternion(this.m_tmpQuaternion);
@@ -126,7 +126,7 @@ export class InterpolatedClipPlanesEvaluator implements ClipPlanesEvaluator {
             // Will be already clamped to minFar due to clamping above.
             farPlane = nearPlane * this.nearFarMultiplier + this.farOffset;
         } else {
-            assert(false, "Unsuported projection type");
+            assert(false, "Unsupported projection type");
         }
 
         const viewRanges: ViewRanges = {
@@ -168,7 +168,7 @@ export abstract class ElevationBasedClipPlanesEvaluator implements ClipPlanesEva
      * bit offset to your assumed maximum elevation.
      * @note Reasonable values are in between (-DeadSeeDepression, MtEverestHeight>, both values
      * are defined in [[EarthConstant]] as [[EarthConstant.MIN_ELEVATION]] and
-     * [[EarthConstant.MAX_ELEVATION]] respectivelly.
+     * [[EarthConstant.MAX_ELEVATION]] respectively.
      * @see minElevation for more information about precision and rounding errors.
      */
     set maxElevation(elevation: number) {
@@ -191,7 +191,7 @@ export abstract class ElevationBasedClipPlanesEvaluator implements ClipPlanesEva
      * @note If you set this parameter to zero you may not see any features rendered if they are
      * just below the sea level more then half of [[nearFarMargin]] assumed. Similarly if set to
      * -100m and rendered features lays exactly in such depression, you may notice that problem.
-     * The errors ussually come from projection precision loss and depth buffer nature (significant
+     * The errors usually come from projection precision loss and depth buffer nature (significant
      * precision loss closer to far plane). Thus is such cases either increase the margin (if you
      * are sure features are just at this elevation, or setup bigger offset for [[minElevation]].
      * Reasonable values are between <-DeadSeaDepression, MtEverestHeight), where the first denotes
@@ -216,7 +216,7 @@ export abstract class ElevationBasedClipPlanesEvaluator implements ClipPlanesEva
 /**
  * Top view, clip planes evaluator that computes view ranges based on ground distance and elevation.
  *
- * This evaluator supports both planar and spherical projections, although it behaviour is
+ * This evaluator supports both planar and spherical projections, although it behavior is
  * slightly different in each case. General algorithm sets near plane and far plane close
  * to ground level, but taking into account maximum and minimum elevation of features on the ground.
  *
@@ -251,10 +251,10 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
      * @param minElevation defines far plane offset from the ground surface, negative values moves
      * far plane below the ground level (use it to render depressions). Default zero - sea level.
      * @param nearMin minimum allowable near plane distance from camera, must be bigger then zero.
-     * @param nearFarMargin minimum distance between near and far plane, have to be significantly
-     * bigger then zero (especially if [[maxElevation]], [[minElevation]] are equal), otherwise you
-     * may notice flickering during rendering, or even render empty scene if frustum planes are
-     * almost equal.
+     * @param nearFarMarginRatio minimum distance between near and far plane, as a ratio of near
+     * plane distance, it have to be significantly bigger then zero (especially if [[maxElevation]],
+     * [[minElevation]] are equal), otherwise you may notice flickering during rendering, or even
+     * render empty scene if frustum planes are almost equal.
      * @param farMaxRatio maximum ratio between ground and far plane distance, allows to limit
      * viewing distance at overall. Have to be bigger then 1.0.
      * @note Keep in mind that this evaluator does not evaluate terrain (or building) elevation
@@ -263,24 +263,25 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
      * repeating [[evaluatePlanes]] step, if your camera is moving you need to evaluate planes
      * anyway.
      * @note You may treat [[minElevation]] and [[maxElevation]] parameters as the maximum and
-     * minimum renderable elevation respectivelly along the surface normal, when camera is
+     * minimum renderable elevation respectively along the surface normal, when camera is
      * constantly looking downwards (top-down view). If you need [[ClipPlanesEvaluator]] for
      * cameras that support tilt or yaw please use [[TiltViewClipPlanesEvaluator]].
      * @note [[nearFarMaxRatio]] does not limit far plane when spherical projection is in use,
      * the algorithm used there estimates distance to point on tangent where line from camera
-     * touches the sphere horizont and there is no reason to clamp it.
+     * touches the sphere horizon and there is no reason to clamp it.
      */
     constructor(
         maxElevation: number = EarthConstants.MAX_BUILDING_HEIGHT,
         minElevation: number = 0,
         readonly nearMin: number = 1.0,
-        readonly nearFarMargin: number = 10.0,
+        readonly nearFarMarginRatio: number = 0.01,
         readonly farMaxRatio = 1.8
     ) {
         super(maxElevation, minElevation);
         assert(nearMin > 0);
-        assert(nearFarMargin > epsilon);
+        assert(nearFarMarginRatio > epsilon);
         assert(farMaxRatio > 1.0);
+        const nearFarMargin = nearFarMarginRatio * nearMin;
         this.m_minimumViewRange = {
             near: nearMin,
             far: nearMin + nearFarMargin,
@@ -295,7 +296,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
         } else if (mapView.projection.type === ProjectionType.Planar) {
             return this.evaluateDistancePlanarProj(mapView.camera, mapView.projection);
         }
-        assert(false, "Unsuported projection type");
+        assert(false, "Unsupported projection type");
         return { ...this.minimumViewRange };
     }
 
@@ -308,7 +309,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
     }
 
     /**
-     * Calculate camera altitute (closest distance) to ground level in world units.
+     * Calculate camera altitude (closest distance) to ground level in world units.
      * @param camera
      * @param projection
      */
@@ -332,9 +333,10 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
         farPlane = groundDistance - this.minElevation;
 
         // Apply the constraints.
-        nearPlane = Math.max(nearPlane - this.nearFarMargin / 2, this.nearMin);
+        const nearFarMargin = this.nearFarMarginRatio * nearPlane;
+        nearPlane = Math.max(nearPlane - nearFarMargin / 2, this.nearMin);
         farPlane = Math.min(farPlane, farMax);
-        farPlane = Math.max(farPlane + this.nearFarMargin / 2, nearPlane + this.nearFarMargin);
+        farPlane = Math.max(farPlane + nearFarMargin / 2, nearPlane + nearFarMargin);
 
         const viewRanges: ViewRanges = {
             near: nearPlane,
@@ -391,7 +393,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
             // The far plane distance calculus requires finding the sphere tangent line that is
             // co-linear with (goes thru) camera position, such tangent creates right angle
             // with sphere diameter where it touches its surface (point T). Given that sphere is
-            // always at world orgin and camera orbits around it we have:
+            // always at world origin and camera orbits around it we have:
             // angle(OTC) = 90
             // sin(OCT) = sin(alpha) = r / d
             // alpha = asin(r / d)
@@ -408,7 +410,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
             // te = sqrt(r^2 + 2*r*e + e^2 - r^2)
             // te = sqrt(2*r*e + e^2)
             // There may be situations when maximum elevation still remains below sea level (< 0) or
-            // it is neglible, in such cases tangent extension (te) is not required.
+            // it is negligible, in such cases tangent extension (te) is not required.
             const te =
                 this.maxElevation < epsilon
                     ? 0
@@ -427,7 +429,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
             );
             // Setup quaternion (based on X axis) for angle between tangent and camera eye.
             this.m_tmpQuaternion.setFromAxisAngle(this.m_tmpVectors[0], alpha);
-            // Aquire camera (eye) forward vector from Z axis reversed (keep it in tmpVectors[2]).
+            // Acquire camera (eye) forward vector from Z axis reversed (keep it in tmpVectors[2]).
             const cameraFwdVec = this.m_tmpVectors[2].negate();
             // Apply quaternion to forward vector, creating tangent vector (store in tmpVectors[1]).
             const tangentVec = this.m_tmpVectors[1]
@@ -435,7 +437,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
                 .applyQuaternion(this.m_tmpQuaternion);
             // Give it a proper length
             tangentVec.multiplyScalar(t + te);
-            // Calculate tanget projection onto camera eye vector, giving far plane distance.
+            // Calculate tangent projection onto camera eye vector, giving far plane distance.
             farPlane = tangentVec.dot(cameraFwdVec);
         }
         // Orthographic camera projection
@@ -463,7 +465,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
             // based on the right triangle:
             // (r+maxElev)^2 = r^2 + te^2
             // te = sqrt((r+maxElev)^2 - r^2)
-            // although we may not calculate it if elevation is neglible:
+            // although we may not calculate it if elevation is negligible:
             const te =
                 this.maxElevation < epsilon
                     ? 0
@@ -474,11 +476,12 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
             // lines are parallel to camera look at vector.
         }
         // Apply the constraints.
-        nearPlane = Math.max(nearPlane - this.nearFarMargin / 2, this.nearMin);
+        const nearFarMargin = this.nearFarMarginRatio * nearPlane;
+        nearPlane = Math.max(nearPlane - nearFarMargin / 2, this.nearMin);
         // In extreme cases the largest depression assumed may be further then tangent
         // based far plane distance, take it into account
         farPlane = Math.max(farPlane, cameraAltitude - this.minElevation);
-        farPlane = Math.max(farPlane + this.nearFarMargin / 2, nearPlane + this.nearFarMargin);
+        farPlane = Math.max(farPlane + nearFarMargin / 2, nearPlane + nearFarMargin);
 
         const viewRanges: ViewRanges = {
             near: nearPlane,
@@ -509,20 +512,20 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         } else if (mapView.projection.type === ProjectionType.Planar) {
             return this.evaluatePlanarProj(mapView);
         }
-        assert(false, "Unsuported projection type");
+        assert(false, "Unsupported projection type");
         return { ...this.minimumViewRange };
     }
 
     /**
      * Calculate the camera distance to the ground in direction of look at vector.
-     * This is not equivalent to camera altitute cause value will change according to look at
+     * This is not equivalent to camera altitude cause value will change according to look at
      * direction. It simply measures the distance of intersection point between ray from
      * camera and ground level, yet without taking into account terrain elevation nor buildings.
      * @param camera
      * @param projection
      * @note Use with extreme care cause due to optimizations the internal temporary vectors
-     * are used (m_tmpVectors[0], m_tmpVectors[1]). Thoose should not be used in outlining
-     * function scope (calle).
+     * are used (m_tmpVectors[0], m_tmpVectors[1]). Those should not be used in outlining
+     * function scope (caller).
      */
     protected getCameraLookAtDistance(camera: THREE.Camera, projection: Projection): number {
         assert(projection.type !== ProjectionType.Spherical);
@@ -578,10 +581,10 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // - z1 == z2 == z, for perspective camera all planes origin its the same
         // - a is a right angle.
         // - e is the look at vector of the camera.
-        // - t and b are the frustum planes of the camera (top and bottom respectivelly).
+        // - t and b are the frustum planes of the camera (top and bottom respectively).
         // - angle between c1 to c2 is the fov.
         // - c1, c2 - vectors from camera to the ground along frustum planes.
-        // - angles between c1 and e or e and c2 splits fov on equal halfs.
+        // - angles between c1 and e or e and c2 splits fov on equal halves.
         // - d1 and d2 are the intersection points of the frustum with the world/ground plane.
         // - angle between z and e is the pitch of the camera.
         // - angle between g and e is the tilt angle.
@@ -591,7 +594,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // plane.
         // This are the distances from C->D1 and C->D2, and are described as
         // c1 and c2. Then we may compensate/correct those distances with actual
-        // ground elevations, which is done by simply offseting camera altitude, as it is
+        // ground elevations, which is done by simply offsetting camera altitude, as it is
         // opposite to elevating ground level.
         const halfPiLimit = Math.PI / 2 - epsilon;
         const cameraAltitude = this.getCameraAltitude(mapView.camera, mapView.projection);
@@ -632,7 +635,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
             // the top/bottom planes are simply parallel to the eye vector:
             topAngleRad = bottomAngleRad = cameraTilt;
             // Although the ray origin is not always the same (eye position) as for
-            // the perspective projections, thus we need to compensate for otrho-cube
+            // the perspective projections, thus we need to compensate for ortho-cube
             // dimensions:
             // sin(tilt) = zc2 / top
             // sin(tilt) = zc1 / bottom
@@ -667,7 +670,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // tilt they may affect near/far planes positions differently.
         const planesDist = this.getFrustumGroundIntersectionDist(mapView);
 
-        // Project cliping plane distances for the top/bottom frustum planes (edges), but
+        // Project clipping plane distances for the top/bottom frustum planes (edges), but
         // only if we deal with perspective camera type, this step is not required
         // for orthographic projections, cause all clip planes are parallel to eye vector.
         if (mapView.camera.type === "PerspectiveCamera") {
@@ -695,11 +698,12 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // Clamp values to constraints.
         const lookAtDist = this.getCameraLookAtDistance(mapView.camera, mapView.projection);
         const farMax = lookAtDist * this.farMaxRatio;
-        viewRanges.near = Math.max(viewRanges.near - this.nearFarMargin / 2, this.nearMin);
+        const nearFarMargin = this.nearFarMarginRatio * viewRanges.near;
+        viewRanges.near = Math.max(viewRanges.near - nearFarMargin / 2, this.nearMin);
         viewRanges.far = Math.min(viewRanges.far, farMax);
         viewRanges.far = Math.max(
-            viewRanges.far + this.nearFarMargin / 2,
-            viewRanges.near + this.nearFarMargin
+            viewRanges.far + nearFarMargin / 2,
+            viewRanges.near + nearFarMargin
         );
         viewRanges.minimum = this.nearMin;
         viewRanges.maximum = farMax;
@@ -710,12 +714,12 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         assert(projection.type === ProjectionType.Spherical);
         const viewRanges = { ...this.minimumViewRange };
 
-        // Near plance calculus is pretty straightforward and does not depent on camera tilt:
+        // Near plane calculus is pretty straightforward and does not depend on camera tilt:
         const cameraAltitude = this.getCameraAltitude(camera, projection);
         viewRanges.near = cameraAltitude - this.maxElevation;
         if (camera instanceof THREE.PerspectiveCamera) {
             // Now we need to account for camera tilt and frustum volume, so the longest
-            // frustum edge does not instersects with sphere, it takes the worst case
+            // frustum edge does not intersects with sphere, it takes the worst case
             // scenario regardless of camera tilt, so may be improved little bit with more
             // sophisticated algorithm.
             // Note, the fov is vertical, otherwise we would need to
@@ -738,7 +742,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         );
         const xaxis = this.m_tmpVectors[0];
         const yaxis = this.m_tmpVectors[1];
-        // Extend the far plane by the margin along the shpere normal (radius).
+        // Extend the far plane by the margin along the sphere normal (radius).
         // In order to calculate far plane distance we need to find sphere tangent
         // line that passes thru camera position, method explanation may be found in
         // TopViewClipPlanesEvaluator.evaluateDistanceSphericalProj() method.
@@ -753,7 +757,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // Apply tangent vector length onto camera to origin vector.
         let td: THREE.Vector3;
         // There may be situations when maximum elevation remains below sea level (< 0), or
-        // is neglible, in such cases simply apply tangent distance to camera to origin vector.
+        // is negligible, in such cases simply apply tangent distance to camera to origin vector.
         if (this.maxElevation < epsilon) {
             // This may be calculated by several methods, firstly:
             // t_d = d_norm * |t|,
@@ -763,7 +767,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
             // By simplifying t_d equation with the second condition, we get:
             // t_d = d_norm * cos(alpha) * |d|, where d = d_norm * |d|
             // t_d = d * cos(alpha)
-            // Cause cameraToOrigin is no longer needed re-use it to calulate td.
+            // Cause cameraToOrigin is no longer needed re-use it to calculate td.
             td = cameraToOrigin.multiplyScalar(cosAlpha);
         }
         // Second case takes into account the elevation above the ground.
@@ -779,7 +783,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
             // |te| = sqrt(2*r*e + e^2)
             const t = cosAlpha * d;
             const te = Math.sqrt(2 * r * this.maxElevation - this.maxElevation * this.maxElevation);
-            // Re-use prealocated vector.
+            // Re-use pre-allocated vector.
             td = cameraToOrigin.copy(dNorm).multiplyScalar(t + te);
         }
         // For tangent, oriented in the direction to origin, we then apply
@@ -797,7 +801,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         const tdrx2 = td.applyQuaternion(rx2);
 
         // Rotated tangents are then added to camera position thus defining far plane
-        // position and orientation - it is enough to have three cooplanar points to
+        // position and orientation - it is enough to have three co-planar points to
         // define the plane.
         // p1 = camera.position + tdrx
         // p2 = camera.position + tdry
@@ -805,19 +809,20 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // const farPlane = new THREE.Plane().setFromCoplanarPoints(p1, p2, p3);
         // viewRanges.far = farPlane.distanceToPoint(camera.position);
 
-        // This of course may be simplified by moving calculus entirelly to camera space,
+        // This of course may be simplified by moving calculus entirely to camera space,
         // because far plane is indeed defined in that space anyway:
         const farPlane = this.m_tmpPlane.setFromCoplanarPoints(tdrx, tdry, tdrx2);
         viewRanges.far = farPlane.constant;
 
         // Finally apply the constraints.
-        viewRanges.near = Math.max(viewRanges.near - this.nearFarMargin / 2, this.nearMin);
+        const nearFarMargin = this.nearFarMarginRatio * viewRanges.near;
+        viewRanges.near = Math.max(viewRanges.near - nearFarMargin / 2, this.nearMin);
         // Take into account largest depression assumed, that may be further then
         // tangent based far plane distance.
         viewRanges.far = Math.max(viewRanges.far, cameraAltitude - this.minElevation);
         viewRanges.far = Math.max(
-            viewRanges.far + this.nearFarMargin / 2,
-            viewRanges.near + this.nearFarMargin
+            viewRanges.far + nearFarMargin / 2,
+            viewRanges.near + nearFarMargin
         );
         viewRanges.minimum = this.nearMin;
         viewRanges.maximum = viewRanges.far;


### PR DESCRIPTION
Instead of using absolute values for obligatory near-far distance (margin),
we calculate margin as quantity relative to near plane distance. This
fixes the problems with frustum calculus (and matrices multiplication)
rounding errors when huge distances (near distance) encounter small planes
distances.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
