### PR TITLE
HARP-7373: Move text style caching to new TextStyleCache in TextEleme…

### DIFF
--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -218,11 +218,13 @@ export class GeoJsonTile extends Tile {
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
+        const styleCache = this.mapView.textElementsRenderer.styleCache;
+
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             path,
-            tileGeometryCreator.getRenderStyle(this, technique),
-            tileGeometryCreator.getLayoutStyle(this, technique),
+            styleCache.getRenderStyle(this, technique),
+            styleCache.getLayoutStyle(this, technique),
             getPropertyValue(priority, this.mapView.zoomLevel),
             xOffset,
             yOffset,
@@ -305,11 +307,12 @@ export class GeoJsonTile extends Tile {
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
+        const styleCache = this.mapView.textElementsRenderer.styleCache;
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             position,
-            tileGeometryCreator.getRenderStyle(this, technique),
-            tileGeometryCreator.getLayoutStyle(this, technique),
+            styleCache.getRenderStyle(this, technique),
+            styleCache.getLayoutStyle(this, technique),
             getPropertyValue(priority, this.mapView.zoomLevel),
             xOffset,
             yOffset,
@@ -387,11 +390,12 @@ export class GeoJsonTile extends Tile {
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
+        const styleCache = this.mapView.textElementsRenderer.styleCache;
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(label),
             position,
-            tileGeometryCreator.getRenderStyle(this, technique),
-            tileGeometryCreator.getLayoutStyle(this, technique),
+            styleCache.getRenderStyle(this, technique),
+            styleCache.getLayoutStyle(this, technique),
             getPropertyValue(priority, this.mapView.zoomLevel),
             xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : xOffset,
             yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : yOffset,

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -55,7 +55,6 @@ import { SkyBackground } from "./SkyBackground";
 import { FrameStats, PerformanceStatistics } from "./Statistics";
 import { TextElement } from "./text/TextElement";
 import { TextElementsRenderer } from "./text/TextElementsRenderer";
-import { TextLayoutStyleCache, TextRenderStyleCache } from "./text/TextStyleCache";
 import { createLight } from "./ThemeHelpers";
 import { ThemeLoader } from "./ThemeLoader";
 import { Tile } from "./Tile";
@@ -649,16 +648,13 @@ export class MapView extends THREE.EventDispatcher {
     dumpNext = false;
 
     /**
-     * Allows discarding the text rendering after the map rendering.
-     */
-    renderLabels: boolean = true;
-
-    /**
      * The instance of [[MapRenderingManager]] managing the rendering of the map. It is a public
      * property to allow access and modification of some parameters of the rendering process at
      * runtime.
      */
     readonly mapRenderingManager: IMapRenderingManager;
+
+    private m_renderLabels: boolean = true;
 
     private m_movementFinishedUpdateTimerId?: any;
     private m_postEffects?: PostEffects;
@@ -724,10 +720,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_maxFps = 0;
     private m_detectedFps: number = FALLBACK_FRAME_RATE;
 
-    private m_textElementsRenderer?: TextElementsRenderer;
-    private m_textElementsRendererTimer?: any;
-    private m_textRenderStyleCache = new TextRenderStyleCache();
-    private m_textLayoutStyleCache = new TextLayoutStyleCache();
+    private m_textElementsRenderer: TextElementsRenderer;
 
     private m_forceCameraAspect: number | undefined = undefined;
 
@@ -999,31 +992,32 @@ export class MapView extends THREE.EventDispatcher {
 
         this.initTheme();
 
+        this.m_textElementsRenderer = this.createTextRenderer();
+
         this.drawFrame();
+    }
+
+    /**
+     * @returns Whether label rendering is enabled.
+     */
+    get renderLabels() {
+        return this.m_renderLabels;
+    }
+
+    /**
+     * Enables or disables rendering of labels.
+     * @param value `true` to enable labels `false` to disable them.
+     */
+    set renderLabels(value: boolean) {
+        this.m_renderLabels = value;
     }
 
     /**
      * @hidden
      * The [[TextElementsRenderer]] select the visible [[TextElement]]s and renders them.
      */
-    get textElementsRenderer(): TextElementsRenderer | undefined {
+    get textElementsRenderer(): TextElementsRenderer {
         return this.m_textElementsRenderer;
-    }
-
-    /**
-     * @hidden
-     * The [[TextRenderStyleCache]] used for this instance of `MapView`.
-     */
-    get textRenderStyleCache(): TextRenderStyleCache {
-        return this.m_textRenderStyleCache;
-    }
-
-    /**
-     * @hidden
-     * The [[TextLayoutStyleCache]] used for this instance of `MapView`.
-     */
-    get textLayoutStyleCache(): TextLayoutStyleCache {
-        return this.m_textLayoutStyleCache;
     }
 
     /**
@@ -1065,11 +1059,6 @@ export class MapView extends THREE.EventDispatcher {
         if (this.m_movementFinishedUpdateTimerId) {
             clearTimeout(this.m_movementFinishedUpdateTimerId);
             this.m_movementFinishedUpdateTimerId = undefined;
-        }
-
-        if (this.m_textElementsRendererTimer !== undefined) {
-            clearTimeout(this.m_textElementsRendererTimer);
-            this.m_textElementsRendererTimer = undefined;
         }
 
         if (this.m_animationFrameHandle !== undefined) {
@@ -1122,9 +1111,8 @@ export class MapView extends THREE.EventDispatcher {
         this.updateImages();
         this.updateLighting();
 
-        if (this.m_textElementsRenderer !== undefined) {
-            this.m_textElementsRenderer.invalidateCache();
-        }
+        this.m_textElementsRenderer.invalidateCache();
+
         this.updateSkyBackground();
         this.update();
     }
@@ -1252,8 +1240,6 @@ export class MapView extends THREE.EventDispatcher {
         this.m_theme.textStyles = theme.textStyles;
         this.m_theme.defaultTextStyle = theme.defaultTextStyle;
         this.m_theme.fontCatalogs = theme.fontCatalogs;
-        this.m_textRenderStyleCache.clear();
-        this.m_textLayoutStyleCache.clear();
 
         this.resetTextRenderer();
 
@@ -1854,8 +1840,7 @@ export class MapView extends THREE.EventDispatcher {
      * @param textElements Array of [[TextElement]] to be added.
      */
     addOverlayText(textElements: TextElement[]): void {
-        this.createTextRendererIfNeeded();
-        this.m_textElementsRenderer!.addOverlayText(textElements);
+        this.m_textElementsRenderer.addOverlayText(textElements);
         this.update();
     }
 
@@ -1865,9 +1850,7 @@ export class MapView extends THREE.EventDispatcher {
      * @param textElements Array of [[TextElement]] to be added.
      */
     clearOverlayText(): void {
-        if (this.m_textElementsRenderer !== undefined) {
-            this.m_textElementsRenderer.clearOverlayText();
-        }
+        this.m_textElementsRenderer.clearOverlayText();
     }
 
     /**
@@ -2695,17 +2678,11 @@ export class MapView extends THREE.EventDispatcher {
 
         const renderList = this.m_visibleTiles.dataSourceTileList;
 
-        let createTextRenderer = this.renderLabels && this.m_textElementsRenderer === undefined;
-
         // no need to check everything if we're not going to create text renderer.
         renderList.forEach(({ zoomLevel, renderedTiles }) => {
             renderedTiles.forEach(tile => {
                 this.renderTileObjects(tile, zoomLevel);
 
-                if (createTextRenderer && tile.hasTextElements()) {
-                    this.enqueueTextRendererCreation();
-                    createTextRenderer = false;
-                }
                 //We know that rendered tiles are visible (in the view frustum), so we update the
                 //frame number, note we don't do this for the visibleTiles because some may still be
                 //loading (and therefore aren't visible in the sense of being seen on the screen).
@@ -2721,29 +2698,15 @@ export class MapView extends THREE.EventDispatcher {
             !this.m_initialTextPlacementDone &&
             !this.m_firstFrameComplete &&
             !this.isDynamicFrame &&
-            !this.m_initialTextPlacementDone &&
             !this.m_themeIsLoading &&
             this.m_poiTableManager.finishedLoading &&
             this.m_visibleTiles.allVisibleTilesLoaded &&
             this.m_connectedDataSources.size + this.m_failedDataSources.size ===
-                this.m_tileDataSources.length
+                this.m_tileDataSources.length &&
+            !this.m_textElementsRenderer.initializing &&
+            !this.m_textElementsRenderer.loading
         ) {
-            const textElementRendererFinished =
-                this.m_textElementsRenderer !== undefined &&
-                this.m_textElementsRenderer.ready &&
-                !this.m_textElementsRenderer.loading;
-
-            if (!this.textElementsRendererRequested || textElementRendererFinished) {
-                if (textElementRendererFinished) {
-                    // Force label placement in this frame. This may change the loading state of the
-                    // TextElementsRenderer and the animation state of MapView.
-                    this.m_textElementsRenderer!.invalidateCache();
-                }
-                this.m_initialTextPlacementDone = true;
-            }
-            // Either render the labels after placing them, or wait for the TextElementsRenderer to
-            // be created (delayed creation).
-            this.update();
+            this.m_initialTextPlacementDone = true;
         }
 
         this.m_mapAnchors.children.forEach((childObject: MapAnchor) => {
@@ -2864,8 +2827,7 @@ export class MapView extends THREE.EventDispatcher {
             !this.m_firstFrameComplete &&
             this.m_initialTextPlacementDone &&
             !this.isDynamicFrame &&
-            (this.m_textElementsRenderer === undefined ||
-                (this.m_textElementsRenderer.ready && !this.m_textElementsRenderer.loading))
+            !this.textElementsRenderer.loading
         ) {
             this.m_firstFrameComplete = true;
 
@@ -2904,23 +2866,22 @@ export class MapView extends THREE.EventDispatcher {
         // particular camera set up is not compatible with the debug camera.
         const debugCameraActive = this.m_pointOfView !== undefined;
 
-        if (
-            this.m_textElementsRenderer === undefined ||
-            !this.m_textElementsRenderer.ready ||
-            debugCameraActive
-        ) {
+        if (debugCameraActive) {
             return;
         }
 
-        const textElementsChanged: boolean =
-            this.checkIfTextElementsChanged() || this.checkIfTilesChanged();
-        this.m_textElementsRenderer.placeText(textElementsChanged, time, this.m_frameNumber);
+        this.m_textElementsRenderer.placeText(
+            this.checkIfTextElementsChanged(),
+            this.checkIfTilesChanged(),
+            time,
+            this.m_frameNumber
+        );
     }
 
     private finishRenderTextElements() {
         const canRenderTextElements = this.m_pointOfView === undefined;
 
-        if (canRenderTextElements && this.m_textElementsRenderer !== undefined) {
+        if (canRenderTextElements) {
             // copy far value from scene camera, as the distance to the POIs matter now.
             this.m_screenCamera.far = this.m_viewRanges.maximum;
             this.m_textElementsRenderer.renderText(this.m_screenCamera);
@@ -3060,17 +3021,15 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     private movementStarted() {
-        if (this.m_textElementsRenderer !== undefined) {
-            this.m_textElementsRenderer.movementStarted();
-        }
+        this.m_textElementsRenderer.movementStarted();
+
         MOVEMENT_STARTED_EVENT.time = Date.now();
         this.dispatchEvent(MOVEMENT_STARTED_EVENT);
     }
 
     private movementFinished() {
-        if (this.m_textElementsRenderer !== undefined) {
-            this.m_textElementsRenderer.movementFinished();
-        }
+        this.m_textElementsRenderer.movementFinished();
+
         MOVEMENT_FINISHED_EVENT.time = Date.now();
         this.dispatchEvent(MOVEMENT_FINISHED_EVENT);
 
@@ -3238,62 +3197,28 @@ export class MapView extends THREE.EventDispatcher {
         this.m_scene.add(this.m_mapAnchors);
     }
 
-    /**
-     * Ensure `TextElementsRenderer` is initialized.
-     */
-    private createTextRendererIfNeeded(): void {
-        if (this.m_textElementsRenderer === undefined) {
-            this.m_textElementsRenderer = new TextElementsRenderer(
-                this,
-                this.m_screenCollisions,
-                this.m_screenProjector,
-                this.m_options.minNumGlyphs,
-                this.m_options.maxNumGlyphs,
-                this.m_theme,
-                this.m_options.maxNumVisibleLabels,
-                this.m_options.numSecondChanceLabels,
-                this.m_options.labelDistanceScaleMin,
-                this.m_options.labelDistanceScaleMax,
-                this.m_options.maxDistanceRatioForTextLabels,
-                this.m_options.maxDistanceRatioForPoiLabels
-            );
-        }
-    }
-
-    /**
-     * Delay creation of `TextElementsRenderer` to out-of-frame to avoid fps lag.
-     */
-    private enqueueTextRendererCreation(): void {
-        if (
-            this.m_textElementsRenderer === undefined &&
-            this.m_textElementsRendererTimer === undefined
-        ) {
-            this.m_textElementsRendererTimer = setTimeout(() => {
-                this.m_textElementsRendererTimer = undefined;
-                this.createTextRendererIfNeeded();
-            }, 0);
-        }
-    }
-
-    /**
-     * @hidden
-     * Is `true` if the [[TextElementsRenderer]] is soon to be created.
-     */
-    private get textElementsRendererRequested(): boolean {
-        return this.m_textElementsRendererTimer !== undefined;
+    private createTextRenderer(): TextElementsRenderer {
+        return new TextElementsRenderer(
+            this,
+            this.m_screenCollisions,
+            this.m_screenProjector,
+            this.m_options.minNumGlyphs,
+            this.m_options.maxNumGlyphs,
+            this.m_theme,
+            this.m_options.maxNumVisibleLabels,
+            this.m_options.numSecondChanceLabels,
+            this.m_options.labelDistanceScaleMin,
+            this.m_options.labelDistanceScaleMax,
+            this.m_options.maxDistanceRatioForTextLabels,
+            this.m_options.maxDistanceRatioForPoiLabels
+        );
     }
 
     private resetTextRenderer(): void {
-        if (this.m_textElementsRenderer !== undefined) {
-            const overlayText = this.m_textElementsRenderer.overlayText;
-            this.m_textElementsRenderer = undefined;
-            this.createTextRendererIfNeeded();
-            if (overlayText !== undefined) {
-                this.m_textElementsRenderer!.addOverlayText(overlayText);
-            }
-        }
-        if (this.m_textElementsRendererTimer !== undefined) {
-            clearTimeout(this.m_textElementsRendererTimer);
+        const overlayText = this.m_textElementsRenderer.overlayText;
+        this.m_textElementsRenderer = this.createTextRenderer();
+        if (overlayText !== undefined) {
+            this.m_textElementsRenderer.addOverlayText(overlayText);
         }
     }
 

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -967,10 +967,10 @@ export class Tile implements CachedResource {
      * Removes all [[TextElement]] from the tile.
      */
     clearTextElements() {
+        this.textElementsChanged = this.hasTextElements();
         this.m_pathBlockingElements.splice(0);
         this.textElementGroups.clear();
         this.userTextElements.elements.length = 0;
-        this.textElementsChanged = true;
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextCanvasRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextCanvasRenderer.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TextCanvas } from "@here/harp-text-canvas";
+import { PoiRenderer } from "../poi/PoiRenderer";
+
+export interface TextCanvasRenderer {
+    fontCatalog: string;
+    textCanvas: TextCanvas;
+    poiRenderer: PoiRenderer;
+}

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -375,7 +375,8 @@ export class TextElementsRenderer {
         time: number,
         frameNumber: number
     ) {
-        if (!this.initialize(tileTextElementsChanged)) {
+        const textElementsAvailable = this.hasOverlayText() || tileTextElementsChanged;
+        if (!this.initialize(textElementsAvailable)) {
             return;
         }
 

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -4,15 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IndexedTechniqueParams, Technique } from "@here/harp-datasource-protocol";
 import {
+    getPropertyValue,
+    IndexedTechniqueParams,
+    LineMarkerTechnique,
+    PoiTechnique,
+    Technique,
+    TextStyleDefinition,
+    TextTechnique,
+    Theme
+} from "@here/harp-datasource-protocol";
+import {
+    FontStyle,
     FontUnit,
+    FontVariant,
     HorizontalAlignment,
+    TextCanvas,
+    TextLayoutParameters,
     TextLayoutStyle,
+    TextRenderParameters,
     TextRenderStyle,
-    VerticalAlignment
+    VerticalAlignment,
+    WrappingMode
 } from "@here/harp-text-canvas";
+import { getOptionValue, LoggerManager } from "@here/harp-utils";
 import { ColorCache } from "../ColorCache";
+import { PoiRenderer } from "../poi/PoiRenderer";
+import { Tile } from "../Tile";
+import { TextCanvasRenderer } from "./TextCanvasRenderer";
+
+const logger = LoggerManager.instance.create("TextStyleCache");
 
 /**
  * [[TextStyle]] id for the default value inside a [[TextRenderStyleCache]] or a
@@ -125,5 +146,373 @@ export class TextLayoutStyleCache {
                 horizontalAlignment: HorizontalAlignment.Center
             })
         );
+    }
+}
+
+export const DEFAULT_FONT_CATALOG_NAME = "default";
+const DEFAULT_STYLE_NAME = "default";
+
+/**
+ * [[TextElementsRenderer]] representation of a [[Theme]]'s TextStyle.
+ */
+export interface TextElementStyle {
+    name: string;
+    fontCatalog: string;
+    renderParams: TextRenderParameters;
+    layoutParams: TextLayoutParameters;
+    textCanvas?: TextCanvas;
+    poiRenderer?: PoiRenderer;
+}
+
+export class TextStyleCache {
+    private m_textRenderStyleCache = new TextRenderStyleCache();
+    private m_textLayoutStyleCache = new TextLayoutStyleCache();
+    /**
+     * Cache for named colors.
+     */
+    private m_colorMap: Map<string, THREE.Color> = new Map();
+
+    private m_textStyles: Map<string, TextElementStyle> = new Map();
+    private m_defaultStyle: TextElementStyle = {
+        name: DEFAULT_STYLE_NAME,
+        fontCatalog: DEFAULT_FONT_CATALOG_NAME,
+        renderParams: this.m_textRenderStyleCache.get(DEFAULT_TEXT_STYLE_CACHE_ID)!.params,
+        layoutParams: this.m_textLayoutStyleCache.get(DEFAULT_TEXT_STYLE_CACHE_ID)!.params
+    };
+
+    constructor(private m_theme: Theme) {}
+
+    initializeDefaultTextElementStyle(defaultFontCatalogName: string) {
+        if (this.m_theme.textStyles === undefined) {
+            this.m_theme.textStyles = [];
+        }
+        const styles = this.m_theme.textStyles;
+
+        const themedDefaultStyle = styles.find(style => style.name === DEFAULT_STYLE_NAME);
+        if (themedDefaultStyle !== undefined) {
+            this.m_defaultStyle = this.createTextElementStyle(
+                themedDefaultStyle,
+                DEFAULT_STYLE_NAME
+            );
+        } else if (this.m_theme.defaultTextStyle !== undefined) {
+            this.m_defaultStyle = this.createTextElementStyle(
+                this.m_theme.defaultTextStyle,
+                DEFAULT_STYLE_NAME
+            );
+        } else if (styles.length > 0) {
+            this.m_defaultStyle = this.createTextElementStyle(styles[0], DEFAULT_STYLE_NAME);
+        }
+        this.m_defaultStyle.fontCatalog = defaultFontCatalogName;
+    }
+
+    initializeTextElementStyles(
+        defaultPoiRenderer: PoiRenderer,
+        defaultTextCanvas: TextCanvas,
+        textRenderers: TextCanvasRenderer[]
+    ) {
+        // Initialize default text style.
+        if (this.m_defaultStyle.fontCatalog !== undefined) {
+            const styledTextRenderer = textRenderers.find(
+                textRenderer => textRenderer.fontCatalog === this.m_defaultStyle.fontCatalog
+            );
+            this.m_defaultStyle.textCanvas =
+                styledTextRenderer !== undefined ? styledTextRenderer.textCanvas : undefined;
+            this.m_defaultStyle.poiRenderer =
+                styledTextRenderer !== undefined ? styledTextRenderer.poiRenderer : undefined;
+        }
+        if (this.m_defaultStyle.textCanvas === undefined) {
+            if (this.m_defaultStyle.fontCatalog !== undefined) {
+                logger.warn(
+                    `FontCatalog '${this.m_defaultStyle.fontCatalog}' set in TextStyle '${
+                        this.m_defaultStyle.name
+                    }' not found, using default fontCatalog(${
+                        defaultTextCanvas!.fontCatalog.name
+                    }).`
+                );
+            }
+            this.m_defaultStyle.textCanvas = defaultTextCanvas;
+            this.m_defaultStyle.poiRenderer = defaultPoiRenderer;
+        }
+
+        // Initialize theme text styles.
+        this.m_theme.textStyles!.forEach(element => {
+            this.m_textStyles.set(
+                element.name!,
+                this.createTextElementStyle(element, element.name!)
+            );
+        });
+        // tslint:disable-next-line:no-unused-variable
+        for (const [, style] of this.m_textStyles) {
+            if (style.textCanvas === undefined) {
+                if (style.fontCatalog !== undefined) {
+                    const styledTextRenderer = textRenderers.find(
+                        textRenderer => textRenderer.fontCatalog === style.fontCatalog
+                    );
+                    style.textCanvas =
+                        styledTextRenderer !== undefined
+                            ? styledTextRenderer.textCanvas
+                            : undefined;
+                    style.poiRenderer =
+                        styledTextRenderer !== undefined
+                            ? styledTextRenderer.poiRenderer
+                            : undefined;
+                }
+                if (style.textCanvas === undefined) {
+                    if (style.fontCatalog !== undefined) {
+                        logger.warn(
+                            `FontCatalog '${style.fontCatalog}' set in TextStyle '${
+                                style.name
+                            }' not found, using default fontCatalog(${
+                                defaultTextCanvas!.fontCatalog.name
+                            }).`
+                        );
+                    }
+                    style.textCanvas = defaultTextCanvas;
+                    style.poiRenderer = defaultPoiRenderer;
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves a [[TextElementStyle]] for [[Theme]]'s [[TextStyle]] id.
+     */
+    getTextElementStyle(styleId?: string): TextElementStyle {
+        let result;
+        if (styleId === undefined) {
+            result = this.m_defaultStyle;
+        } else {
+            result = this.m_textStyles.get(styleId);
+            if (result === undefined) {
+                result = this.m_defaultStyle;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Gets the appropriate [[TextRenderStyle]] to use for a label. Depends heavily on the label's
+     * [[Technique]] and the current zoomLevel.
+     *
+     * @param technique Label's technique.
+     * @param techniqueIdx Label's technique index.
+     */
+    getRenderStyle(
+        tile: Tile,
+        technique: TextTechnique | PoiTechnique | LineMarkerTechnique
+    ): TextRenderStyle {
+        const mapView = tile.mapView;
+        const dataSource = tile.dataSource;
+        const zoomLevel = mapView.zoomLevel;
+
+        const cacheId = computeStyleCacheId(dataSource.name, technique, Math.floor(zoomLevel));
+        let renderStyle = this.m_textRenderStyleCache.get(cacheId);
+        if (renderStyle === undefined) {
+            const defaultRenderParams = this.m_defaultStyle.renderParams;
+
+            if (technique.color !== undefined) {
+                const hexColor = getPropertyValue(technique.color, Math.floor(zoomLevel));
+                this.m_colorMap.set(cacheId, ColorCache.instance.getColor(hexColor));
+            }
+            if (technique.backgroundColor !== undefined) {
+                const hexBgColor = getPropertyValue(
+                    technique.backgroundColor,
+                    Math.floor(zoomLevel)
+                );
+                this.m_colorMap.set(cacheId + "_bg", ColorCache.instance.getColor(hexBgColor));
+            }
+
+            const renderParams = {
+                fontName: getOptionValue(technique.fontName, defaultRenderParams.fontName),
+                fontSize: {
+                    unit: FontUnit.Pixel,
+                    size:
+                        technique.size !== undefined
+                            ? getPropertyValue(technique.size, Math.floor(zoomLevel))
+                            : defaultRenderParams.fontSize!.size,
+                    backgroundSize:
+                        technique.backgroundSize !== undefined
+                            ? getPropertyValue(technique.backgroundSize, Math.floor(zoomLevel))
+                            : defaultRenderParams.fontSize!.backgroundSize
+                },
+                fontStyle:
+                    technique.fontStyle === "Regular" ||
+                    technique.fontStyle === "Bold" ||
+                    technique.fontStyle === "Italic" ||
+                    technique.fontStyle === "BoldItalic"
+                        ? FontStyle[technique.fontStyle]
+                        : defaultRenderParams.fontStyle,
+                fontVariant:
+                    technique.fontVariant === "Regular" ||
+                    technique.fontVariant === "AllCaps" ||
+                    technique.fontVariant === "SmallCaps"
+                        ? FontVariant[technique.fontVariant]
+                        : defaultRenderParams.fontVariant,
+                rotation: getOptionValue(technique.rotation, defaultRenderParams.rotation),
+                color: getOptionValue(this.m_colorMap.get(cacheId), defaultRenderParams.color),
+                backgroundColor: getOptionValue(
+                    this.m_colorMap.get(cacheId + "_bg"),
+                    defaultRenderParams.backgroundColor
+                ),
+                opacity:
+                    technique.opacity !== undefined
+                        ? getPropertyValue(technique.opacity, Math.floor(zoomLevel))
+                        : defaultRenderParams.opacity,
+                backgroundOpacity:
+                    technique.backgroundOpacity !== undefined
+                        ? getPropertyValue(technique.backgroundOpacity, Math.floor(zoomLevel))
+                        : technique.backgroundColor !== undefined &&
+                          technique.backgroundSize !== undefined &&
+                          getPropertyValue(technique.backgroundSize, Math.floor(zoomLevel)) > 0
+                        ? 1.0 // make label opaque when backgroundColor and backgroundSize are set
+                        : defaultRenderParams.backgroundOpacity
+            };
+
+            const themeRenderParams = this.getTextElementStyle(technique.style).renderParams;
+            renderStyle = new TextRenderStyle({
+                ...themeRenderParams,
+                ...renderParams
+            });
+            this.m_textRenderStyleCache.set(cacheId, renderStyle);
+        }
+
+        return renderStyle;
+    }
+
+    /**
+     * Gets the appropriate [[TextRenderStyle]] to use for a label. Depends heavily on the label's
+     * [[Technique]] and the current zoomLevel.
+     *
+     * @param tile The [[Tile]] to process.
+     * @param technique Label's technique.
+     */
+    getLayoutStyle(
+        tile: Tile,
+        technique: TextTechnique | PoiTechnique | LineMarkerTechnique
+    ): TextLayoutStyle {
+        const floorZoomLevel = Math.floor(tile.mapView.zoomLevel);
+        const cacheId = computeStyleCacheId(tile.dataSource.name, technique, floorZoomLevel);
+        let layoutStyle = this.m_textLayoutStyleCache.get(cacheId);
+
+        if (layoutStyle === undefined) {
+            const defaultLayoutParams = this.m_defaultStyle.layoutParams;
+
+            const hAlignment = getPropertyValue(technique.hAlignment, floorZoomLevel) as
+                | string
+                | undefined;
+            const vAlignment = getPropertyValue(technique.vAlignment, floorZoomLevel) as
+                | string
+                | undefined;
+
+            const horizontalAlignment: HorizontalAlignment | undefined =
+                hAlignment === "Left" || hAlignment === "Center" || hAlignment === "Right"
+                    ? HorizontalAlignment[hAlignment]
+                    : defaultLayoutParams.horizontalAlignment;
+
+            const verticalAlignment: VerticalAlignment | undefined =
+                vAlignment === "Above" || vAlignment === "Center" || vAlignment === "Below"
+                    ? VerticalAlignment[vAlignment]
+                    : defaultLayoutParams.verticalAlignment;
+
+            const layoutParams = {
+                tracking: getOptionValue(technique.tracking, defaultLayoutParams.tracking),
+                leading: getOptionValue(technique.leading, defaultLayoutParams.leading),
+                maxLines: getOptionValue(technique.maxLines, defaultLayoutParams.maxLines),
+                lineWidth: getOptionValue(technique.lineWidth, defaultLayoutParams.lineWidth),
+                canvasRotation: getOptionValue(
+                    technique.canvasRotation,
+                    defaultLayoutParams.canvasRotation
+                ),
+                lineRotation: getOptionValue(
+                    technique.lineRotation,
+                    defaultLayoutParams.lineRotation
+                ),
+                wrappingMode:
+                    technique.wrappingMode === "None" ||
+                    technique.wrappingMode === "Character" ||
+                    technique.wrappingMode === "Word"
+                        ? WrappingMode[technique.wrappingMode]
+                        : defaultLayoutParams.wrappingMode,
+                horizontalAlignment,
+                verticalAlignment
+            };
+
+            const themeLayoutParams = this.getTextElementStyle(technique.style);
+            layoutStyle = new TextLayoutStyle({
+                ...themeLayoutParams,
+                ...layoutParams
+            });
+            this.m_textLayoutStyleCache.set(cacheId, layoutStyle);
+        }
+
+        return layoutStyle;
+    }
+
+    private createTextElementStyle(
+        style: TextStyleDefinition,
+        styleName: string
+    ): TextElementStyle {
+        return {
+            name: styleName,
+            fontCatalog: getOptionValue(style.fontCatalogName, this.m_defaultStyle.fontCatalog),
+            renderParams: {
+                fontName: style.fontName,
+                fontSize: {
+                    unit: FontUnit.Pixel,
+                    size: 32,
+                    backgroundSize: style.backgroundSize || 8
+                },
+                fontStyle:
+                    style.fontStyle === "Regular" ||
+                    style.fontStyle === "Bold" ||
+                    style.fontStyle === "Italic" ||
+                    style.fontStyle === "BoldItalic"
+                        ? FontStyle[style.fontStyle]
+                        : undefined,
+                fontVariant:
+                    style.fontVariant === "Regular" ||
+                    style.fontVariant === "AllCaps" ||
+                    style.fontVariant === "SmallCaps"
+                        ? FontVariant[style.fontVariant]
+                        : undefined,
+                rotation: style.rotation,
+                color:
+                    style.color !== undefined
+                        ? ColorCache.instance.getColor(style.color)
+                        : undefined,
+                backgroundColor:
+                    style.backgroundColor !== undefined
+                        ? ColorCache.instance.getColor(style.backgroundColor)
+                        : undefined,
+                opacity: style.opacity,
+                backgroundOpacity: style.backgroundOpacity
+            },
+            layoutParams: {
+                tracking: style.tracking,
+                leading: style.leading,
+                maxLines: style.maxLines,
+                lineWidth: style.lineWidth,
+                canvasRotation: style.canvasRotation,
+                lineRotation: style.lineRotation,
+                wrappingMode:
+                    style.wrappingMode === "None" ||
+                    style.wrappingMode === "Character" ||
+                    style.wrappingMode === "Word"
+                        ? WrappingMode[style.wrappingMode]
+                        : WrappingMode.Word,
+                verticalAlignment:
+                    style.vAlignment === "Above" ||
+                    style.vAlignment === "Center" ||
+                    style.vAlignment === "Below"
+                        ? VerticalAlignment[style.vAlignment]
+                        : VerticalAlignment.Center,
+                horizontalAlignment:
+                    style.hAlignment === "Left" ||
+                    style.hAlignment === "Center" ||
+                    style.hAlignment === "Right"
+                        ? HorizontalAlignment[style.hAlignment]
+                        : HorizontalAlignment.Center
+            }
+        };
     }
 }


### PR DESCRIPTION
…ntsRenderer.

- Consolidate text style caches into a TextStyleCache instance owned by TextElementsRenderer.
- Remove duplicated code in PoiManager and TileGeometryCreator to get text styles.
- Simplify TextElementsRenderer initialization. The object it's always available in MapView,
only its initialization is delayed until the view is configured to render labels and there's
labels available from some data source.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
