### PR TITLE
HARP-8455: Fix crash in TileDecoderService.

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDecoderService.ts
+++ b/@here/harp-mapview-decoder/lib/TileDecoderService.ts
@@ -102,7 +102,7 @@ export class TileDecoderService extends WorkerService {
                 if (
                     geom.objInfos !== undefined &&
                     geom.objInfos.length === 1 &&
-                    geom.objInfos[0] !== undefined &&
+                    typeof geom.objInfos[0] === "object" &&
                     "displacementMap" in (geom.objInfos[0] as any)
                 ) {
                     transferList.push((geom.objInfos[0] as any).displacementMap.buffer);


### PR DESCRIPTION
Check that geom.objInfos[0] is an object before trying to check if
it has the "displacementMap" property.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
