### PR TITLE
Rendering tests for Mac.

### DIFF
--- a/scripts/rendering-tests-reference-platform.sh
+++ b/scripts/rendering-tests-reference-platform.sh
@@ -1,11 +1,35 @@
 #!/bin/sh
 
+#
+# Run harp.gl rendering tests (see [../test/README.md]) on reference platform i.e
+#
+#   Headless Chrome 78 on Linux with GPU disabled
+#
+
+#
+# Docker image with chrome
+#
+# See https://github.com/SeleniumHQ/docker-selenium/releases.
+#
+# xenon stands for chrome 78
+REFERENCE_IMAGE=selenium/standalone-chrome:3.141.59-xenon
+
 yarn build-tests
 
-npx ts-node -- \
-    ./scripts/with-http-server.ts -r ../@here/harp-test-utils/lib/rendering/RenderingTestResultServer.ts -C dist/test -p 7777 -- \
-        ./scripts/with-docker-selenium.sh --image selenium/standalone-chrome:3.141.59-xenon \
-            mocha-webdriver-runner \
-                -C browserName=chrome \
-                -C goog:chromeOptions.args='["--headless", "--disable-gpu=true", "--no-sandbox", "--disable-dev-shm-usage", "--window-size=1280,800"]' \
-                http://localhost:7777/rendering.html
+OSNAME=`uname`
+if [ "$OSNAME" = "Linux" ]; then
+    testAppHost="localhost"
+else
+    testAppHost="host.docker.internal"
+fi
+
+npx ts-node -- ./scripts/with-http-server.ts \
+    -r ../@here/harp-test-utils/lib/rendering/RenderingTestResultServer.ts \
+    -C dist/test \
+    -p 7777 \
+    -- \
+    ./scripts/with-docker-selenium.sh --image $REFERENCE_IMAGE \
+        npx mocha-webdriver-runner \
+            -C browserName=chrome \
+            -C goog:chromeOptions.args='["--headless", "--disable-gpu=true", "--no-sandbox", "--disable-dev-shm-usage", "--window-size=1280,800"]' \
+            http://$testAppHost:7777/rendering.html

--- a/scripts/with-docker-selenium.sh
+++ b/scripts/with-docker-selenium.sh
@@ -6,17 +6,22 @@
 # Designed for local testing with tests served on `locahost`, so docker operates in `host` network
 # mode and thus bind to real localhost and more importantly can access real localhost urls.
 #
+#
 # Example
 #
 #    bash with-docker-selenium.sh --firefox npx mocha-webdriver-runner http://localhost:8080/
 #    bash with-docker-selenium.sh --chrome npx mocha-webdriver-runner http://localhost:8080/
+#
+# Note: On non-Linux platforms (Mac,Windows) you must use `host.docker.internal`, in future maybe
+# all platforms will use `host.docker.internal`.
+# See: https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-docker-for-mac-host-internal
 #
 # Usage
 #
 #    with-docker-selenium.sh [options] COMMAND
 #
 # Options
-#    --chrome - select latest Chrome image
+#    --chrome - select latest Chrome image (default)
 #    --firefox - select latest Firefox image
 #    -i, --image IMAGE - select particular image
 #
@@ -32,10 +37,12 @@
 # to find image versions for particular browser versions. As example, image
 # `selenium/standalone-chrome:3.141.59-radium` will always point at Chrome 75.0.3770.90
 
+SCRIPT_NAME=with-docker-selenium
 
 dir=.
 port=4444
-image=selenium/standalone-firefox
+image=selenium/standalone-chrome
+export SELENIUM_BROWSER=${SELENIUM_BROWSER-chrome}
 
 while [ -n "$1" ]; do
     case "$1" in
@@ -57,19 +64,26 @@ while [ -n "$1" ]; do
     esac
 done
 
-dockerCommand="docker run --rm -d --network=host $image"
-echo "$0: $dockerCommand &" >&2
+OSNAME=`uname`
+
+dockerCommand="docker run --rm -d -p 4444:4444"
+if [ "$OSNAME" = "Linux" ]; then
+    dockerCommand="$dockerCommand --network=host"
+fi
+dockerCommand="$dockerCommand $image"
+
+echo "$SCRIPT_NAME: $dockerCommand &" >&2
 if ! containerId=$($dockerCommand) ; then
     echo "$0: failed to start docker image $image"  >&2
     exit 2
 fi
 
-echo "$0: # started docker container $containerId" >&2
+echo "$SCRIPT_NAME: # started docker container $containerId" >&2
 attemptNumber=0
 while ! curl -fI http://localhost:$port/wd/hub >/dev/null 2>&1  ; do
     # check if we have some attempts left
     if [ "$attemptNumber" -gt 10 ] ; then
-        echo "$0: # stopping docker container $containerId" >&2
+        echo "$SCRIPT_NAME: # stopping docker container $containerId" >&2
         docker kill $containerId
         exit 1
     fi
@@ -77,13 +91,13 @@ while ! curl -fI http://localhost:$port/wd/hub >/dev/null 2>&1  ; do
     sleep 1
 done
 
-echo "$0: $@" >&2
+echo "$SCRIPT_NAME: $@" >&2
 export SELENIUM_REMOTE_URL=http://localhost:$port/wd/hub
 
 "$@"
 
 exitCode=$?
 
-echo "$0: # stopping docker container $containerId" >&2
+echo "$SCRIPT_NAME: # stopping docker container $containerId" >&2
 docker stop $containerId
 exit $exitCode


### PR DESCRIPTION
Allow running rendering test on Mac using `host.docker.internal` feature of Docker for Mac.

Related-to: HARP-6510
Followup of: #1025 