### PR TITLE
HARP-7373: Add FontCatalogLoader.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -56,6 +56,7 @@ import { ScreenCollisions, ScreenCollisionsDebug } from "./ScreenCollisions";
 import { ScreenProjector } from "./ScreenProjector";
 import { SkyBackground } from "./SkyBackground";
 import { FrameStats, PerformanceStatistics } from "./Statistics";
+import { FontCatalogLoader } from "./text/FontCatalogLoader";
 import { MapViewState } from "./text/MapViewState";
 import { TextCanvasFactory } from "./text/TextCanvasFactory";
 import { TextElement } from "./text/TextElement";
@@ -3188,6 +3189,7 @@ export class MapView extends THREE.EventDispatcher {
             new TextCanvasFactory(this.m_renderer),
             this.m_poiManager,
             new PoiRendererFactory(this),
+            new FontCatalogLoader(this.m_theme),
             this.m_theme,
             this.m_options
         );

--- a/@here/harp-mapview/lib/text/FontCatalogLoader.ts
+++ b/@here/harp-mapview/lib/text/FontCatalogLoader.ts
@@ -19,11 +19,14 @@ export class FontCatalogLoader {
 
     constructor(private readonly m_theme: Theme) {}
 
+    /**
+     * Initializes font catalog loader.
+     * @param defaultFontCatalogUrl Url of the font catalog that will be used by default if the
+     * theme doesn't define any font catalog.
+     * @returns Name of the default font catalog.
+     */
     initialize(defaultFontCatalogUrl: string): string {
-        if (
-            this.m_theme.fontCatalogs === undefined ||
-            (Array.isArray(this.m_theme.fontCatalogs) && this.m_theme.fontCatalogs.length === 0)
-        ) {
+        if (this.m_theme.fontCatalogs === undefined || this.m_theme.fontCatalogs.length === 0) {
             this.m_theme.fontCatalogs = [
                 {
                     name: DEFAULT_FONT_CATALOG_NAME,
@@ -33,7 +36,8 @@ export class FontCatalogLoader {
             return DEFAULT_FONT_CATALOG_NAME;
         }
 
-        return this.m_theme.fontCatalogs[0].name;
+        const defaultFontCatalogName = this.m_theme.fontCatalogs[0].name;
+        return defaultFontCatalogName;
     }
 
     async loadCatalogs(catalogCallback: FontCatalogCallback): Promise<void[]> {

--- a/@here/harp-mapview/lib/text/FontCatalogLoader.ts
+++ b/@here/harp-mapview/lib/text/FontCatalogLoader.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Theme } from "@here/harp-datasource-protocol";
+import { FontCatalog } from "@here/harp-text-canvas";
+import { assert, LoggerManager } from "@here/harp-utils";
+
+export const DEFAULT_FONT_CATALOG_NAME = "default";
+
+const logger = LoggerManager.instance.create("FontCatalogLoader");
+
+type FontCatalogCallback = (name: string, catalog: FontCatalog) => void;
+
+export class FontCatalogLoader {
+    private m_catalogsLoading: number = 0;
+
+    constructor(private readonly m_theme: Theme) {}
+
+    initialize(defaultFontCatalogUrl: string): string {
+        if (
+            this.m_theme.fontCatalogs === undefined ||
+            (Array.isArray(this.m_theme.fontCatalogs) && this.m_theme.fontCatalogs.length === 0)
+        ) {
+            this.m_theme.fontCatalogs = [
+                {
+                    name: DEFAULT_FONT_CATALOG_NAME,
+                    url: defaultFontCatalogUrl
+                }
+            ];
+            return DEFAULT_FONT_CATALOG_NAME;
+        }
+
+        return this.m_theme.fontCatalogs[0].name;
+    }
+
+    async loadCatalogs(catalogCallback: FontCatalogCallback): Promise<void[]> {
+        assert(this.m_theme.fontCatalogs !== undefined);
+        assert(this.m_theme.fontCatalogs!.length > 0);
+
+        const promises: Array<Promise<void>> = [];
+
+        this.m_theme.fontCatalogs!.forEach(fontCatalogConfig => {
+            this.m_catalogsLoading += 1;
+            const fontCatalogPromise: Promise<void> = FontCatalog.load(fontCatalogConfig.url, 1024)
+                .then<void>(catalogCallback.bind(undefined, fontCatalogConfig.name))
+                .catch((error: Error) => {
+                    logger.error("Failed to load FontCatalog: ", error);
+                })
+                .finally(() => {
+                    this.m_catalogsLoading -= 1;
+                });
+            promises.push(fontCatalogPromise);
+        });
+
+        return Promise.all(promises);
+    }
+
+    get loading(): boolean {
+        return this.m_catalogsLoading > 0;
+    }
+}

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -36,6 +36,7 @@ import { ScreenProjector } from "../ScreenProjector";
 import { Tile } from "../Tile";
 import { MapViewUtils } from "../Utils";
 import { DataSourceTileList } from "../VisibleTileSet";
+import { FontCatalogLoader } from "./FontCatalogLoader";
 import {
     checkReadyForPlacement,
     computePointTextOffset,
@@ -58,7 +59,7 @@ import {
 import { TextElementState } from "./TextElementState";
 import { TextElementStateCache } from "./TextElementStateCache";
 import { TextElementType } from "./TextElementType";
-import { DEFAULT_FONT_CATALOG_NAME, TextStyleCache } from "./TextStyleCache";
+import { TextStyleCache } from "./TextStyleCache";
 import { UpdateStats } from "./UpdateStats";
 import { ViewState } from "./ViewState";
 
@@ -228,7 +229,6 @@ export class TextElementsRenderer {
     private m_overloaded: boolean = false;
     private m_cacheInvalidated: boolean = false;
     private m_forceNewLabelsPass: boolean = false;
-    private m_catalogsLoading: number = 0;
 
     private readonly m_textElementStateCache: TextElementStateCache = new TextElementStateCache();
 
@@ -246,6 +246,7 @@ export class TextElementsRenderer {
      * @param m_textCanvasFactory To create TextCanvas instances.
      * @param m_poiRendererFactory To create PoiRenderer instances.
      * @param m_poiManager To prepare pois for rendering.
+     * @param m_fontCatalogLoader To load font catalogs.
      * @param m_theme Theme defining  text styles.
      * @param options Configuration options for the text renderer. See
      * [[TextElementsRendererOptions]].
@@ -259,6 +260,7 @@ export class TextElementsRenderer {
         private m_textCanvasFactory: TextCanvasFactory,
         private m_poiManager: PoiManager,
         private m_poiRendererFactory: PoiRendererFactory,
+        private m_fontCatalogLoader: FontCatalogLoader,
         private m_theme: Theme,
         options: TextElementsRendererOptions
     ) {
@@ -490,7 +492,7 @@ export class TextElementsRenderer {
      * `true` if any resource used by any `FontCatalog` is still loading.
      */
     get loading(): boolean {
-        let isLoading = this.m_catalogsLoading > 0;
+        let isLoading = this.m_fontCatalogLoader.loading;
         for (const textRenderer of this.m_textRenderers) {
             isLoading = isLoading || textRenderer.textCanvas.fontCatalog.isLoading;
         }
@@ -830,63 +832,24 @@ export class TextElementsRenderer {
     }
 
     private initializeDefaultAssets(): void {
-        // Initialize default font catalog.
-        if (
-            this.m_theme.fontCatalogs === undefined ||
-            (Array.isArray(this.m_theme.fontCatalogs) && this.m_theme.fontCatalogs.length === 0)
-        ) {
-            this.m_theme.fontCatalogs = [
-                {
-                    name: DEFAULT_FONT_CATALOG_NAME,
-                    url: this.m_options.fontCatalog!
-                }
-            ];
-        }
-        const fontCatalogs = this.m_theme.fontCatalogs;
-
-        let defaultFontCatalogName: string | undefined;
-        if (fontCatalogs.length > 0) {
-            for (const fontCatalog of fontCatalogs) {
-                if (fontCatalog.name !== undefined) {
-                    defaultFontCatalogName = fontCatalog.name;
-                    break;
-                }
-            }
-            if (defaultFontCatalogName === undefined) {
-                defaultFontCatalogName = DEFAULT_FONT_CATALOG_NAME;
-                fontCatalogs[0].name = defaultFontCatalogName;
-            }
-        }
-
-        this.m_textStyleCache.initializeDefaultTextElementStyle(defaultFontCatalogName!);
+        const defaultFontCatalogName = this.m_fontCatalogLoader.initialize(
+            this.m_options.fontCatalog!
+        );
+        this.m_textStyleCache.initializeDefaultTextElementStyle(defaultFontCatalogName);
     }
 
     private async initializeTextCanvases(): Promise<void> {
-        const promises: Array<Promise<void>> = [];
-        this.m_theme.fontCatalogs!.forEach(fontCatalogConfig => {
-            this.m_catalogsLoading += 1;
-            const fontCatalogPromise: Promise<void> = FontCatalog.load(fontCatalogConfig.url, 1024)
-                .then((loadedFontCatalog: FontCatalog) => {
-                    const loadedTextCanvas = this.m_textCanvasFactory.createTextCanvas(
-                        loadedFontCatalog
-                    );
+        const catalogCallback = (name: string, catalog: FontCatalog) => {
+            const loadedTextCanvas = this.m_textCanvasFactory.createTextCanvas(catalog);
 
-                    this.m_textRenderers.push({
-                        fontCatalog: fontCatalogConfig.name,
-                        textCanvas: loadedTextCanvas,
-                        poiRenderer: this.m_poiRendererFactory.createPoiRenderer(loadedTextCanvas)
-                    });
-                })
-                .catch((error: Error) => {
-                    logger.error("Failed to load FontCatalog: ", error);
-                })
-                .finally(() => {
-                    this.m_catalogsLoading -= 1;
-                });
-            promises.push(fontCatalogPromise);
-        });
+            this.m_textRenderers.push({
+                fontCatalog: name,
+                textCanvas: loadedTextCanvas,
+                poiRenderer: this.m_poiRendererFactory.createPoiRenderer(loadedTextCanvas)
+            });
+        };
 
-        return Promise.all(promises).then(() => {
+        return this.m_fontCatalogLoader.loadCatalogs(catalogCallback).then(() => {
             // Find the default TextCanvas and PoiRenderer.
             let defaultTextCanvas: TextCanvas | undefined;
             this.m_textRenderers.forEach(textRenderer => {

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -149,7 +149,6 @@ export class TextLayoutStyleCache {
     }
 }
 
-export const DEFAULT_FONT_CATALOG_NAME = "default";
 const DEFAULT_STYLE_NAME = "default";
 
 /**
@@ -175,7 +174,7 @@ export class TextStyleCache {
     private m_textStyles: Map<string, TextElementStyle> = new Map();
     private m_defaultStyle: TextElementStyle = {
         name: DEFAULT_STYLE_NAME,
-        fontCatalog: DEFAULT_FONT_CATALOG_NAME,
+        fontCatalog: "",
         renderParams: this.m_textRenderStyleCache.get(DEFAULT_TEXT_STYLE_CACHE_ID)!.params,
         layoutParams: this.m_textLayoutStyleCache.get(DEFAULT_TEXT_STYLE_CACHE_ID)!.params
     };


### PR DESCRIPTION
Move font catalog loading out of TextElementsRenderer into
a separate class.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
