### PR TITLE
Adapted before-render callback for ThreeJS 0.110.0

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -728,7 +728,7 @@ export class TileGeometryCreator {
                 if (isFillTechnique(technique)) {
                     object.onBeforeRender = chainCallbacks(
                         object.onBeforeRender,
-                        (_renderer, _scene, _camera, _geometry, _material) => {
+                        (_renderer, _scene, _camera, _geometry, _material, _group) => {
                             if (_material.clippingPlanes === null) {
                                 _material.clippingPlanes = this.clippingPlanes;
                                 // TODO: Add clipping for Spherical projection.


### PR DESCRIPTION
Adapted the definition of the `onBeforeRender` callback for the
fill technique, in order to make it compliant with the latest definition
for the `Object3D` class in ThreeJS 0.110.0

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
