### PR TITLE
HARP-8201: Avoid glitches when rendering transparent lines

### DIFF
--- a/@here/harp-lines/test/rendering/RenderLines.ts
+++ b/@here/harp-lines/test/rendering/RenderLines.ts
@@ -86,6 +86,10 @@ describe("Rendering lines: ", function() {
         {
             name: "line at obtuse angle - right",
             points: [-50, 0, 10, 0, 0, 10, 50, -50, 10]
+        },
+        {
+            name: "lines that cross",
+            points: [-50, 0, 0, 50, 0, 0, 0, 50, 0, 0, -50, 0]
         }
     ];
 
@@ -193,6 +197,10 @@ describe("Rendering lines: ", function() {
         {
             name: "line 3 points - right: -3",
             points: [-50, 0, 0, 0, 0, 0, 0, -3, 0]
+        },
+        {
+            name: "lines that cross",
+            points: [-50, 0, 0, 50, 0, 0, 0, 50, 0, 0, -50, 0]
         }
     ];
 

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -34,6 +34,7 @@ import {
     TilingScheme,
     Vector3Like
 } from "@here/harp-geoutils";
+import { SolidLineMaterial } from "@here/harp-materials";
 import {
     assert,
     getOptionValue,
@@ -891,6 +892,9 @@ export class MapView extends THREE.EventDispatcher {
     private m_env: MapEnv = new MapEnv({});
 
     private m_enableMixedLod: boolean | undefined;
+
+    private readonly m_renderOrderStencilValues = new Map<number, number>();
+    private m_stencilValue: number = 0;
 
     /**
      * Constructs a new `MapView` with the given options or canvas element.
@@ -2729,6 +2733,27 @@ export class MapView extends THREE.EventDispatcher {
         return this.m_fog;
     }
 
+    private getStencilValue(renderOrder: number) {
+        if (!this.m_drawing) {
+            throw new Error("failed to get the stencil value");
+        }
+
+        return (
+            this.m_renderOrderStencilValues.get(renderOrder) ??
+            this.allocateStencilValue(renderOrder)
+        );
+    }
+
+    private allocateStencilValue(renderOrder: number) {
+        if (!this.m_drawing) {
+            throw new Error("failed to allocate stencil value");
+        }
+
+        const stencilValue = this.m_stencilValue++;
+        this.m_renderOrderStencilValues.set(renderOrder, stencilValue);
+        return stencilValue;
+    }
+
     private setPostEffects() {
         // First clear all the effects, then enable them from what is specified.
         this.mapRenderingManager.bloom.enabled = false;
@@ -3232,6 +3257,9 @@ export class MapView extends THREE.EventDispatcher {
         RENDER_EVENT.time = frameStartTime;
         this.dispatchEvent(RENDER_EVENT);
 
+        this.m_stencilValue = 0;
+        this.m_renderOrderStencilValues.clear();
+
         ++this.m_frameNumber;
 
         let currentFrameEvent: FrameStats | undefined;
@@ -3502,6 +3530,13 @@ export class MapView extends THREE.EventDispatcher {
                 if (!this.processTileObject(tile, object, mapObjectAdapter)) {
                     continue;
                 }
+
+                // TODO: acquire a new style value of if transparent
+                const material: SolidLineMaterial | undefined = (object as any).material;
+                if (object.renderOrder !== undefined && material instanceof SolidLineMaterial) {
+                    material.stencilRef = this.getStencilValue(object.renderOrder);
+                }
+
                 object.position.copy(tile.center);
                 if (object.displacement !== undefined) {
                     object.position.add(object.displacement);

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -160,6 +160,8 @@ const DEFAULT_MIN_CAMERA_HEIGHT = 20;
  */
 const DEFAULT_POLAR_STYLE_SET_NAME = "polar";
 
+const DEFAULT_STENCIL_VALUE = 1;
+
 /**
  * The type of `RenderEvent`.
  */
@@ -894,7 +896,8 @@ export class MapView extends THREE.EventDispatcher {
     private m_enableMixedLod: boolean | undefined;
 
     private readonly m_renderOrderStencilValues = new Map<number, number>();
-    private m_stencilValue: number = 0;
+    // Valid values start at 1, because the screen is cleared to zero
+    private m_stencilValue: number = DEFAULT_STENCIL_VALUE;
 
     /**
      * Constructs a new `MapView` with the given options or canvas element.
@@ -3257,7 +3260,7 @@ export class MapView extends THREE.EventDispatcher {
         RENDER_EVENT.time = frameStartTime;
         this.dispatchEvent(RENDER_EVENT);
 
-        this.m_stencilValue = 0;
+        this.m_stencilValue = DEFAULT_STENCIL_VALUE;
         this.m_renderOrderStencilValues.clear();
 
         ++this.m_frameNumber;

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -228,7 +228,21 @@ void main() {
     // Decrease the line opacity by the distToEdge, making the transition steeper when the slope
     // of distToChange increases (i.e. the line is further away).
     float width = fwidth(distToEdge);
-    alpha *= (1.0 - smoothstep(-width, width, distToEdge));
+
+#ifndef USE_DASHED_LINE
+    float s = opacity < 0.98
+        ? clamp((distToEdge + width) / (2.0 * width), 0.0, 1.0) // prefer a boxstep
+        : smoothstep(-width, width, distToEdge);
+
+    if (opacity < 0.98 && 1.0 - s < opacity) {
+        // drop the fragment when the line is using opacity.
+        discard;
+    }
+#else
+    float s = smoothstep(-width, width, distToEdge);
+#endif
+
+    alpha *= 1.0 - s;
 
     #ifdef USE_DASHED_LINE
     // Compute the distance to the dash origin (0.0: dashOrigin, 1.0: dashEnd, (d+g)/d: gapEnd).
@@ -496,6 +510,12 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
         this.m_fog = fogParam;
         this.m_opacity = opacityParam;
 
+        // initialize the stencil pass
+        this.stencilFunc = THREE.NotEqualStencilFunc;
+        this.stencilZPass = THREE.ReplaceStencilOp;
+        this.stencilRef = 1;
+        this.stencilWrite = false;
+
         enforceBlending(this);
         this.extensions.derivatives = true;
 
@@ -631,6 +651,10 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
         if (this.uniforms !== undefined) {
             this.uniforms.opacity.value = value;
         }
+
+        if (this.uniforms?.gapSize?.value === 0) {
+            this.stencilWrite = this.m_opacity < 0.98;
+        }
     }
 
     /**
@@ -714,6 +738,10 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
     set gapSize(value: number) {
         this.uniforms.gapSize.value = value;
         setShaderMaterialDefine(this, "USE_DASHED_LINE", value > 0.0);
+
+        if (this.uniforms?.gapSize?.value === 0) {
+            this.stencilWrite = this.m_opacity < 0.98;
+        }
     }
 
     /**

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -229,7 +229,6 @@ void main() {
     // of distToChange increases (i.e. the line is further away).
     float width = fwidth(distToEdge);
 
-#ifndef USE_DASHED_LINE
     float s = opacity < 0.98
         ? clamp((distToEdge + width) / (2.0 * width), 0.0, 1.0) // prefer a boxstep
         : smoothstep(-width, width, distToEdge);
@@ -238,9 +237,6 @@ void main() {
         // drop the fragment when the line is using opacity.
         discard;
     }
-#else
-    float s = smoothstep(-width, width, distToEdge);
-#endif
 
     alpha *= 1.0 - s;
 
@@ -652,9 +648,7 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
             this.uniforms.opacity.value = value;
         }
 
-        if (this.uniforms?.gapSize?.value === 0) {
-            this.stencilWrite = this.m_opacity < 0.98;
-        }
+        this.stencilWrite = this.m_opacity < 0.98;
     }
 
     /**


### PR DESCRIPTION
This change should avoid seeing circles when
rendering adjacent segments of solid lines.

Use the stencil buffer and prefer boxstep to smoothstep
when rendering solid-lines with opacity less than 0.98.
Note that we are using 0.98 instead of 1.0 to avoid possible
issues when interpolations give values close to 1.0 instead
of 1.0.
