### PR TITLE
HARP-7373: Move TextElementStateCache update to beginning of frame.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -98,20 +98,12 @@ export class TextElementStateCache {
     }
 
     /**
-     * Clears the visited flag of all cached group states.
-     */
-    clearVisited() {
-        for (const groupState of this.m_referenceMap.values()) {
-            groupState.visited = false;
-        }
-    }
-
-    /**
      * Updates state of all cached groups, discarding those that are not needed anymore.
      * @param time The current time.
+     * @param clearVisited `True` to clear visited flag in group states.
      * @param disableFading `True` if fading is currently disabled, `false` otherwise.
      */
-    update(time: number, disableFading: boolean) {
+    update(time: number, clearVisited: boolean, disableFading: boolean) {
         for (const [key, groupState] of this.m_referenceMap.entries()) {
             const visible = groupState.updateFading(time, disableFading);
             const keep: boolean = visible || groupState.visited;
@@ -119,6 +111,8 @@ export class TextElementStateCache {
             if (!keep) {
                 this.m_referenceMap.delete(key);
                 this.m_sortedGroupStates = undefined;
+            } else if (clearVisited) {
+                groupState.visited = false;
             }
         }
         this.m_textMap.clear();

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -364,11 +364,10 @@ export class TextElementsRenderer {
     /**
      * Update state at the end of a frame.
      */
-    update(time: number, labelsPlaced: boolean) {
+    updateTextRenderers() {
         for (const textRenderer of this.m_textRenderers) {
             textRenderer.poiRenderer.update();
         }
-        this.m_textElementStateCache.update(time, this.m_mapView.disableFading);
     }
 
     /**
@@ -420,6 +419,10 @@ export class TextElementsRenderer {
         logger.debug(
             `FRAME: ${this.m_mapView.frameNumber}, ZOOM LEVEL: ${this.m_mapView.zoomLevel}`
         );
+
+        const clearVisitedGroups = updateTextElements;
+        this.m_textElementStateCache.update(time, clearVisitedGroups, this.m_mapView.disableFading);
+
         if (updateTextElements) {
             this.updateTextElements();
         }
@@ -428,7 +431,7 @@ export class TextElementsRenderer {
         this.prepopulateScreenWithBlockingElements();
         this.placeTextElements(time, frameNumber);
         this.placeOverlay();
-        this.update(time, updateTextElements);
+        this.updateTextRenderers();
     }
 
     /**
@@ -1150,8 +1153,6 @@ export class TextElementsRenderer {
         }
 
         this.m_cacheInvalidated = false;
-
-        this.m_textElementStateCache.clearVisited();
 
         const renderList = this.m_mapView.visibleTileSet.dataSourceTileList;
 


### PR DESCRIPTION
Fading state must be updated at the beginning of the frame, otherwise
label opacity will be 0 for the two first frames it's fading in.
In other words, we would be rendering labels with the opacity corresponding
to the previous frame.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
