### PR TITLE
Fix bogus FirstFrameComplete delay.

### DIFF
--- a/@here/harp-mapview/lib/CameraMovementDetector.ts
+++ b/@here/harp-mapview/lib/CameraMovementDetector.ts
@@ -58,8 +58,12 @@ export class CameraMovementDetector {
         const newAttitude = MapViewUtils.extractAttitude(mapView, mapView.camera);
         const newCameraPos = mapView.camera.getWorldPosition(this.m_newCameraPos);
 
+        if (this.m_lastAttitude === undefined) {
+            this.m_lastCameraPos.copy(newCameraPos);
+            this.m_lastAttitude = newAttitude;
+            return false;
+        }
         const cameraMoved =
-            this.m_lastAttitude === undefined ||
             !this.m_lastCameraPos.equals(newCameraPos) ||
             newAttitude.yaw !== this.m_lastAttitude.yaw ||
             newAttitude.pitch !== this.m_lastAttitude.pitch ||

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -214,7 +214,6 @@ export class SimpleTileGeometryLoader implements TileGeometryLoader {
 
             this.setDecodedTile(tile.decodedTile);
             this.prepareForRender(enabledKinds, disabledKinds);
-            this.finish();
         }
     }
 
@@ -254,6 +253,7 @@ export class SimpleTileGeometryLoader implements TileGeometryLoader {
         const decodedTile = this.m_decodedTile;
         this.m_decodedTile = undefined;
         if (decodedTile === undefined || tile.disposed || !tile.isVisible) {
+            this.finish();
             return;
         }
         this.m_timeout = setTimeout(() => {
@@ -272,6 +272,7 @@ export class SimpleTileGeometryLoader implements TileGeometryLoader {
                         `Decoded tile: ${tile.dataSource.name} # lvl=${tile.tileKey.level} col=${tile.tileKey.column} row=${tile.tileKey.row} DISCARDED - invisible`
                     );
                 }
+                this.finish();
                 return;
             }
             let now = 0;


### PR DESCRIPTION
* CameraMovementDetector fix

  FirstFrameComplete was unnecessary delayed by bogus movement detected by
  CameraMovementDetector because CMD detected initial camera setup as move
  and then blocked FFC for 300ms because of its timeout.

  Initial camera setup is by no means movement and shouldn't set dynamic
  frame state for 300ms.

* TileGeometryLoader fix

  Additionally, CVM improvement revealed race condition i TGL, which
  reported allGeometryLoaded=true before it really finished.

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>
