### PR TITLE
HARP-7373: Remove unnecessary render batch check in PoiRenderer.compu…

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1572,14 +1572,14 @@ export class TextElementsRenderer {
             renderIcon && poiRenderer.prepareRender(pointLabel, this.m_viewState.zoomLevel);
 
         if (iconReady) {
-            const iconIsVisible =
-                poiRenderer.computeIconScreenBox(
-                    poiInfo!,
-                    tempPoiScreenPosition,
-                    distanceScaleFactor,
-                    this.m_viewState.zoomLevel,
-                    tempBox2D
-                ) && this.m_screenCollisions.isVisible(tempBox2D);
+            PoiRenderer.computeIconScreenBox(
+                poiInfo!,
+                tempPoiScreenPosition,
+                distanceScaleFactor,
+                this.m_viewState.zoomLevel,
+                tempBox2D
+            );
+            const iconIsVisible = this.m_screenCollisions.isVisible(tempBox2D);
 
             // If the icon is prepared and valid, but just not visible, try again next time.
             if (!iconIsVisible) {


### PR DESCRIPTION
…teIconScreenBox()

A precondition to call computeIconScreenBox() is that prepareRender() was successfully
called first. If that's true, then poiInfo.poiRenderBatch should have the assigned a valid batch
index. That's checked within an assertion. There's no further need to double check that the batch
can be retrieved, and there's no need for the method to return a boolean.
The method is now static since it doesn't use any object member.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
