### PR TITLE
HARP-7872: Reimplement interpolations as dynamic expressions.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -27,11 +27,8 @@ import {
     VarExpr
 } from "./Expr";
 import { ExprPool } from "./ExprPool";
-import { isInterpolatedProperty, isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
-import {
-    InterpolatedProperty,
-    interpolatedPropertyDefinitionToJsonExpr
-} from "./InterpolatedPropertyDefs";
+import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
+import { interpolatedPropertyDefinitionToJsonExpr } from "./InterpolatedPropertyDefs";
 import { AttrScope, mergeTechniqueDescriptor, TechniquePropNames } from "./TechniqueDescriptor";
 import { IndexedTechnique, Technique, techniqueDescriptors } from "./Techniques";
 import {
@@ -57,7 +54,7 @@ interface StyleInternalParams {
     _minZoomLevelExpr?: Expr;
     _maxZoomLevelExpr?: Expr;
 
-    _staticAttributes?: Array<[string, Value | InterpolatedProperty]>;
+    _staticAttributes?: Array<[string, Value]>;
 
     /**
      * These attributes are used to instantiate Technique variants.
@@ -73,7 +70,7 @@ interface StyleInternalParams {
      *
      * @see [[TechniqueAttrScope.Feature]]
      */
-    _dynamicFeatureAttributes?: Array<[string, Expr | InterpolatedProperty]>;
+    _dynamicFeatureAttributes?: Array<[string, Expr]>;
 
     /**
      * These attributes are forwarded as serialized by decoder to main thread, so they are resolved
@@ -83,7 +80,7 @@ interface StyleInternalParams {
      *  - interpolants from [[TechiqueDescriptor.techniquePropNames]]
      *  - expressions [[TechniqueDescriptor.dynamicPropNames]] (Future)
      */
-    _dynamicForwardedAttributes?: Array<[string, Expr | InterpolatedProperty]>;
+    _dynamicForwardedAttributes?: Array<[string, Expr]>;
     _dynamicTechniques?: Map<string, IndexedTechnique>;
 
     /**
@@ -716,15 +713,11 @@ export class StyleSetEvaluator {
 
         const processAttribute = (
             attrName: TechniquePropNames<Technique>,
-            attrValue: Value | JsonExpr | InterpolatedProperty | undefined
+            attrValue: Value | JsonExpr | undefined
         ) => {
             if (attrValue === undefined) {
                 return;
             }
-
-            const attrScope: AttrScope | undefined = (techniqueDescriptor.attrScopes as any)[
-                attrName as any
-            ];
 
             if (isJsonExpr(attrValue)) {
                 attrValue = Expr.fromJSON(
@@ -739,26 +732,39 @@ export class StyleSetEvaluator {
                 ).intern(this.m_exprPool);
             }
 
-            if (attrValue instanceof Expr) {
+            if (Expr.isExpr(attrValue)) {
                 const deps = attrValue.dependencies();
 
-                if (deps.properties.size === 0) {
+                if (!deps.zoom && deps.properties.size === 0) {
                     // no data-dependencies detected.
                     attrValue = attrValue.evaluate(this.m_emptyEnv);
                 }
             }
 
-            if (isInterpolatedProperty(attrValue) || attrValue instanceof Expr) {
+            if (Expr.isExpr(attrValue)) {
+                let attrScope: AttrScope | undefined = (techniqueDescriptor.attrScopes as any)[
+                    attrName as any
+                ];
+
+                if (attrScope === undefined) {
+                    // Use [[AttrScope.TechniqueGeometry]] as default scope for the attribute.
+                    attrScope = AttrScope.TechniqueGeometry;
+                }
+
+                const deps = attrValue.dependencies();
+
                 switch (attrScope) {
                     case AttrScope.FeatureGeometry:
                         dynamicFeatureAttributes.push([attrName, attrValue]);
                         break;
-                    case AttrScope.TechniqueRendering:
                     case AttrScope.TechniqueGeometry:
-                        if (attrValue instanceof Expr) {
-                            dynamicTechniqueAttributes.push([attrName, attrValue]);
-                        } else {
+                        dynamicTechniqueAttributes.push([attrName, attrValue]);
+                        break;
+                    case AttrScope.TechniqueRendering:
+                        if (deps.properties.size === 0) {
                             dynamicForwardedAttributes.push([attrName, attrValue]);
+                        } else {
+                            dynamicTechniqueAttributes.push([attrName, attrValue]);
                         }
                         break;
                 }
@@ -798,8 +804,15 @@ export class StyleSetEvaluator {
             return [];
         }
 
+        const instantiationContext = { env };
+
         return style._dynamicTechniqueAttributes.map(([attrName, attrExpr]) => {
             try {
+                if (attrExpr.isDynamic()) {
+                    const reducedExpr = attrExpr.instantiate(instantiationContext);
+                    return [attrName, reducedExpr];
+                }
+
                 const evaluatedValue = attrExpr.evaluate(
                     env,
                     ExprScope.Value,
@@ -841,11 +854,12 @@ export class StyleSetEvaluator {
 
         if (style._dynamicForwardedAttributes !== undefined) {
             for (const [attrName, attrValue] of style._dynamicForwardedAttributes) {
-                if (attrValue instanceof Expr) {
-                    // TODO: We don't support `Expr` instances in main thread yet.
-                    continue;
+                // tslint:disable-next-line: prefer-conditional-expression
+                if (Expr.isExpr(attrValue)) {
+                    technique[attrName] = attrValue.toJSON();
+                } else {
+                    technique[attrName] = attrValue;
                 }
-                technique[attrName] = attrValue;
             }
         }
 
@@ -907,9 +921,9 @@ export function makeDecodedTechnique(technique: IndexedTechnique): IndexedTechni
         if (!technique.hasOwnProperty(attrName)) {
             continue;
         }
-        const attrValue: any = (technique as any)[attrName];
-        if (attrValue instanceof Expr) {
-            continue;
+        let attrValue: any = (technique as any)[attrName];
+        if (Expr.isExpr(attrValue)) {
+            attrValue = attrValue.toJSON();
         }
         (result as any)[attrName] = attrValue;
     }

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -68,11 +68,11 @@ export function evaluateTechniqueAttr<T = Value>(
     const env = context instanceof Env ? context : context.env;
 
     let evaluated: Value | undefined;
-    if (attrValue instanceof Expr) {
+    if (Expr.isExpr(attrValue)) {
         try {
             evaluated = attrValue.evaluate(
                 env,
-                ExprScope.Value,
+                ExprScope.Dynamic,
                 !(context instanceof Env) ? context.cachedExprResults : undefined
             );
         } catch (error) {

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -18,8 +18,7 @@ import {
     MapEnv,
     ValueMap
 } from "../lib/Expr";
-import { getPropertyValue, isInterpolatedProperty } from "../lib/InterpolatedProperty";
-import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
+import { getPropertyValue } from "../lib/InterpolatedProperty";
 
 import * as THREE from "three";
 
@@ -498,22 +497,12 @@ describe("ExprEvaluator", function() {
 
     describe("Operator 'interpolate'", function() {
         it("parse", function() {
-            assert.isTrue(
-                isInterpolatedProperty(
-                    evaluate(["interpolate", ["linear"], ["zoom"], 0, 0, 1, 1, 2, 2])
-                )
-            );
+            assert.isNotNull(evaluate(["interpolate", ["linear"], ["zoom"], 0, 0, 1, 1, 2, 2]));
 
-            assert.isTrue(
-                isInterpolatedProperty(
-                    evaluate(["interpolate", ["discrete"], ["zoom"], 0, 0, 1, 1, 2, 2])
-                )
-            );
+            assert.isNotNull(evaluate(["interpolate", ["discrete"], ["zoom"], 0, 0, 1, 1, 2, 2]));
 
-            assert.isTrue(
-                isInterpolatedProperty(
-                    evaluate(["interpolate", ["exponential", 2], ["zoom"], 0, 0, 1, 1, 2, 2])
-                )
+            assert.isNotNull(
+                evaluate(["interpolate", ["exponential", 2], ["zoom"], 0, 0, 1, 1, 2, 2])
             );
 
             assert.throws(() => evaluate(["interpolate"]), "expected an interpolation type");
@@ -694,25 +683,23 @@ describe("ExprEvaluator", function() {
         });
 
         it("dynamic interpolation (without step 0)", function() {
-            const interpolation: InterpolatedProperty = evaluate([
-                "step",
-                ["zoom"],
-                "#ff0000",
-                13,
-                "#000000"
-            ]) as any;
-            assert.isTrue(isInterpolatedProperty(interpolation));
-            assert.strictEqual(interpolation.interpolationMode, InterpolationMode.Discrete);
-            for (let i = 0; i < 13; ++i) {
-                assert.strictEqual(getPropertyValue(interpolation, i), 0xff0000);
+            const interpolation = evaluate(["step", ["zoom"], "#ff0000", 13, "#000000"]);
+            for (let zoom = 0; zoom < 13; ++zoom) {
+                assert.strictEqual(
+                    getPropertyValue(interpolation, zoom),
+                    getPropertyValue("#ff0000", zoom)
+                );
             }
-            for (let i = 13; i < 20; ++i) {
-                assert.strictEqual(getPropertyValue(interpolation, i), 0x000000);
+            for (let zoom = 13; zoom < 20; ++zoom) {
+                assert.strictEqual(
+                    getPropertyValue(interpolation, zoom),
+                    getPropertyValue("#000000", zoom)
+                );
             }
         });
 
         it("dynamic interpolation (with step 0)", function() {
-            const interpolation: InterpolatedProperty = evaluate([
+            const interpolation = evaluate([
                 "step",
                 ["zoom"],
                 "#ff0000",
@@ -720,17 +707,24 @@ describe("ExprEvaluator", function() {
                 "#00ff00",
                 13,
                 "#000000"
-            ]) as any;
-            assert.isTrue(isInterpolatedProperty(interpolation));
-            assert.strictEqual(interpolation.interpolationMode, InterpolationMode.Discrete);
+            ]);
 
-            assert.strictEqual(getPropertyValue(interpolation, -1), 0xff0000);
+            assert.strictEqual(
+                getPropertyValue(interpolation, -1),
+                getPropertyValue("#ff0000", -1)
+            );
 
-            for (let i = 0; i < 13; ++i) {
-                assert.strictEqual(getPropertyValue(interpolation, i), 0x00ff00);
+            for (let zoom = 0; zoom < 13; ++zoom) {
+                assert.strictEqual(
+                    getPropertyValue(interpolation, zoom),
+                    getPropertyValue("#00ff00", zoom)
+                );
             }
-            for (let i = 13; i < 20; ++i) {
-                assert.strictEqual(getPropertyValue(interpolation, i), 0x000000);
+            for (let zoom = 13; zoom < 20; ++zoom) {
+                assert.strictEqual(
+                    getPropertyValue(interpolation, zoom),
+                    getPropertyValue("#000000", zoom)
+                );
             }
         });
 
@@ -779,9 +773,13 @@ describe("ExprEvaluator", function() {
 
         it("default value of a step", function() {
             assert.strictEqual(
-                evaluate(["step", ["get", "x"], "default value", 0, "value"], {
-                    x: null
-                }),
+                evaluate(
+                    ["step", ["get", "x"], "default value", 0, "value"],
+                    {
+                        x: null
+                    },
+                    ExprScope.Dynamic
+                ),
                 "default value"
             );
         });

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -15,7 +15,7 @@ function evaluate(expr: string | JsonExpr | Expr, env?: Env | ValueMap): Value {
     if (typeof env === "object" && !(env instanceof Env)) {
         env = new MapEnv(env);
     }
-    return (expr instanceof Expr
+    return (Expr.isExpr(expr)
         ? expr
         : typeof expr === "string"
         ? Expr.parse(expr)

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -9,8 +9,10 @@
 
 import { assert } from "chai";
 import { MapEnv, ValueMap } from "../lib/Expr";
-import { createInterpolatedProperty } from "../lib/InterpolatedProperty";
-import { InterpolatedPropertyDefinition } from "../lib/InterpolatedPropertyDefs";
+import {
+    InterpolatedPropertyDefinition,
+    interpolatedPropertyDefinitionToJsonExpr
+} from "../lib/InterpolatedPropertyDefs";
 import { StyleSetEvaluator } from "../lib/StyleSetEvaluator";
 import { FillTechnique, isSolidLineTechnique, SolidLineTechnique } from "../lib/Techniques";
 import { Definitions, StyleDeclaration, StyleSet } from "../lib/Theme";
@@ -238,12 +240,11 @@ describe("StyleSetEvaluator", function() {
             const sse = new StyleSetEvaluator([sampleStyleDeclaration], sampleDefinitions);
             const techniques = sse.getMatchingTechniques(new MapEnv({ kind: "park" }));
 
-            const expectedInterpolator = createInterpolatedProperty(interpolator);
             assert.equal(techniques.length, 1);
             assert.deepNestedInclude(techniques[0], {
                 name: "fill",
                 lineWidth: 123,
-                color: expectedInterpolator,
+                color: interpolatedPropertyDefinitionToJsonExpr(interpolator),
                 renderOrder: 0
             });
         });

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -19,6 +19,7 @@ import {
     TEXTURE_PROPERTY_KEYS,
     TextureProperties
 } from "@here/harp-datasource-protocol";
+import { Expr } from "@here/harp-datasource-protocol/lib/Expr";
 import {
     CirclePointsMaterial,
     HighPrecisionLineMaterial,
@@ -57,7 +58,7 @@ export interface MaterialOptions {
     /**
      * The active zoom level at material creation for zoom-dependent properties.
      */
-    level?: number;
+    level: number;
 
     /**
      * Properties to skip.
@@ -426,7 +427,7 @@ export function getMaterialConstructor(technique: Technique): MaterialConstructo
 export function applyTechniqueToMaterial(
     technique: Technique,
     material: THREE.Material,
-    level?: number,
+    level: number,
     skipExtraProps?: string[]
 ) {
     Object.getOwnPropertyNames(technique).forEach(propertyName => {
@@ -444,7 +445,7 @@ export function applyTechniqueToMaterial(
             return;
         }
         let value = technique[prop];
-        if (level !== undefined && isInterpolatedProperty(value)) {
+        if (isInterpolatedProperty(value) || Expr.isExpr(value)) {
             value = getPropertyValue(value, level);
         }
         applyTechniquePropertyToMaterial(material, prop, value);

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -7,10 +7,10 @@
 import {
     ExtendedTileInfo,
     getPropertyValue,
-    isInterpolatedProperty,
     LineTechnique,
     SolidLineTechnique
 } from "@here/harp-datasource-protocol";
+import { Expr } from "@here/harp-datasource-protocol/lib/Expr";
 import { assert, LoggerManager, Math2D } from "@here/harp-utils";
 import * as THREE from "three";
 import { MapView } from "./MapView";
@@ -70,7 +70,7 @@ export class RoadPicker {
 
             const isDynamic =
                 technique.metricUnit === "Pixel" ||
-                isInterpolatedProperty(technique.lineWidth) ||
+                Expr.isExpr(technique.lineWidth) ||
                 typeof technique.lineWidth === "string";
 
             widths[i] =

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -19,7 +19,6 @@ import {
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
     isFillTechnique,
-    isInterpolatedProperty,
     isLineMarkerTechnique,
     isLineTechnique,
     isPoiTechnique,
@@ -52,6 +51,7 @@ import { ContextualArabicConverter } from "@here/harp-text-canvas";
 import { assert, chainCallbacks, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
 
+import { Expr, isJsonExpr } from "@here/harp-datasource-protocol/lib/Expr";
 import { AnimatedExtrusionTileHandler } from "../AnimatedExtrusionHandler";
 import { ColorCache } from "../ColorCache";
 import { createMaterial, getBufferAttribute, getObjectConstructor } from "../DecodedTileHelpers";
@@ -181,6 +181,24 @@ export class TileGeometryCreator {
                 group.createdOffsets = [];
             }
         }
+
+        // compile the dynamic expressions.
+        decodedTile.techniques.forEach((technique: any) => {
+            for (const propertyName in technique) {
+                if (!technique.hasOwnProperty(propertyName)) {
+                    continue;
+                }
+                const value = technique[propertyName];
+                if (isJsonExpr(value) && propertyName !== "kind") {
+                    // "kind" is reserved.
+                    try {
+                        technique[propertyName] = Expr.fromJSON(value);
+                    } catch (error) {
+                        logger.error("#initDecodedTile: Failed to compile expression:", error);
+                    }
+                }
+            }
+        });
     }
 
     /**
@@ -790,7 +808,7 @@ export class TileGeometryCreator {
                     isLineTechnique(technique) ||
                     (isSegmentsTechnique(technique) &&
                         technique.color !== undefined &&
-                        isInterpolatedProperty(technique.color))
+                        Expr.isExpr(technique.color))
                 ) {
                     const fadingParams = this.getFadingParams(displayZoomLevel, technique);
                     FadingFeature.addRenderHelper(
@@ -878,10 +896,7 @@ export class TileGeometryCreator {
                 if (isExtrudedLineTechnique(technique)) {
                     // extruded lines are normal meshes, and need transparency only when fading or
                     // dynamic properties is defined.
-                    if (
-                        technique.fadeFar !== undefined ||
-                        isInterpolatedProperty(technique.color)
-                    ) {
+                    if (technique.fadeFar !== undefined || Expr.isExpr(technique.color)) {
                         const fadingParams = this.getFadingParams(
                             displayZoomLevel,
                             technique as StandardExtrudedLineTechnique
@@ -894,7 +909,7 @@ export class TileGeometryCreator {
                             fadingParams.fadeFar,
                             true,
                             true,
-                            technique.color !== undefined && isInterpolatedProperty(technique.color)
+                            technique.color !== undefined && Expr.isExpr(technique.color)
                                 ? (renderer, mat) => {
                                       const extrudedMaterial = mat as
                                           | MapMeshStandardMaterial
@@ -916,10 +931,8 @@ export class TileGeometryCreator {
                     // filled polygons are normal meshes, and need transparency only when fading or
                     // dynamic properties is defined.
                     const hasDynamicColor =
-                        (technique.color !== undefined &&
-                            isInterpolatedProperty(technique.color)) ||
-                        (isExtrudedPolygonTechnique(technique) &&
-                            isInterpolatedProperty(technique.emissive));
+                        (technique.color !== undefined && Expr.isExpr(technique.color)) ||
+                        (isExtrudedPolygonTechnique(technique) && Expr.isExpr(technique.emissive));
                     if (technique.fadeFar !== undefined || hasDynamicColor) {
                         const fadingParams = this.getFadingParams(displayZoomLevel, technique);
                         FadingFeature.addRenderHelper(
@@ -1076,7 +1089,7 @@ export class TileGeometryCreator {
                         false,
                         false,
                         extrudedPolygonTechnique.lineColor !== undefined &&
-                            isInterpolatedProperty(extrudedPolygonTechnique.lineColor)
+                            Expr.isExpr(extrudedPolygonTechnique.lineColor)
                             ? (renderer, mat) => {
                                   edgeMaterial.color.set(
                                       getPropertyValue(
@@ -1156,7 +1169,7 @@ export class TileGeometryCreator {
                         true,
                         false,
                         fillTechnique.lineColor !== undefined &&
-                            isInterpolatedProperty(fillTechnique.lineColor)
+                            Expr.isExpr(fillTechnique.lineColor)
                             ? (renderer, mat) => {
                                   const edgeMaterial = mat as EdgeMaterial;
                                   edgeMaterial.color.set(

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -26,7 +26,8 @@ describe("Tile Creation", function() {
             },
             renderOrder: 0
         };
-        const shaderMaterial = createMaterial({ technique });
+        const level = 14;
+        const shaderMaterial = createMaterial({ technique, level });
         assert.isTrue(
             shaderMaterial instanceof THREE.ShaderMaterial,
             "expected a THREE.ShaderMaterial"


### PR DESCRIPTION
This change modifies the logic of the StyleSetEvaluator so preserve
(and eventually forward to the main thread) the interpolations. That is,
after this change, the interpolations are handled like any other
dynamic expression.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
