### PR TITLE
HARP-7517: Partial support for rgba[..] and "rgba(..)" expressions in style.

### DIFF
--- a/@here/harp-datasource-protocol/README.md
+++ b/@here/harp-datasource-protocol/README.md
@@ -300,4 +300,4 @@ Most common properties include:
 - `renderOrder`: which enables to define the render order of the objects created using a particular
  technique.
 - `color`: color in hexadecimal or CSS-style notation, for example: `"#e4e9ec"`, `"#fff"`,
- `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.
+ `"rgb(255, 0, 0)"`, `"rgba(127, 127, 127, 1.0)"`, or `"hsl(35, 11%, 88%)"`.

--- a/@here/harp-datasource-protocol/StyleExpressions.md
+++ b/@here/harp-datasource-protocol/StyleExpressions.md
@@ -148,6 +148,21 @@ Creates a `color` from the RGB components. The components must be integers betwe
 ["rgb", number, number, number]
 ```
 
+## rgba
+
+Creates a `color` from the RGBA components. The color channels (R, G, B) must be defined as
+integers between 0 and 255, while last component - alpha - holds floating point value between
+0.0 and 1.0 inclusively.
+
+```javascript
+["rgba", number, number, number, number]
+```
+
+> NOTE:
+>
+> Currently alpha channel value is silently ignored, thus full support for defining opacity with
+**rgba** expression needs to be implemented.
+
 ## hsl
 
 Creates a `color` from the HSL components:

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -22,7 +22,8 @@ import {
     StringEncodedNumeralFormats,
     StringEncodedNumeralType,
     StringEncodedPixels,
-    StringEncodedRGB
+    StringEncodedRGB,
+    StringEncodedRGBA
 } from "./StringEncodedNumeral";
 
 const logger = LoggerManager.instance.create("InterpolatedProperty");
@@ -109,6 +110,7 @@ export function getPropertyValue<T>(
                     return matchedFormat.decoder(property)[0] * pixelToMeters;
                 case StringEncodedNumeralType.Hex:
                 case StringEncodedNumeralType.RGB:
+                case StringEncodedNumeralType.RGBA:
                 case StringEncodedNumeralType.HSL:
                     const hslValues = matchedFormat.decoder(property);
                     return tmpColor.setHSL(hslValues[0], hslValues[1], hslValues[2]).getHex();
@@ -123,6 +125,7 @@ export function getPropertyValue<T>(
                 return getInterpolatedLength(property, level, pixelToMeters);
             case StringEncodedNumeralType.Hex:
             case StringEncodedNumeralType.RGB:
+            case StringEncodedNumeralType.RGBA:
             case StringEncodedNumeralType.HSL:
                 return getInterpolatedColor(property, level);
         }
@@ -275,7 +278,7 @@ function removeDuplicatePropertyValues<T>(p: InterpolatedPropertyDefinition<T>) 
     }
 }
 
-const colorFormats = [StringEncodedHSL, StringEncodedHex, StringEncodedRGB];
+const colorFormats = [StringEncodedHSL, StringEncodedHex, StringEncodedRGB, StringEncodedRGBA];
 const worldSizeFormats = [StringEncodedMeters, StringEncodedPixels];
 
 function procesStringEnocodedNumeralInterpolatedProperty(

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -16,6 +16,7 @@ export enum StringEncodedNumeralType {
     Pixels,
     Hex,
     RGB,
+    RGBA,
     HSL
 }
 
@@ -73,6 +74,25 @@ export const StringEncodedRGB: StringEncodedNumeralFormat = {
         return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
     }
 };
+export const StringEncodedRGBA: StringEncodedNumeralFormat = {
+    type: StringEncodedNumeralType.RGBA,
+    size: 3,
+    // tslint:disable-next-line:max-line-length
+    regExp: /rgba\((?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:(0(?:\.[0-9]+)?|1(?:\.0+)?))\)/,
+    decoder: (encodedValue: string) => {
+        const channels = StringEncodedRGBA.regExp.exec(encodedValue)!;
+        // For now we simply ignore alpha channel value.
+        // TODO: To be resolved with HARP-7517
+        tmpColor
+            .setRGB(
+                parseInt(channels[1], 10) / 255,
+                parseInt(channels[2], 10) / 255,
+                parseInt(channels[3], 10) / 255
+            )
+            .getHSL(tmpHSL);
+        return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
+    }
+};
 export const StringEncodedHSL: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.HSL,
     size: 3,
@@ -97,5 +117,6 @@ export const StringEncodedNumeralFormats: StringEncodedNumeralFormat[] = [
     StringEncodedPixels,
     StringEncodedHex,
     StringEncodedRGB,
+    StringEncodedRGBA,
     StringEncodedHSL
 ];

--- a/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
@@ -7,27 +7,46 @@
 import * as THREE from "three";
 
 import { CallExpr } from "../Expr";
