### PR TITLE
HARP-7373: Perf improvements in point label deduplication.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -5,21 +5,15 @@
  */
 
 import { assert } from "@here/harp-utils";
-import { TextElement } from "./TextElement";
 import { TextElementGroup } from "./TextElementGroup";
 import { TextElementState } from "./TextElementState";
 
 /**
  * Type of functions used to do early rejection of elements during group state creation or update.
- * @param textElement The text element to check.
- * @param lastFrameNumber Last frame the element was processed for rendering if available, otherwise
- * `undefined`.
+ * @param textElementState The state of the text element to check.
  * @returns `undefined` if element was rejected, otherwise its current view distance.
  */
-export type TextElementFilter = (
-    textElement: TextElement,
-    lastFrameNumber?: number
-) => number | undefined;
+export type TextElementFilter = (textElementState: TextElementState) => number | undefined;
 
 /**
  * `TextElementGroupState` keeps the state of a text element group and each element in it while
@@ -50,9 +44,9 @@ export class TextElementGroupState {
         //    primitive field in the label state.
         for (let i = 0; i < length; ++i) {
             const textElement = group.elements[i];
-            const textDistance = filter(textElement);
-
-            const state = new TextElementState(textElement, this, textDistance);
+            const state = new TextElementState(textElement);
+            const textDistance = filter(state);
+            state.update(this, textDistance);
             this.m_textElementStates[i] = state;
         }
     }
@@ -99,11 +93,7 @@ export class TextElementGroupState {
      */
     updateElements(filter: TextElementFilter) {
         for (const elementState of this.m_textElementStates) {
-            const lastFrameNumber = elementState.initialized
-                ? elementState.textRenderState!.lastFrameNumber
-                : undefined;
-            const textDistance = filter(elementState.element, lastFrameNumber);
-
+            const textDistance = filter(elementState);
             elementState.update(this, textDistance);
         }
     }

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -35,15 +35,7 @@ export class TextElementState {
      */
     private m_textRenderState?: RenderState;
 
-    constructor(
-        private readonly m_textElement: TextElement,
-        groupState: TextElementGroupState,
-        viewDistance: number | undefined
-    ) {
-        if (viewDistance !== undefined) {
-            this.initialize(groupState, viewDistance);
-        }
-    }
+    constructor(private readonly m_textElement: TextElement) {}
 
     get initialized(): boolean {
         return this.m_textRenderState !== undefined || this.m_iconRenderStates !== undefined;

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -131,9 +131,9 @@ export class TextElementStateCache {
         // Other labels found with the same text. Check if they're near enough to be considered
         // duplicates.
         const entryCount = cachedEntries.length;
+        const elementPosition = element.points as THREE.Vector3;
         let duplicateIndex: number = -1;
         for (let i = 0; i < entryCount; ++i) {
-            const elementPosition = element.points as THREE.Vector3;
             const cachedElementPosition = cachedEntries[i].element.position;
 
             if (

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -5,9 +5,9 @@
  */
 
 import { assert } from "@here/harp-utils";
-import { TextElement } from "./TextElement";
 import { TextElementGroup } from "./TextElementGroup";
 import { TextElementFilter, TextElementGroupState } from "./TextElementGroupState";
+import { TextElementState } from "./TextElementState";
 
 /**
  * Label distance threshold squared in meters. Point labels with the same name that are closer in
@@ -15,29 +15,6 @@ import { TextElementFilter, TextElementGroupState } from "./TextElementGroupStat
  * Used to identify duplicate labels in overlapping tiles.
  */
 const MAX_LABEL_DUPLICATE_DIST_SQ = 100;
-
-interface TextMapValue {
-    element: TextElement;
-    lastFrameNumber?: number;
-}
-
-/**
- * Determine if the new text duplicate was rendered most recently than the cached one. This allows
- * to keep the render state for fading.
- * @param newValue New duplicate (not yet cached).
- * @param cachedValue Cached duplicate.
- * @returns Whether the new duplicate was rendered more recently than the cached one.
- */
-function isNewTextElementLatest(newValue: TextMapValue, cachedValue: TextMapValue): boolean {
-    if (newValue.lastFrameNumber === undefined || newValue.lastFrameNumber < 0) {
-        return false;
-    }
-    if (cachedValue.lastFrameNumber === undefined || cachedValue.lastFrameNumber < 0) {
-        return true;
-    }
-
-    return newValue.lastFrameNumber > cachedValue.lastFrameNumber;
-}
 
 /**
  * Caches the state of text element groups currently rendered as well as the text element states
@@ -48,7 +25,7 @@ export class TextElementStateCache {
     private m_sortedGroupStates: TextElementGroupState[] | undefined;
 
     // Cache for point labels which may have duplicates in same tile or in neighboring tiles.
-    private readonly m_textMap = new Map<string, TextMapValue[]>();
+    private readonly m_textMap = new Map<string, TextElementState[]>();
 
     /**
      * Gets the state corresponding to a given text element group or sets a newly created state if
@@ -133,15 +110,12 @@ export class TextElementStateCache {
      * @returns True if it's the remaining element after deduplication, false if it's been marked
      * as duplicate.
      */
-    deduplicateElement(element: TextElement, lastFrameNumber: number | undefined): boolean {
+    deduplicateElement(elementState: TextElementState): boolean {
+        const element = elementState.element;
+
         if (!element.isPointLabel) {
             return true;
         }
-
-        const currentEntry = {
-            element,
-            lastFrameNumber
-        };
 
         // Point labels may have duplicates (as can path labels), Identify them
         // and keep the one we already display.
@@ -150,34 +124,39 @@ export class TextElementStateCache {
 
         if (cachedEntries === undefined) {
             // No labels found with the same text.
-            this.m_textMap.set(element.text, [currentEntry]);
+            this.m_textMap.set(element.text, [elementState]);
             return true;
         }
 
         // Other labels found with the same text. Check if they're near enough to be considered
         // duplicates.
-        const duplicateIndex = cachedEntries.findIndex(cachedEntry => {
+        const entryCount = cachedEntries.length;
+        let duplicateIndex: number = -1;
+        for (let i = 0; i < entryCount; ++i) {
             const elementPosition = element.points as THREE.Vector3;
-            const cachedElementPosition = cachedEntry.element.position;
+            const cachedElementPosition = cachedEntries[i].element.position;
 
-            return (
+            if (
                 elementPosition.distanceToSquared(cachedElementPosition) <
                 MAX_LABEL_DUPLICATE_DIST_SQ
-            );
-        });
+            ) {
+                duplicateIndex = i;
+                break;
+            }
+        }
 
         if (duplicateIndex === -1) {
             // No duplicate found.
-            cachedEntries.push(currentEntry);
+            cachedEntries.push(elementState);
             return true;
         }
 
-        // Duplicate found, check which label is fresher (was rendered more recently).
+        // Duplicate found, check whether there's a label already visible and keep that one.
         const cachedDuplicate = cachedEntries[duplicateIndex];
 
-        if (isNewTextElementLatest(currentEntry, cachedDuplicate)) {
-            // Current label is a fresher duplicate, substitute the cached label.
-            cachedEntries[duplicateIndex] = currentEntry;
+        if (!cachedDuplicate.visible && elementState.visible) {
+            // New label is visible, substitute the cached label.
+            cachedEntries[duplicateIndex] = elementState;
 
             return true;
         }

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1049,11 +1049,10 @@ export class TextElementsRenderer {
         }
 
         const textElementSelection: TextElementFilter = (
-            textElement: TextElement,
-            lastFrameNumber?: number
+            textElementState: TextElementState
         ): number | undefined => {
             let { result, viewDistance } = checkReadyForPlacement(
-                textElement,
+                textElementState.element,
                 this.m_viewState,
                 this.m_viewCamera,
                 this.m_poiManager,
@@ -1063,7 +1062,7 @@ export class TextElementsRenderer {
 
             if (
                 result === PrePlacementResult.Ok &&
-                !this.m_textElementStateCache.deduplicateElement(textElement, lastFrameNumber)
+                !this.m_textElementStateCache.deduplicateElement(textElementState)
             ) {
                 result = PrePlacementResult.Duplicate;
                 viewDistance = undefined;


### PR DESCRIPTION
Simplify deduplication cache to avoid creating an object for each entry. Now it only holds references to text element state objects.
Also, simplify logic to decide which duplicate is kept and which one is discarded.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
