### PR TITLE
HARP-7808 Fixing issue with tile offset + some artifacts

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -729,14 +729,14 @@ export class TileGeometryCreator {
                     object.onBeforeRender = chainCallbacks(
                         object.onBeforeRender,
                         (_renderer, _scene, _camera, _geometry, _material) => {
-                            const worldOffsetX =
-                                mapView.projection.worldExtent(0, 0).max.x * tile.offset;
                             if (_material.clippingPlanes === null) {
                                 _material.clippingPlanes = this.clippingPlanes;
                                 // TODO: Add clipping for Spherical projection.
                             }
                             if (mapView.projection.type === ProjectionType.Planar) {
-                                // This prevents 1 pixel errors in the IBCT
+                                const worldOffsetX =
+                                    mapView.projection.worldExtent(0, 0).max.x * tile.offset;
+                                // This prevents aliasing issues in the pixel shader.
                                 const expandFactor = 1.01;
                                 const planes = _material.clippingPlanes;
                                 const rightConstant =

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -729,24 +729,29 @@ export class TileGeometryCreator {
                     object.onBeforeRender = chainCallbacks(
                         object.onBeforeRender,
                         (_renderer, _scene, _camera, _geometry, _material) => {
+                            const worldOffsetX =
+                                mapView.projection.worldExtent(0, 0).max.x * tile.offset;
                             if (_material.clippingPlanes === null) {
                                 _material.clippingPlanes = this.clippingPlanes;
                                 // TODO: Add clipping for Spherical projection.
                             }
                             if (mapView.projection.type === ProjectionType.Planar) {
                                 // This prevents 1 pixel errors in the IBCT
-                                const expandFactor = 1.001;
+                                const expandFactor = 1.01;
                                 const planes = _material.clippingPlanes;
                                 const rightConstant =
                                     tile.center.x -
                                     mapView.worldCenter.x +
-                                    tile.boundingBox.extents.x * expandFactor;
+                                    tile.boundingBox.extents.x * expandFactor +
+                                    worldOffsetX;
+
                                 planes[0].constant = rightConstant;
 
                                 const leftConstant =
                                     tile.center.x -
                                     mapView.worldCenter.x -
-                                    tile.boundingBox.extents.x * expandFactor;
+                                    tile.boundingBox.extents.x * expandFactor +
+                                    worldOffsetX;
                                 planes[1].constant = -leftConstant;
 
                                 const topConstant =


### PR DESCRIPTION
- Increased the expand factor to 1% when zooming out, the factor was not enough to prevent some aliasing at the tile borders
- fixed the calculation of the right / left offsets to take into consideration the tile's offsets.

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>
