### PR TITLE
HARP-7517: Do not force material update when blending mode changes.

### DIFF
--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -646,6 +646,7 @@ export function applyBaseColorToMaterial(
 
     opacity = THREE.Math.clamp(opacity, 0, 1);
     material.opacity = opacity;
+    materialColor.setRGB(r, g, b);
 
     const opaque = opacity >= 1.0;
     if (!opaque) {
@@ -653,8 +654,6 @@ export function applyBaseColorToMaterial(
     } else {
         disableBlending(material);
     }
-    materialColor.setRGB(r, g, b);
-    material.needsUpdate = true;
 }
 
 /**

--- a/@here/harp-materials/lib/Utils.ts
+++ b/@here/harp-materials/lib/Utils.ts
@@ -44,6 +44,8 @@ export interface ForcedBlending {
  * `CustomBlending` with the same parameters as the `NormalBlending`.
 
  * @param material `Material` that should use blending
+ * @note This function should not be used in frame update after material has been passed to WebGL.
+ * In such cases use [[enableBlending]] instead.
  */
 export function enforceBlending(
     material: (THREE.Material | THREE.ShaderMaterialParameters) & ForcedBlending
@@ -57,6 +59,18 @@ export function enforceBlending(
     material.forcedBlending = true;
 }
 
+/**
+ * Enable alpha blending using THREE.CustomBlending setup.
+ *
+ * Function enables blending using one of predefined modes, for both color and alpha components:
+ * - Src: [[THREE.SrcAlphaFactor]], Dst: [[THREE.OneMinusSrcAlphaFactor]]
+ * - Src: [[THREE.OneFactor]], Dst: [[THREE.OneMinusSrcAlphaFactor]]
+ * The second blending equation is used when [[THREE.Material.premultipliedAlpha]] is enabled
+ * for this material.
+ * @note Blending mode change does not require material update.
+ * @see THREE.Material.needsUpdate.
+ * @param material The material or material parameters to modify.
+ */
 export function enableBlending(
     material: (THREE.Material | THREE.ShaderMaterialParameters) & ForcedBlending
 ) {
@@ -79,6 +93,14 @@ export function enableBlending(
     }
 }
 
+/**
+ * Disable alpha blending using THREE.CustomBlending mode, switches to [[THREE.NormalBlending]].
+ *
+ * @note Blending mode change does not require material update.
+ * @see THREE.Material.needsUpdate.
+ * @see enableBlending.
+ * @param material The material or material parameters to modify.
+ */
 export function disableBlending(
     material: (THREE.Material | THREE.ShaderMaterialParameters) & ForcedBlending
 ) {


### PR DESCRIPTION
Introduces performance fix. Blending mode changes does not require material updates
(shader recompilation or getting from the cache), blend modes are solely implemented
using glBlendFunc in THREE.js, without affecting the shaders. Remove material
updates on blend modes changes.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
