### PR TITLE
Add support for evaluating expressions to 'getPropertyValue'.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -164,13 +164,27 @@ export enum ExprScope {
     /**
      * The scope of an [[Expr]] used in a [[Technique]] `when` condition.
      */
-    Condition
+    Condition,
+
+    /**
+     * The scope of an [[Expr]] used as dynamic property attribute value.
+     */
+    Dynamic
 }
 
 /**
  * Abstract class defining a shape of a [[Theme]]'s expression
  */
 export abstract class Expr {
+    /**
+     * Tests of given value is an [[Expr]].
+     *
+     * @param value The object to test.
+     */
+    static isExpr(value: any): value is Expr {
+        return value instanceof Expr;
+    }
+
     /**
      * Creates an expression from the given `code`.
      *

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -932,4 +932,19 @@ describe("ExprEvaluator", function() {
             );
         });
     });
+
+    describe("getPropertyValue", function() {
+        const env = new MapEnv({
+            $zoom: 14,
+            $pixelsToMeters: 2,
+            time: 1
+        });
+
+        it("evaluate", function() {
+            assert.strictEqual(
+                getPropertyValue(Expr.fromJSON(["rgb", 255, 0, ["*", ["get", "time"], 255]]), env),
+                "#ff00ff"
+            );
+        });
+    });
 });


### PR DESCRIPTION
This change adds an overload to getPropertyValue that accepts
enviroments. Also, it introduces a new evaluation scope
called ExprScope.Dynamic that can be used by the Expr operators
to provide different semantics depending on how the expression is used
(e.g. an expression used during decoding vs an expression
used at rending time can potentially have different values).

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
