### PR TITLE
MINOR: Fix ground plane depthWrite.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -1511,8 +1511,7 @@ export class TileGeometryCreator {
         // TODO cache the material HARP-4207
         const material = new MapMeshBasicMaterial({
             color: colorHex,
-            visible: isVisible,
-            depthWrite: false
+            visible: isVisible
         });
         const plane = new THREE.Mesh(geometry, material);
         plane.position.copy(planeCenter);


### PR DESCRIPTION
The ground plane used to need a `depthWrite: false` for webtiles and satellite tiles. That is no longer the case. 

On the contrary writing the depth is necessary for the ground to hide what is below it, when adding objects in particular:
![depth](https://i.postimg.cc/W3YR49j3/image.png)