### PR TITLE
HARP-7517: Transparency support for colors (RGBA) defined in techniques.

### DIFF
--- a/@here/harp-datasource-protocol/lib/ColorUtils.ts
+++ b/@here/harp-datasource-protocol/lib/ColorUtils.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { assert } from "@here/harp-utils";
+import * as THREE from "three";
+
+const SHIFT_TRANSPARENCY: number = 24;
+const SHIFT_RED: number = 16;
+const SHIFT_GREEN: number = 8;
+const SHIFT_BLUE: number = 0;
+
+// tslint:disable: no-bitwise
+//    Allow bitwise operations for colors decoding
+
+// tslint:disable-next-line: no-bitwise
+const HEX_FULL_CHANNEL: number = 0xff;
+const HEX_TRGB_MASK: number = 0xffffffff;
+
+const tmpColor = new THREE.Color();
+
+/**
+ * Utilities to convert RGBA colors encoded in custom number (hex) format to THREE.Color objects.
+ *
+ * The functions provided allows for conversion from and to our custom number based color format,
+ * which contains transparency, red, green and blue color channels in a way that each channel
+ * occupies 8 bits of resulting number (color format 0xTTRRGGBB).
+ * In order to preserve compatibility with THREE.Color class and its hexadecimal color
+ * representation, we do not store __alpha__ channel in encoded color's number, but replace it
+ * with __transparency__ channel, which is simply opposite to alpha:
+ * ```transparency = 0xFF - alpha```
+ * Such channel value is stored on the oldest bits (octet) in the integral color (numeric) value,
+ * so it is fully compatible with THREE.Color numerical representation (@see [[THREE.Color.getHex]],
+ * [[THREE.Color.setHex]]).
+ * See also [[getHexFromRgba]] and [[getRgbaFromHex]] for more info about conversion.
+ */
+export namespace ColorUtils {
+    /**
+     * Encodes RGBA channels in custom number coded format (represented in hex as 0xTTRRGGBB).
+     *
+     * We do not use direct alpha channel mapping to hex in order to preserve compatibility
+     * with THREE.js color format (0xRRGGBB). This is done by encoding transparency
+     * (255 - alpha) instead of alpha on the oldest bits, shifted by [[SHIFT_TRANSPARENCY]].
+     * This way simple 0xRRGGBB color is equal to 0x00RRGGBB without transparency and
+     * color defining transparency (alpha < 255) is always recognizable by the oldest
+     * bit set:
+     * ```typescript
+     * (color >> SHIFT_TRANSPARENCY) !== 0.
+     * ```
+     * @note All input components are floating points in <0, 1> range (inclusively).
+     * @note Although method encodes transparency channel in single number value, it is still
+     * compatible with THREE.js number based color coding (0xRRGGBB), so you may pass this value to
+     * [[THREE.Color]] c-tor, but keep in mind that transparency will be silently ignored.
+     */
+    export function getHexFromRgba(r: number, g: number, b: number, a: number): number {
+        assert(a >= 0 && a <= 1);
+        const t = HEX_FULL_CHANNEL - Math.floor(a * HEX_FULL_CHANNEL);
+        return (t << SHIFT_TRANSPARENCY) ^ getHexFromRgb(r, g, b);
+    }
+
+    /**
+     * Encodes RGB all color channels in single number with format 0xRRGGBB.
+     *
+     * All input channels should be in <0, 1> range (inclusively).
+     * See also [[getHexFromRgba]] for more information about [[THREE.Color]] compatibility.
+     *
+     * @note This method is fully compatible with THREE.js color encoding, so
+     * you may pass this value directly to THREE.Color c-tor.
+     */
+    export function getHexFromRgb(r: number, g: number, b: number): number {
+        assert(r >= 0 && r <= 1);
+        assert(g >= 0 && g <= 1);
+        assert(b >= 0 && b <= 1);
+        return (
+            ((r * HEX_FULL_CHANNEL) << SHIFT_RED) ^
+            ((g * HEX_FULL_CHANNEL) << SHIFT_GREEN) ^
+            ((b * HEX_FULL_CHANNEL) << SHIFT_BLUE)
+        );
+    }
+
+    /**
+     * Encode and convert HSL value to number coded color format (0xRRGGBB).
+     *
+     * @see getHexFromRgb.
+     * @param h Hue component value between 0 and 1.
+     * @param s Saturation value between 0 and 1.
+     * @param l Lightness channel between 0 and 1.
+     */
+    export function getHexFromHsl(h: number, s: number, l: number): number {
+        assert(h >= 0 && h <= 1);
+        assert(s >= 0 && s <= 1);
+        assert(l >= 0 && l <= 1);
+        return tmpColor.setHSL(h, s, l).getHex();
+    }
+
+    /**
+     * Retrieve RGBA channels separately from number encoded custom color format.
+     *
+     * Provides an easy way for channels extraction (r, g, b, a) from custom number coded color
+     * format.
+     *
+     * @see getHexFromRgba.
+     * @param hex The number encoded color value (0xRRGGBB or 0xTTRRGGBB in hex).
+     * @returns r, g, b, a channels in simple object, where each channel value is saved as floating
+     * point from 0 to 1 inclusively.
+     */
+    export function getRgbaFromHex(hex: number): { r: number; g: number; b: number; a: number } {
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        return {
+            r: ((hex >> SHIFT_RED) & HEX_FULL_CHANNEL) / HEX_FULL_CHANNEL,
+            g: ((hex >> SHIFT_GREEN) & HEX_FULL_CHANNEL) / HEX_FULL_CHANNEL,
+            b: ((hex >> SHIFT_BLUE) & HEX_FULL_CHANNEL) / HEX_FULL_CHANNEL,
+            a:
+                (HEX_FULL_CHANNEL - ((hex >> SHIFT_TRANSPARENCY) & HEX_FULL_CHANNEL)) /
+                HEX_FULL_CHANNEL
+        };
+    }
+
+    /**
+     * Determines if number encoded color contains alpha (opacity) defined and different then 255.
+     *
+     * @param hex The number encoded color (0xRRGGBB or 0xTTRRGGBB in hex).
+     * @returns True if color has transparency defined.
+     */
+    export function hasAlphaInHex(hex: number): boolean {
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        return hex >> SHIFT_TRANSPARENCY !== 0;
+    }
+
+    /**
+     * Retrieves alpha color channel from hex encoded color value.
+     *
+     * @see getHexFromRgba.
+     * @param hex The number encoded color value (representable as 0xRRGGBB or 0xTTRRGGBB in hex).
+     * @returns The floating point alpha component in <0, 1> range.
+     */
+    export function getAlphaFromHex(hex: number): number {
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        return (hex >> SHIFT_TRANSPARENCY) / 255;
+    }
+}

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -5,6 +5,7 @@
  */
 import { assert } from "@here/harp-utils";
 import { Color } from "three";
