### PR TITLE
HARP-4888: Test glyph BBs on label collision.

### DIFF
--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -99,7 +99,7 @@ export class TestFixture {
     private readonly m_theme: Theme = {};
     private m_viewState: ViewState;
     private m_options: TextElementsRendererOptions = {};
-    private m_screenCollisionsIsAllocatedStub: sinon.SinonStub | undefined;
+    private m_screenCollisionTestStub: sinon.SinonStub | undefined;
     private m_textCanvasStub: TextCanvas | undefined;
     private m_textRenderer: TextElementsRenderer | undefined;
     private m_defaultTile: Tile | undefined;
@@ -227,12 +227,12 @@ export class TestFixture {
      */
     async renderFrame(time: number, tileIndices: number[], collisionEnabled: boolean = true) {
         this.sandbox.resetHistory();
-        if (collisionEnabled && this.m_screenCollisionsIsAllocatedStub !== undefined) {
-            this.m_screenCollisionsIsAllocatedStub.restore();
-            this.m_screenCollisionsIsAllocatedStub = undefined;
-        } else if (!collisionEnabled && this.m_screenCollisionsIsAllocatedStub === undefined) {
-            this.m_screenCollisionsIsAllocatedStub = (this.sandbox
-                .stub(this.m_screenCollisions, "isAllocated")
+        if (collisionEnabled && this.m_screenCollisionTestStub !== undefined) {
+            this.m_screenCollisionTestStub.restore();
+            this.m_screenCollisionTestStub = undefined;
+        } else if (!collisionEnabled && this.m_screenCollisionTestStub === undefined) {
+            this.m_screenCollisionTestStub = (this.sandbox
+                .stub(this.m_screenCollisions, "intersectsDetails")
                 .returns(false) as unknown) as sinon.SinonStub;
         }
         if (this.textRenderer.loading) {

--- a/@here/harp-utils/lib/Math2D.ts
+++ b/@here/harp-utils/lib/Math2D.ts
@@ -47,6 +47,22 @@ export namespace Math2D {
         }
 
         /**
+         * Test box for inclusion of another box.
+         *
+         * @param other Box 2 to test for inclusion.
+         */
+        containsBox(other: Box): boolean {
+            const xmax = other.x + other.w;
+            const ymax = other.y + other.h;
+            return (
+                this.contains(other.x, other.y) &&
+                this.contains(xmax, other.y) &&
+                this.contains(other.x, ymax) &&
+                this.contains(xmax, ymax)
+            );
+        }
+
+        /**
          * Test two boxes for intersection.
          *
          * @param other Box 2 to test for intersection.


### PR DESCRIPTION
Glyph BBs are now saved together with the label global BB in the screen collision RTree.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
