### PR TITLE
HARP-7517: Partial support for HEX encoded RGBA colors.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -31,7 +31,7 @@ export interface StringEncodedNumeralFormat {
     // TODO: Add target/output array as parameter to minimize arrays creation.
     decoder: (encodedValue: string) => number[];
 }
-export const StringEncodedMeters: StringEncodedNumeralFormat = {
+const StringEncodedMeters: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.Meters,
     size: 1,
     regExp: /((?=\.\d|\d)(?:\d+)?(?:\.?\d*))m/,
@@ -39,7 +39,7 @@ export const StringEncodedMeters: StringEncodedNumeralFormat = {
         return [Number(StringEncodedMeters.regExp.exec(encodedValue)![1])];
     }
 };
-export const StringEncodedPixels: StringEncodedNumeralFormat = {
+const StringEncodedPixels: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.Pixels,
     size: 1,
     mask: 1.0,
@@ -48,16 +48,37 @@ export const StringEncodedPixels: StringEncodedNumeralFormat = {
         return [Number(StringEncodedPixels.regExp.exec(encodedValue)![1])];
     }
 };
-export const StringEncodedHex: StringEncodedNumeralFormat = {
+const StringEncodedHex: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.Hex,
     size: 3,
-    regExp: /#([0-9A-Fa-f]{1,2})([0-9A-Fa-f]{1,2})([0-9A-Fa-f]{1,2})/,
+    regExp: /\#([0-9A-Fa-f]{1,8})/,
     decoder: (encodedValue: string) => {
-        tmpColor.set(encodedValue);
+        const match = StringEncodedHex.regExp.exec(encodedValue)!;
+        const hex = match[1];
+        const size = hex.length;
+        // Note that we simply ignore alpha channel value.
+        // TODO: To be resolved with HARP-7517
+        if (size === 3 || size === 4) {
+            // #RGB or #RGBA
+            tmpColor.setRGB(
+                parseInt(hex.charAt(0) + hex.charAt(0), 16) / 255,
+                parseInt(hex.charAt(1) + hex.charAt(1), 16) / 255,
+                parseInt(hex.charAt(2) + hex.charAt(2), 16) / 255
+            );
+        } else if (size === 6 || size === 8) {
+            // #RRGGBB or #RRGGBBAA
+            tmpColor.setRGB(
+                parseInt(hex.charAt(0) + hex.charAt(1), 16) / 255,
+                parseInt(hex.charAt(2) + hex.charAt(3), 16) / 255,
+                parseInt(hex.charAt(4) + hex.charAt(5), 16) / 255
+            );
+        } else {
+            throw new Error(`unsupported hex color '${encodedValue}'`);
+        }
         return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
-export const StringEncodedRGB: StringEncodedNumeralFormat = {
+const StringEncodedRGB: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.RGB,
     size: 3,
     // tslint:disable-next-line:max-line-length
@@ -72,7 +93,7 @@ export const StringEncodedRGB: StringEncodedNumeralFormat = {
         return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
-export const StringEncodedRGBA: StringEncodedNumeralFormat = {
+const StringEncodedRGBA: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.RGBA,
     size: 3,
     // tslint:disable-next-line:max-line-length
@@ -89,7 +110,7 @@ export const StringEncodedRGBA: StringEncodedNumeralFormat = {
         return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
-export const StringEncodedHSL: StringEncodedNumeralFormat = {
+const StringEncodedHSL: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.HSL,
     size: 3,
     // tslint:disable-next-line:max-line-length
@@ -106,14 +127,84 @@ export const StringEncodedHSL: StringEncodedNumeralFormat = {
 };
 
 /**
- * Array of supported [[StringEncodedNumeralFormat]]s (inteded to be indexed with
- * [[StringEncodedNumeralType]] enum).
+ * Array of all supported [[StringEncodedNumeralFormat]]s describing sizes, lengths and distances.
  */
-export const StringEncodedNumeralFormats: StringEncodedNumeralFormat[] = [
+export const StringEncodedMetricFormats: StringEncodedNumeralFormat[] = [
     StringEncodedMeters,
-    StringEncodedPixels,
+    StringEncodedPixels
+];
+
+/**
+ * Array of all supported [[StringEncodedNumeralFormat]]s describing color data.
+ */
+export const StringEncodedColorFormats: StringEncodedNumeralFormat[] = [
     StringEncodedHex,
     StringEncodedRGB,
     StringEncodedRGBA,
     StringEncodedHSL
 ];
+
+/**
+ * Array of supported [[StringEncodedNumeralFormat]]s (intended to be indexed with
+ * [[StringEncodedNumeralType]] enum).
+ */
+export const StringEncodedNumeralFormats: StringEncodedNumeralFormat[] = [
+    ...StringEncodedMetricFormats,
+    ...StringEncodedColorFormats
+];
+
+/**
+ * Parse string encoded numeral values using all known [[StringEncodedNumeralFormats]].
+ *
+ * @param numeral The string representing numeric value.
+ * @param pixelToMeters The ratio used to convert from meters to pixels (default 1.0).
+ * @returns Number parsed or __undefined__ if non of the numeral patterns matches the expression
+ * provided in [[numeral]].
+ */
+export function parseStringEncodedNumeral(
+    numeral: string,
+    pixelToMeters: number = 1.0
+): number | undefined {
+    const matchedFormat = StringEncodedNumeralFormats.find(format => format.regExp.test(numeral));
+    if (matchedFormat === undefined) {
+        return undefined;
+    }
+    switch (matchedFormat.type) {
+        case StringEncodedNumeralType.Meters:
+            return matchedFormat.decoder(numeral)[0];
+        case StringEncodedNumeralType.Pixels:
+            return matchedFormat.decoder(numeral)[0] * pixelToMeters;
+        case StringEncodedNumeralType.Hex:
+        case StringEncodedNumeralType.RGB:
+        case StringEncodedNumeralType.RGBA:
+        case StringEncodedNumeralType.HSL:
+            const rgbValues = matchedFormat.decoder(numeral);
+            return tmpColor.setRGB(rgbValues[0], rgbValues[1], rgbValues[2]).getHex();
+        default:
+            return matchedFormat.decoder(numeral)[0];
+    }
+}
+
+/**
+ * Parse string encoded color value using all known [[StringEncodedColorFormats]].
+ *
+ * @param color The string encoded color expression (i.e. '#FFF', 'rgb(255, 0, 0)', etc.).
+ * @returns The color parsed or __undefined__ if non of the known representations matches
+ * the expression provided in [[color]].
+ */
+export function parseStringEncodedColor(color: string): number | undefined {
+    const matchedFormat = StringEncodedColorFormats.find(format => format.regExp.test(color));
+    if (matchedFormat === undefined) {
+        return undefined;
+    }
+    switch (matchedFormat.type) {
+        case StringEncodedNumeralType.Hex:
+        case StringEncodedNumeralType.RGB:
+        case StringEncodedNumeralType.RGBA:
+        case StringEncodedNumeralType.HSL:
+            const rgbValues = matchedFormat.decoder(color);
+            return tmpColor.setRGB(rgbValues[0], rgbValues[1], rgbValues[2]).getHex();
+        default:
+            return matchedFormat.decoder(color)[0];
+    }
+}

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -14,6 +14,7 @@ import {
     isStandardTechnique,
     isTerrainTechnique,
     isTextureBuffer,
+    parseStringEncodedColor,
     Technique,
     TEXTURE_PROPERTY_KEYS,
     TextureProperties
@@ -475,6 +476,12 @@ function applyTechniquePropertyToMaterial(
 ) {
     const m = material as any;
     if (m[prop] instanceof THREE.Color) {
+        if (typeof value === "string") {
+            value = parseStringEncodedColor(value);
+            if (value === undefined) {
+                throw new Error(`Unsupported color format: '${value}'`);
+            }
+        }
         m[prop].set(value);
         // Trigger setter notifying change
         m[prop] = m[prop];


### PR DESCRIPTION
This patch-set provides support for defining theme colors in extended HEX
formats that contains alpha channel, such as
- #RGBA (#F008 - semi opaque red),
- #RRGGBBAA (#FF000088 - as above).
Although such colors may be defined in themes, there is no internal engine
support for alpha channel specified, which is silently ignored.

Note:
This also fixes RGBA colors parsing that were not passing via
getPropertyValue() call - static (not interpolated) color values.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
