### PR TITLE
HARP_7373: PoiInfo and TextElement builders for testing.

### DIFF
--- a/@here/harp-mapview/test/PoiInfoBuilder.ts
+++ b/@here/harp-mapview/test/PoiInfoBuilder.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LineMarkerTechnique, PoiTechnique } from "@here/harp-datasource-protocol";
+import { PoiInfo, TextElement } from "../lib/text/TextElement";
+
+export class PoiInfoBuilder {
+    static readonly DEF_ICON_TEXT_MIN_ZL: number = 0;
+    static readonly DEF_ICON_TEXT_MAX_ZL: number = 20;
+    static readonly DEF_TEXT_OPT: boolean = false;
+    static readonly DEF_ICON_OPT: boolean = false;
+    static readonly DEF_MAY_OVERLAP: boolean = false;
+    static readonly DEF_RESERVE_SPACE: boolean = true;
+    static readonly DEF_VALID: boolean = true;
+    static readonly DEF_RENDER_ON_MOVE: boolean = true;
+    static readonly DEF_WIDTH_HEIGHT: number = 10;
+    static readonly POI_TECHNIQUE: PoiTechnique = {
+        name: "labeled-icon",
+        renderOrder: 0
+    };
+    static readonly LINE_MARKER_TECHNIQUE: LineMarkerTechnique = {
+        name: "line-marker",
+        renderOrder: 0
+    };
+    static readonly DEF_TECHNIQUE = PoiInfoBuilder.POI_TECHNIQUE;
+
+    private m_iconMinZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MIN_ZL;
+    private m_iconMaxZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MAX_ZL;
+    private m_textMinZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MIN_ZL;
+    private m_textMaxZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MAX_ZL;
+    private m_textOpt: boolean = PoiInfoBuilder.DEF_TEXT_OPT;
+    private m_iconOpt: boolean = PoiInfoBuilder.DEF_ICON_OPT;
+    private m_mayOverlap: boolean = PoiInfoBuilder.DEF_MAY_OVERLAP;
+    private m_reserveSpace: boolean = PoiInfoBuilder.DEF_RESERVE_SPACE;
+    private m_valid: boolean = PoiInfoBuilder.DEF_VALID;
+    private m_renderOnMove: boolean = PoiInfoBuilder.DEF_RENDER_ON_MOVE;
+    private m_width: number = PoiInfoBuilder.DEF_WIDTH_HEIGHT;
+    private m_height: number = PoiInfoBuilder.DEF_WIDTH_HEIGHT;
+    private m_technique: PoiTechnique | LineMarkerTechnique = PoiInfoBuilder.DEF_TECHNIQUE;
+
+    withPoiTechnique(): PoiInfoBuilder {
+        this.m_technique = { ...PoiInfoBuilder.POI_TECHNIQUE };
+        return this;
+    }
+
+    withLineMarkerTechnique(): PoiInfoBuilder {
+        this.m_technique = { ...PoiInfoBuilder.LINE_MARKER_TECHNIQUE };
+        return this;
+    }
+
+    withIconOffset(x: number, y: number): PoiInfoBuilder {
+        this.m_technique.iconXOffset = x;
+        this.m_technique.iconYOffset = y;
+        return this;
+    }
+
+    build(textElement: TextElement): PoiInfo {
+        return {
+            technique: this.m_technique,
+            imageTextureName: "",
+            iconMinZoomLevel: this.m_iconMinZl,
+            iconMaxZoomLevel: this.m_iconMaxZl,
+            textMinZoomLevel: this.m_textMinZl,
+            textMaxZoomLevel: this.m_textMaxZl,
+            textIsOptional: this.m_textOpt,
+            iconIsOptional: this.m_iconOpt,
+            mayOverlap: this.m_mayOverlap,
+            reserveSpace: this.m_reserveSpace,
+            isValid: this.m_valid,
+            renderTextDuringMovements: this.m_renderOnMove,
+            computedWidth: this.m_width,
+            computedHeight: this.m_height,
+            textElement,
+            poiRenderBatch: 0
+        };
+    }
+}

