### PR TITLE
HARP-7850: Add support for filtering style rules based on the zoom level

### DIFF
--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -365,6 +365,16 @@ export interface BaseStyle {
     renderOrder?: number | JsonExpr;
 
     /**
+     * Minimal zoom level. If the current zoom level is smaller, the technique will not be used.
+     */
+    minZoomLevel?: number;
+
+    /**
+     * Maximum zoom level. If the current zoom level is larger, the technique will not be used.
+     */
+    maxZoomLevel?: number;
+
+    /**
      * Optional. If `true`, no IDs will be saved for the geometry this style creates. Default is
      * `false`.
      */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -367,12 +367,12 @@ export interface BaseStyle {
     /**
      * Minimal zoom level. If the current zoom level is smaller, the technique will not be used.
      */
-    minZoomLevel?: number;
+    minZoomLevel?: number | JsonExpr;
 
     /**
      * Maximum zoom level. If the current zoom level is larger, the technique will not be used.
      */
-    maxZoomLevel?: number;
+    maxZoomLevel?: number | JsonExpr;
 
     /**
      * Optional. If `true`, no IDs will be saved for the geometry this style creates. Default is

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -572,5 +572,26 @@ describe("StyleSetEvaluator", function() {
                 }
             ])
         );
+
+        assert.isNotEmpty(
+            getMatchingTechniques({ ...defaultProperties, $zoom: 15, minLevel: 14, maxLevel: 15 }, [
+                {
+                    when: ["==", ["geometry-type"], "Polygon"],
+                    technique: "extruded-polygon",
+                    minZoomLevel: ["get", "minLevel"],
+                    maxZoomLevel: ["get", "maxLevel"]
+                }
+            ])
+        );
+
+        assert.isEmpty(
+            getMatchingTechniques({ ...defaultProperties, $zoom: 15, maxLevel: 14 }, [
+                {
+                    when: ["==", ["geometry-type"], "Polygon"],
+                    technique: "extruded-polygon",
+                    maxZoomLevel: ["get", "maxLevel"]
+                }
+            ])
+        );
     });
 });

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -9,8 +9,7 @@
             "value": [
                 "all",
                 ["==", ["get", "$layer"], "buildings"],
-                ["==", ["get", "$geometryType"], "polygon"],
-                [">", ["zoom"], 15]
+                ["==", ["get", "$geometryType"], "polygon"]
             ]
         },
         "defaultBuildingColor": {
@@ -38,6 +37,7 @@
             "description": "extruded buildings",
             "technique": "extruded-polygon",
             "when": ["ref", "extrudedBuildingsCondition"],
+            "minZoomLevel": 16,
             "attr": {
                 "height": ["get", "height"],
                 "color": ["ref", "defaultBuildingColor"],
@@ -265,9 +265,9 @@
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "highway"],
                     ["==", ["get", "kind_detail"], "motorway"],
-                    ["has", "ref"],
-                    [">", ["zoom"], 8]
+                    ["has", "ref"]
                 ],
+                "minZoomLevel": 9,
                 "technique": "line-marker",
                 "attr": {
                     "style": "smallSign",
@@ -445,9 +445,9 @@
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 2],
-                    [">", ["zoom"], 11]
+                    ["==", ["length", ["get", "ref"]], 2]
                 ],
+                "minZoomLevel": 12,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -479,9 +479,9 @@
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 3],
-                    [">", ["zoom"], 11]
+                    ["==", ["length", ["get", "ref"]], 3]
                 ],
+                "minZoomLevel": 12,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -513,9 +513,9 @@
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 4],
-                    [">", ["zoom"], 11]
+                    ["==", ["length", ["get", "ref"]], 4]
                 ],
+                "minZoomLevel": 12,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -547,9 +547,9 @@
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
-                    ["==", ["length", ["get", "ref"]], 5],
-                    [">", ["zoom"], 11]
+                    ["==", ["length", ["get", "ref"]], 5]
                 ],
+                "minZoomLevel": 12,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -581,9 +581,9 @@
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "primary"],
                     ["has", "ref"],
-                    [">", ["length", ["get", "ref"]], 5],
-                    [">", ["zoom"], 11]
+                    [">", ["length", ["get", "ref"]], 5]
                 ],
+                "minZoomLevel": 12,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -788,9 +788,9 @@
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "secondary"],
-                    ["has", "ref"],
-                    [">", ["zoom"], 12]
+                    ["has", "ref"]
                 ],
+                "minZoomLevel": 13,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -883,9 +883,9 @@
                     ["==", ["get", "$layer"], "roads"],
                     ["==", ["get", "kind"], "major_road"],
                     ["==", ["get", "kind_detail"], "tertiary"],
-                    ["has", "ref"],
-                    [">", ["zoom"], 14]
+                    ["has", "ref"]
                 ],
+                "minZoomLevel": 15,
                 "technique": "line-marker",
                 "attr": {
                     "label": "ref",
@@ -2580,9 +2580,9 @@
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["==", ["get", "kind"], "address"],
-                    [">", ["zoom"], "17"]
+                    ["==", ["get", "kind"], "address"]
                 ],
+                "minZoomLevel": 18,
                 "technique": "text",
                 "attr": {
                     "color": "#A9A9A9",

--- a/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
@@ -2096,10 +2096,10 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"],
-                    [">", ["zoom"], 15]
+                    ["==", ["get", "$geometryType"], "polygon"]
                 ],
                 "technique": "extruded-polygon",
+                "minZoomLevel": 16,
                 "attr": {
                     "color": "#F2ECE0",
                     "opacity": 0.7,
@@ -2125,9 +2125,9 @@
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["==", ["get", "kind"], "address"],
-                    [">", ["zoom"], 17]
+                    ["==", ["get", "kind"], "address"]
                 ],
+                "minZoomLevel": 18,
                 "technique": "text",
                 "attr": {
                     "color": "#C0BDB1",

--- a/@here/harp-map-theme/resources/berlin_tilezen_effects_outlines.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_effects_outlines.json
@@ -2056,10 +2056,10 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"],
-                    [">", ["zoom"], 15]
+                    ["==", ["get", "$geometryType"], "polygon"]
                 ],
                 "technique": "extruded-polygon",
+                "minZoomLevel": 16,
                 "attr": {
                     "color": "#494B4C",
                     "opacity": 0.85,
@@ -2086,9 +2086,9 @@
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["==", ["get", "kind"], "address"],
-                    [">", ["zoom"], 17]
+                    ["==", ["get", "kind"], "address"]
                 ],
+                "minZoomLevel": 18,
                 "technique": "text",
                 "attr": {
                     "color": "#131313",

--- a/@here/harp-map-theme/resources/berlin_tilezen_effects_streets.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_effects_streets.json
@@ -2056,10 +2056,10 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"],
-                    [">", ["zoom"], 15]
+                    ["==", ["get", "$geometryType"], "polygon"]
                 ],
                 "technique": "extruded-polygon",
+                "minZoomLevel": 16,
                 "attr": {
                     "color": "#494B4C",
                     "opacity": 0.85,
@@ -2086,10 +2086,10 @@
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["==", ["get", "kind"], "address"],
-                    [">", ["zoom"], 17]
+                    ["==", ["get", "kind"], "address"]
                 ],
                 "technique": "text",
+                "minZoomLevel": 18,
                 "attr": {
                     "color": "#131313",
                     "label": "addr_housenumber",

--- a/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
@@ -2107,10 +2107,10 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"],
-                    [">", ["zoom"], 15]
+                    ["==", ["get", "$geometryType"], "polygon"]
                 ],
                 "technique": "extruded-polygon",
+                "minZoomLevel": 16,
                 "attr": {
                     "color": "#7C7F81",
                     "opacity": 0.95,
@@ -2136,10 +2136,10 @@
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
                     ["==", ["get", "$geometryType"], "point"],
-                    ["==", ["get", "kind"], "address"],
-                    [">", ["zoom"], 17]
+                    ["==", ["get", "kind"], "address"]
                 ],
                 "technique": "text",
+                "minZoomLevel": 18,
                 "attr": {
                     "color": "#131313",
                     "label": "addr_housenumber",


### PR DESCRIPTION
This change adds the property 'minZoomLevel' and 'maxZoomLevel'
to the style rules. These properties can be used to filter the rule
based on the zoom level.
    
