### PR TITLE
HARP-7898: Color interpolation switches to RGB space instead of HSL.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -6,7 +6,6 @@
 import { Color } from "three";
 
 const tmpColor = new Color();
-const tmpHSL = { h: 0, s: 0, l: 0 };
 
 /**
  * Enumeration of supported string encoded numerals.
@@ -29,6 +28,7 @@ export interface StringEncodedNumeralFormat {
     size: number;
     regExp: RegExp;
     mask?: number;
+    // TODO: Add target/output array as parameter to minimize arrays creation.
     decoder: (encodedValue: string) => number[];
 }
 export const StringEncodedMeters: StringEncodedNumeralFormat = {
@@ -53,8 +53,8 @@ export const StringEncodedHex: StringEncodedNumeralFormat = {
     size: 3,
     regExp: /#([0-9A-Fa-f]{1,2})([0-9A-Fa-f]{1,2})([0-9A-Fa-f]{1,2})/,
     decoder: (encodedValue: string) => {
-        tmpColor.set(encodedValue).getHSL(tmpHSL);
-        return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
+        tmpColor.set(encodedValue);
+        return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
 export const StringEncodedRGB: StringEncodedNumeralFormat = {
@@ -64,14 +64,12 @@ export const StringEncodedRGB: StringEncodedNumeralFormat = {
     regExp: /rgb\((?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]))\)/,
     decoder: (encodedValue: string) => {
         const channels = StringEncodedRGB.regExp.exec(encodedValue)!;
-        tmpColor
-            .setRGB(
-                parseInt(channels[1], 10) / 255,
-                parseInt(channels[2], 10) / 255,
-                parseInt(channels[3], 10) / 255
-            )
-            .getHSL(tmpHSL);
-        return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
+        tmpColor.setRGB(
+            parseInt(channels[1], 10) / 255,
+            parseInt(channels[2], 10) / 255,
+            parseInt(channels[3], 10) / 255
+        );
+        return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
 export const StringEncodedRGBA: StringEncodedNumeralFormat = {
@@ -83,14 +81,12 @@ export const StringEncodedRGBA: StringEncodedNumeralFormat = {
         const channels = StringEncodedRGBA.regExp.exec(encodedValue)!;
         // For now we simply ignore alpha channel value.
         // TODO: To be resolved with HARP-7517
-        tmpColor
-            .setRGB(
-                parseInt(channels[1], 10) / 255,
-                parseInt(channels[2], 10) / 255,
-                parseInt(channels[3], 10) / 255
-            )
-            .getHSL(tmpHSL);
-        return [tmpHSL.h, tmpHSL.s, tmpHSL.l];
+        tmpColor.setRGB(
+            parseInt(channels[1], 10) / 255,
+            parseInt(channels[2], 10) / 255,
+            parseInt(channels[3], 10) / 255
+        );
+        return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
 export const StringEncodedHSL: StringEncodedNumeralFormat = {
@@ -100,11 +96,12 @@ export const StringEncodedHSL: StringEncodedNumeralFormat = {
     regExp: /hsl\(((?:[0-9]|[1-9][0-9]|1[0-9]{1,2}|2[0-9]{1,2}|3[0-5][0-9]|360)), ?(?:([0-9]|[1-9][0-9]|100)%), ?(?:([0-9]|[1-9][0-9]|100)%)\)/,
     decoder: (encodedValue: string) => {
         const channels = StringEncodedHSL.regExp.exec(encodedValue)!;
-        return [
+        tmpColor.setHSL(
             parseInt(channels[1], 10) / 360,
             parseInt(channels[2], 10) / 100,
             parseInt(channels[3], 10) / 100
-        ];
+        );
+        return [tmpColor.r, tmpColor.g, tmpColor.b];
     }
 };
 

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -29,7 +29,8 @@ const booleanProperty: InterpolatedProperty = {
 const colorProperty: InterpolatedProperty = {
     interpolationMode: InterpolationMode.Discrete,
     zoomLevels: levels,
-    values: [0, 1, 0.5, 120 / 360, 1, 0.5, 240 / 360, 1, 0.5],
+    // [r0, g0, b0, r1, g1, b1, ...]
+    values: [1, 0, 0, 0, 1, 0, 0, 0, 1],
     _stringEncodedNumeralType: StringEncodedNumeralType.Hex
 };
 
@@ -87,9 +88,11 @@ describe("Interpolation", function() {
 
         assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
         assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xfeff00);
+        // rgb: [ 0.5, 0.5, 0 ]
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0x7f7f00);
         assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00feff);
+        // rgb: [ 0, 0.5, 0.5 ]
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x007f7f);
         assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
         assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });
@@ -107,9 +110,11 @@ describe("Interpolation", function() {
 
         assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
         assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xfeff00);
+        // rgb: [ 0.4375, 0.625, 0 ]
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0x6f9f00);
         assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00feff);
+        // rgb: [ 0, 0.625, 0.4375 ]
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x009f6f);
         assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
         assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });
@@ -127,9 +132,11 @@ describe("Interpolation", function() {
 
         assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
         assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xff7f00);
+        // rgb: [ 0.75, 0.25, 0 ]
+        assert.equal(getPropertyValue(colorProperty, 2.5), 0xbf3f00);
         assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00ff7f);
+        // rgb: [ 0, 0.75, 0.25 ]
+        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00bf3f);
         assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
         assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
     });


### PR DESCRIPTION
Default conversion to HSL color space causes inaccuracy's even when
using static colors in themes. Current unit tests (and methods) works only
because of passing color definition (string encoded) directly into to
THREE.js library (without HSL conversion).
In order to support for RGBA color channels and provide common mechanism
for colors decoding, color values may not be converted between spaces
unless needed or requested by special interpolation methods (to be
implemented).

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