-
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const tmpColor = new THREE.Color();
 const operators = {
+    rgba: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const r = context.evaluate(call.args[0]);
+            const g = context.evaluate(call.args[1]);
+            const b = context.evaluate(call.args[2]);
+            const a = context.evaluate(call.args[3]);
+            if (
+                typeof r === "number" &&
+                typeof g === "number" &&
+                typeof b === "number" &&
+                typeof a === "number" &&
+                r >= 0 &&
+                g >= 0 &&
+                b >= 0 &&
+                a >= 0 &&
+                a <= 1
+            ) {
+                return rgbaToString(r, g, b, a);
+            }
+            throw new Error(`unknown color 'rgba(${r},${g},${b},${a})'`);
+        }
+    },
     rgb: {
         call: (context: ExprEvaluatorContext, call: CallExpr) => {
             const r = context.evaluate(call.args[0]);
             const g = context.evaluate(call.args[1]);
             const b = context.evaluate(call.args[2]);
-            if (typeof r === "number" && typeof g === "number" && typeof b === "number") {
-                return (
-                    "#" +
-                    tmpColor
-                        .setRGB(
-                            THREE.Math.clamp(r, 0, 255) / 255,
-                            THREE.Math.clamp(g, 0, 255) / 255,
-                            THREE.Math.clamp(b, 0, 255) / 255
-                        )
-                        .getHexString()
-                );
+            if (
+                typeof r === "number" &&
+                typeof g === "number" &&
+                typeof b === "number" &&
+                r >= 0 &&
+                g >= 0 &&
+                b >= 0
+            ) {
+                return rgbaToString(r, g, b);
             }
             throw new Error(`unknown color 'rgb(${r},${g},${b})'`);
         }
@@ -45,12 +64,31 @@ const operators = {
                 s >= 0 &&
                 l >= 0
             ) {
-                return `hsl(${h},${Math.round(s)}%,${Math.round(l)}%)`;
+                return hslToString(h, s, l);
             }
             throw new Error(`unknown color 'hsl(${h},${s}%,${l}%)'`);
         }
     }
 };
+
+function rgbaToString(r: number, g: number, b: number, a?: number): string {
+    // For now we simply ignore alpha component from rgba(...) expressions.
+    // TODO: To be resolved with HARP-7517.
+    return (
+        "#" +
+        tmpColor
+            .setRGB(
+                THREE.Math.clamp(r, 0, 255) / 255,
+                THREE.Math.clamp(g, 0, 255) / 255,
+                THREE.Math.clamp(b, 0, 255) / 255
+            )
+            .getHexString()
+    );
+}
+
+function hslToString(h: number, s: number, l: number): string {
+    return `hsl(${h},${Math.round(s)}%,${Math.round(l)}%)`;
+}
 
 export const ColorOperators: OperatorDescriptorMap = operators;
 export type ColorOperatorNames = keyof typeof operators;

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -860,7 +860,76 @@ describe("ExprEvaluator", function() {
                 new THREE.Color("rgb(127, 127, 127)").getHexString()
             );
 
+            assert.throw(() => evaluate(["rgb", -20, 40, 50]), "unknown color 'rgb(-20,40,50)'");
             assert.throw(() => evaluate(["rgb", "a", 40, 50]), "unknown color 'rgb(a,40,50)'");
+        });
+    });
+
+    describe("Operator 'rgba'", function() {
+        it("call", function() {
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 0, 0, 0, 1.0]) as string).getHexString(),
+                new THREE.Color("rgb(0, 0, 0)").getHexString()
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 255, 0, 0, 1]) as string).getHexString(),
+                new THREE.Color("rgb(255, 0, 0)").getHexString()
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 255, 255, 0, 1]) as string).getHexString(),
+                new THREE.Color("rgb(255, 255, 0)").getHexString()
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 255, 255, 255, 1]) as string).getHexString(),
+                new THREE.Color("rgb(255, 255, 255)").getHexString()
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 127, 127, 127, 1]) as string).getHexString(),
+                new THREE.Color("rgb(127, 127, 127)").getHexString()
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 500, 500, 500, 1]) as string).getHexString(),
+                new THREE.Color("rgb(500, 500, 500)").getHexString()
+            );
+
+            // Still equal - ignores alpha.
+            // Some assumptions will change after fully implementing HARP-7517
+            assert.strictEqual(
+                evaluate(["rgba", 255, 0, 0, 0.5]) as string,
+                evaluate(["rgba", 255, 0, 0, 0.6]) as string
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["rgba", 255, 255, 255, 0.5]) as string).getHexString(),
+                new THREE.Color("rgb(255, 255, 255)").getHexString()
+            );
+
+            // Bad statements.
+            assert.throw(
+                () => evaluate(["rgba", -20, 40, 50, 1]),
+                "unknown color 'rgba(-20,40,50,1)'"
+            );
+            assert.throw(
+                () => evaluate(["rgba", 20, 40, 50, -1]),
+                "unknown color 'rgba(20,40,50,-1)'"
+            );
+            assert.throw(
+                () => evaluate(["rgba", 20, 40, 50, "a"]),
+                "unknown color 'rgba(20,40,50,a)'"
+            );
+            assert.throw(
+                () => evaluate(["rgba", 20, 40, 50, 1.1]),
+                "unknown color 'rgba(20,40,50,1.1)'"
+            );
+            assert.throw(
+                () => evaluate(["rgba", 20, 40, 50, 2]),
+                "unknown color 'rgba(20,40,50,2)'"
+            );
         });
     });
 });


### PR DESCRIPTION
Gives compatibility for themes using 4 channel colors in styling with
attributes expressions like:
- color: rgba[255, 255, 255, 0.5]
- backgroundColor: "rgba(255, 255, 255, 0.5)"

Although those styling attributes will be parsed and read, the alpha
channel component will be silently ignored. Full support for alpha channel
need to be implemented.

TODO:
- support RGBA/ARGB colors internally in engine,
- alpha channel mapping to THREE.js opacity and transparent material
properties,
- support four channel color interpolation,
- more unit tests.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
