### PR TITLE
Disable Github CI on mac.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node_version: [10, 11, 12]
-        os: [ubuntu-latest,macOS-latest,windows-latest]
+        os: [ubuntu-latest,windows-latest]
 
     steps:
     - name: Reset git settings (Windows)


### PR DESCRIPTION
Github Actions mac checks are failing globally: https://github.community/t5/GitHub-Actions/macOS-VM-failing-immediately/m-p/36969#M2743

Disabling them until workaround and/or fix is available.

Related-To: HARP-7766

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>
