### PR TITLE
HARP-7373: Stub TextElementsRenderer dependencies for testing.

### DIFF
--- a/@here/harp-mapview/test/stubFontCatalog.ts
+++ b/@here/harp-mapview/test/stubFontCatalog.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FontCatalog, GlyphData } from "@here/harp-text-canvas";
+import * as sinon from "sinon";
+import * as THREE from "three";
+
+const DEF_TEXTURE_SIZE = 1;
+
+/**
+ * Creates a font catalog stub that returns stubbed glyph data.
+ * @param sandbox Sinon sandbox to keep track of created stubs.
+ * @returns FontCatalog stub.
+ */
+export function stubFontCatalog(sandbox: sinon.SinonSandbox): FontCatalog {
+    const fontCatalogStub = sinon.createStubInstance(FontCatalog);
+    sandbox.stub(fontCatalogStub, "isLoading").get(() => {
+        return false;
+    });
+    const defaultTextureSize = new THREE.Vector2(DEF_TEXTURE_SIZE, DEF_TEXTURE_SIZE);
+    sandbox.stub(fontCatalogStub, "textureSize").get(() => {
+        return defaultTextureSize;
+    });
+    const defaultTexture = new THREE.Texture();
+    sandbox.stub(fontCatalogStub, "texture").get(() => {
+        return defaultTexture;
+    });
+    fontCatalogStub.loadCharset.resolves([]);
+    fontCatalogStub.getGlyphs.callsFake(() => {
+        return [(sinon.createStubInstance(GlyphData) as unknown) as GlyphData];
+    });
+
+    return (fontCatalogStub as unknown) as FontCatalog;
+}

--- a/@here/harp-mapview/test/stubFontCatalogLoader.ts
+++ b/@here/harp-mapview/test/stubFontCatalogLoader.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FontCatalog } from "@here/harp-text-canvas";
+import * as sinon from "sinon";
+import { DEFAULT_FONT_CATALOG_NAME, FontCatalogLoader } from "../lib/text/FontCatalogLoader";
+
+/**
+ * Stubs font catalog loader.
+ * @param sandbox Sinon sandbox to keep track of created stubs.
+ * @param fontCatalog Font catalog the loader will always return.
+ * @returns FontCatalogLoader stub.
+ */
+export function stubFontCatalogLoader(
+    sandbox: sinon.SinonSandbox,
+    fontCatalog: FontCatalog
+): FontCatalogLoader {
+    const fontCatalogLoaderStub = sinon.createStubInstance(FontCatalogLoader);
+
+    sandbox.stub(fontCatalogLoaderStub, "loading").get(() => {
+        return false;
+    });
+    fontCatalogLoaderStub.loadCatalogs
+        .yields([DEFAULT_FONT_CATALOG_NAME, fontCatalog])
+        .resolves([]);
+
+    return (fontCatalogLoaderStub as unknown) as FontCatalogLoader;
+}

--- a/@here/harp-mapview/test/stubPoiManager.ts
+++ b/@here/harp-mapview/test/stubPoiManager.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import * as sinon from "sinon";
+import { PoiManager } from "../lib/poi/PoiManager";
+
+/**
+ * Stubs poi manager.
+ * @param sandbox Sinon sandbox used to track created stubs.
+ * @returns PoiManager stub.
+ */
+export function stubPoiManager(sandbox: sinon.SinonSandbox): PoiManager {
+    const stub = sandbox.createStubInstance(PoiManager);
+    stub.updatePoiFromPoiTable.returns(true);
+
+    return (stub as unknown) as PoiManager;
+}