+import { ColorUtils } from "./ColorUtils";
 
 const tmpColor = new Color();
 
@@ -56,7 +57,7 @@ const StringEncodedPixels: StringEncodedNumeralFormat = {
 };
 const StringEncodedHex: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.Hex,
-    size: 3,
+    size: 4,
     regExp: /^\#((?:[0-9A-Fa-f][0-9A-Fa-f]){3,4}|[0-9A-Fa-f]{3,4})$/,
     decoder: (encodedValue: string, target: number[]) => {
         const match = StringEncodedHex.regExp.exec(encodedValue);
@@ -77,11 +78,13 @@ const StringEncodedHex: StringEncodedNumeralFormat = {
             target[0] = parseInt(hex.charAt(0) + hex.charAt(0), 16) / 255;
             target[1] = parseInt(hex.charAt(1) + hex.charAt(1), 16) / 255;
             target[2] = parseInt(hex.charAt(2) + hex.charAt(2), 16) / 255;
+            target[3] = size === 4 ? parseInt(hex.charAt(3) + hex.charAt(3), 16) / 255 : 1;
         } else if (size === 6 || size === 8) {
             // #RRGGBB or #RRGGBBAA
             target[0] = parseInt(hex.charAt(0) + hex.charAt(1), 16) / 255;
             target[1] = parseInt(hex.charAt(2) + hex.charAt(3), 16) / 255;
             target[2] = parseInt(hex.charAt(4) + hex.charAt(5), 16) / 255;
+            target[3] = size === 8 ? parseInt(hex.charAt(6) + hex.charAt(7), 16) / 255 : 1;
         }
         return true;
     }
