### PR TITLE
HARP-7373: Lazy initialization of glyph debugging mesh.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -301,15 +301,8 @@ export class TextElementsRenderer {
             return;
         }
 
-        const debugGlyphs = debugContext.getValue("DEBUG_GLYPHS");
-        if (
-            debugGlyphs !== undefined &&
-            this.m_debugGlyphTextureCacheMesh !== undefined &&
-            this.m_debugGlyphTextureCacheWireMesh !== undefined
-        ) {
-            this.m_debugGlyphTextureCacheMesh.visible = debugGlyphs;
-            this.m_debugGlyphTextureCacheWireMesh.visible = debugGlyphs;
-        }
+        this.updateGlyphDebugMesh();
+
         for (const textRenderer of this.m_textRenderers) {
             textRenderer.textCanvas.render(camera);
         }
@@ -867,52 +860,70 @@ export class TextElementsRenderer {
                 this.m_textRenderers
             );
 
-            const defaultFontCatalog = this.m_textRenderers[0].textCanvas.fontCatalog;
-
-            // Initialize glyph-debugging mesh.
-            const planeGeometry = new THREE.PlaneGeometry(
-                defaultFontCatalog.textureSize.width / 2.5,
-                defaultFontCatalog.textureSize.height / 2.5,
-                defaultFontCatalog.textureSize.width / defaultFontCatalog.maxWidth,
-                defaultFontCatalog.textureSize.height / defaultFontCatalog.maxHeight
-            );
-            const material = new THREE.MeshBasicMaterial({
-                transparent: true,
-                depthWrite: false,
-                depthTest: false,
-                map: defaultFontCatalog.texture
-            });
-            this.m_debugGlyphTextureCacheMesh = new THREE.Mesh(planeGeometry, material);
-            this.m_debugGlyphTextureCacheMesh.renderOrder = 10000;
-            this.m_debugGlyphTextureCacheMesh.visible = false;
-
-            this.m_debugGlyphTextureCacheMesh.name = "glyphDebug";
-
-            const wireframe = new THREE.WireframeGeometry(planeGeometry);
-            const wireframeMaterial = new THREE.LineBasicMaterial({
-                transparent: true,
-                color: 0x999999,
-                depthWrite: false,
-                depthTest: false
-            });
-            this.m_debugGlyphTextureCacheWireMesh = new THREE.LineSegments(
-                wireframe,
-                wireframeMaterial
-            );
-            this.m_debugGlyphTextureCacheWireMesh.renderOrder = 9999;
-            this.m_debugGlyphTextureCacheWireMesh.visible = false;
-
-            this.m_debugGlyphTextureCacheWireMesh.name = "glyphDebug";
-
-            this.m_textRenderers[0].textCanvas
-                .getLayer(DEFAULT_TEXT_CANVAS_LAYER)!
-                .storage.scene.add(
-                    this.m_debugGlyphTextureCacheMesh,
-                    this.m_debugGlyphTextureCacheWireMesh
-                );
-
             this.m_viewUpdateCallback();
         });
+    }
+
+    private updateGlyphDebugMesh() {
+        const debugGlyphs = debugContext.getValue("DEBUG_GLYPHS");
+        if (debugGlyphs === undefined) {
+            return;
+        }
+
+        if (debugGlyphs && this.m_debugGlyphTextureCacheMesh === undefined) {
+            this.initializeGlyphDebugMesh();
+        }
+        assert(this.m_debugGlyphTextureCacheMesh !== undefined);
+        assert(this.m_debugGlyphTextureCacheWireMesh !== undefined);
+
+        this.m_debugGlyphTextureCacheMesh!.visible = debugGlyphs;
+        this.m_debugGlyphTextureCacheWireMesh!.visible = debugGlyphs;
+    }
+
+    private initializeGlyphDebugMesh() {
+        const defaultFontCatalog = this.m_textRenderers[0].textCanvas.fontCatalog;
+
+        // Initialize glyph-debugging mesh.
+        const planeGeometry = new THREE.PlaneGeometry(
+            defaultFontCatalog.textureSize.width / 2.5,
+            defaultFontCatalog.textureSize.height / 2.5,
+            defaultFontCatalog.textureSize.width / defaultFontCatalog.maxWidth,
+            defaultFontCatalog.textureSize.height / defaultFontCatalog.maxHeight
+        );
+        const material = new THREE.MeshBasicMaterial({
+            transparent: true,
+            depthWrite: false,
+            depthTest: false,
+            map: defaultFontCatalog.texture
+        });
+        this.m_debugGlyphTextureCacheMesh = new THREE.Mesh(planeGeometry, material);
+        this.m_debugGlyphTextureCacheMesh.renderOrder = 10000;
+        this.m_debugGlyphTextureCacheMesh.visible = false;
+
+        this.m_debugGlyphTextureCacheMesh.name = "glyphDebug";
+
+        const wireframe = new THREE.WireframeGeometry(planeGeometry);
+        const wireframeMaterial = new THREE.LineBasicMaterial({
+            transparent: true,
+            color: 0x999999,
+            depthWrite: false,
+            depthTest: false
+        });
+        this.m_debugGlyphTextureCacheWireMesh = new THREE.LineSegments(
+            wireframe,
+            wireframeMaterial
+        );
+        this.m_debugGlyphTextureCacheWireMesh.renderOrder = 9999;
+        this.m_debugGlyphTextureCacheWireMesh.visible = false;
+
+        this.m_debugGlyphTextureCacheWireMesh.name = "glyphDebug";
+
+        this.m_textRenderers[0].textCanvas
+            .getLayer(DEFAULT_TEXT_CANVAS_LAYER)!
+            .storage.scene.add(
+                this.m_debugGlyphTextureCacheMesh,
+                this.m_debugGlyphTextureCacheWireMesh
+            );
     }
 
     /**


### PR DESCRIPTION
Till now mesh was always initialized when TextElementsRenderer
was initialized.
Now it's not initialized until DEBUG_GLYPHS debug option is enabled.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
