### PR TITLE
HARP-4888: Fix path text flicker caused by state reset on rejection.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -739,7 +739,7 @@ export class TextElementsRenderer {
                             placementStats.numPathTooSmall++;
                         }
                     }
-                    textElementState.reset();
+                    textElementState.textRenderState!.reset();
                     continue;
                 }
             }
@@ -1936,7 +1936,7 @@ export class TextElementsRenderer {
             if (placementStats) {
                 ++placementStats.tooFar;
             }
-            labelState.reset();
+            labelState.textRenderState!.reset();
             return false;
         }
 
@@ -1950,7 +1950,7 @@ export class TextElementsRenderer {
             if (placementStats) {
                 ++placementStats.tooFar;
             }
-            labelState.reset();
+            labelState.textRenderState!.reset();
             return false;
         }
 
@@ -2006,7 +2006,7 @@ export class TextElementsRenderer {
             if (placementStats) {
                 ++placementStats.numNotVisible;
             }
-            labelState.reset();
+            labelState.textRenderState!.reset();
             return false;
         }
 
@@ -2024,6 +2024,7 @@ export class TextElementsRenderer {
                 if (placementStats) {
                     ++placementStats.numNotVisible;
                 }
+                labelState.textRenderState!.reset();
                 return false;
             }
         }


### PR DESCRIPTION
Path text state was being fully resetted after it was rejected, which
meant that the label was rejected for the next frames until the next
label update took place.

Now only the fade state is rejected but the view distance is kept. That
way the label will go through placement on the the next frames.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
