### PR TITLE
Revert: MINOR: Release only when tags are added to release branch (#103)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ jobs:
           script: ./scripts/publish-packages.sh
           skip_cleanup: true
           on:
-            tags: true
             branch: release
         - provider: pages
           skip_cleanup: true
@@ -52,7 +51,6 @@ jobs:
           local-dir: dist/gh_deploy
           github-token: $GITHUB_TOKEN
           on:
-            tags: true
             branch: release
         - provider: s3
           access_key_id: $AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Removing the condition of `tags:true` as it does not behave as expected.
We are reworking the way we tag releases

Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>
