### PR TITLE
HARP-8361: Reduce forced material updates (needsUpdate flag usage).

### DIFF
--- a/@here/harp-materials/lib/CirclePointsMaterial.ts
+++ b/@here/harp-materials/lib/CirclePointsMaterial.ts
@@ -101,7 +101,6 @@ export class CirclePointsMaterial extends THREE.ShaderMaterial {
     set size(size: number) {
         this.m_size = size;
         this.uniforms.size.value = size;
-        this.needsUpdate = true;
     }
 
     /**
@@ -117,6 +116,5 @@ export class CirclePointsMaterial extends THREE.ShaderMaterial {
     set color(color: string) {
         this.m_color.set(color);
         this.uniforms.diffuse.value.set(this.m_color);
-        this.needsUpdate = true;
     }
 }

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -202,12 +202,21 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
         return this.uniforms.edgeColorMix.value as number;
     }
     set colorMix(value: number) {
+        if (this.uniforms.edgeColorMix.value === value) {
+            return;
+        }
         this.uniforms.edgeColorMix.value = value;
-        this.updateColorMixFeature();
-    }
-
-    private updateColorMixFeature(): void {
-        this.defines.USE_COLOR = this.colorMix > 0.0 ? 1 : 0;
+        const doMixColor = value > 0.0;
+        if (doMixColor) {
+            // NOTE: We can not check Material.needsUpdate current value cause there is
+            // no getter for this property, setting it to true increments Material version
+            // which in turn forces invalidation.
+            this.needsUpdate = this.defines.USE_COLOR === undefined;
+            this.defines.USE_COLOR = "";
+        } else {
+            this.needsUpdate = this.defines.USE_COLOR !== undefined;
+            delete this.defines.USE_COLOR;
+        }
     }
 
     get fadeNear(): number {
@@ -221,13 +230,16 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
         return this.uniforms.fadeFar.value as number;
     }
     set fadeFar(value: number) {
+        if (this.uniforms.fadeFar.value === value) {
+            return;
+        }
         this.uniforms.fadeFar.value = value;
-        const doFade = value !== undefined && value > 0.0;
+        const doFade = value > 0.0;
         if (doFade) {
-            this.needsUpdate = this.needsUpdate || this.defines.USE_FADING === undefined;
+            this.needsUpdate = this.defines.USE_FADING === undefined;
             this.defines.USE_FADING = "";
         } else {
-            this.needsUpdate = this.needsUpdate || this.defines.USE_FADING !== undefined;
+            this.needsUpdate = this.defines.USE_FADING !== undefined;
             delete this.defines.USE_FADING;
         }
     }
@@ -236,13 +248,16 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
         return this.uniforms.extrusionRatio.value as number;
     }
     set extrusionRatio(value: number) {
+        if (this.uniforms.extrusionRatio.value === value) {
+            return;
+        }
         this.uniforms.extrusionRatio.value = value;
-        const doExtrusion = value !== undefined && value >= ExtrusionFeature.DEFAULT_RATIO_MIN;
+        const doExtrusion = value >= ExtrusionFeature.DEFAULT_RATIO_MIN;
         if (doExtrusion) {
-            this.needsUpdate = this.needsUpdate || this.defines.USE_EXTRUSION === undefined;
+            this.needsUpdate = this.defines.USE_EXTRUSION === undefined;
             this.defines.USE_EXTRUSION = "";
         } else {
-            this.needsUpdate = this.needsUpdate || this.defines.USE_EXTRUSION !== undefined;
+            this.needsUpdate = this.defines.USE_EXTRUSION !== undefined;
             delete this.defines.USE_EXTRUSION;
         }
     }
@@ -252,14 +267,17 @@ export class EdgeMaterial extends THREE.RawShaderMaterial
     }
 
     set displacementMap(map: THREE.Texture | undefined) {
+        if (this.uniforms.displacementMap.value === map) {
+            return;
+        }
         this.uniforms.displacementMap.value = map;
         if (map !== undefined) {
             this.uniforms.displacementMap.value.needsUpdate = true;
+            this.needsUpdate = this.defines.USE_DISPLACEMENTMAP === undefined;
             this.defines.USE_DISPLACEMENTMAP = "";
-            this.needsUpdate = this.needsUpdate || this.defines.USE_DISPLACEMENTMAP === undefined;
         } else {
+            this.needsUpdate = this.defines.USE_DISPLACEMENTMAP !== undefined;
             delete this.defines.USE_DISPLACEMENTMAP;
-            this.needsUpdate = this.needsUpdate || this.defines.USE_DISPLACEMENTMAP !== undefined;
         }
     }
 }

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -471,8 +471,10 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
      */
     updateFog(enableFog: boolean) {
         if (!enableFog) {
+            this.needsUpdate = this.defines.USE_FOG !== undefined;
             delete this.defines.USE_FOG;
         } else {
+            this.needsUpdate = this.defines.USE_FOG === undefined;
             this.defines.USE_FOG = "";
         }
     }


### PR DESCRIPTION
Because THREE.js material update may take quite a long time and force
new shader buildup, it is recommended to use Material.needsUpdate flag
carefully.
This patch-set limits material updates only to real state changes,
affecting shader structure, thus reducing needs for shader re-build to
minimum.
Fixed classes:
- MapViewFog,
- CirclePointsMaterial,
- EdgeMaterial.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
