### PR TITLE
HARP-8188: Use custom blending for solid lines.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -819,7 +819,7 @@ export class TileGeometryCreator {
                         viewRanges,
                         fadingParams.fadeNear,
                         fadingParams.fadeFar,
-                        true,
+                        false,
                         false,
                         (renderer, mat) => {
                             const lineMaterial = mat as SolidLineMaterial;

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -401,7 +401,7 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
                 THREE.UniformsLib.fog
             ]),
             defines,
-            transparent: true,
+            blending: THREE.CustomBlending,
             fog: true
         };
 


### PR DESCRIPTION
This change removes the special code that overrides the `transparent`
property of the material before rendering solid lines.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
