### PR TITLE
Fix z-fighting of animated buildings with 0 height.

### DIFF
--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -5,7 +5,7 @@
  */
 
 import { TileKey } from "@here/harp-geoutils";
-import { ExtrusionFeature } from "@here/harp-materials";
+import { ExtrusionFeature, ExtrusionFeatureDefs } from "@here/harp-materials";
 import { MathUtils } from "@here/harp-utils";
 import { MapView, MapViewEventNames, RenderEvent } from "./MapView";
 import { Tile } from "./Tile";
@@ -165,7 +165,7 @@ export class AnimatedExtrusionHandler {
  */
 export class AnimatedExtrusionTileHandler {
     private m_extrudedObjects: THREE.Object3D[] = [];
-    private m_animatedExtrusionRatio: number = ExtrusionFeature.DEFAULT_RATIO_MAX;
+    private m_animatedExtrusionRatio: number = ExtrusionFeatureDefs.DEFAULT_RATIO_MAX;
     private m_animatedExtrusionState: AnimatedExtrusionState = AnimatedExtrusionState.None;
     private m_animatedExtrusionStartTime: number | undefined = undefined;
     private m_mapView: MapView;
@@ -355,8 +355,8 @@ export class AnimatedExtrusionTileHandler {
         );
 
         this.extrusionRatio = MathUtils.easeInOutCubic(
-            ExtrusionFeature.DEFAULT_RATIO_MIN,
-            ExtrusionFeature.DEFAULT_RATIO_MAX,
+            ExtrusionFeatureDefs.DEFAULT_RATIO_MIN,
+            ExtrusionFeatureDefs.DEFAULT_RATIO_MAX,
             timeProgress / this.m_animatedExtrusionDuration
         );
 

--- a/@here/harp-materials/index.ts
+++ b/@here/harp-materials/index.ts
@@ -11,6 +11,7 @@ export * from "./lib/HighPrecisionLineMaterial";
 export * from "./lib/HighPrecisionPointMaterial";
 export * from "./lib/IconMaterial";
 export * from "./lib/LuminosityHighPassShader";
+export * from "./lib/MapMeshMaterialsDefs";
 export * from "./lib/MapMeshMaterials";
 export * from "./lib/MSAAMaterial";
 export * from "./lib/SepiaShader";

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -13,6 +13,7 @@ import {
     FadingFeature,
     FadingFeatureParameters
 } from "./MapMeshMaterials";
+import { ExtrusionFeatureDefs } from "./MapMeshMaterialsDefs";
 import { enforceBlending } from "./Utils";
 
 const vertexSource: string = `
@@ -150,7 +151,7 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
                 edgeColorMix: new THREE.Uniform(EdgeMaterial.DEFAULT_COLOR_MIX),
                 fadeNear: new THREE.Uniform(FadingFeature.DEFAULT_FADE_NEAR),
                 fadeFar: new THREE.Uniform(FadingFeature.DEFAULT_FADE_FAR),
-                extrusionRatio: new THREE.Uniform(ExtrusionFeature.DEFAULT_RATIO_MIN),
+                extrusionRatio: new THREE.Uniform(ExtrusionFeatureDefs.DEFAULT_RATIO_MIN),
                 displacementMap: new THREE.Uniform(
                     hasDisplacementMap ? params!.displacementMap : new THREE.Texture()
                 )
@@ -252,7 +253,7 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
             return;
         }
         this.uniforms.extrusionRatio.value = value;
-        const doExtrusion = value >= ExtrusionFeature.DEFAULT_RATIO_MIN;
+        const doExtrusion = value >= ExtrusionFeatureDefs.DEFAULT_RATIO_MIN;
         if (doExtrusion) {
             this.needsUpdate = this.defines.USE_EXTRUSION === undefined;
             this.defines.USE_EXTRUSION = "";

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -10,6 +10,7 @@ import { insertShaderInclude } from "./Utils";
 
 import * as THREE from "three";
 
+import { ExtrusionFeatureDefs } from "./MapMeshMaterialsDefs";
 import extrusionShaderChunk from "./ShaderChunks/ExtrusionChunks";
 import fadingShaderChunk from "./ShaderChunks/FadingChunks";
 
@@ -413,7 +414,6 @@ export namespace FadingFeature {
                     fadeFar === undefined
                         ? FadingFeature.DEFAULT_FADE_FAR
                         : cameraToWorldDistance(fadeFar, viewRanges);
-
                 if (updateUniforms) {
                     const properties = renderer.properties.get(material);
 
@@ -544,15 +544,6 @@ export class FadingFeatureMixin implements FadingFeature {
 
 export namespace ExtrusionFeature {
     /**
-     * Minimum ratio value for extrusion effect
-     */
-    export const DEFAULT_RATIO_MIN: number = 0.001;
-    /**
-     * Maximum ratio value for extrusion effect
-     */
-    export const DEFAULT_RATIO_MAX: number = 1;
-
-    /**
      * Patch the THREE.ShaderChunk on first call with some extra shader chunks.
      */
     export function patchGlobalShaderChunks() {
@@ -575,7 +566,7 @@ export namespace ExtrusionFeature {
 
         if (
             extrusionMaterial.extrusionRatio !== undefined &&
-            extrusionMaterial.extrusionRatio >= ExtrusionFeature.DEFAULT_RATIO_MIN
+            extrusionMaterial.extrusionRatio >= ExtrusionFeatureDefs.DEFAULT_RATIO_MIN
         ) {
             // Add this define to differentiate it internally from other MeshBasicMaterial
             extrusionMaterial.defines.EXTRUSION_MATERIAL = "";
@@ -662,7 +653,7 @@ export namespace ExtrusionFeature {
             properties.shader.uniforms.extrusionRatio !== undefined
         ) {
             properties.shader.uniforms.extrusionRatio.value =
-                extrusionMaterial.extrusionRatio || ExtrusionFeature.DEFAULT_RATIO_MAX;
+                extrusionMaterial.extrusionRatio || ExtrusionFeatureDefs.DEFAULT_RATIO_MAX;
             extrusionMaterial.uniformsNeedUpdate = true;
         }
     }
@@ -678,7 +669,7 @@ export namespace ExtrusionFeature {
 export class ExtrusionFeatureMixin implements ExtrusionFeature {
     needsUpdate?: boolean;
     uniformsNeedUpdate?: boolean;
-    private m_extrusion: number = ExtrusionFeature.DEFAULT_RATIO_MAX;
+    private m_extrusion: number = ExtrusionFeatureDefs.DEFAULT_RATIO_MAX;
 
     /**
      * @see [[ExtrusionFeature#extrusion]]
@@ -815,7 +806,7 @@ export class MapMeshBasicMaterial extends THREE.MeshBasicMaterial
     }
 
     get extrusionRatio(): number {
-        return ExtrusionFeature.DEFAULT_RATIO_MAX;
+        return ExtrusionFeatureDefs.DEFAULT_RATIO_MAX;
     }
     // tslint:disable-next-line:no-unused-variable
     set extrusionRatio(value: number) {
@@ -947,7 +938,7 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
     }
 
     get extrusionRatio(): number {
-        return ExtrusionFeature.DEFAULT_RATIO_MAX;
+        return ExtrusionFeatureDefs.DEFAULT_RATIO_MAX;
     }
     // tslint:disable-next-line:no-unused-variable
     set extrusionRatio(value: number) {

--- a/@here/harp-materials/lib/MapMeshMaterialsDefs.ts
+++ b/@here/harp-materials/lib/MapMeshMaterialsDefs.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export namespace ExtrusionFeatureDefs {
+    /**
+     * Minimum ratio value for extrusion effect
+     */
+    export const DEFAULT_RATIO_MIN: number = 0.0;
+    /**
+     * Maximum ratio value for extrusion effect
+     */
+    export const DEFAULT_RATIO_MAX: number = 1;
+
+    /**
+     * Buildings height used whenever no height-data is present or height is very small.
+     *
+     * Used to avoid z-fighting between ground plane and building.
+     */
+    export const MIN_BUILDING_HEIGHT = 0.01;
+}

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -75,6 +75,7 @@ import {
 } from "@here/harp-datasource-protocol/lib/TechniqueAttr";
 // tslint:disable-next-line:max-line-length
 import { SphericalGeometrySubdivisionModifier } from "@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier";
+import { ExtrusionFeatureDefs } from "@here/harp-materials/lib/MapMeshMaterialsDefs";
 
 const logger = LoggerManager.instance.create("OmvDecodedTileEmitter");
 
@@ -99,12 +100,6 @@ const tmpPointC = new THREE.Vector3();
 const tmpPointD = new THREE.Vector3();
 const tmpPointE = new THREE.Vector3();
 const tmpLine = new THREE.Line3();
-
-/**
- * Height buildings take whenever no height-data is present. Used to avoid z-fighting and other
- * graphics artifacts.
- */
-const MIN_BUILDING_HEIGHT = 1e-18;
 
 /**
  * Minimum number of pixels per character. Used during estimation if there is enough screen space
@@ -1042,9 +1037,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
 
         // Prevent that extruded buildings are completely flat (can introduce errors in normal
         // computation and extrusion).
-        if (height === floorHeight) {
-            height += MIN_BUILDING_HEIGHT;
-        }
+        height = Math.max(floorHeight + ExtrusionFeatureDefs.MIN_BUILDING_HEIGHT, height);
 
         const styleSetConstantHeight = getOptionValue(
             extrudedPolygonTechnique.constantHeight,

--- a/@here/harp-omv-datasource/package.json
+++ b/@here/harp-omv-datasource/package.json
@@ -32,6 +32,7 @@
         "@here/harp-geometry": "^0.11.0",
         "@here/harp-geoutils": "^0.11.0",
         "@here/harp-lines": "^0.11.1",
+        "@here/harp-materials": "^0.11.1",
         "@here/harp-lrucache": "^0.11.1",
         "@here/harp-mapview": "^0.11.2",
         "@here/harp-mapview-decoder": "^0.11.2",


### PR DESCRIPTION
Don't animate appearance of extruded buildings with height near 0 (or very small)
to prevent flickering caused by float precision issues when panning & overlapping tiles

Fixes:
* flickering of whole building area of appearing building with height ~0
* most of flickering of said buildings on tile borders

At expense of _not animating_ exposure or height of those buildings at all.

Fallback tiles still cause flickering from time to time.

Related-to: HARP-8279
