### PR TITLE
HARP-8165: Clean unneeded feature ids.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -146,12 +146,6 @@ export interface Geometry {
     uuid?: string;
 
     /**
-     * Optional list of feature IDs. Currently only `Number` is supported, will fail if features
-     * have IDs with type `Long`.
-     */
-    featureIds?: Array<number | undefined>;
-
-    /**
      * Optional list of feature start indices. The indices point into the index attribute.
      */
     featureStarts?: number[];

--- a/@here/harp-datasource-protocol/lib/IMeshBuffers.ts
+++ b/@here/harp-datasource-protocol/lib/IMeshBuffers.ts
@@ -28,12 +28,6 @@ export interface IMeshBuffers {
     readonly edgeIndices: number[];
 
     /**
-     * Optional list of feature IDs. Currently only Number is supported, will fail if features have
-     * IDs with type Long.
-     */
-    readonly featureIds: Array<number | undefined>;
-
-    /**
      * Optional list of feature start indices. The indices point into the index attribute.
      */
     readonly featureStarts: number[];

--- a/@here/harp-geojson-datasource/lib/GeoJsonGeometryCreator.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonGeometryCreator.ts
@@ -46,11 +46,6 @@ class MeshBuffer implements IMeshBuffers {
      */
     readonly featureStarts: number[] = [];
     /**
-     * Optional list of feature IDs. Currently only Number is supported, will fail if features have
-     * IDs with type Long.
-     */
-    readonly featureIds: Array<number | undefined> = [];
-    /**
      * Optional object containing the geojson properties defined by the end-user.
      */
     readonly geojsonProperties: AttributeMap[] = [];
@@ -292,14 +287,7 @@ export class GeoJsonGeometryCreator {
         techniqueIndex: number
     ): Geometry {
         const meshBuffer = new MeshBuffer();
-        const {
-            positions,
-            indices,
-            groups,
-            featureStarts,
-            featureIds,
-            geojsonProperties
-        } = meshBuffer;
+        const { positions, indices, groups, featureStarts, geojsonProperties } = meshBuffer;
 
         const holesVertices: number[][] = [];
 
@@ -321,9 +309,6 @@ export class GeoJsonGeometryCreator {
             }
 
             featureStarts.push(indices.length / 3);
-            // featureIds should be the id of the feature, but for geoJSON datasource we do not have
-            // it in integers, and we do not use them. Therefore, zeroes are added.
-            featureIds.push(0);
             geojsonProperties.push(polygon.geojsonProperties);
 
             for (let i = 0; i < polygon.vertices.length; i += 3) {
@@ -373,7 +358,6 @@ export class GeoJsonGeometryCreator {
                 type: "uint32"
             };
             geometry.featureStarts = meshBuffer.featureStarts;
-            geometry.featureIds = meshBuffer.featureIds;
             geometry.objInfos = meshBuffer.geojsonProperties;
         }
 
@@ -386,7 +370,7 @@ export class GeoJsonGeometryCreator {
         tileWorldExtents: number
     ): Geometry {
         const meshBuffer = new MeshBuffer();
-        const { indices, featureStarts, featureIds, geojsonProperties } = meshBuffer;
+        const { indices, featureStarts, geojsonProperties } = meshBuffer;
 
         let contour: number[];
         const holesVertices: number[][] = [];
@@ -424,9 +408,6 @@ export class GeoJsonGeometryCreator {
             }
 
             featureStarts.push(indices.length / 3);
-            // featureIds should be the id of the feature, but for geoJSON datasource we do not have
-            // it in integers, and we do not use them. Therefore, zeroes are added.
-            featureIds.push(0);
             geojsonProperties.push(polygon.geojsonProperties);
         }
 
@@ -471,7 +452,6 @@ export class GeoJsonGeometryCreator {
                 type: "uint32"
             };
             geometry.featureStarts = meshBuffer.featureStarts;
-            geometry.featureIds = meshBuffer.featureIds;
             geometry.objInfos = meshBuffer.geojsonProperties;
         }
 

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeometryType, Technique } from "@here/harp-datasource-protocol";
+import { GeometryType, getFeatureId, Technique } from "@here/harp-datasource-protocol";
 import * as THREE from "three";
 
 import { MapView } from "./MapView";
@@ -168,8 +168,11 @@ export class PickHandler {
 
             this.addObjInfo(featureData, intersect, pickResult);
 
-            if (featureData.ids !== undefined) {
-                const featureId = featureData.ids.length === 1 ? featureData.ids[0] : undefined;
+            if (featureData.objInfos !== undefined) {
+                const featureId =
+                    featureData.objInfos.length === 1
+                        ? getFeatureId(featureData.objInfos[0])
+                        : undefined;
                 pickResult.featureId = featureId;
             }
 

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -58,11 +58,6 @@ export interface TileFeatureData {
     geometryType?: GeometryType;
 
     /**
-     * An optional array of feature IDs.
-     */
-    ids?: Array<number | undefined>;
-
-    /**
      * An optional array of indices into geometry where the feature starts. The lists of IDs
      * and starting indices (starts) must have the same size.
      */
@@ -87,9 +82,6 @@ const MINIMUM_OBJECT_SIZE_ESTIMATION = 100;
 export function getFeatureDataSize(featureData: TileFeatureData): number {
     let numBytes = MINIMUM_OBJECT_SIZE_ESTIMATION;
 
-    if (featureData.ids !== undefined) {
-        numBytes += featureData.ids.length * 8;
-    }
     if (featureData.starts !== undefined) {
         numBytes += featureData.starts.length * 8;
     }

--- a/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
+++ b/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
@@ -6,7 +6,7 @@
 
 import * as THREE from "three";
 
-import { GeometryType } from "@here/harp-datasource-protocol";
+import { GeometryType, getFeatureId } from "@here/harp-datasource-protocol";
 import { assert, LoggerManager } from "@here/harp-utils";
 import { Tile, TileFeatureData } from "../Tile";
 import {
@@ -157,9 +157,9 @@ export class TileDataAccessor {
         // and the visitor wants to ignore that featureId
         if (
             featureData === undefined ||
-            (featureData.ids !== undefined &&
-                featureData.ids.length === 1 &&
-                !this.visitor.wantsFeature(featureData.ids[0]))
+            (featureData.objInfos !== undefined &&
+                featureData.objInfos.length === 1 &&
+                !this.visitor.wantsFeature(getFeatureId(featureData.objInfos[0])))
         ) {
             return;
         }
@@ -170,13 +170,12 @@ export class TileDataAccessor {
             return;
         }
 
-        assert(featureData.ids !== undefined, "featureData.ids missing");
-        assert(Array.isArray(featureData.ids), "featureData.ids is not an array");
+        assert(featureData.objInfos !== undefined, "featureData.ids missing");
         assert(featureData.starts !== undefined, "featureData.starts missing");
         assert(Array.isArray(featureData.starts), "featureData.starts is not an array");
-        if (featureData.ids !== undefined && featureData.starts !== undefined) {
+        if (featureData.objInfos !== undefined && featureData.starts !== undefined) {
             assert(
-                featureData.ids.length === featureData.starts.length,
+                featureData.objInfos.length === featureData.starts.length,
                 "featureData.ids and featureData.starts have unequal length"
             );
         }
@@ -332,18 +331,18 @@ export class TileDataAccessor {
      * @param featureData Dataset stored along with the object.
      */
     protected visitMesh(meshObject: THREE.Mesh, featureData: TileFeatureData): void {
-        const { ids, starts } = featureData;
+        const { objInfos, starts } = featureData;
         const geometryType = featureData.geometryType;
 
         // make linter happy: we already know that these both are valid
-        if (ids === undefined || starts === undefined || geometryType === undefined) {
+        if (objInfos === undefined || starts === undefined || geometryType === undefined) {
             return;
         }
 
         let geometryAccessor: IGeometryAccessor | undefined;
 
-        for (let featureIndex = 0; featureIndex < ids.length; featureIndex++) {
-            const featureId = ids[featureIndex];
+        for (let featureIndex = 0; featureIndex < objInfos.length; featureIndex++) {
+            const featureId = getFeatureId(objInfos[featureIndex]);
 
             if (!this.visitor.wantsFeature(featureId)) {
                 continue;

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -1426,21 +1426,17 @@ export class TileGeometryCreator {
      */
     private addFeatureData(srcGeometry: Geometry, technique: Technique, object: THREE.Object3D) {
         if (
-            ((srcGeometry.featureIds !== undefined && srcGeometry.featureIds.length > 0) ||
+            ((srcGeometry.objInfos !== undefined && srcGeometry.objInfos.length > 0) ||
                 isCirclesTechnique(technique) ||
                 isSquaresTechnique(technique)) &&
             !isSolidLineTechnique(technique)
         ) {
             const featureData: TileFeatureData = {
                 geometryType: srcGeometry.type,
-                ids: srcGeometry.featureIds,
-                starts: srcGeometry.featureStarts
+                starts: srcGeometry.featureStarts,
+                objInfos: srcGeometry.objInfos
             };
             object.userData.feature = featureData;
-
-            if (srcGeometry.objInfos !== undefined) {
-                object.userData.feature.objInfos = srcGeometry.objInfos;
-            }
         }
     }
 

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+    AttributeMap,
     Definitions,
     GeometryType,
     ITileDecoder,
@@ -35,10 +36,9 @@ export interface LinesGeometry {
     technique: number;
 
     /**
-     * Optional list of feature IDs. Currently only `Number` is supported, will fail if features
-     * have IDs with type `Long`.
+     * Optional array of objects. It can be used to pass user data from the geometry to the mesh.
      */
-    featureIds?: Array<number | undefined>;
+    objInfos?: AttributeMap[];
 
     /**
      * Optional list of feature start indices. The indices point into the index attribute.


### PR DESCRIPTION
IDs are now extracted directly from 'objInfos' member in Geometry interface,
which contains the whole attribute map.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
