### PR TITLE
HARP-8050: Remove style properties for tuning the render order

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -682,7 +682,6 @@ export class StyleSetEvaluator {
         };
 
         processAttribute("renderOrder", style.renderOrder);
-        processAttribute("renderOrderOffset", style.renderOrderOffset);
 
         // TODO: What the heck is that !?
         processAttribute("label", style.labelProperty);
@@ -772,63 +771,14 @@ export class StyleSetEvaluator {
     }
 }
 
-interface ComputeDefaultRenderOrderState {
-    techniqueRenderOrder: number;
-    styleSetIndex: number;
-    renderOrderBiasGroups: Map<string, number>;
-}
-
 function computeDefaultRenderOrder(styleSet: InternalStyle[]) {
-    const options = {
-        techniqueRenderOrder: 0,
-        styleSetIndex: 0,
-        renderOrderBiasGroups: new Map()
-    };
+    let techniqueRenderOrder = 0;
+    let styleSetIndex = 0;
     for (const style of styleSet) {
-        computeStyleDefaultRenderOrder(style, options);
-    }
-}
-
-function computeStyleDefaultRenderOrder(
-    style: InternalStyle,
-    state: ComputeDefaultRenderOrderState
-) {
-    if (style.renderOrderBiasGroup !== undefined) {
-        const renderOrderBiasGroupOrder = style.renderOrderBiasGroup
-            ? state.renderOrderBiasGroups.get(style.renderOrderBiasGroup)
-            : undefined;
-        if (style.renderOrderBiasRange !== undefined && renderOrderBiasGroupOrder === undefined) {
-            if (style.renderOrder !== undefined) {
-                logger.warn(
-                    "WARN: style.renderOrder will be overridden if " +
-                        "renderOrderBiasGroup is set:",
-                    style
-                );
-            }
-            const [minRange, maxRange] = style.renderOrderBiasRange;
-            style.renderOrder =
-                minRange < 0
-                    ? state.techniqueRenderOrder + Math.abs(minRange)
-                    : state.techniqueRenderOrder;
-            state.techniqueRenderOrder += Math.abs(minRange) + maxRange;
-            if (style.renderOrderBiasGroup) {
-                state.renderOrderBiasGroups.set(style.renderOrderBiasGroup, style.renderOrder);
-            }
-            state.techniqueRenderOrder++;
-        } else if (renderOrderBiasGroupOrder) {
-            if (style.renderOrder !== undefined) {
-                logger.warn(
-                    "WARN: style.renderOrder will be overridden if " +
-                        "renderOrderBiasGroup is set:",
-                    style
-                );
-            }
-            style.renderOrder = renderOrderBiasGroupOrder;
+        style._styleSetIndex = styleSetIndex++;
+        if (style.technique !== undefined && style.renderOrder === undefined) {
+            style.renderOrder = techniqueRenderOrder++;
         }
-    }
-    style._styleSetIndex = state.styleSetIndex++;
-    if (style.technique !== undefined && style.renderOrder === undefined) {
-        style.renderOrder = state.techniqueRenderOrder++;
     }
 }
 

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -365,36 +365,6 @@ export interface BaseStyle {
     renderOrder?: number | JsonExpr;
 
     /**
-     * Offset added on top of `renderOrder` of object.
-     *
-     * May be uses to adjust final `renderOrder` without interferring with automatically assigned
-     * values.
-     *
-     * Using [[renderOrderBiasProperty]]
-     *
-     * @default 0
-     */
-    renderOrderOffset?: number | JsonExpr;
-
-    /**
-     * Property that is used to hold the z-order delta in [[renderOrderBiasRange]].
-     *
-     * @deprecated, Use `renderOrderOffset` with `["get", "<propName>"]` instead.
-     */
-    renderOrderBiasProperty?: string;
-
-    /**
-     * Minimum and maximum z-order delta values.
-     */
-    renderOrderBiasRange?: [number, number];
-
-    /**
-     * Z-order group. For example: used to set same render order for all roads
-     * to be able to use the z-order delta when drawing tunnels or bridges over or under the roads.
-     */
-    renderOrderBiasGroup?: string;
-
-    /**
      * Optional. If `true`, no IDs will be saved for the geometry this style creates. Default is
      * `false`.
      */

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -136,31 +136,6 @@ describe("StyleSetEvaluator", function() {
         assert.equal(parsedStyles[2].renderOrder, 1);
     });
 
-    it("supports renderOrderGroups", function() {
-        const styleSetWithRenderOrderBiasGroups: StyleSet = [
-            {
-                description: "first",
-                technique: "fill",
-                renderOrderBiasGroup: "bar",
-                renderOrderBiasRange: [0, 1000],
-                when: "kind == 'bar'",
-                attr: { color: "yellow" }
-            },
-            {
-                description: "second",
-                technique: "fill",
-                renderOrderBiasGroup: "park",
-                renderOrderBiasRange: [0, 100],
-                when: "kind == 'park'",
-                attr: { color: "green" }
-            }
-        ];
-        const ev = new StyleSetEvaluator(styleSetWithRenderOrderBiasGroups);
-
-        const parsedStyles = ev.styleSet;
-        assert.equal(parsedStyles[0].renderOrder, 0);
-        assert.equal(parsedStyles[1].renderOrder, 1001);
-    });
     describe("dynamic technique atribute support", function() {
         const testStyle: StyleSet = [
             {

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -348,15 +348,7 @@ export function getObjectConstructor(technique: Technique): ObjectConstructor | 
 /**
  * Non material properties of [[BaseTechnique]]
  */
-export const BASE_TECHNIQUE_NON_MATERIAL_PROPS = [
-    "name",
-    "id",
-    "renderOrder",
-    "renderOrderBiasProperty",
-    "renderOrderBiasGroup",
-    "renderOrderBiasRange",
-    "transient"
-];
+export const BASE_TECHNIQUE_NON_MATERIAL_PROPS = ["name", "id", "renderOrder", "transient"];
 
 /**
  * Generic material type constructor.


### PR DESCRIPTION
Offsets, scales and biases can be implemented using expressions, e.g.

    "renderOrder": ["+", ["get", "sort_rank"], 123]
