### PR TITLE
Re-enable GitHub CI checks on macOS.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node_version: [10, 11, 12]
-        os: [ubuntu-latest,windows-latest]
+        os: [ubuntu-latest,macOS-latest,windows-latest]
 
     steps:
     - name: Reset git settings (Windows)


### PR DESCRIPTION
Re-enabling checks disabled in #997.

See, https://github.community/t5/GitHub-Actions/macOS-VM-failing-immediately/td-p/36969/page/2

Related-to: HARP-7766

