### PR TITLE
Harp 8066: Fix bug with fallback + IBCT tests.

### DIFF
--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -929,7 +929,7 @@ export class VisibleTileSet {
                     ) {
                         const parentCode = TileOffsetUtils.getParentKeyFromKey(tileKeyCode);
 
-                        if (!checkedTiles.has(parentCode) && !renderedTiles.get(parentCode)) {
+                        if (!checkedTiles.has(parentCode)) {
                             checkedTiles.add(parentCode);
 
                             const {
@@ -955,6 +955,9 @@ export class VisibleTileSet {
                             if (nextLevelDiff < this.options.quadTreeSearchDistanceUp) {
                                 nextLevelCandidates.set(parentCode, SearchDirection.UP);
                             }
+                        } else if (renderedTiles.get(parentCode)) {
+                            // The parent tile already covers this, so we can skip it.
+                            return;
                         }
                     }
 

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -915,7 +915,7 @@ export class VisibleTileSet {
 
             // Minor optimization for the fallback search, only check parent tiles once, otherwise
             // the recursive algorithm checks all parent tiles multiple times, the key is the code
-            // of the tile that is checked and the value is whether
+            // of the tile that is checked and the value is whether a parent was found or not.
             const checkedTiles = new Map<number, boolean>();
             // Iterate over incomplete (not loaded tiles) and find their parents or children that
             // are in cache that can be rendered temporarily until tile is loaded. Note, we favour
@@ -1005,8 +1005,10 @@ export class VisibleTileSet {
         // Check if another sibling has already added the parent.
         if (renderedTiles.get(parentCode) !== undefined) {
             return true;
-        } else if (checkedTiles.has(parentCode)) {
-            return checkedTiles.get(parentCode)!;
+        }
+        const exists = checkedTiles.get(parentCode)!;
+        if (exists !== undefined) {
+            return exists;
         }
 
         const { offset, mortonCode } = TileOffsetUtils.extractOffsetAndMortonKeyFromKey(parentCode);


### PR DESCRIPTION
This fixes a bug in the fallback logic where if a parent was already added to the set of renderedTiles, then subsequent siblings would search for their children, giving strange results. Now if there is a parent tile found, it is added and all siblings don't search for their children.
Added tests also, see gerrit.