### PR TITLE
Fix technique leak in StyleSetEvaluator.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -402,6 +402,18 @@ export class StyleSetEvaluator {
     }
 
     /**
+     * Reset array of techniques.
+     *
+     * Cleans technique array and indices, so it doesn't accumulate accross several decoding runs.
+     */
+    resetTechniques() {
+        for (const techinque of this.m_techniques) {
+            techinque._index = undefined!;
+        }
+        this.m_techniques.length = 0;
+    }
+
+    /**
      * Get the (current) array of techniques that have been created during decoding.
      */
     get techniques(): IndexedTechnique[] {
@@ -631,17 +643,17 @@ export class StyleSetEvaluator {
     private getTechniqueForStyleMatch(env: Env, style: InternalStyle) {
         this.checkStyleDynamicAttributes(style);
 
+        let technique: IndexedTechnique | undefined;
         if (style._dynamicTechniques !== undefined) {
             const dynamicAttributes = this.evaluateTechniqueProperties(style, env);
             const key = this.getDynamicTechniqueKey(style, dynamicAttributes);
-            let technique = style._dynamicTechniques!.get(key);
+            technique = style._dynamicTechniques!.get(key);
             if (technique === undefined) {
                 technique = this.createTechnique(style, key, dynamicAttributes);
                 style._dynamicTechniques!.set(key, technique);
             }
-            return technique;
         } else {
-            let technique = style._staticTechnique;
+            technique = style._staticTechnique;
             if (technique === undefined) {
                 style._staticTechnique = technique = this.createTechnique(
                     style,
@@ -649,8 +661,13 @@ export class StyleSetEvaluator {
                     []
                 ) as IndexedTechnique;
             }
-            return technique;
         }
+
+        if (technique._index === undefined) {
+            technique._index = this.m_techniques.length;
+            this.m_techniques.push(technique);
+        }
+        return technique;
     }
 
     private getDynamicTechniqueKey(

--- a/@here/harp-geojson-datasource/lib/GeoJsonDecoder.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonDecoder.ts
@@ -110,6 +110,7 @@ class GeoJsonDecoder {
         const tileInfo = new ExtendedTileInfo(tileKey, this.m_storeExtendedTags);
         const tileInfoWriter = new ExtendedTileInfoWriter(tileInfo, this.m_storeExtendedTags);
 
+        this.m_styleSetEvaluator.resetTechniques();
         const extendedTile = {
             info: tileInfo,
             writer: tileInfoWriter

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -205,6 +205,8 @@ export class OmvDecoder implements IGeometryProcessor {
             };
         }
 
+        this.m_styleSetEvaluator.resetTechniques();
+
         const tileSizeOnScreen = this.estimatedTileSizeOnScreen();
         const decodeInfo = new OmvDecoder.DecodeInfo(
             dataAdapter.id,
@@ -252,6 +254,8 @@ export class OmvDecoder implements IGeometryProcessor {
         if (dataAdapter === undefined) {
             return new ExtendedTileInfo(tileKey, false);
         }
+
+        this.m_styleSetEvaluator.resetTechniques();
 
         const tileSizeOnScreen = this.estimatedTileSizeOnScreen();
         const decodeInfo = new OmvDecoder.DecodeInfo(


### PR DESCRIPTION
StyleSetEvaluator instances are reused in several tiles, so we need
to reset technique list that accumulates techniques for one tile.
