### PR TITLE
HARP-8319: Check world offset on text deduplication with feature id.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -457,7 +457,8 @@ export class TileGeometryCreator {
                     featureId,
                     technique.style,
                     fadeNear,
-                    fadeFar
+                    fadeFar,
+                    tile.offset
                 );
                 textElement.minZoomLevel =
                     technique.minZoomLevel !== undefined
@@ -542,7 +543,10 @@ export class TileGeometryCreator {
                         technique.xOffset || 0.0,
                         technique.yOffset || 0.0,
                         featureId,
-                        technique.style
+                        technique.style,
+                        undefined,
+                        undefined,
+                        tile.offset
                     );
 
                     textElement.minZoomLevel =

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -520,7 +520,8 @@ export class PoiManager {
             featureId,
             technique.style,
             fadeNear,
-            fadeFar
+            fadeFar,
+            tile.offset
         );
 
         textElement.mayOverlap = technique.textMayOverlap === true;

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -353,7 +353,8 @@ export class TextElement {
         public featureId?: number,
         public style?: string,
         public fadeNear?: number,
-        public fadeFar?: number
+        public fadeFar?: number,
+        readonly tileOffset?: number
     ) {
         if (renderParams instanceof TextRenderStyle) {
             this.renderStyle = renderParams;

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -174,10 +174,8 @@ export class TextElementStateCache {
         }
 
         if (cacheResult.index === -1) {
-            if (!element.hasFeatureId()) {
-                // No duplicate found among elements with same text,add this one to cache.
-                cacheResult.entries.push(elementState);
-            }
+            // No duplicate found among elements with same text,add this one to cache.
+            cacheResult.entries.push(elementState);
             return true;
         }
 
@@ -259,14 +257,17 @@ export class TextElementStateCache {
         tmpCachedDuplicate.entries = cachedEntries;
 
         if (element.hasFeatureId()) {
-            // Duplicate with same feature id found.
-            assert(cachedEntries.length === 1);
-            const cachedElement = cachedEntries[0].element;
+            // Cached entries with same feature id found, find the entry with the same tile offset.
+            tmpCachedDuplicate.index = cachedEntries.findIndex(
+                entry => entry.element.tileOffset === element.tileOffset
+            );
+            if (tmpCachedDuplicate.index === -1) {
+                return tmpCachedDuplicate;
+            }
+            const cachedElement = cachedEntries[tmpCachedDuplicate.index].element;
             assert(element.featureId === cachedElement.featureId);
 
-            if (cachedElement.text === element.text) {
-                tmpCachedDuplicate.index = 0;
-            } else {
+            if (cachedElement.text !== element.text) {
                 tmpCachedDuplicate.index = -1;
                 // Labels with different text shouldn't share the same feature id. This points to
                 // an issue on the map data side. Submit a ticket to the corresponding map backend

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -855,11 +855,10 @@ export class TextElementsRenderer {
                     textCanvas.textRenderStyle,
                     textElement.glyphCaseArray
                 );
-                let result = true;
                 if (textElement.type !== TextElementType.PathLabel) {
                     textElement.bounds = new THREE.Box2();
                     tempParams.poiMeasurementParams.letterCaseArray = textElement.glyphCaseArray!;
-                    result = textCanvas.measureText(
+                    textCanvas.measureText(
                         textElement.glyphs!,
                         textElement.bounds,
                         tempParams.poiMeasurementParams

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -855,10 +855,11 @@ export class TextElementsRenderer {
                     textCanvas.textRenderStyle,
                     textElement.glyphCaseArray
                 );
+                let result = true;
                 if (textElement.type !== TextElementType.PathLabel) {
                     textElement.bounds = new THREE.Box2();
                     tempParams.poiMeasurementParams.letterCaseArray = textElement.glyphCaseArray!;
-                    textCanvas.measureText(
+                    result = textCanvas.measureText(
                         textElement.glyphs!,
                         textElement.bounds,
                         tempParams.poiMeasurementParams


### PR DESCRIPTION
If world offset is not taken into account, two equivalent text elements
(same feature id) belonging to different world offsets in mercator
projection are considered duplicates, and hence only one is displayed.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
