### PR TITLE
HARP-7373: Add methods to wait for TextElementsRenderer initializatio…

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -541,7 +541,7 @@ export class TextElementsRenderer {
             return true;
         }
 
-        if (this.m_initPromise === undefined) {
+        if (!this.initializing) {
             return false;
         }
         await this.m_initPromise;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -488,13 +488,16 @@ export class TextElementsRenderer {
     /**
      * Waits till all pending resources from any `FontCatalog` are loaded.
      */
-    async waitLoaded(): Promise<void> {
-        this.waitInitialized();
-
-        if (this.m_loadPromise !== undefined) {
-            await this.m_loadPromise;
+    async waitLoaded(): Promise<boolean> {
+        const initialized = await this.waitInitialized();
+        if (!initialized) {
+            return false;
         }
-        return;
+        if (this.m_loadPromise === undefined) {
+            return false;
+        }
+        await this.m_loadPromise;
+        return true;
     }
 
     /**


### PR DESCRIPTION
…n and loading.

Also, move MapView update call to the end of TextElementsRenderer initialization.
Update must be called after the renderer has been completely initialized.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
