### PR TITLE
MINOR: Minor examples improvements.

### DIFF
--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -6,7 +6,6 @@
 
 import { StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { FeaturesDataSource } from "@here/harp-features-datasource";
-import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
@@ -150,24 +149,24 @@ export namespace GeoJsonExample {
             theme
         });
         mapView.renderLabels = false;
-        mapView.setCameraGeolocationAndZoom(new GeoCoordinates(30, 0), 2);
 
         CopyrightElementHandler.install("copyrightNotice", mapView);
 
         const controls = new MapControls(mapView);
         const ui = new MapControlsUI(controls);
-        const editorWidthNumber = Math.min(parseInt(editorWidth, undefined), innerWidth * 0.4);
-        ui.domElement.style.right = editorWidthNumber + 10 + "px";
+        const width =
+            innerWidth <= 450 ? 0 : Math.min(parseInt(editorWidth, undefined), innerWidth * 0.4);
+        ui.domElement.style.right = width + 10 + "px";
         canvas.parentElement!.appendChild(ui.domElement);
 
         window.addEventListener("resize", () => {
-            const width =
+            const _width =
                 innerWidth <= 450
                     ? 0
                     : Math.min(parseInt(editorWidth, undefined), innerWidth * 0.4);
             canvas.className = "full";
-            ui.domElement.style.right = width + 10 + "px";
-            mapView.resize(innerWidth - width, innerHeight);
+            ui.domElement.style.right = _width + 10 + "px";
+            mapView.resize(innerWidth - _width, innerHeight);
         });
 
         const baseMap = new OmvDataSource({
@@ -280,7 +279,7 @@ export namespace GeoJsonExample {
                 }
             </style>
             <div id=editor>
-                <button>Update</button>
+                <button style="left:5px;position:absolute;">Update</button>
                 <textarea></textarea>
             </div>
 

--- a/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
+++ b/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
@@ -76,6 +76,7 @@
             mapControls.maxTiltAngle = 50;
             const NY = new harp.GeoCoordinates(40.707, -74.01);
             map.lookAt(NY, 3500, 50);
+            map.zoomLevel = 16.1;
 
             const ui = new harp.MapControlsUI(mapControls, { zoomLevel: "input" });
             canvas.parentElement.appendChild(ui.domElement);

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -89,6 +89,7 @@ export namespace HelloWorldExample {
         // Look at New York.
         const NY = new GeoCoordinates(40.707, -74.01);
         map.lookAt(NY, 3500, 50, -20);
+        map.zoomLevel = 16.1;
         // end:harp_gl_hello_world_example_look_at.ts
 
         // Add an UI.

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -30,6 +30,7 @@ export namespace ThemesExample {
 
         const moscow = new GeoCoordinates(55.7525631, 37.6234006);
         map.lookAt(moscow, 3500, 50, 300);
+        map.zoomLevel = 16.1;
 
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -45,12 +45,26 @@ export namespace PickingExample {
                 display: inline-block;
                 visibility: hidden;
                 text-align: left;
+                right:50px;
             }
             #mapCanvas {
               top: 0;
             }
+            #info{
+                color: #fff;
+                width: 80%;
+                left: 50%;
+                position: relative;
+                margin: 10px 0 0 -40%;
+                font-size: 15px;
+            }
+            @media screen and (max-width: 700px) {
+                #info{
+                    font-size:11px;
+                }
+            }
         </style>
-
+        <p id=info>Click a feature on the map to read its data (Land masses are not features).</p>
         <pre id="mouse-picked-result"></pre>
     `;
 

--- a/@here/harp-examples/src/rendering_post-effects_all.ts
+++ b/@here/harp-examples/src/rendering_post-effects_all.ts
@@ -41,6 +41,7 @@ export namespace EffectsAllExample {
         mapControls.maxTiltAngle = 60;
         const singapour = new GeoCoordinates(1.2893999, 103.8537169);
         mapView.lookAt(singapour, 3500, 60, 240);
+        mapView.zoomLevel = 16.1;
 
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);

--- a/@here/harp-examples/src/rendering_post-effects_themes.ts
+++ b/@here/harp-examples/src/rendering_post-effects_themes.ts
@@ -30,6 +30,7 @@ export namespace EffectsExample {
         mapControls.maxTiltAngle = 60;
         const NY = new GeoCoordinates(40.707, -74.01);
         mapView.lookAt(NY, 4000, 60);
+        mapView.zoomLevel = 16.1;
 
         const ui = new MapControlsUI(mapControls);
         canvas.parentElement!.appendChild(ui.domElement);

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -49,6 +49,30 @@ import { accessToken, copyrightInfo } from "../config";
  */
 
 export namespace HelloCustomThemeExample {
+    document.body.innerHTML +=
+        `
+    <style>
+        #mapCanvas {
+          top: 0;
+        }
+        #info{
+            color: #fff;
+            width: 80%;
+            left: 50%;
+            position: relative;
+            margin: 10px 0 0 -40%;
+            font-size: 15px;
+        }
+        @media screen and (max-width: 700px) {
+            #info{
+                font-size:11px;
+            }
+        }
+    </style>
+    <p id=info>This example shows the theme extension mechanism: the styles for the parks ` +
+        `and the buildings are overwritten from an original theme to make them respectively green` +
+        ` and brown.< /p>
+`;
     // Create a new MapView for the HTMLCanvasElement of the given id.
     function initializeMapView(id: string): MapView {
         const canvas = document.getElementById(id) as HTMLCanvasElement;
@@ -84,6 +108,7 @@ export namespace HelloCustomThemeExample {
         // Look at New York.
         const rome = new GeoCoordinates(41.9005332, 12.494249);
         map.lookAt(rome, 3000, 50, 200);
+        map.zoomLevel = 16.1;
 
         // Add an UI.
         const ui = new MapControlsUI(mapControls);

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -21,7 +21,21 @@ export namespace TiledGeoJsonTechniquesExample {
             #mapCanvas {
               top: 0;
             }
+            #info{
+                color: #fff;
+                width: 80%;
+                left: 50%;
+                position: relative;
+                margin: 10px 0 0 -40%;
+                font-size: 15px;
+            }
+            @media screen and (max-width: 700px) {
+                #info{
+                    font-size:11px;
+                }
+            }
         </style>
+        <p id=info>Zoom in and out to smoothly transition between themes.</p>
     `;
 
     const theme: Theme = {

--- a/@here/harp-examples/src/synchronized-views.ts
+++ b/@here/harp-examples/src/synchronized-views.ts
@@ -91,9 +91,9 @@ export namespace TripleViewExample {
             canvas.parentElement!.appendChild(ui.domElement);
         }
 
-        // center the camera somewhere around Berlin geo locations
         const frankfurt = new GeoCoordinates(50.1125867, 8.6720831);
         mapView.lookAt(frankfurt, 1000, 45, 200);
+        mapView.zoomLevel = 16.2;
 
         setupSyncViewsGrid(mapView, gridPositionX, gridPositionY);
         // react on resize events

--- a/@here/harp-examples/src/theme_data-driven.ts
+++ b/@here/harp-examples/src/theme_data-driven.ts
@@ -11,6 +11,28 @@ import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
 import { accessToken, copyrightInfo } from "../config";
 
 export namespace DataDrivenThemeExample {
+    document.body.innerHTML +=
+        `
+    <style>
+        #mapCanvas {
+          top: 0;
+        }
+        #info{
+            color: #fff;
+            width: 80%;
+            left: 50%;
+            position: relative;
+            margin: 10px 0 0 -40%;
+            font-size: 15px;
+        }
+        @media screen and (max-width: 700px) {
+            #info{
+                font-size:11px;
+            }
+        }
+    </style>
+    <p id=info>This example shows how to utilize the data from the styles.<br/>` +
+        `Here the population of a country is displayed below its name.</p>`;
     function initializeMapView(id: string): MapView {
         const canvas = document.getElementById(id) as HTMLCanvasElement;
 

--- a/@here/harp-examples/src/threejs_add-object.ts
+++ b/@here/harp-examples/src/threejs_add-object.ts
@@ -54,6 +54,7 @@ export namespace ThreejsAddSimpleObject {
     // Create a new MapView for the HTMLCanvasElement of the given id.
     function addMouseEventListener(mapView: MapView) {
         const canvas = mapView.canvas;
+        mapView.zoomLevel = 15.5;
 
         // tslint:disable:no-unused-expression
         new LongPressHandler(canvas, event => {
@@ -79,12 +80,16 @@ export namespace ThreejsAddSimpleObject {
     }
 
     const message = document.createElement("div");
-    message.innerHTML = `Long click to add a ${scale}m wide cube to scene.`;
+    message.innerHTML = `Long click to add a ${scale}m wide cube to the scene.`;
+    message.style.cssText = `
+        color: #000;
+        width: 80%;
+        left: 50%;
+        position: relative;
+        margin-left: -40%;
+        font-size: 15px;
+    `;
 
-    message.style.position = "absolute";
-    message.style.cssFloat = "right";
-    message.style.top = "10px";
-    message.style.right = "10px";
     document.body.appendChild(message);
 
     addMouseEventListener(HelloWorldExample.mapView);

--- a/@here/harp-examples/src/threejs_camera-animation.ts
+++ b/@here/harp-examples/src/threejs_camera-animation.ts
@@ -61,10 +61,14 @@ export namespace ThreejsCameraAnimation {
 <br>
 Tap our use left/right keys to change location`;
 
-    message.style.position = "absolute";
-    message.style.cssFloat = "right";
-    message.style.top = "10px";
-    message.style.right = "10px";
+    message.style.cssText = `
+    color: #000;
+    width: 80%;
+    left: 50%;
+    position: relative;
+    margin-left: -40%;
+    font-size: 15px;
+    `;
     document.body.appendChild(message);
 
     function startTransition(mapView: MapView, location: Location) {

--- a/@here/harp-examples/src/threejs_raycast.ts
+++ b/@here/harp-examples/src/threejs_raycast.ts
@@ -30,7 +30,7 @@ import { accessToken, copyrightInfo } from "../config";
  * [[ThreejsAddSimpleObject]] example.
  */
 export namespace ThreejsRaycast {
-    const scale = 10;
+    const scale = 100;
     const geometry = new THREE.BoxGeometry(1 * scale, 1 * scale, 1 * scale);
     const material = new THREE.MeshStandardMaterial({
         color: 0x00ff00fe
@@ -114,14 +114,28 @@ export namespace ThreejsRaycast {
         return map;
     }
 
-    const message = document.createElement("div");
-    message.innerHTML = `Long click to add a 10m^3 pink box under the mouse cursor location.`;
-
-    message.style.position = "absolute";
-    message.style.cssFloat = "right";
-    message.style.top = "10px";
-    message.style.right = "10px";
-    document.body.appendChild(message);
+    document.body.innerHTML +=
+        `<style>
+            #mapCanvas{
+                top:0;
+            }
+            #info{
+                color: #000;
+                width: 80%;
+                left: 50%;
+                position: relative;
+                margin: 10px 0 0 -40%;
+                font-size: 15px;
+            }
+            @media screen and (max-width: 700px) {
+                #info{
+                    font-size:11px;
+                }
+            }
+        </style>
+        <p id=info>Long click to add a pink box under the mouse cursor, with respect of ` +
+        `buildings' height.</p>
+    `;
 
     const mapView = initializeMapView("mapCanvas");
 


### PR DESCRIPTION
Harmonizes the CSS, adds missing descriptions where needed, sets the zoom level to 16.1 when it is needed to see the buildings, like in the hello world examples (using the distance in `lookAt` results in different zoom levels depending on the height of the viewport).