### PR TITLE
HARP-7373: Remove fade out for non-visited labels.

### DIFF
--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -165,11 +165,10 @@ export class RenderState {
      *
      * @param time Current time.
      * @param disableFading `true` if fading is disabled, `false` otherwise.
-     * @returns `true` if visible after the update, false otherwise.
      */
-    updateFading(time: number, disableFading: boolean): boolean {
+    updateFading(time: number, disableFading: boolean): void {
         if (this.m_state !== FadingState.FadingIn && this.m_state !== FadingState.FadingOut) {
-            return this.m_state === FadingState.FadedIn;
+            return;
         }
 
         if (this.startTime === 0) {
@@ -185,7 +184,6 @@ export class RenderState {
             this.opacity = endValue;
             this.m_state =
                 this.m_state === FadingState.FadingIn ? FadingState.FadedIn : FadingState.FadedOut;
-            return this.m_state === FadingState.FadedIn;
         } else {
             // TODO: HARP-7648. Do this once for all labels (calculate the last frame value
             // increment).
@@ -196,8 +194,7 @@ export class RenderState {
                 0,
                 1
             );
+            assert(this.isFading());
         }
-        assert(this.isFading());
-        return true;
     }
 }

--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -71,26 +71,26 @@ export class TextElementGroupState {
      * Updates the fading state of all text elements within the group to the specified time.
      * @param time The time to which the fading state will be updated.
      * @param disableFading `true` if fading is disabled, `false` otherwise.
-     * @param visibleElementsCallback If provided, it will be called for every visible text element
-     * in the group.
-     * @returns True if any element visible after fading.
      */
-    updateFading(
-        time: number,
-        disableFading: boolean,
-        visibleElementsCallback?: (e: TextElementState) => void
-    ): boolean {
-        let groupVisible = false;
+    updateFading(time: number, disableFading: boolean): void {
         for (const elementState of this.m_textElementStates) {
             if (elementState !== undefined) {
-                const elementVisible = elementState.updateFading(time, disableFading);
-                groupVisible = groupVisible || elementVisible;
-                if (elementVisible && visibleElementsCallback !== undefined) {
-                    visibleElementsCallback(elementState);
-                }
+                elementState.updateFading(time, disableFading);
             }
         }
-        return groupVisible;
+    }
+
+    /**
+     * Calls the specified callback for every visible text elements in the group.
+     * @param visibleElementsCallback Functions that will be called for every visible text element
+     * in the group.
+     */
+    traverseVisibleElements(visibleElementsCallback: (e: TextElementState) => void): void {
+        for (const elementState of this.m_textElementStates) {
+            if (elementState !== undefined && elementState.visible) {
+                visibleElementsCallback(elementState);
+            }
+        }
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -182,25 +182,24 @@ export class TextElementState {
     }
 
     /**
-     * @returns True if any element visible after fading.
+     * Updates the fading state to the specified time.
+     * @param time The current time.
+     * @param disableFading If `True` there will be no fading transitions, i.e., state will go
+     * directly from FadedIn to FadedOut and viceversa.
      */
-    updateFading(time: number, disableFading: boolean) {
-        let visible = false;
-
+    updateFading(time: number, disableFading: boolean): void {
         if (this.m_textRenderState !== undefined) {
-            visible = this.m_textRenderState.updateFading(time, disableFading);
+            this.m_textRenderState.updateFading(time, disableFading);
         }
 
         if (this.iconRenderState !== undefined) {
             const iconRenderState = this.m_iconRenderStates as RenderState;
-            visible = iconRenderState.updateFading(time, disableFading) || visible;
+            iconRenderState.updateFading(time, disableFading);
         } else if (this.iconRenderStates !== undefined) {
             for (const renderState of this.m_iconRenderStates as RenderState[]) {
-                visible = renderState.updateFading(time, disableFading) || visible;
+                renderState.updateFading(time, disableFading);
             }
         }
-
-        return visible;
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -112,14 +112,12 @@ export class TextElementStateCache {
 
         let anyEviction = false;
         for (const [key, groupState] of this.m_referenceMap.entries()) {
-            const visible = groupState.updateFading(
-                time,
-                disableFading,
-                groupState.visited ? undefined : replaceCallback
-            );
-            const keep: boolean = visible || groupState.visited;
-
-            if (!keep) {
+            if (groupState.visited) {
+                groupState.updateFading(time, disableFading);
+            } else {
+                if (findReplacements) {
+                    groupState.traverseVisibleElements(replaceCallback!);
+                }
                 this.m_referenceMap.delete(key);
                 this.m_sortedGroupStates = undefined;
                 anyEviction = true;


### PR DESCRIPTION
Fade out transitions for non-visited labels causes a lot of flickering,
especially on quick zoom out movements.
Google maps, mapbox and tangram don't fade out for unvisited labels either.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
