### PR TITLE
HARP-4888: Change path label duplicate criteria.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -423,6 +423,7 @@ export class TileGeometryCreator {
                     fadeFar,
                     tile.offset
                 );
+                textElement.pathLengthSqr = textPath.pathLengthSqr;
                 textElement.minZoomLevel =
                     technique.minZoomLevel !== undefined
                         ? technique.minZoomLevel

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -315,6 +315,8 @@ export class TextElement {
      */
     dbgPathTooSmall?: boolean;
 
+    pathLengthSqr?: number;
+
     type: TextElementType;
 
     private m_poiInfo?: PoiInfo;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -2037,6 +2037,7 @@ export class TextElementsRenderer {
         }
 
         if (labelState.textRenderState!.opacity === 0) {
+            textCanvas.textRenderStyle.fontSize.size = prevSize;
             return false;
         }
 

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -2036,6 +2036,10 @@ export class TextElementsRenderer {
             renderParams.fadeAnimationRunning = true;
         }
 
+        if (labelState.textRenderState!.opacity === 0) {
+            return false;
+        }
+
         const prevOpacity = textCanvas.textRenderStyle.opacity;
         const prevBgOpacity = textCanvas.textRenderStyle.backgroundOpacity;
         const distanceFadeFactor = this.getDistanceFadingFactor(

--- a/@here/harp-mapview/test/TextElementBuilder.ts
+++ b/@here/harp-mapview/test/TextElementBuilder.ts
@@ -55,6 +55,8 @@ export class TextElementBuilder {
     private m_xOffset: number | undefined;
     private m_yOffset: number | undefined;
     private m_featureId: number | undefined;
+    private m_pathLengthSqr: number | undefined;
+    private m_userData: any;
 
     withPoiInfo(poiInfoBuilder: PoiInfoBuilder): TextElementBuilder {
         this.m_poiInfoBuilder = poiInfoBuilder;
@@ -105,6 +107,16 @@ export class TextElementBuilder {
         return this;
     }
 
+    withUserData(data: any): TextElementBuilder {
+        this.m_userData = data;
+        return this;
+    }
+
+    withPathLengthSqr(lengthSqr: number): TextElementBuilder {
+        this.m_pathLengthSqr = lengthSqr;
+        return this;
+    }
+
     build(sandbox: sinon.SinonSandbox): TextElement {
         const textElement = new TextElement(
             this.m_text,
@@ -120,6 +132,8 @@ export class TextElementBuilder {
         if (this.m_poiInfoBuilder !== undefined) {
             textElement.poiInfo = this.m_poiInfoBuilder.build(textElement);
         }
+        textElement.userData = this.m_userData;
+        textElement.pathLengthSqr = this.m_pathLengthSqr;
         // Stub render style setter, so that a spy is installed on the style opacity
         // whenever it's called.
         const renderStyleProperty = Object.getOwnPropertyDescriptor(

--- a/@here/harp-mapview/test/stubTextCanvas.ts
+++ b/@here/harp-mapview/test/stubTextCanvas.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+    AdditionParameters,
     FontCatalog,
     GlyphData,
     MeasurementParameters,
@@ -25,7 +26,8 @@ import { TextCanvasFactory } from "../lib/text/TextCanvasFactory";
 export function stubTextCanvas(
     sandbox: sinon.SinonSandbox,
     fontCatalog: FontCatalog,
-    textWidthHeight: number
+    textWidthHeight: number,
+    addTextSpy: sinon.SinonSpy
 ): TextCanvas {
     const renderer = ({} as unknown) as THREE.WebGLRenderer;
     const textCanvas = new TextCanvas({
@@ -35,7 +37,23 @@ export function stubTextCanvas(
         maxGlyphCount: 1
     });
 
-    sandbox.stub(textCanvas, "addText").returns(true);
+    // Workaround to capture the value of params.pickingData on the time of the call,
+    // otherwise it's lost afterwards since the same parameter object is reused between calls.
+    sandbox
+        .stub(textCanvas, "addText")
+        .callsFake(
+            (
+                _text: string | GlyphData[],
+                _position: THREE.Vector3,
+                params?: AdditionParameters
+            ) => {
+                if (params !== undefined) {
+                    addTextSpy(params.pickingData);
+                }
+                return true;
+            }
+        );
+
     sandbox
         .stub(textCanvas, "measureText")
         .callsFake(


### PR DESCRIPTION
Now there's different criteria to select the "best" label duplicate for point labels and for path labels when feature ids are not available.

- For point labels the best duplicate is the closest label with same text (as long as it's within the maximum distance tolerance to consider a label a duplicate).
- For path labels, the best duplicate is the longest path label with same text within the maximum distance tolerance. Choosing the longest path makes it more likely that it'll remain visible for a longer time even if there's camera changes, since paths shorter than a minimum length are discarded.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
