### PR TITLE
HARP-7985 Correct offset for fallback tiles

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2832,9 +2832,8 @@ export class MapView extends THREE.EventDispatcher {
                 // of -10000, see addGroundPlane in TileGeometryCreator), only then can we be sure
                 // that nothing of the parent will be rendered on top of the children, as such, we
                 // shift using the FALLBACK_RENDER_ORDER_OFFSET.
-                object.renderOrder = tile.isFallback
-                    ? object._backupRenderOrder - FALLBACK_RENDER_ORDER_OFFSET
-                    : object._backupRenderOrder;
+                object.renderOrder =
+                    object._backupRenderOrder + FALLBACK_RENDER_ORDER_OFFSET * tile.levelOffset;
 
                 this.m_mapTilesRoot.add(object);
             }

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -343,7 +343,17 @@ export class Tile implements CachedResource {
      * Prepared text geometries optimized for display.
      */
     preparedTextPaths: TextPathGeometry[] | undefined;
-    isFallback: boolean = false;
+
+    /**
+     * @hidden
+     *
+     * Used to tell if the Tile is used temporarily as a fallback tile.
+     *
+     * levelOffset is in in the range [-quadTreeSearchDistanceUp,
+     * quadTreeSearchDistanceDown], where these values come from the
+     * [[VisibleTileSetOptions]]
+     */
+    levelOffset: number = 0;
 
     private m_disposed: boolean = false;
     private m_localTangentSpace = false;


### PR DESCRIPTION
Fallback tiles now store the offset from the requested tile, for example
Grandparent tiles are -2, parent are -1 and children's children are +1

This ensures that grandparent and parent tiles don't overlap and cause
artifacts as shown in HARP-7985

There are cases, theoretically where the child's child's child overlaps
the child's child, this is also handled (because +2 has a higher render
order than +1).

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>
