### PR TITLE
HARP-4888: Remove TempParams parameter from TextElementsRenderer func…

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -74,11 +74,6 @@ interface RenderParams {
     time: number;
 }
 
-interface TempParams {
-    poiMeasurementParams: MeasurementParameters;
-    bufferAdditionParams: TextBufferAdditionParameters;
-}
-
 enum Pass {
     PersistentLabels,
     NewLabels
@@ -145,6 +140,8 @@ const tempPoiScreenPosition = new THREE.Vector2();
 const tempTextOffset = new THREE.Vector2();
 const tmpTextBufferCreationParams: TextBufferCreationParameters = {};
 const tmpAdditionParams: AdditionParameters = {};
+const tmpPoiMeasurementParams: MeasurementParameters = {};
+const tmpBufferAdditionParams: TextBufferAdditionParameters = {};
 
 class TileTextElements {
     constructor(readonly tile: Tile, readonly group: TextElementGroup) {}
@@ -183,6 +180,21 @@ function checkIfTextElementsChanged(dataSourceTileList: DataSourceTileList[]) {
     });
 
     return textElementsChanged;
+}
+
+function addTextToCanvas(
+    textElement: TextElement,
+    canvas: TextCanvas,
+    screenPosition: THREE.Vector3,
+    path?: THREE.Path,
+    pathOverflow?: boolean
+) {
+    tmpAdditionParams.path = path;
+    tmpAdditionParams.pathOverflow = pathOverflow;
+    tmpAdditionParams.layer = textElement.renderOrder;
+    tmpAdditionParams.letterCaseArray = textElement.glyphCaseArray;
+    tmpAdditionParams.pickingData = textElement.userData ? textElement : undefined;
+    canvas.addText(textElement.glyphs!, screenPosition, tmpAdditionParams);
 }
 
 export type ViewUpdateCallback = () => void;
@@ -654,11 +666,6 @@ export class TextElementsRenderer {
         }
 
         const shieldGroups: number[][] = [];
-
-        const temp: TempParams = {
-            poiMeasurementParams: {},
-            bufferAdditionParams: {}
-        };
         const hiddenKinds = this.m_viewState.hiddenGeometryKinds;
 
         for (const textElementState of groupState.textElementStates) {
@@ -740,7 +747,7 @@ export class TextElementsRenderer {
                 }
             }
 
