### PR TITLE
HARP-7072: Add support to evaluate interpolation in dynamic scopes.

### DIFF
--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -6,7 +6,7 @@
 
 import { CallExpr, Expr, ExprScope, NumberLiteralExpr, Value } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
-import { createInterpolatedProperty } from "../InterpolatedProperty";
+import { createInterpolatedProperty, getPropertyValue } from "../InterpolatedProperty";
 import { InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
 
 /**
@@ -149,6 +149,10 @@ const operators = {
                 throw new Error("failed to create interpolator");
             }
 
+            if (context.scope === ExprScope.Dynamic) {
+                return getPropertyValue(result, context.env);
+            }
+
             return result;
         }
     },
@@ -161,7 +165,7 @@ const operators = {
             const input = call.args[0];
 
             if (
-                context.scope === ExprScope.Value &&
+                (context.scope === ExprScope.Value || context.scope === ExprScope.Dynamic) &&
                 input instanceof CallExpr &&
                 input.op === "zoom"
             ) {
@@ -196,6 +200,10 @@ const operators = {
 
                 if (interpolation === undefined) {
                     throw new Error("failed to create interpolator");
+                }
+
+                if (context.scope === ExprScope.Dynamic) {
+                    return getPropertyValue(interpolation, context.env);
                 }
 
                 return interpolation;

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -934,16 +934,61 @@ describe("ExprEvaluator", function() {
     });
 
     describe("getPropertyValue", function() {
-        const env = new MapEnv({
-            $zoom: 14,
-            $pixelsToMeters: 2,
-            time: 1
-        });
+        const env = new MapEnv(
+            {
+                $zoom: 14,
+                $pixelToMeters: 2,
+                time: 1
+            },
+            new MapEnv(defaultEnv)
+        );
 
         it("evaluate", function() {
             assert.strictEqual(
                 getPropertyValue(Expr.fromJSON(["rgb", 255, 0, ["*", ["get", "time"], 255]]), env),
                 "#ff00ff"
+            );
+
+            assert.strictEqual(
+                getPropertyValue(
+                    Expr.fromJSON(["step", ["zoom"], ["get", "one"], 14, ["get", "two"]]),
+                    env
+                ),
+                2
+            );
+
+            assert.strictEqual(
+                getPropertyValue(Expr.fromJSON(["step", ["zoom"], "10px", 14, "20px"]), env),
+                40
+            );
+
+            assert.strictEqual(
+                getPropertyValue(Expr.fromJSON(["step", ["zoom"], "10px", 15, "20px"]), env),
+                20
+            );
+
+            assert.strictEqual(
+                getPropertyValue(
+                    Expr.fromJSON([
+                        "interpolate",
+                        ["linear"],
+                        ["zoom"],
+                        0,
+                        0,
+                        20,
+                        ["*", ["get", "two"], 10]
+                    ]),
+                    env
+                ),
+                14
+            );
+
+            assert.strictEqual(
+                getPropertyValue(
+                    Expr.fromJSON(["interpolate", ["linear"], ["zoom"], 1, "1px", 20, "20px"]),
+                    env
+                ),
+                28
             );
         });
     });


### PR DESCRIPTION
Expressions used in a "dynamic evaluation scope" should evaluate their
interpolations instead of returning the unvaluated interpolators.
    

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
