### PR TITLE
HARP-8047: Remove support for nested style rules.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -283,11 +283,6 @@ export interface StyleSelector {
     layer?: string;
 
     /**
-     * Array of substyles.
-     */
-    styles?: StyleDeclaration[];
-
-    /**
      * Optional. If `true`, no more matching styles will be evaluated.
      */
     final?: boolean;

--- a/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
+++ b/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
@@ -27,13 +27,6 @@ export class ThemeVisitor {
             if (visitFunc(style)) {
                 return true;
             }
-            if (style.styles !== undefined) {
-                for (const currStyle of style.styles) {
-                    if (visit(currStyle)) {
-                        return true;
-                    }
-                }
-            }
             return false;
         };
         if (this.theme.styles !== undefined) {


### PR DESCRIPTION
Nesting the style rules is not well supported by our tools.
Also, thanks to the "style expressions" and the StyleSetEvaluator
caching of the filter conditions, nesting rules is not needed.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
