### PR TITLE
HARP-7819: Fix missing labels in Asia in zl 4.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -615,7 +615,7 @@ export class TextElementsRenderer {
         renderList.forEach(renderListEntry => {
             const startLinePointProj = new THREE.Vector3();
             const endLinePointProj = new THREE.Vector3();
-            for (const tile of renderListEntry.visibleTiles) {
+            for (const tile of renderListEntry.renderedTiles.values()) {
                 for (const pathBlockingElement of tile.blockingElements) {
                     if (pathBlockingElement.points.length < 2) {
                         continue;
@@ -1171,7 +1171,7 @@ export class TextElementsRenderer {
             this.updateTextElementsFromSource(
                 tileList.dataSource,
                 tileList.storageLevel,
-                tileList.visibleTiles,
+                Array.from(tileList.renderedTiles.values()),
                 updateStartTime
             );
         });

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1714,7 +1714,6 @@ export class TextElementsRenderer {
         // Check if icon should be rendered at this zoomLevel
         let renderIcon =
             poiInfo !== undefined &&
-            groupState.visited &&
             MathUtils.isClamped(
                 mapViewState.zoomLevel,
                 poiInfo.iconMinZoomLevel,
@@ -1738,7 +1737,18 @@ export class TextElementsRenderer {
                 tempBox2D
             );
 
-            if (iconIsVisible) {
+            // If the icon is prepared and valid, but just not visible, try again next time.
+            if (!iconIsVisible) {
+                // Forced making it un-current.
+                iconRenderState.lastFrameNumber = -1;
+
+                if (placementStats) {
+                    ++placementStats.numNotVisible;
+                }
+                return false;
+            }
+
+            if (groupState.visited) {
                 iconSpaceAvailable = poiRenderer.isSpaceAvailable(
                     this.m_screenCollisions,
                     tempBox2D
@@ -1772,16 +1782,9 @@ export class TextElementsRenderer {
                         iconRenderState.startFadeIn(mapViewState.frameNumber, mapViewState.time);
                     }
                 }
-            }
-            // If the icon is prepared and valid, but just not visible, try again next time.
-            else {
-                // Forced making it un-current.
-                iconRenderState.lastFrameNumber = -1;
-
-                if (placementStats) {
-                    ++placementStats.numNotVisible;
-                }
-                return false;
+            } else if (iconRenderState.isVisible()) {
+                iconRenderState.startFadeOut(mapViewState.frameNumber, mapViewState.time);
+                iconRenderState.lastFrameNumber = mapViewState.frameNumber;
             }
         }
 


### PR DESCRIPTION
TextElementsRenderer was taking labels for placement from
VisibleTileSet's visibleTiles. Changed to use renderedTiles instead.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
