### PR TITLE
HARP-8165: Add gatherFeatureAttributes to OmvDataSourceParameters.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -275,10 +275,18 @@ export function getProjectionName(projection: Projection): string | never {
 /**
  * @returns Feature id from the provided attribute map.
  */
-export function getFeatureId(attributeMap: AttributeMap | undefined): number | undefined {
-    if (attributeMap === undefined || typeof attributeMap === "number") {
+export function getFeatureId(attributeMap: AttributeMap | undefined): number {
+    if (attributeMap === undefined) {
+        return 0;
+    }
+
+    if (typeof attributeMap === "number") {
         return attributeMap;
     }
 
-    return attributeMap!.$id as number | undefined;
+    if (attributeMap.hasOwnProperty("$id")) {
+        return attributeMap.$id as number;
+    }
+
+    return 0;
 }

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -114,7 +114,7 @@ export namespace GeoJsonStylingGame {
         dataProvider: geoJsonDataProvider,
         name: "geojson",
         styleSetName: "geojson",
-        gatherFeatureIds: true
+        gatherFeatureAttributes: true
     });
 
     mapView.addDataSource(geoJsonDataSource).then(() => {

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -14,9 +14,9 @@ import { accessToken, copyrightInfo } from "../config";
  *
  * To enable line picking set `enableRoadPicking: true` in [[MapViewOptions]] and set
  * `createTileInfo: true` in [[OmvWithRestClientParams]] or in [[OmvWithCustomDataProvider]].
- * To enable polygon picking set `gatherFeatureIds: true` in
+ * To enable polygon picking set `gatherFeatureAttributes: true` in
  * [[OmvWithRestClientParams]] or in [[OmvWithCustomDataProvider]].
- * To enable text element picking set `gatherFeatureIds: true` in
+ * To enable text element picking set `gatherFeatureAttributes: true` in
  * [[OmvWithRestClientParams]] or in [[OmvWithCustomDataProvider]].
  *
  * Now, let's write an event that fires when the user clicks the map canvas:
@@ -140,7 +140,7 @@ export namespace PickingExample {
             styleSetName: "tilezen",
             maxZoomLevel: 17,
             authenticationCode: accessToken,
-            gatherFeatureIds: true,
+            gatherFeatureAttributes: true,
             createTileInfo: true,
             copyrightInfo
         });

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -94,8 +94,15 @@ export interface OmvDataSourceParameters {
 
     /**
      * Gather feature IDs from `OmvData`. Defaults to `false`.
+     * @deprecated, FeatureIds are always gathered, use [[gatherFeatureAttributes]] to gather
+     * all feature attributes.
      */
     gatherFeatureIds?: boolean;
+
+    /**
+     * Gather feature attributes from `OmvData`. Defaults to `false`.
+     */
+    gatherFeatureAttributes?: boolean;
 
     /**
      * Gather road segments data from [[OmvData]]. Defaults to `false`.
@@ -225,7 +232,7 @@ export class OmvDataSource extends TileDataSource<OmvTile> {
         this.m_decoderOptions = {
             showMissingTechniques: this.m_params.showMissingTechniques === true,
             filterDescription: this.m_params.filterDescr,
-            gatherFeatureIds: this.m_params.gatherFeatureIds === true,
+            gatherFeatureAttributes: this.m_params.gatherFeatureAttributes === true,
             createTileInfo: this.m_params.createTileInfo === true,
             gatherRoadSegments: this.m_params.gatherRoadSegments === true,
             featureModifierId: this.m_params.featureModifierId,

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -161,7 +161,7 @@ export class OmvDecoder implements IGeometryProcessor {
         private readonly m_showMissingTechniques: boolean,
         private readonly m_dataFilter?: OmvFeatureFilter,
         private readonly m_featureModifier?: OmvFeatureModifier,
-        private readonly m_gatherFeatureIds = true,
+        private readonly m_gatherFeatureAttributes = false,
         private readonly m_createTileInfo = false,
         private readonly m_gatherRoadSegments = false,
         private readonly m_skipShortLabels = true,
@@ -216,7 +216,7 @@ export class OmvDecoder implements IGeometryProcessor {
         this.m_decodedTileEmitter = new OmvDecodedTileEmitter(
             decodeInfo,
             this.m_styleSetEvaluator,
-            this.m_gatherFeatureIds,
+            this.m_gatherFeatureAttributes,
             this.m_skipShortLabels,
             this.m_enableElevationOverlay,
             this.m_languages
@@ -569,7 +569,7 @@ export class OmvTileDecoder extends ThemedTileDecoder {
     private m_showMissingTechniques: boolean = false;
     private m_featureFilter?: OmvFeatureFilter;
     private m_featureModifier?: OmvFeatureModifier;
-    private m_gatherFeatureIds: boolean = true;
+    private m_gatherFeatureAttributes: boolean = false;
     private m_createTileInfo: boolean = false;
     private m_gatherRoadSegments: boolean = false;
     private m_skipShortLabels: boolean = true;
@@ -593,7 +593,7 @@ export class OmvTileDecoder extends ThemedTileDecoder {
             this.m_showMissingTechniques,
             this.m_featureFilter,
             this.m_featureModifier,
-            this.m_gatherFeatureIds,
+            this.m_gatherFeatureAttributes,
             this.m_createTileInfo,
             this.m_gatherRoadSegments,
             this.m_skipShortLabels,
@@ -627,7 +627,7 @@ export class OmvTileDecoder extends ThemedTileDecoder {
             this.m_showMissingTechniques,
             this.m_featureFilter,
             this.m_featureModifier,
-            this.m_gatherFeatureIds,
+            this.m_gatherFeatureAttributes,
             this.m_createTileInfo,
             this.m_gatherRoadSegments,
             this.m_skipShortLabels,
@@ -675,8 +675,8 @@ export class OmvTileDecoder extends ThemedTileDecoder {
                 }
             }
 
-            if (omvOptions.gatherFeatureIds !== undefined) {
-                this.m_gatherFeatureIds = omvOptions.gatherFeatureIds === true;
+            if (omvOptions.gatherFeatureAttributes !== undefined) {
+                this.m_gatherFeatureAttributes = omvOptions.gatherFeatureAttributes === true;
             }
             if (omvOptions.createTileInfo !== undefined) {
                 this.m_createTileInfo = omvOptions.createTileInfo === true;

--- a/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoderDefs.ts
@@ -146,9 +146,9 @@ export interface OmvDecoderOptions {
     showMissingTechniques?: boolean;
 
     /**
-     * Gather feature IDs from [[OmvData]]. Defaults to true.
+     * Gather feature attributes from [[OmvData]]. Defaults to false.
      */
-    gatherFeatureIds?: boolean;
+    gatherFeatureAttributes?: boolean;
     createTileInfo?: boolean;
     gatherRoadSegments?: boolean;
 

--- a/@here/harp-omv-datasource/test/MapViewPickingTest.ts
+++ b/@here/harp-omv-datasource/test/MapViewPickingTest.ts
@@ -164,7 +164,7 @@ describe.skip("MapView Picking", async function() {
             dataProvider: geoJsonDataProvider,
             name: "geojson",
             styleSetName: "geojson",
-            gatherFeatureIds: true,
+            gatherFeatureAttributes: true,
             createTileInfo: true
         });
 


### PR DESCRIPTION
'gatherFeatureIds' is deprecated. Feature ids are always decoded,
the rest of the attributes are decoded only if gatherFeatureAttributes
option is set to true (default is false).

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
