### PR TITLE
HARP-7856 Background plane added only during fallback

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -347,6 +347,13 @@ export class Tile implements CachedResource {
      */
     levelOffset: number = 0;
 
+    /**
+     * @hidden
+     *
+     * Background mesh used for the fallback logic.
+     */
+    backgroundPlane?: THREE.Mesh;
+
     private m_disposed: boolean = false;
     private m_localTangentSpace = false;
 
@@ -961,6 +968,7 @@ export class Tile implements CachedResource {
             disposeObject(rootObject);
         });
         this.objects.length = 0;
+        this.backgroundPlane = undefined;
 
         if (this.preparedTextPaths) {
             this.preparedTextPaths = [];
@@ -1013,6 +1021,17 @@ export class Tile implements CachedResource {
      */
     computeWorldOffsetX(): number {
         return this.projection.worldExtent(0, 0).max.x * this.offset;
+    }
+
+    /**
+     * Adds the supplied mesh to the list of three.js objects and keeps track of the mesh
+     * internally. Note, only one background mesh may be added to a Tile.
+     * @param plane
+     */
+    addBackgroundPlane(plane: THREE.Mesh) {
+        assert(this.backgroundPlane === undefined, "Only one background plane is supported");
+        this.backgroundPlane = plane;
+        this.objects.push(plane);
     }
 
     private computeResourceInfo(): void {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -1350,7 +1350,7 @@ export class TileGeometryCreator {
             const mesh = new THREE.Mesh(g, material);
             mesh.renderOrder = renderOrder;
             this.registerTileObject(tile, mesh, GeometryKind.Background);
-            tile.objects.push(mesh);
+            tile.addBackgroundPlane(mesh);
         } else {
             // Add a ground plane to the tile.
             tile.boundingBox.getSize(tmpV);
@@ -1364,7 +1364,7 @@ export class TileGeometryCreator {
             );
 
             this.registerTileObject(tile, groundPlane, GeometryKind.Background);
-            tile.objects.push(groundPlane);
+            tile.addBackgroundPlane(groundPlane);
         }
     }
 


### PR DESCRIPTION
The background plane is used to hide the details of parents that are shown at a lower render order.