### PR TITLE
Fix performance benchmark example.

### DIFF
--- a/@here/harp-examples/lib/PerformanceUtils.ts
+++ b/@here/harp-examples/lib/PerformanceUtils.ts
@@ -106,13 +106,12 @@ export namespace PerformanceUtils {
             decoderCount,
             theme: theme.resource,
             enableStatistics: true,
-            enablePhasedLoading: phasedLoading !== false,
+            enablePhasedLoading: phasedLoading === true,
             collisionDebugCanvas: canvasOverlay,
             powerPreference
         });
 
-        mapView.camera.position.set(0, 0, 800);
-        mapView.geoCenter = new GeoCoordinates(52.518611, 13.376111, 0);
+        mapView.lookAt(new GeoCoordinates(52.518611, 13.376111), 8000, 0, 0);
 
         const mapControls = MapControls.create(mapView);
 
@@ -278,9 +277,7 @@ export namespace PerformanceUtils {
         if (cameraHeight === undefined) {
             cameraHeight = mapView.camera.position.z;
         }
-        mapView.geoCenter = new GeoCoordinates(lat, long, 0);
-        mapView.camera.position.setZ(cameraHeight);
-        mapView.camera.matrixWorldNeedsUpdate = true;
+        mapView.lookAt(new GeoCoordinates(lat, long), cameraHeight);
 
         if (force === true) {
             await delay(0);

--- a/@here/harp-examples/src/performance_benchmark.ts
+++ b/@here/harp-examples/src/performance_benchmark.ts
@@ -85,8 +85,8 @@ function getPowerPreference(str: string): string | undefined {
 function updateUrlOptions() {
     const numDecodersOptionValueStr =
         decoderCount !== undefined ? decoderCount.toFixed(0) : undefined;
-    // Default is "on", so it will not be written to the URL.
-    const phasedLoadingOptionValueStr = phasedLoading === false ? "off" : undefined;
+    // Default is "off", so it will not be written to the URL.
+    const phasedLoadingOptionValueStr = phasedLoading === true ? "on" : undefined;
 
     let searchStr = "";
 
@@ -782,7 +782,7 @@ export namespace PerformanceBenchmark {
                     updateUrlOptions();
                 }
             })
-            .setValue(phasedLoading !== false);
+            .setValue(phasedLoading === true);
 
         benchmarksFolder
             .add(guiOptions, "PixelRatio", guiOptions.PixelRatio)


### PR DESCRIPTION
Fix performance benchmark example by using proper API to set initial map location.
