### PR TITLE
Allow custom URLs patterns in OmvDataSource.

### DIFF
--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -7,7 +7,7 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import { accessToken, copyrightInfo } from "../config";
 
 /**
@@ -114,11 +114,12 @@ export namespace HelloWorldExample {
     function addOmvDataSource(map: MapView) {
         // snippet:harp_gl_hello_world_example_4.ts
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
-            apiFormat: APIFormat.XYZOMV,
+            url: "https://xyz.api.here.com/tiles/herebase.02/{z}/{x}/{y}/omv",
             styleSetName: "tilezen",
             maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            urlParams: {
+                access_token: accessToken
+            },
             copyrightInfo
         });
         // end:harp_gl_hello_world_example_4.ts

--- a/@here/harp-examples/src/theme_data-driven.ts
+++ b/@here/harp-examples/src/theme_data-driven.ts
@@ -7,7 +7,7 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import { accessToken, copyrightInfo } from "../config";
 
 export namespace DataDrivenThemeExample {
@@ -94,11 +94,12 @@ export namespace DataDrivenThemeExample {
         const map = initializeMapView("mapCanvas");
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/osmbase/512/all",
-            apiFormat: APIFormat.XYZMVT,
+            url: "https://xyz.api.here.com/tiles/osmbase/512/all/{z}/{x}/{y}.mvt",
+            urlParams: {
+                access_token: accessToken
+            },
             styleSetName: "tilezen",
             maxZoomLevel: 17,
-            authenticationCode: accessToken,
             copyrightInfo
         });
 

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -194,10 +194,13 @@ export interface OmvDataSourceParameters {
 function getDataProvider(params: OmvWithRestClientParams | OmvWithCustomDataProvider) {
     if ((params as OmvWithCustomDataProvider).dataProvider) {
         return (params as OmvWithCustomDataProvider).dataProvider;
-    } else if ((params as OmvWithRestClientParams).baseUrl) {
+    } else if (
+        (params as OmvWithRestClientParams).baseUrl ||
+        (params as OmvWithRestClientParams).url
+    ) {
         return new OmvRestClient(params as OmvRestClientParameters);
     } else {
-        throw new Error("OmvDataSource: missing baseUrl or dataProvider params");
+        throw new Error("OmvDataSource: missing url, baseUrl or dataProvider params");
     }
 }
 

--- a/@here/harp-omv-datasource/test/OmvRestClientTest.ts
+++ b/@here/harp-omv-datasource/test/OmvRestClientTest.ts
@@ -46,6 +46,30 @@ describe("OmvRestClient", function() {
         downloadSpy.restore();
     });
 
+    it("supports url pattern", async function() {
+        const restClient = new OmvRestClient({
+            url: "https://some.base.url/somepath/{z}/{x}/{y}/omv",
+            downloadManager: mockDownloadManager
+        });
+        await restClient.getTile(new TileKey(1, 2, 3));
+        assert.equal(downloadSpy.args[0][0], "https://some.base.url/somepath/3/2/1/omv");
+    });
+
+    it("supports url pattern and custom `urlParams`", async function() {
+        const restClient = new OmvRestClient({
+            url: "https://some.base.url/somepath/{z}/{x}/{y}.mvt",
+            urlParams: {
+                token: "1234567890abcdefg"
+            },
+            downloadManager: mockDownloadManager
+        });
+        await restClient.getTile(new TileKey(1, 2, 3));
+        assert.equal(
+            downloadSpy.args[0][0],
+            "https://some.base.url/somepath/3/2/1.mvt?token=1234567890abcdefg"
+        );
+    });
+
     it("generates proper Url with HEREV1 Format", async function() {
         const restClient = new OmvRestClient({
             baseUrl: "https://some.base.url",


### PR DESCRIPTION
Support url-pattern for locating tiles in `OMVRestClient` and
`OMVDataSource`. Example:

   https://my-base-url.com/vector-tiles/{z}/{x}/{y}.mvt

Implements #904
Related-to: HARP-7392
Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>

