### PR TITLE
HARP-7907: Limit number of raycasts used for Camera tilt calculus.

### DIFF
--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -704,15 +704,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         // opposite to elevating ground level.
         const halfPiLimit = Math.PI / 2 - epsilon;
         const cameraAltitude = this.getCameraAltitude(camera, projection);
-        const target = MapViewUtils.rayCastWorldCoordinates(mapView, 0, 0);
-        if (target === null) {
-            throw new Error("MapView does not support a view pointing in the void.");
-        }
-        const cameraTilt = MapViewUtils.extractSphericalCoordinatesFromLocation(
-            mapView,
-            camera,
-            projection.unprojectPoint(target)
-        ).tilt;
+        const cameraTilt = this.getCameraTilt(mapView);
         // Angle between z and c2
         let topAngleRad: number;
         // Angle between z and c1
@@ -875,7 +867,7 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
 
         // Apply the constraints.
         const farMin = cameraAltitude - this.minElevation;
-        const farMax = mapView.lookAtDistance * this.farMaxRatio;
+        const farMax = mapView.targetDistance * this.farMaxRatio;
         viewRanges.near = Math.max(viewRanges.near, this.nearMin);
         viewRanges.far = MathUtils.clamp(viewRanges.far, farMin, farMax);
 
@@ -952,6 +944,10 @@ export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
         const cameraPitch = Math.acos(MathUtils.clamp(cosAlpha1, -1.0, 1.0));
 
         return cameraPitch;
+    }
+
+    private getCameraTilt(mapView: MapView): number {
+        return MapViewUtils.extractCameraTilt(mapView.camera, mapView.projection);
     }
 }
 

--- a/@here/harp-mapview/lib/MapViewFog.ts
+++ b/@here/harp-mapview/lib/MapViewFog.ts
@@ -108,18 +108,8 @@ export class MapViewFog {
             // The fraction of maximum viewing range at which fog fully covers geometry.
             const endRatio = 1.0;
             assert(startRatio <= endRatio);
-            const target = MapViewUtils.rayCastWorldCoordinates(mapView, 0, 0);
-            if (target === null) {
-                throw new Error("MapView does not support a view pointing in the void.");
-            }
             const t = Math.abs(
-                Math.cos(
-                    MapViewUtils.extractSphericalCoordinatesFromLocation(
-                        mapView,
-                        mapView.camera,
-                        mapView.projection.unprojectPoint(target)
-                    ).tilt
-                )
+                Math.cos(MapViewUtils.extractCameraTilt(mapView.camera, mapView.projection))
             );
             const density = MathUtils.smoothStep(horizontalDensity, verticalDensity, t);
             this.m_fog.near = MathUtils.lerp(viewRange * startRatio, viewRange, 1.0 - density);

--- a/@here/harp-mapview/lib/text/MapViewState.ts
+++ b/@here/harp-mapview/lib/text/MapViewState.ts
@@ -33,7 +33,7 @@ export class MapViewState implements ViewState {
         return this.m_mapView.frameNumber;
     }
     get lookAtDistance(): number {
-        return this.m_mapView.lookAtDistance;
+        return this.m_mapView.targetDistance;
     }
     get isDynamic(): boolean {
         return this.m_mapView.isDynamicFrame;


### PR DESCRIPTION
In some cases focus point (and tilt angle) may not be calculated because
Camera is looking to the void. In this scenarios the last known focus point
is used and the highest possible tilt value is exposed (90 degrees).
This allows to keep camera pivot consistent (when changing the projection
type, or manipulating camera manually) and computations based on tilt
stable (using maximum tilt), this may be: fog, fading effect, etc.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
