### PR TITLE
HARP-8337: Fix small caps rendering.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -95,9 +95,10 @@ export class TextElementState {
         predecessor.m_textRenderState = undefined;
         predecessor.m_iconRenderStates = undefined;
 
-        // Use the predecessor glyphs and bounds until proper ones are computed.
+        // Use the predecessor glyphs, bounds and case array until proper ones are computed.
         this.element.glyphs = predecessor.element.glyphs;
         this.element.bounds = predecessor.element.bounds;
+        this.element.glyphCaseArray = predecessor.element.glyphCaseArray;
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -10,6 +10,7 @@ import {
     FontCatalog,
     MeasurementParameters,
     TextBufferAdditionParameters,
+    TextBufferCreationParameters,
     TextCanvas,
     TextLayoutStyle,
     TextRenderStyle
@@ -144,6 +145,7 @@ const tempScreenPosition = new THREE.Vector2();
 const tempScreenPoints: THREE.Vector2[] = [];
 const tempPoiScreenPosition = new THREE.Vector2();
 const tempTextOffset = new THREE.Vector2();
+const tmpTextBufferCreationParams: TextBufferCreationParameters = {};
 
 class TileTextElements {
     constructor(readonly tile: Tile, readonly group: TextElementGroup) {}
@@ -1714,9 +1716,11 @@ export class TextElementsRenderer {
                         pointLabel.renderStyle!.opacity;
                     if (opacity > 0) {
                         // Compute the TextBufferObject when we know we're gonna render this label.
+                        tmpTextBufferCreationParams.letterCaseArray = pointLabel.glyphCaseArray;
                         if (pointLabel.textBufferObject === undefined) {
                             pointLabel.textBufferObject = textCanvas.createTextBufferObject(
-                                pointLabel.glyphs!
+                                pointLabel.glyphs!,
+                                tmpTextBufferCreationParams
                             );
                         }
                         const backgroundIsVisible =


### PR DESCRIPTION
Small caps were being applied to measure text but not
to create the text buffer object. As a result small caps were
actually rendered in all caps, but with a smaller bounding box.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
