### PR TITLE
HARP-7872: Add 'Expr.isDynamic()'

### DIFF
--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -39,6 +39,14 @@ import { StringOperators } from "./operators/StringOperators";
 import { TypeOperators } from "./operators/TypeOperators";
 
 export interface OperatorDescriptor {
+    /**
+     * Returns `true` if this operator requires a dynamic execution context (e.g. ["zoom"]).
+     */
+    isDynamicOperator?: (call: CallExpr) => boolean;
+
+    /**
+     * Evaluates the given expression.
+     */
     call: (context: ExprEvaluatorContext, call: CallExpr) => Value;
 }
 
@@ -128,6 +136,14 @@ export class ExprEvaluator implements ExprVisitor<Value, ExprEvaluatorContext> {
         Object.getOwnPropertyNames(builtins).forEach(p => {
             this.defineOperator(p, builtins[p]);
         });
+    }
+
+    /**
+     * Returns the [[OperatorDescriptor]] for the given operator name.
+     * @hidden
+     */
+    static getOperator(op: string): OperatorDescriptor | undefined {
+        return operatorDescriptors.get(op);
     }
 
     visitVarExpr(expr: VarExpr, context: ExprEvaluatorContext): Value {

--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -62,6 +62,9 @@ function step(context: ExprEvaluatorContext, args: Expr[]) {
 
 const operators = {
     interpolate: {
+        isDynamicOperator: (call: CallExpr): boolean => {
+            return call.args[1] && call.args[1].isDynamic();
+        },
         call: (context: ExprEvaluatorContext, call: CallExpr): Value => {
             const interpolatorType = call.args[0];
             const input = call.args[1];
@@ -134,6 +137,9 @@ const operators = {
         }
     },
     step: {
+        isDynamicOperator: (call: CallExpr): boolean => {
+            return call.args[0] && call.args[0].isDynamic();
+        },
         call: (context: ExprEvaluatorContext, call: CallExpr): Value => {
             if (call.args[0] === undefined) {
                 throw new Error("expected the input of the 'step' operator");

--- a/@here/harp-datasource-protocol/lib/operators/MapOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MapOperators.ts
@@ -18,6 +18,9 @@ const operators = {
         }
     },
     zoom: {
+        isDynamicOperator: (): boolean => {
+            return true;
+        },
         call: (context: ExprEvaluatorContext): Value => {
             if (context.scope === ExprScope.Condition) {
                 const zoom = context.env.lookup("$zoom")!;


### PR DESCRIPTION
This change adds the method 'isDynamic()' to the class Expr. This
method can be used to classify expressions based on their expected
execution context. For example, ["zoom"] is expected to always be
executed using a dynamic context.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
