### PR TITLE
Make the type attribute of theme definitions optional

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -11,7 +11,7 @@ import { ExprParser } from "./ExprParser";
 import { ExprPool } from "./ExprPool";
 import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
 import { interpolatedPropertyDefinitionToJsonExpr } from "./InterpolatedPropertyDefs";
-import { Definitions, isSelectorDefinition, isValueDefinition } from "./Theme";
+import { Definitions, isBoxedDefinition, isLiteralDefinition } from "./Theme";
 
 export * from "./Env";
 
@@ -858,11 +858,10 @@ function resolveReference(node: JsonArray, referenceResolverState?: ReferenceRes
         return cachedEntry;
     }
     let definitionEntry = referenceResolverState.definitions[name] as any;
-    if (isSelectorDefinition(definitionEntry)) {
-        definitionEntry = definitionEntry.value;
-    }
     let result: Expr;
-    if (isValueDefinition(definitionEntry)) {
+    if (isLiteralDefinition(definitionEntry)) {
+        return Expr.fromJSON(definitionEntry);
+    } else if (isBoxedDefinition(definitionEntry)) {
         if (isInterpolatedPropertyDefinition(definitionEntry.value)) {
             // found a reference to an interpolation using
             // the deprecated object-like syntax.
@@ -873,6 +872,7 @@ function resolveReference(node: JsonArray, referenceResolverState?: ReferenceRes
             return Expr.fromJSON(definitionEntry.value);
         }
     }
+
     if (isJsonExpr(definitionEntry)) {
         referenceResolverState.lockedNames.add(name);
         try {

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -56,12 +56,18 @@ describe("Expr", function() {
     describe("#fromJson", function() {
         describe("ref operator support", function() {
             const baseDefinitions: Definitions = {
-                color: { type: "color", value: "#ff0" },
-                number: { type: "number", value: 123 }
+                color: "#ff0",
+                string: { value: "abc" },
+                number: { type: "number", value: 123 },
+                number2: { value: 234 },
+                boolean: true
             };
             it("supports literal references", function() {
                 assert.equal(evaluate(Expr.fromJSON(["ref", "color"], baseDefinitions)), "#ff0");
+                assert.equal(evaluate(Expr.fromJSON(["ref", "string"], baseDefinitions)), "abc");
                 assert.equal(evaluate(Expr.fromJSON(["ref", "number"], baseDefinitions)), 123);
+                assert.equal(evaluate(Expr.fromJSON(["ref", "number2"], baseDefinitions)), 234);
+                assert.equal(evaluate(Expr.fromJSON(["ref", "boolean"], baseDefinitions)), true);
             });
             it("throws on missing definitions", function() {
                 assert.throws(() => {
@@ -70,9 +76,13 @@ describe("Expr", function() {
             });
             it("supports basic expression references", function() {
                 const definitions: Definitions = {
-                    basicExpr: { type: "selector", value: ["+", 2, 3] }
+                    literalExpr: ["+", 2, 3],
+                    boxedTypedExpr: { type: "selector", value: ["+", 3, 4] },
+                    boxedUntypedExpr: { value: ["+", 4, 5] }
                 };
-                assert.equal(evaluate(Expr.fromJSON(["ref", "basicExpr"], definitions)), 5);
+                assert.equal(evaluate(Expr.fromJSON(["ref", "literalExpr"], definitions)), 5);
+                assert.equal(evaluate(Expr.fromJSON(["ref", "boxedTypedExpr"], definitions)), 7);
+                assert.equal(evaluate(Expr.fromJSON(["ref", "boxedUntypedExpr"], definitions)), 9);
             });
             it("supports embedded basic embedded references", function() {
                 const definitions: Definitions = {
@@ -83,20 +93,12 @@ describe("Expr", function() {
             });
             it("supports complex embedded references", function() {
                 const definitions: Definitions = {
-                    number: { type: "number", value: 1 },
-                    refConstantExpr: { type: "selector", value: ["+", 1, ["ref", "number"]] },
-                    refExpr1: {
-                        // 1 + 1+ 2 -> 6
-                        type: "selector",
-                        value: ["+", ["ref", "number"], ["ref", "number"], ["ref", "refExpr2"]]
-                    },
-                    refExpr2: {
-                        // 2*2 -> 4
-                        type: "selector",
-                        value: ["*", ["ref", "refConstantExpr"], ["ref", "refConstantExpr"]]
-                    },
+                    number: 1,
+                    refConstantExpr: ["+", 1, ["ref", "number"]],
+                    refExpr1: ["+", ["ref", "number"], ["ref", "number"], ["ref", "refExpr2"]],
+                    refExpr2: ["*", ["ref", "refConstantExpr"], ["ref", "refConstantExpr"]],
                     refTopExpr: {
-                        // 6 - 4 -> 2
+                        // 6 - 4 -> 2, old syntax
                         type: "selector",
                         value: ["-", ["ref", "refExpr1"], ["ref", "refExpr2"]]
                     }

--- a/@here/harp-map-theme/resources/berlin_derived.json
+++ b/@here/harp-map-theme/resources/berlin_derived.json
@@ -2,10 +2,7 @@
     "extends": "berlin_tilezen_base.json",
 
     "definitions": {
-        "parkColor": {
-            "type": "color",
-            "value": "red"
-        },
+        "parkColor": "red",
         "extrudedBuildings": {
             "technique": "fill",
             "when": ["ref", "extrudedBuildingsCondition"],
@@ -13,39 +10,36 @@
                 "color": "blue"
             }
         },
-        "countryBorderLineWidth": {
-            "type": "number",
-            "value": [
-                "interpolate",
-                ["linear"],
-                ["zoom"],
-                2,
-                2000,
-                3,
-                1400,
-                4,
-                1000,
-                5,
-                500,
-                6,
-                220,
-                7,
-                90,
-                8,
-                50,
-                9,
-                30,
-                10,
-                20,
-                11,
-                15,
-                12,
-                10,
-                13,
-                5,
-                14,
-                2
-            ]
-        }
+        "countryBorderLineWidth": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            2,
+            2000,
+            3,
+            1400,
+            4,
+            1000,
+            5,
+            500,
+            6,
+            220,
+            7,
+            90,
+            8,
+            50,
+            9,
+            30,
+            10,
+            20,
+            11,
+            15,
+            12,
+            10,
+            13,
+            5,
+            14,
+            2
+        ]
     }
 }

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -1,25 +1,13 @@
 {
     "definitions": {
-        "parkColor": {
-            "type": "color",
-            "value": "#6C9478"
-        },
-        "extrudedBuildingsCondition": {
-            "type": "selector",
-            "value": [
-                "all",
-                ["==", ["get", "$layer"], "buildings"],
-                ["==", ["get", "$geometryType"], "polygon"]
-            ]
-        },
-        "defaultBuildingColor": {
-            "type": "color",
-            "value": "#EDE7E1E6"
-        },
-        "waterColor": {
-            "type": "color",
-            "value": "#436981"
-        },
+        "parkColor": "#6C9478",
+        "extrudedBuildingsCondition": [
+            "all",
+            ["==", ["get", "$layer"], "buildings"],
+            ["==", ["get", "$geometryType"], "polygon"]
+        ],
+        "defaultBuildingColor": "#EDE7E1E6",
+        "waterColor": "#436981",
         "waterPolygons": {
             "description": "water",
             "when": [
@@ -57,84 +45,72 @@
             },
             "renderOrder": 2000
         },
-        "countryBorderLineWidth": {
-            "type": "number",
-            "value": [
-                "interpolate",
-                ["linear"],
-                ["zoom"],
-                2,
-                2000,
-                3,
-                1400,
-                4,
-                1000,
-                5,
-                500,
-                6,
-                220,
-                7,
-                90,
-                8,
-                50,
-                9,
-                30,
-                10,
-                20,
-                11,
-                15,
-                12,
-                10,
-                13,
-                5,
-                14,
-                2
-            ]
-        },
-        "roadsFadeNear": {
-            "type": "number",
-            "value": 0.9
-        },
-        "roadsFadeFar": {
-            "type": "number",
-            "value": 0.95
-        },
-        "countryBorderOutlineWidth": {
-            "type": "number",
-            "value": [
-                "interpolate",
-                ["linear"],
-                ["zoom"],
-                1,
-                10000,
-                2,
-                8000,
-                3,
-                7000,
-                4,
-                5000,
-                5,
-                3000,
-                6,
-                2000,
-                7,
-                1000,
-                8,
-                500,
-                9,
-                250,
-                10,
-                120,
-                11,
-                80,
-                12,
-                40,
-                13,
-                20,
-                14,
-                10
-            ]
-        },
+        "countryBorderLineWidth": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            2,
+            2000,
+            3,
+            1400,
+            4,
+            1000,
+            5,
+            500,
+            6,
+            220,
+            7,
+            90,
+            8,
+            50,
+            9,
+            30,
+            10,
+            20,
+            11,
+            15,
+            12,
+            10,
+            13,
+            5,
+            14,
+            2
+        ],
+        "roadsFadeNear": 0.9,
+        "roadsFadeFar": 0.95,
+        "countryBorderOutlineWidth": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            1,
+            10000,
+            2,
+            8000,
+            3,
+            7000,
+            4,
+            5000,
+            5,
+            3000,
+            6,
+            2000,
+            7,
+            1000,
+            8,
+            500,
+            9,
+            250,
+            10,
+            120,
+            11,
+            80,
+            12,
+            40,
+            13,
+            20,
+            14,
+            10
+        ],
         "countryBorderLine": {
             "description": "country border",
             "when": [

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { isJsonExpr } from "@here/harp-datasource-protocol";
 import {
     Definitions,
     isActualSelectorDefinition,
+    isBoxedDefinition,
     isJsonExprReference,
-    isValueDefinition,
+    isLiteralDefinition,
     ResolvedStyleDeclaration,
     ResolvedStyleSet,
     StyleDeclaration,
@@ -456,14 +458,15 @@ export class ThemeLoader {
                     failed = true;
                     return undefined;
                 }
-                if (!isValueDefinition(def)) {
-                    contextLogger.warn(
-                        `invalid reference '${defName}' - expected value definition`
-                    );
-                    failed = true;
-                    return undefined;
+                if (isLiteralDefinition(def) || isJsonExpr(def)) {
+                    return def;
                 }
-                return def.value;
+                if (isBoxedDefinition(def)) {
+                    return def.value;
+                }
+                contextLogger.warn(`invalid reference '${defName}' - expected value definition`);
+                failed = true;
+                return undefined;
             } else if (Array.isArray(node)) {
                 const result = [...node];
                 for (let i = 1; i < result.length; ++i) {

--- a/@here/harp-mapview/test/ThemeLoaderTest.ts
+++ b/@here/harp-mapview/test/ThemeLoaderTest.ts
@@ -16,8 +16,8 @@ import * as nodeUrl from "url";
 const URL = typeof window !== "undefined" ? window.URL : nodeUrl.URL;
 
 import {
+    BoxedSelectorDefinition,
     ResolvedStyleSet,
-    SelectorValueDefinition,
     SolidLineStyle,
     StyleSelector,
     StyleSet,
@@ -140,7 +140,9 @@ describe("ThemeLoader", function() {
         it("resolves ref expression in technique attr values", async function() {
             const theme: Theme = {
                 definitions: {
-                    roadColor: { type: "color", value: "#f00" }
+                    roadColor: "#f00",
+                    roadWidth: { type: "number", value: 123 },
+                    roadOutlineWidth: { value: 33 }
                 },
                 styles: {
                     tilezen: [
@@ -149,7 +151,9 @@ describe("ThemeLoader", function() {
                             when: "kind == 'road",
                             technique: "solid-line",
                             attr: {
-                                lineColor: ["ref", "roadColor"]
+                                lineColor: ["ref", "roadColor"],
+                                lineWidth: ["ref", "roadWidth"],
+                                outlineWidth: ["ref", "roadOutlineWidth"]
                             }
                         }
                     ]
@@ -167,6 +171,8 @@ describe("ThemeLoader", function() {
             assert.equal(roadStyle.technique, "solid-line");
             const roadStyleCasted = (roadStyle as any) as SolidLineStyle;
             assert.equal(roadStyleCasted.attr!.lineColor, "#f00");
+            assert.equal(roadStyleCasted.attr!.lineWidth, 123);
+            assert.equal(roadStyleCasted.attr!.outlineWidth, 33);
         });
 
         it("resolves ref expressions in Style", async function() {
@@ -201,7 +207,7 @@ describe("ThemeLoader", function() {
             assert.equal(roadStyleCasted.description, "roads");
             assert.deepEqual(
                 roadStyleCasted.when,
-                (theme.definitions!.roadCondition as SelectorValueDefinition).value
+                (theme.definitions!.roadCondition as BoxedSelectorDefinition).value
             );
             assert.equal(roadStyleCasted.attr!.lineColor, "#f00");
         });


### PR DESCRIPTION
Currently theme definitions require a `type` attribute to classify values and selectors.
Introduce shortcut syntax, where literal string/number/boolean values:.

    "definitions": {
      "a": { "value": 123},
      "b": { "value", "#f00f00"},
      "foo": 123,
      "bar": "#f0f0f0",
      "spam": true
    }

Related-to: HARP-8438
