### PR TITLE
MINOR: Change TextElementsRenderer's overload mode logging.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -2353,11 +2353,12 @@ export class TextElementsRenderer {
                 numTextElementsInScene += tile.userTextElements.elements.length;
             }
         });
-        this.m_overloaded = numTextElementsInScene > OVERLOAD_LABEL_LIMIT;
+        const newOverloaded = numTextElementsInScene > OVERLOAD_LABEL_LIMIT;
 
-        if (this.m_overloaded) {
-            logger.log("Overloaded Mode enabled.");
+        if (newOverloaded && !this.m_overloaded) {
+            logger.debug("Overloaded Mode enabled.");
         }
+        this.m_overloaded = newOverloaded;
         return this.m_overloaded;
     }
 }


### PR DESCRIPTION
Moved to debug channel. Also now it's logged only when entering
overload mode instead of logging on every frame with text updates.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
