### PR TITLE
HARP-4888: Remove path label priority tweaking w.r.t path length.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -79,19 +79,6 @@ import { TileGeometryLoader } from "./TileGeometryLoader";
 const logger = LoggerManager.instance.create("TileGeometryCreator");
 
 /**
- * The SORT_WEIGHT_PATH_LENGTH constants control how the priority of the labels are computed based
- * on the length of the label strings.
- *
- * Consequently, the [[Technique]]s priority is slightly modified while generating
- * [[TextElement]]s from the [[DecodedTile]], to get a more meaningful priority and stable results.
- */
-
-/**
- * Gives [[TextElement]]s with longer paths a higher priority.
- */
-const SORT_WEIGHT_PATH_LENGTH = 0.1;
-
-/**
  * Parameters that control fading.
  */
 export interface FadingParameters {
@@ -392,20 +379,6 @@ export class TileGeometryCreator {
                 textFilter
             );
 
-            // Compute maximum street length (squared). Longer streets should be labelled first,
-            // they have a higher chance of being placed in case the number of text elements is
-            // limited.
-            let maxPathLengthSqr = 0;
-            for (const textPath of textPathGeometries) {
-                const technique = decodedTile.techniques[textPath.technique];
-                if (technique.enabled === false || !isTextTechnique(technique)) {
-                    continue;
-                }
-                if (textPath.pathLengthSqr > maxPathLengthSqr) {
-                    maxPathLengthSqr = textPath.pathLengthSqr;
-                }
-            }
-
             for (const textPath of textPathGeometries) {
                 const technique = decodedTile.techniques[textPath.technique];
 
@@ -428,14 +401,11 @@ export class TileGeometryCreator {
                     );
                 }
 
-                // Make sorting stable and make pathLengthSqr a differentiator for placement.
+                // Make sorting stable.
                 const priority =
-                    (technique.priority !== undefined
+                    technique.priority !== undefined
                         ? getPropertyValue(technique.priority, displayZoomLevel)
-                        : 0) +
-                    (maxPathLengthSqr > 0
-                        ? (SORT_WEIGHT_PATH_LENGTH * textPath.pathLengthSqr) / maxPathLengthSqr
-                        : 0);
+                        : 0;
                 const fadeNear =
                     technique.fadeNear !== undefined
                         ? getPropertyValue(technique.fadeNear, displayZoomLevel)

--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -64,7 +64,7 @@ export class TextElementGroupState {
      * @returns the priority of the text elements in the group.
      */
     get priority() {
-        return this.m_textElementStates[0].element.priority;
+        return this.group.priority;
     }
 
     /**


### PR DESCRIPTION
Tweaked priority was not being used anyway since the label group priority
is floored.
Furthermore, there's better options to ensure longer path labels get displayed:
1. Give higher priority to higher category street labels in the style.
2. Use OMV street label layer (ticket in backlog) to improve placement of
path labels so that they don't collide with intersecting streets.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
