### PR TITLE
HARP-8356: Fix label intersections.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -95,10 +95,12 @@ export class TextElementState {
         predecessor.m_textRenderState = undefined;
         predecessor.m_iconRenderStates = undefined;
 
-        // Use the predecessor glyphs, bounds and case array until proper ones are computed.
-        this.element.glyphs = predecessor.element.glyphs;
-        this.element.bounds = predecessor.element.bounds;
-        this.element.glyphCaseArray = predecessor.element.glyphCaseArray;
+        if (this.element.glyphs === undefined) {
+            // Use the predecessor glyphs, bounds and case array until proper ones are computed.
+            this.element.glyphs = predecessor.element.glyphs;
+            this.element.bounds = predecessor.element.bounds;
+            this.element.glyphCaseArray = predecessor.element.glyphCaseArray;
+        }
     }
 
     /**


### PR DESCRIPTION
When a label was replaced, the glyphs of its predecessor where
always used, even if the replacement already had its glyphs loaded.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
