### PR TITLE
HARP-7916: Remove label sorting by camera distance.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -20,11 +20,8 @@ export type TextElementFilter = (textElementState: TextElementState) => number |
  * they're being rendered.
  */
 export class TextElementGroupState {
-    // Sorted list of element states belonging to the group state. It does NOT have the same order
-    // as their elements in the group.
     private m_textElementStates: TextElementState[];
     private m_visited: boolean = false;
-    private m_needsSorting: boolean = false;
 
     /**
      * Creates the state for specified group.
@@ -102,44 +99,11 @@ export class TextElementGroupState {
         return this.m_textElementStates.length;
     }
 
-    get needsSorting(): boolean {
-        return this.m_needsSorting;
-    }
-
-    invalidateSorting() {
-        this.m_needsSorting = true;
-    }
-
     /**
-     * Returns text element states sorted by view distance.
-     * NOTE: The order does not match with the text elements in the group!.
-     * @param maxViewDistance Maximum distance from the view center that a visible element may have.
-     * @returns Array of sorted element states.
+     * Returns text element states.
+     * @returns Array of element states.
      */
-    sortedTextElementStates(maxViewDistance: number): TextElementState[] {
-        if (!this.m_needsSorting) {
-            return this.m_textElementStates;
-        }
-
-        // Do the actual sort based on view distance.
-        this.m_textElementStates.sort((a: TextElementState, b: TextElementState) => {
-            // Move elements with undefined view distance to the end.
-            if (a.viewDistance === b.viewDistance) {
-                return 0;
-            }
-            if (a.viewDistance === undefined) {
-                return 1;
-            }
-
-            if (b.viewDistance === undefined) {
-                return -1;
-            }
-
-            // Both elements have valid view distances.
-            return a.viewDistance - b.viewDistance;
-        });
-        this.m_needsSorting = false;
-
+    get textElementStates(): TextElementState[] {
         return this.m_textElementStates;
     }
 }

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -121,9 +121,6 @@ export class TextElementState {
             return;
         }
         this.m_viewDistance = viewDistance;
-        if (this.m_viewDistance !== undefined) {
-            groupState.invalidateSorting();
-        }
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -622,10 +622,6 @@ export class TextElementsRenderer {
             return false;
         }
 
-        const textElementStates = groupState.sortedTextElementStates(
-            this.m_viewState.maxVisibilityDist
-        );
-
         const shieldGroups: number[][] = [];
 
         const temp: TempParams = {
@@ -636,7 +632,7 @@ export class TextElementsRenderer {
         };
         const hiddenKinds = this.m_viewState.hiddenGeometryKinds;
 
-        for (const textElementState of textElementStates) {
+        for (const textElementState of groupState.textElementStates) {
             if (pass === Pass.PersistentLabels) {
                 if (placementStats) {
                     ++placementStats.total;
@@ -1219,9 +1215,6 @@ export class TextElementsRenderer {
             const textElementGroupState = groupStates[i];
             if (placementStats) {
                 ++placementStats.totalGroups;
-                if (textElementGroupState.needsSorting) {
-                    ++placementStats.resortedGroups;
-                }
             }
 
             const newPriority = textElementGroupState.priority;


### PR DESCRIPTION
Sorting labels by camera distance is one of the bottlenecks in label placement.
Also, current implementation is broken, since sorting is done per tile
and not across tiles.
Furthermore, the improvement brought by sorting labels by distance is arguable.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
