### PR TITLE
Fix: Raycaster is a `PickingRaycaster` object

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -47,6 +47,7 @@ import { SimpleTileGeometryManager, TileGeometryManager } from "./geometry/TileG
 import { MapViewImageCache } from "./image/MapViewImageCache";
 import { MapViewFog } from "./MapViewFog";
 import { PickHandler, PickResult } from "./PickHandler";
+import { PickingRaycaster } from "./PickingRaycaster";
 import { PoiManager } from "./poi/PoiManager";
 import { PoiTableManager } from "./poi/PoiTableManager";
 import { PolarTileDataSource } from "./PolarTileDataSource";
@@ -691,7 +692,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_enablePolarDataSource: boolean = true;
 
     // gestures
-    private readonly m_raycaster = new THREE.Raycaster();
+    private readonly m_raycaster = new PickingRaycaster(this);
     private readonly m_plane = new THREE.Plane(new THREE.Vector3(0, 0, 1));
     private readonly m_sphere = new THREE.Sphere(undefined, EarthConstants.EQUATORIAL_RADIUS);
 


### PR DESCRIPTION
Adding point geometries from XYZ led to an error being thrown
when trying to map-pick. This was due to the fact that the raycast
method in the `MapViewPoints` class expected a raycaster object of
type `PickingRaycaster` in order to access the mapView object.
Providing it instead with a `THREE.Raycaster` object would result
in an error.

This commit addresses that by changing the type of raycaster the
`m_raycaster` object in the `MapView` class.

Signed-off-by: ESTIB <jose.vega@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
