### PR TITLE
HARP-7072: Reimplement "all", "any" and "none" as flow operators.

### DIFF
--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -192,56 +192,28 @@ export class ExprEvaluator implements ExprVisitor<Value, ExprEvaluatorContext> {
     }
 
     visitCallExpr(expr: CallExpr, context: ExprEvaluatorContext): Value {
-        switch (expr.op) {
-            case "all":
-                for (const childExpr of expr.args) {
-                    if (!childExpr.accept(this, context)) {
-                        return false;
-                    }
-                }
-                return true;
-
-            case "any":
-                for (const childExpr of expr.args) {
-                    if (childExpr.accept(this, context)) {
-                        return true;
-                    }
-                }
-                return false;
-
-            case "none":
-                for (const childExpr of expr.args) {
-                    if (childExpr.accept(this, context)) {
-                        return false;
-                    }
-                }
-                return true;
-
-            default: {
-                if (context.cache !== undefined) {
-                    const v = context.cache.get(expr);
-                    if (v !== undefined) {
-                        return v;
-                    }
-                }
-
-                const descriptor = expr.descriptor || operatorDescriptors.get(expr.op);
-
-                if (descriptor) {
-                    expr.descriptor = descriptor;
-
-                    const result = descriptor.call(context, expr);
-
-                    if (context.cache) {
-                        context.cache.set(expr, result);
-                    }
-
-                    return result;
-                }
-
-                throw new Error(`undefined operator '${expr.op}`);
+        if (context.cache !== undefined) {
+            const v = context.cache.get(expr);
+            if (v !== undefined) {
+                return v;
             }
-        } // switch
+        }
+
+        const descriptor = expr.descriptor || operatorDescriptors.get(expr.op);
+
+        if (descriptor) {
+            expr.descriptor = descriptor;
+
+            const result = descriptor.call(context, expr);
+
+            if (context.cache) {
+                context.cache.set(expr, result);
+            }
+
+            return result;
+        }
+
+        throw new Error(`undefined operator '${expr.op}`);
     }
 }
 

--- a/@here/harp-datasource-protocol/lib/operators/FlowOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FlowOperators.ts
@@ -25,6 +25,39 @@ function conditionalCast(context: ExprEvaluatorContext, type: string, args: Expr
 }
 
 const operators = {
+    all: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            for (const childExpr of call.args) {
+                if (!context.evaluate(childExpr)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    },
+
+    any: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            for (const childExpr of call.args) {
+                if (context.evaluate(childExpr)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    },
+
+    none: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            for (const childExpr of call.args) {
+                if (context.evaluate(childExpr)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    },
+
     boolean: {
         call: (context: ExprEvaluatorContext, call: CallExpr) => {
             return conditionalCast(context, "boolean", call.args);


### PR DESCRIPTION
Move the implementation of common control flow operators to
FlowOperators.ts. This will allow ExprEvaluator to potentially
cache previous computed expressions containing these operators.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