-            if (!this.initializeGlyphs(textElement, textElementStyle, temp)) {
+            if (!this.initializeGlyphs(textElement, textElementStyle)) {
                 continue;
             }
 
@@ -763,7 +770,7 @@ export class TextElementsRenderer {
 
             switch (elementType) {
                 case TextElementType.PoiLabel:
-                    this.addPoiLabel(textElementState, poiRenderer, textCanvas, renderParams, temp);
+                    this.addPoiLabel(textElementState, poiRenderer, textCanvas, renderParams);
                     break;
                 case TextElementType.LineMarker:
                     this.addLineMarkerLabel(
@@ -771,8 +778,7 @@ export class TextElementsRenderer {
                         poiRenderer,
                         shieldGroups,
                         textCanvas,
-                        renderParams,
-                        temp
+                        renderParams
                     );
                     break;
                 case TextElementType.PathLabel:
@@ -784,8 +790,7 @@ export class TextElementsRenderer {
 
     private initializeGlyphs(
         textElement: TextElement,
-        textElementStyle: TextElementStyle,
-        tempParams: TempParams
+        textElementStyle: TextElementStyle
     ): boolean {
         // Trigger the glyph load if needed.
         if (textElement.loadingState === LoadingState.Initialized) {
@@ -847,11 +852,11 @@ export class TextElementsRenderer {
                 );
                 if (textElement.type !== TextElementType.PathLabel) {
                     textElement.bounds = new THREE.Box2();
-                    tempParams.poiMeasurementParams.letterCaseArray = textElement.glyphCaseArray!;
+                    tmpPoiMeasurementParams.letterCaseArray = textElement.glyphCaseArray!;
                     textCanvas.measureText(
                         textElement.glyphs!,
                         textElement.bounds,
-                        tempParams.poiMeasurementParams
+                        tmpPoiMeasurementParams
                     );
                 }
                 textElement.loadingState = LoadingState.Initialized;
@@ -1314,9 +1319,6 @@ export class TextElementsRenderer {
         const screenXOrigin = -screenSize.width / 2.0;
         const screenYOrigin = screenSize.height / 2.0;
 
-        const tempAdditionParams: AdditionParameters = {};
-        const tempBufferAdditionParams: TextBufferAdditionParameters = {};
-
         // Place text elements one by one.
         for (const textElement of this.m_overlayTextElements!) {
             // Get the TextElementStyle.
@@ -1400,12 +1402,7 @@ export class TextElementsRenderer {
                 tempPosition.x = tempScreenPosition.x;
                 tempPosition.y = tempScreenPosition.y;
                 tempPosition.z = 0.0;
-
-                tempBufferAdditionParams.position = tempPosition;
-                tempAdditionParams.layer = textElement.renderOrder;
-                tempAdditionParams.letterCaseArray = textElement.glyphCaseArray;
-                tempAdditionParams.pickingData = textElement.userData ? textElement : undefined;
-                textCanvas.addText(textElement.glyphs!, tempPosition, tempAdditionParams);
+                addTextToCanvas(textElement, textCanvas, tempPosition);
             } else {
                 // Adjust the label positioning.
                 tempScreenPosition.x = screenXOrigin;
@@ -1430,13 +1427,7 @@ export class TextElementsRenderer {
                 for (let i = 0; i < screenPoints.length - 1; ++i) {
                     textPath.add(new THREE.LineCurve(screenPoints[i], screenPoints[i + 1]));
                 }
-
-                tempAdditionParams.path = textPath;
-                tempAdditionParams.pathOverflow = true;
-                tempAdditionParams.layer = textElement.renderOrder;
-                tempAdditionParams.letterCaseArray = textElement.glyphCaseArray;
-                tempAdditionParams.pickingData = textElement.userData ? textElement : undefined;
-                textCanvas.addText(textElement.glyphs!, tempPosition, tempAdditionParams);
+                addTextToCanvas(textElement, textCanvas, tempPosition, textPath, true);
             }
         }
     }
@@ -1493,7 +1484,6 @@ export class TextElementsRenderer {
         poiRenderer: PoiRenderer,
         textCanvas: TextCanvas,
         renderParams: RenderParams,
-        temp: TempParams,
         iconIndex?: number
     ): boolean {
         const pointLabel: TextElement = labelState.element;
@@ -1717,20 +1707,20 @@ export class TextElementsRenderer {
                             pointLabel.renderStyle!.backgroundOpacity > 0 &&
                             textCanvas.textRenderStyle.fontSize.backgroundSize > 0;
 
-                        temp.bufferAdditionParams.layer = pointLabel.renderOrder;
-                        temp.bufferAdditionParams.position = tempPosition;
-                        temp.bufferAdditionParams.scale = textScale;
-                        temp.bufferAdditionParams.opacity = opacity;
-                        temp.bufferAdditionParams.backgroundOpacity = backgroundIsVisible
-                            ? temp.bufferAdditionParams.opacity *
+                        tmpBufferAdditionParams.layer = pointLabel.renderOrder;
+                        tmpBufferAdditionParams.position = tempPosition;
+                        tmpBufferAdditionParams.scale = textScale;
+                        tmpBufferAdditionParams.opacity = opacity;
+                        tmpBufferAdditionParams.backgroundOpacity = backgroundIsVisible
+                            ? tmpBufferAdditionParams.opacity *
                               pointLabel.renderStyle!.backgroundOpacity
                             : 0.0;
-                        temp.bufferAdditionParams.pickingData = pointLabel.userData
+                        tmpBufferAdditionParams.pickingData = pointLabel.userData
                             ? pointLabel
                             : undefined;
                         textCanvas.addTextBufferObject(
                             pointLabel.textBufferObject!,
-                            temp.bufferAdditionParams
+                            tmpBufferAdditionParams
                         );
                         if (placementStats) {
                             placementStats.numRenderedPoiTexts++;
@@ -1780,8 +1770,7 @@ export class TextElementsRenderer {
         labelState: TextElementState,
         poiRenderer: PoiRenderer,
         textCanvas: TextCanvas,
-        renderParams: RenderParams,
-        temp: TempParams
+        renderParams: RenderParams
     ): boolean {
         const poiLabel = labelState.element;
         const worldPosition = poiLabel.points as THREE.Vector3;
@@ -1797,8 +1786,7 @@ export class TextElementsRenderer {
             tempScreenPosition,
             poiRenderer,
             textCanvas,
-            renderParams,
-            temp
+            renderParams
         );
     }
 
@@ -1807,8 +1795,7 @@ export class TextElementsRenderer {
         poiRenderer: PoiRenderer,
         shieldGroups: number[][],
         textCanvas: TextCanvas,
-        renderParams: RenderParams,
-        temp: TempParams
+        renderParams: RenderParams
     ): void {
         const lineMarkerLabel = labelState.element;
         const path = lineMarkerLabel.points as THREE.Vector3[];
@@ -1870,7 +1857,6 @@ export class TextElementsRenderer {
                                 poiRenderer,
                                 textCanvas,
                                 renderParams,
-                                temp,
                                 pointIndex
                             )
                         ) {
@@ -1893,7 +1879,6 @@ export class TextElementsRenderer {
                         poiRenderer,
                         textCanvas,
                         renderParams,
-                        temp,
                         pointIndex
                     );
                 }
@@ -2016,12 +2001,7 @@ export class TextElementsRenderer {
 
         tempPosition.z = labelState.renderDistance;
 
-        tmpAdditionParams.path = textPath;
-        tmpAdditionParams.layer = pathLabel.renderOrder;
-        tmpAdditionParams.letterCaseArray = pathLabel.glyphCaseArray;
-        tmpAdditionParams.pickingData = pathLabel.userData ? pathLabel : undefined;
-        textCanvas.addText(pathLabel.glyphs!, tempPosition, tmpAdditionParams);
-
+        addTextToCanvas(pathLabel, textCanvas, tempPosition, textPath);
         renderParams.numRenderedTextElements++;
 
         // Restore previous style values for text elements using the same style.


### PR DESCRIPTION
…tions.

- Move duplicate code into addTextToCanvas aux function.
- Change TextElementsRenderer unit tests to copy opacity argument on call
 to fake addTextBufferObject function, since the passed parameter object is
reused in subsequent calls.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
