### PR TITLE
Improve resolving @here/harp-utils symbols in web target.

### DIFF
--- a/@here/harp-utils/index-common.ts
+++ b/@here/harp-utils/index-common.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./lib/GroupedPriorityList";
+export * from "./lib/Logger";
+export * from "./lib/Math2D";
+export * from "./lib/MathUtils";
+export * from "./lib/Mixins";
+export * from "./lib/assert";
+export * from "./lib/CachedResource";
+export * from "./lib/ContextLogger";
+export * from "./lib/PerformanceTimer";
+export * from "./lib/ObjectUtils";
+export * from "./lib/OptionsUtils";
+export * from "./lib/UriResolver";
+export * from "./lib/UrlUtils";
+export * from "./lib/Functions";

--- a/@here/harp-utils/index.web.ts
+++ b/@here/harp-utils/index.web.ts
@@ -5,4 +5,4 @@
  */
 
 export * from "./index-common";
-export * from "./lib/UrlPlatformUtils";
+export * from "./lib/UrlPlatformUtils.web";

--- a/@here/harp-utils/package.json
+++ b/@here/harp-utils/package.json
@@ -3,6 +3,7 @@
     "version": "0.11.1",
     "description": "Provides utilities: logging, debugging.",
     "main": "index.js",
+    "browser": "index.web.js",
     "scripts": {
         "build": "tsc",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",


### PR DESCRIPTION
@here/harp-utils contains platform-dependent module - UrlPlatformUtils
that has to be resolved differently in node and web context.

Follow strategy from `@node/fetch` and use `package.json`s `browser`
field, so `.web` versions are default in `web` target.