--- a/@here/harp-mapview/test/stubPoiRenderer.ts
+++ b/@here/harp-mapview/test/stubPoiRenderer.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Math2D } from "@here/harp-utils";
+import * as sinon from "sinon";
+import * as THREE from "three";
+import { PoiRenderer } from "../lib/poi/PoiRenderer";
+import { PoiRendererFactory } from "../lib/poi/PoiRendererFactory";
+import { ScreenCollisions } from "../lib/ScreenCollisions";
+import { PoiInfo } from "../lib/text/TextElement";
+
+/**
+ * Creates a PoiRenderer stub.
+ * @param sandbox Sinon sandbox used to keep track of created stubs.
+ * @param renderPoiSpy Spy that will be called when [[renderPoi]] method is called on
+ * the created PoiRenderer stub.
+ * @returns PoiRenderer stub.
+ */
+export function stubPoiRenderer(
+    sandbox: sinon.SinonSandbox,
+    renderPoiSpy: sinon.SinonSpy
+): sinon.SinonStubbedInstance<PoiRenderer> {
+    const stub = sandbox.createStubInstance(PoiRenderer);
+    stub.prepareRender.returns(true);
+
+    // Workaround to capture the value of screenPosition vector on the time of the call,
+    // otherwise it's lost afterwards since the same vector is used to pass positions for
+    // other pois.
+    stub.renderPoi.callsFake(
+        (
+            poiInfo: PoiInfo,
+            screenPosition: THREE.Vector2,
+            screenCollisions: ScreenCollisions,
+            _viewDistance: number,
+            scale: number,
+            allocateScreenSpace: boolean,
+            opacity: number,
+            zoomLevel: number
+        ) => {
+            // TODO: HARP-7648 Refactor PoiRenderer.renderPoi, to take out
+            // bbox computation(already done during placement) and screen allocation (should
+            // be done during placement instead).
+            const bbox = new Math2D.Box();
+            PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scale, zoomLevel, bbox);
+            if (allocateScreenSpace) {
+                screenCollisions.allocate(bbox);
+            }
+            const screenPosCopy = screenPosition.toArray();
+            renderPoiSpy(poiInfo, screenPosCopy, opacity);
+        }
+    );
+
+    return stub;
+}
+
+/**
+ * Creates a PoiRendererFactory stub.
+ * @param sandbox Sinon sandbox used to keep track of created stubs.
+ * @param poiRendererStub Poi renderer that will be returned by the factory.
+ * @returns PoiRendererFactory stub.
+ */
+export function stubPoiRendererFactory(
+    sandbox: sinon.SinonSandbox,
+    poiRendererStub: sinon.SinonStubbedInstance<PoiRenderer>
+) {
+    const factoryStub = sandbox.createStubInstance(PoiRendererFactory);
+    factoryStub.createPoiRenderer.returns((poiRendererStub as unknown) as PoiRenderer);
+
+    return (factoryStub as unknown) as PoiRendererFactory;
+}

--- a/@here/harp-mapview/test/stubScreenProjector.ts
+++ b/@here/harp-mapview/test/stubScreenProjector.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { Vector3Like } from "@here/harp-geoutils";
+import * as sinon from "sinon";
+import * as THREE from "three";
+import { ScreenProjector } from "../lib/ScreenProjector";
+
+/**
+ * Creates a fake projector that takes as input NDC coordinates (from -1 to 1) and outputs screen
+ * coordinates.
+ * @param sandbox Sinon sandbox used to track created stubs.
+ * @param screenWidth Screen width in pixels.
+ * @param screenHeight Screen height in pixels.
+ * @returns Screen projector stub.
+ */
+export function stubScreenProjector(
+    sandbox: sinon.SinonSandbox,
+    screenWidth: number,
+    screenHeight: number
+): ScreenProjector {
+    const camera = new THREE.PerspectiveCamera();
+    const screenProjector = new ScreenProjector(camera);
+    screenProjector.update(camera, screenWidth, screenHeight);
+
+    sandbox
+        .stub(screenProjector, "projectVector")
+        .callsFake(function(source: Vector3Like, target: THREE.Vector3) {
+            target.set(source.x, source.y, source.z);
+            return target;
+        });
+    return screenProjector;
+}


### PR DESCRIPTION
Add helper functions for testing that stub dependencies for
TextElementsRenderer unit tests.
Unit tests are implemented in follow-up PR.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