--- a/@here/harp-mapview/test/TextElementBuilder.ts
+++ b/@here/harp-mapview/test/TextElementBuilder.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    TextLayoutParameters,
+    TextRenderParameters,
+    TextRenderStyle
+} from "@here/harp-text-canvas";
+import * as THREE from "three";
+import { TextElement } from "../lib/text/TextElement";
+import { PoiInfoBuilder } from "./PoiInfoBuilder";
+
+export const DEF_TEXT: string = "Text";
+export const DEF_RENDER_PARAMS: TextRenderParameters = {};
+export const DEF_LAYOUT_PARAMS: TextLayoutParameters = {};
+export const DEF_PRIORITY: number = 0;
+export const DEF_POSITION = new THREE.Vector3(0, 0, 0);
+export const DEF_PATH = [new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.1, 0.1, 0)];
+export const DEF_IGNORE_DISTANCE: boolean = true;
+const DEF_TILE_CENTER = new THREE.Vector3(0, 0, 0.1);
+
+export function pointTextBuilder(text: string = DEF_TEXT): TextElementBuilder {
+    return new TextElementBuilder().withText(text).withPositionVec(DEF_POSITION);
+}
+
+export function poiBuilder(text: string = DEF_TEXT): TextElementBuilder {
+    return new TextElementBuilder()
+        .withText(text)
+        .withPositionVec(DEF_POSITION.clone())
+        .withPoiInfo(new PoiInfoBuilder().withPoiTechnique());
+}
+
+export function pathTextBuilder(text: string = DEF_TEXT): TextElementBuilder {
+    return new TextElementBuilder()
+        .withText(text)
+        .withPath(DEF_PATH.map((point: THREE.Vector3) => point.clone()));
+}
+
+export function lineMarkerBuilder(text: string = DEF_TEXT): TextElementBuilder {
+    return new TextElementBuilder()
+        .withText(text)
+        .withPath(DEF_PATH.map((point: THREE.Vector3) => point.clone()))
+        .withPoiInfo(new PoiInfoBuilder().withLineMarkerTechnique());
+}
+
+export class TextElementBuilder {
+    private m_text: string = DEF_TEXT;
+    private m_priority: number = DEF_PRIORITY;
+    private m_points: THREE.Vector3 | THREE.Vector3[] = DEF_POSITION.clone();
+    private m_ignoreDistance: boolean = DEF_IGNORE_DISTANCE;
+    private m_poiInfoBuilder: PoiInfoBuilder | undefined;
+    private m_xOffset: number | undefined;
+    private m_yOffset: number | undefined;
+
+    withPoiInfo(poiInfoBuilder: PoiInfoBuilder): TextElementBuilder {
+        this.m_poiInfoBuilder = poiInfoBuilder;
+        return this;
+    }
+
+    withText(text: string): TextElementBuilder {
+        this.m_text = text;
+        return this;
+    }
+
+    withPriority(priority: number): TextElementBuilder {
+        this.m_priority = priority;
+        return this;
+    }
+
+    withPosition(x: number, y: number, z: number = 0): TextElementBuilder {
+        this.m_points = new THREE.Vector3(x, y, z).add(DEF_TILE_CENTER);
+        return this;
+    }
+
+    withPositionVec(position: THREE.Vector3): TextElementBuilder {
+        this.m_points = position.add(DEF_TILE_CENTER);
+        return this;
+    }
+
+    withPath(path: THREE.Vector3[]): TextElementBuilder {
+        for (const point of path) {
+            point.add(DEF_TILE_CENTER);
+        }
+        this.m_points = path;
+        return this;
+    }
+
+    withIgnoreDistance(ignoreDistance: boolean): TextElementBuilder {
+        this.m_ignoreDistance = ignoreDistance;
+        return this;
+    }
+
+    withOffset(x: number, y: number): TextElementBuilder {
+        this.m_xOffset = x;
+        this.m_yOffset = y;
+        return this;
+    }
+
+    build(sandbox: sinon.SinonSandbox): TextElement {
+        const textElement = new TextElement(
+            this.m_text,
+            this.m_points,
+            DEF_RENDER_PARAMS,
+            DEF_LAYOUT_PARAMS,
+            this.m_priority,
+            this.m_xOffset,
+            this.m_yOffset
+        );
+        textElement.ignoreDistance = this.m_ignoreDistance;
+        if (this.m_poiInfoBuilder !== undefined) {
+            textElement.poiInfo = this.m_poiInfoBuilder.build(textElement);
+        }
+        // Stub render style setter, so that a spy is installed on the style opacity
+        // whenever it's called.
+        const renderStyleProperty = Object.getOwnPropertyDescriptor(
+            TextElement.prototype,
+            "renderStyle"
+        )!;
+        sandbox.stub(textElement, "renderStyle").set((style: TextRenderStyle) => {
+            sandbox.spy(style, "opacity", ["set"]);
+            return renderStyleProperty.set!.call(textElement, style);
+        });
+        sandbox.stub(textElement, "renderStyle").get(renderStyleProperty.get!);
+        return textElement;
+    }
+}


### PR DESCRIPTION
Facilitate the construction of text element and poi info objects
for testing using the builder pattern.

Used in TextElementsRenderer tests in follow-up PR.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
