### PR TITLE
HARP-8439: Add support for the ppi-scale family operators.

### DIFF
--- a/@here/harp-datasource-protocol/lib/operators/MapOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MapOperators.ts
@@ -4,10 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExprScope, Value } from "../Expr";
+import { CallExpr, ExprScope, Value } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {
+    "ppi-scale": {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const value = context.evaluate(call.args[0]) as number;
+            const scaleFactor = call.args[1] ? (context.evaluate(call.args[1]) as number) : 1;
+            return value * scaleFactor;
+        }
+    },
+    "world-ppi-scale": {
+        isDynamicOperator: (): boolean => {
+            return true;
+        },
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const pixels = context.evaluate(call.args[0]) as number;
+            const scaleFactor = call.args[1] ? (context.evaluate(call.args[1]) as number) : 1;
+            const zoom = context.env.lookup("$zoom") as number;
+            const zoomWidth = Math.pow(2, 17) / Math.pow(2, zoom);
+            const v = pixels * zoomWidth * scaleFactor;
+            return v;
+        }
+    },
+    "world-discrete-ppi-scale": {
+        isDynamicOperator: (): boolean => {
+            return true;
+        },
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            const pixels = context.evaluate(call.args[0]) as number;
+            const scaleFactor = call.args[1] ? (context.evaluate(call.args[1]) as number) : 1;
+            const zoom = context.env.lookup("$zoom") as number;
+            const zoomWidthDiscrete = Math.pow(2, 17) / Math.pow(2, Math.floor(zoom));
+            const v = pixels * zoomWidthDiscrete * scaleFactor;
+            return v;
+        }
+    },
     ppi: {
         call: (context: ExprEvaluatorContext) => {
             const ppi = context.env.lookup("$ppi");


### PR DESCRIPTION
These operators are used to convert from pixels to world space
based on the reference ppi (always 72 for now), the zoom level,
and the reference zoom level (for harp.gl it is defined to be 17).