@@ -104,7 +107,7 @@ const StringEncodedRGB: StringEncodedNumeralFormat = {
 };
 const StringEncodedRGBA: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.RGBA,
-    size: 3,
+    size: 4,
     // tslint:disable-next-line:max-line-length
     regExp: /^rgba\( ?(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:(0(?:\.[0-9]+)?|1(?:\.0+)?)) ?\)$/,
     decoder: (encodedValue: string, target: number[]) => {
@@ -112,11 +115,10 @@ const StringEncodedRGBA: StringEncodedNumeralFormat = {
         if (channels === null) {
             return false;
         }
-        // For now we simply ignore alpha channel value.
-        // TODO: To be resolved with HARP-7517
         target[0] = parseInt(channels[1], 10) / 255;
         target[1] = parseInt(channels[2], 10) / 255;
         target[2] = parseInt(channels[3], 10) / 255;
+        target[3] = parseInt(channels[4], 10);
         return true;
     }
 };
@@ -209,10 +211,18 @@ export function parseStringEncodedNumeral(
                     result = tmpBuffer[0] * pixelToMeters;
                     break;
                 case StringEncodedNumeralType.Hex:
-                case StringEncodedNumeralType.RGB:
                 case StringEncodedNumeralType.RGBA:
+                    // In case alpha is not decoded from hex, set it to 1.0
+                    tmpBuffer[3] = 1.0;
+                    result = ColorUtils.getHexFromRgba(
+                        tmpBuffer[0],
+                        tmpBuffer[1],
+                        tmpBuffer[2],
+                        tmpBuffer[3]
+                    );
+                case StringEncodedNumeralType.RGB:
                 case StringEncodedNumeralType.HSL:
-                    result = tmpColor.setRGB(tmpBuffer[0], tmpBuffer[1], tmpBuffer[2]).getHex();
+                    result = ColorUtils.getHexFromRgb(tmpBuffer[0], tmpBuffer[1], tmpBuffer[2]);
                     break;
                 default:
                     result = tmpBuffer[0];
@@ -240,10 +250,18 @@ export function parseStringEncodedColor(color: string): number | undefined {
     }
     switch (matchedFormat.type) {
         case StringEncodedNumeralType.Hex:
-        case StringEncodedNumeralType.RGB:
         case StringEncodedNumeralType.RGBA:
+            // Set alpha to 1.0 in case it is not set in hex format
+            tmpBuffer[3] = 1.0;
+            return ColorUtils.getHexFromRgba(
+                tmpBuffer[0],
+                tmpBuffer[1],
+                tmpBuffer[2],
+                tmpBuffer[3]
+            );
+        case StringEncodedNumeralType.RGB:
         case StringEncodedNumeralType.HSL:
-            return tmpColor.setRGB(tmpBuffer[0], tmpBuffer[1], tmpBuffer[2]).getHex();
+            return ColorUtils.getHexFromRgb(tmpBuffer[0], tmpBuffer[1], tmpBuffer[2]);
         default:
             return tmpBuffer[0];
     }

--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
@@ -53,6 +53,7 @@ export type TechniquePropScopes<T> = {
 };
 
 export interface TechniqueDescriptor<T> {
+    attrTransparencyColor?: string;
     attrScopes: TechniquePropScopes<T>;
 }
 
@@ -70,6 +71,9 @@ export function mergeTechniqueDescriptor<T>(
         attrScopes: {}
     };
     for (const descriptor of descriptors) {
+        if (descriptor.attrTransparencyColor !== undefined) {
+            result.attrTransparencyColor = descriptor.attrTransparencyColor;
+        }
         if (descriptor.attrScopes !== undefined) {
             result.attrScopes = { ...result.attrScopes, ...descriptor.attrScopes };
         }

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -68,6 +68,9 @@ export type MakeTechniqueAttrs<T> = {
 export const techniqueDescriptors: TechniqueDescriptorRegistry = {};
 
 export const baseTechniqueParamsDescriptor: TechniqueDescriptor<BaseTechniqueParams> = {
+    // TODO: Choose which techniques should support color with transparency.
+    // For now we chosen all, but it maybe not suitable for text or line marker techniques.
+    attrTransparencyColor: "color",
     attrScopes: {
         renderOrder: AttrScope.TechniqueGeometry,
         renderOrderOffset: AttrScope.TechniqueGeometry,

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -822,7 +822,17 @@ describe("ExprEvaluator", function() {
             );
 
             assert.strictEqual(
+                new THREE.Color(evaluate(["hsl", 20, 100, 50]) as number).getHexString(),
+                new THREE.Color("hsl(20, 100%, 50%)").getHexString()
+            );
+
+            assert.strictEqual(
                 new THREE.Color(evaluate(["hsl", 370, 100, 50]) as string).getHexString(),
+                new THREE.Color("hsl(370, 100%, 50%)").getHexString()
+            );
+
+            assert.strictEqual(
+                new THREE.Color(evaluate(["hsl", 370, 100, 50]) as number).getHexString(),
                 new THREE.Color("hsl(370, 100%, 50%)").getHexString()
             );
 
@@ -897,13 +907,38 @@ describe("ExprEvaluator", function() {
                 new THREE.Color("rgb(500, 500, 500)").getHexString()
             );
 
-            // Still equal - ignores alpha.
-            // Some assumptions will change after fully implementing HARP-7517
-            assert.strictEqual(
+            // Difference in alpha channel should be recognizable when color is represented
+            // (stored) in internal format.
+            assert.notEqual(
                 evaluate(["rgba", 255, 0, 0, 0.5]) as string,
                 evaluate(["rgba", 255, 0, 0, 0.6]) as string
             );
 
+            // When alpha is 1.0, colors should be the same with and without alpha specified.
+            // This is the unique property of our own hex color format and applies only to it.
+            assert.strictEqual(
+                evaluate(["rgba", 0, 0, 255, 1.0]) as string,
+                evaluate(["rgb", 0, 0, 255]) as string
+            );
+
+            assert.strictEqual(
+                evaluate(["rgba", 0, 0, 0, 1.0]) as number,
+                evaluate(["rgb", 0, 0, 0]) as number
+            );
+            assert.strictEqual(
+                evaluate(["rgba", 255, 0, 0, 1.0]) as number,
+                evaluate(["rgb", 255, 0, 0]) as number
+            );
+            assert.strictEqual(
+                evaluate(["rgba", 0, 255, 0, 1.0]) as number,
+                evaluate(["rgb", 0, 255, 0]) as number
+            );
+            assert.strictEqual(
+                evaluate(["rgba", 0, 0, 255, 1.0]) as number,
+                evaluate(["rgb", 0, 0, 255]) as number
+            );
+
+            // After passing to THREE, alpha should be silently ignored.
             assert.strictEqual(
                 new THREE.Color(evaluate(["rgba", 255, 255, 255, 0.5]) as string).getHexString(),
                 new THREE.Color("rgb(255, 255, 255)").getHexString()
@@ -946,7 +981,7 @@ describe("ExprEvaluator", function() {
         it("evaluate", function() {
             assert.strictEqual(
                 getPropertyValue(Expr.fromJSON(["rgb", 255, 0, ["*", ["get", "time"], 255]]), env),
-                "#ff00ff"
+                0xff00ff
             );
 
             assert.strictEqual(


### PR DESCRIPTION
Alpha channel of RGBA colors defined in rgba() or hex (#RRGGBBAA)
expressions is now decoded. The alpha channel is then stored as
transparency factor in custom #TTRRGGBB hex format, which preserves
compatibility with THREE.js Color, such as first octets #TT are silently
ignored inside THREE Color c-tor.
The format chosen allows for great compatibility because, non transparent
#00RRGGBB color exactly equals #RRGGBB color in THREE.js. Similarly
if any bit from transparency is set we may recognize and differentiate
such color from simple RGB color used.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
