### PR TITLE
HARP-8008 Fix bug in PolarTileDataSource

### DIFF
--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -205,6 +205,7 @@ export class PolarTileDataSource extends DataSource {
         const isNorthPole = north > 0 && south >= 0;
         const material = isNorthPole ? this.m_northPoleMaterial : this.m_southPoleMaterial;
         if (material === undefined) {
+            tile.forceHasGeometry(true);
             return;
         }
 


### PR DESCRIPTION
- Tiles that are generated by the PolarTileDataSource without a material
return early, they have no geometry, so the VisibleTileSet thinks
that these are still loading, and the FRAME_COMPLETE event never arrives,
by forcing the geometry, then we get the FRAME_COMPLETE event.

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>

