### PR TITLE
Support style expressions returning invalid values.

### DIFF
--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -88,16 +88,28 @@ export function isInterpolatedProperty(p: any): p is InterpolatedProperty {
 export function getPropertyValue(
     property: Value | Expr | InterpolatedProperty | undefined,
     env: Env
-): any {
+): Value {
     if (Expr.isExpr(property)) {
-        return property.evaluate(env, ExprScope.Dynamic);
+        try {
+            return property.evaluate(env, ExprScope.Dynamic);
+        } catch (error) {
+            logger.log(
+                "failed to evaluate expression",
+                JSON.stringify(property),
+                "error",
+                String(error)
+            );
+            return null;
+        }
     }
 
     if (isInterpolatedProperty(property)) {
         return evaluateInterpolatedProperty(property, env);
     }
 
-    if (typeof property !== "string") {
+    if (property === null || typeof property === "undefined") {
+        return null;
+    } else if (typeof property !== "string") {
         // Property in numeric or array, etc. format
         return property;
     } else {

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -1060,7 +1060,8 @@ describe("ExprEvaluator", function() {
         ]);
 
         for (let zoom = 0; zoom < 7; zoom += 0.5) {
-            const value = getPropertyValue(interp, envForZoom(zoom));
+            const value = getPropertyValue(interp, envForZoom(zoom)) as number;
+            assert.isNumber(value);
             if (zoom < 4) {
                 assert.strictEqual(value, 0);
             } else {

--- a/@here/harp-datasource-protocol/test/StringDecodersTest.ts
+++ b/@here/harp-datasource-protocol/test/StringDecodersTest.ts
@@ -27,7 +27,6 @@ describe("StringEncodedNumeral", function() {
         testRGBColor();
     });
     it("RGBA Colors", () => {
-        // TODO: Update RGBA colors test when HARP-7517 is done.
         testRGBAColor();
     });
     it("HSL Colors", () => {

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -7,7 +7,6 @@
 import {
     DecodedTile,
     Env,
-    getPropertyValue,
     isPoiTechnique,
     isTextTechnique,
     PoiGeometry,
@@ -19,6 +18,7 @@ import {
 import {
     DEFAULT_TEXT_DISTANCE_SCALE,
     getBufferAttribute,
+    getNumberPropertyValueSafe,
     TextElement,
     Tile,
     TileObject
@@ -228,7 +228,7 @@ export class GeoJsonTile extends Tile {
             path,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.env),
+            getNumberPropertyValueSafe(priority, 0, this.mapView.env),
             xOffset,
             yOffset,
             featureId
@@ -309,7 +309,7 @@ export class GeoJsonTile extends Tile {
             position,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.env),
+            getNumberPropertyValueSafe(priority, 0, this.mapView.env),
             xOffset,
             yOffset,
             featureId
@@ -378,8 +378,16 @@ export class GeoJsonTile extends Tile {
         const label = DEFAULT_LABELED_ICON.label;
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
-        const xOffset = getPropertyValue(technique.xOffset, env);
-        const yOffset = getPropertyValue(technique.yOffset, env);
+        const xOffset = getNumberPropertyValueSafe(
+            technique.xOffset,
+            DEFAULT_LABELED_ICON.xOffset,
+            env
+        );
+        const yOffset = getNumberPropertyValueSafe(
+            technique.yOffset,
+            DEFAULT_LABELED_ICON.yOffset,
+            env
+        );
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
@@ -389,9 +397,9 @@ export class GeoJsonTile extends Tile {
             position,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, env),
-            xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : xOffset,
-            yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : yOffset,
+            getNumberPropertyValueSafe(priority, 0, env),
+            xOffset,
+            yOffset,
             featureId
         );
 

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -6,7 +6,7 @@
 
 import * as THREE from "three";
 
-import { ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
+import { Env, ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
 import { ColorUtils } from "@here/harp-datasource-protocol/lib/ColorUtils";
 import { enforceBlending, MapMeshStandardMaterial } from "@here/harp-materials";
 import { evaluateBaseColorProperty } from "./DecodedTileHelpers";
@@ -30,7 +30,7 @@ const DEPTH_PRE_PASS_RENDER_ORDER_OFFSET = 1e-6;
  *
  * @param technique [[BaseStandardTechnique]] instance to be checked
  */
-export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique) {
+export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique, env: Env) {
     // Depth pass explicitly disabled
     if (technique.enableDepthPrePass === false) {
         return false;
@@ -43,7 +43,7 @@ export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique)
     if (!transparent) {
         // We do not support switching depth pass during alpha interpolation, ignore zoom level
         // when calculating base color value.
-        const color = evaluateBaseColorProperty(technique);
+        const color = evaluateBaseColorProperty(technique, env);
         if (color !== undefined) {
             const alpha = ColorUtils.getAlphaFromHex(color);
             transparent = alpha > 0.0 && alpha < 1.0;

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -6,14 +6,14 @@
 
 import {
     ExtendedTileInfo,
-    getPropertyValue,
     LineTechnique,
     SolidLineTechnique
 } from "@here/harp-datasource-protocol";
 import { Expr } from "@here/harp-datasource-protocol/lib/Expr";
+import { SolidLineMaterial } from "@here/harp-materials";
 import { assert, LoggerManager, Math2D } from "@here/harp-utils";
 import * as THREE from "three";
-import { compileTechniques } from "./DecodedTileHelpers";
+import { compileTechniques, getNumberPropertyValueSafe } from "./DecodedTileHelpers";
 import { MapView } from "./MapView";
 import { PickObjectType, PickResult } from "./PickHandler";
 import { RoadIntersectionData, Tile } from "./Tile";
@@ -83,7 +83,11 @@ export class RoadPicker {
                               const unitFactor =
                                   technique.metricUnit === "Pixel" ? mapView.pixelToWorld : 1.0;
                               return (
-                                  getPropertyValue(technique.lineWidth, mapView.env) *
+                                  getNumberPropertyValueSafe(
+                                      technique.lineWidth,
+                                      SolidLineMaterial.DEFAULT_WIDTH,
+                                      mapView.env
+                                  ) *
                                   unitFactor *
                                   0.5
                               );

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -63,6 +63,8 @@ import {
     compileTechniques,
     createMaterial,
     getBufferAttribute,
+    getColorPropertyValueSafe,
+    getNumberPropertyValueSafe,
     getObjectConstructor
 } from "../DecodedTileHelpers";
 import {
@@ -392,18 +394,17 @@ export class TileGeometryCreator {
                 }
 
                 // Make sorting stable.
-                const priority =
-                    technique.priority !== undefined
-                        ? getPropertyValue(technique.priority, discreteZoomEnv)
-                        : 0;
-                const fadeNear =
-                    technique.fadeNear !== undefined
-                        ? getPropertyValue(technique.fadeNear, discreteZoomEnv)
-                        : technique.fadeNear;
-                const fadeFar =
-                    technique.fadeFar !== undefined
-                        ? getPropertyValue(technique.fadeFar, discreteZoomEnv)
-                        : technique.fadeFar;
+                const priority = getNumberPropertyValueSafe(technique.priority, 0, discreteZoomEnv);
+                const fadeNear = getNumberPropertyValueSafe(
+                    technique.fadeNear,
+                    undefined,
+                    discreteZoomEnv
+                );
+                const fadeFar = getNumberPropertyValueSafe(
+                    technique.fadeFar,
+                    undefined,
+                    discreteZoomEnv
+                );
                 const userData = textPath.objInfos;
                 const featureId = getFeatureId(userData);
                 const textElement = new TextElement(
@@ -469,18 +470,17 @@ export class TileGeometryCreator {
                     continue;
                 }
 
-                const priority =
-                    technique.priority !== undefined
-                        ? getPropertyValue(technique.priority, discreteZoomEnv)
-                        : 0;
-                const fadeNear =
-                    technique.fadeNear !== undefined
-                        ? getPropertyValue(technique.fadeNear, discreteZoomEnv)
-                        : technique.fadeNear;
-                const fadeFar =
-                    technique.fadeFar !== undefined
-                        ? getPropertyValue(technique.fadeFar, discreteZoomEnv)
-                        : technique.fadeFar;
+                const priority = getNumberPropertyValueSafe(technique.priority, 0, discreteZoomEnv);
+                const fadeNear = getNumberPropertyValueSafe(
+                    technique.fadeNear,
+                    undefined,
+                    discreteZoomEnv
+                );
+                const fadeFar = getNumberPropertyValueSafe(
+                    technique.fadeFar,
+                    undefined,
+                    discreteZoomEnv
+                );
 
                 for (let i = 0; i < numPositions; ++i) {
                     const x = positions.getX(i) + worldOffsetX;
@@ -772,26 +772,41 @@ export class TileGeometryCreator {
                             }
 
                             lineMaterial.lineWidth =
-                                getPropertyValue(technique.lineWidth, mapView.env) *
+                                getNumberPropertyValueSafe(
+                                    technique.lineWidth,
+                                    SolidLineMaterial.DEFAULT_WIDTH,
+                                    mapView.env
+                                ) *
                                 unitFactor *
                                 0.5;
 
                             if (technique.outlineWidth !== undefined) {
                                 lineMaterial.outlineWidth =
-                                    getPropertyValue(technique.outlineWidth, mapView.env) *
-                                    unitFactor;
+                                    getNumberPropertyValueSafe(
+                                        technique.outlineWidth,
+                                        SolidLineMaterial.DEFAULT_OUTLINE_WIDTH,
+                                        mapView.env
+                                    ) * unitFactor;
                             }
 
                             if (technique.dashSize !== undefined) {
                                 lineMaterial.dashSize =
-                                    getPropertyValue(technique.dashSize, mapView.env) *
+                                    getNumberPropertyValueSafe(
+                                        technique.dashSize,
+                                        SolidLineMaterial.DEFAULT_DASH_SIZE,
+                                        mapView.env
+                                    ) *
                                     unitFactor *
                                     0.5;
                             }
 
                             if (technique.gapSize !== undefined) {
                                 lineMaterial.gapSize =
-                                    getPropertyValue(technique.gapSize, mapView.env) *
+                                    getNumberPropertyValueSafe(
+                                        technique.gapSize,
+                                        SolidLineMaterial.DEFAULT_GAP_SIZE,
+                                        mapView.env
+                                    ) *
                                     unitFactor *
                                     0.5;
                             }
@@ -911,7 +926,8 @@ export class TileGeometryCreator {
                         technique.animateExtrusion,
                         discreteZoomEnv
                     );
-                    if (animateExtrusionValue !== undefined) {
+
+                    if (animateExtrusionValue !== null) {
                         animateExtrusionValue =
                             typeof animateExtrusionValue === "boolean"
                                 ? animateExtrusionValue
@@ -920,14 +936,15 @@ export class TileGeometryCreator {
                                 : false;
                     }
                     extrusionAnimationEnabled =
-                        animateExtrusionValue !== undefined &&
+                        animateExtrusionValue !== null &&
                         animatedExtrusionHandler.forceEnabled === false
                             ? animateExtrusionValue
                             : animatedExtrusionHandler.enabled;
                 }
 
                 const renderDepthPrePass =
-                    isExtrudedPolygonTechnique(technique) && isRenderDepthPrePassEnabled(technique);
+                    isExtrudedPolygonTechnique(technique) &&
+                    isRenderDepthPrePassEnabled(technique, mapView.env);
 
                 if (renderDepthPrePass) {
                     const depthPassMesh = createDepthPrePassMesh(object as THREE.Mesh);
@@ -1152,12 +1169,14 @@ export class TileGeometryCreator {
                             }
 
                             if (outlineTechnique.secondaryWidth !== undefined) {
-                                const techniqueLineWidth = getPropertyValue(
-                                    outlineTechnique.lineWidth!,
+                                const techniqueLineWidth = getNumberPropertyValueSafe(
+                                    outlineTechnique.lineWidth,
+                                    SolidLineMaterial.DEFAULT_WIDTH,
                                     mapView.env
                                 );
-                                const techniqueSecondaryWidth = getPropertyValue(
-                                    outlineTechnique.secondaryWidth!,
+                                const techniqueSecondaryWidth = getNumberPropertyValueSafe(
+                                    outlineTechnique.secondaryWidth,
+                                    SolidLineMaterial.DEFAULT_OUTLINE_WIDTH,
                                     mapView.env
                                 );
                                 const techniqueOpacity = getPropertyValue(
@@ -1476,14 +1495,16 @@ export class TileGeometryCreator {
         env: Env,
         technique: MakeTechniqueAttrs<BaseTechniqueParams>
     ): FadingParameters {
-        const fadeNear =
-            technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, env)
-                : FadingFeature.DEFAULT_FADE_NEAR;
-        const fadeFar =
-            technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, env)
-                : FadingFeature.DEFAULT_FADE_FAR;
+        const fadeNear = getNumberPropertyValueSafe(
+            technique.fadeNear,
+            FadingFeature.DEFAULT_FADE_NEAR,
+            env
+        );
+        const fadeFar = getNumberPropertyValueSafe(
+            technique.fadeFar,
+            FadingFeature.DEFAULT_FADE_FAR,
+            env
+        );
         return {
             fadeNear,
             fadeFar
@@ -1497,41 +1518,35 @@ export class TileGeometryCreator {
         env: Env,
         technique: FillTechnique | ExtrudedPolygonTechnique
     ): PolygonFadingParameters {
-        let color: string | number | undefined;
+        const color = getColorPropertyValueSafe(
+            technique.lineColor,
+            EdgeMaterial.DEFAULT_COLOR,
+            env
+        );
+
         let colorMix = EdgeMaterial.DEFAULT_COLOR_MIX;
 
-        if (technique.lineColor !== undefined) {
-            color = getPropertyValue(technique.lineColor, env);
-            if (isExtrudedPolygonTechnique(technique)) {
-                const extrudedPolygonTechnique = technique as ExtrudedPolygonTechnique;
-                colorMix =
-                    extrudedPolygonTechnique.lineColorMix !== undefined
-                        ? extrudedPolygonTechnique.lineColorMix
-                        : EdgeMaterial.DEFAULT_COLOR_MIX;
-            }
+        if (isExtrudedPolygonTechnique(technique)) {
+            const extrudedPolygonTechnique = technique as ExtrudedPolygonTechnique;
+            colorMix =
+                extrudedPolygonTechnique.lineColorMix !== undefined
+                    ? extrudedPolygonTechnique.lineColorMix
+                    : EdgeMaterial.DEFAULT_COLOR_MIX;
         }
 
-        const fadeNear =
-            technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, env)
-                : FadingFeature.DEFAULT_FADE_NEAR;
-        const fadeFar =
-            technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, env)
-                : FadingFeature.DEFAULT_FADE_FAR;
+        const fadeNear = getNumberPropertyValueSafe(
+            technique.fadeNear,
+            FadingFeature.DEFAULT_FADE_NEAR,
+            env
+        );
+        const fadeFar = getNumberPropertyValueSafe(
+            technique.fadeFar,
+            FadingFeature.DEFAULT_FADE_FAR,
+            env
+        );
 
-        const lineFadeNear =
-            technique.lineFadeNear !== undefined
-                ? getPropertyValue(technique.lineFadeNear, env)
-                : fadeNear;
-        const lineFadeFar =
-            technique.lineFadeFar !== undefined
-                ? getPropertyValue(technique.lineFadeFar, env)
-                : fadeFar;
-
-        if (color === undefined) {
-            color = EdgeMaterial.DEFAULT_COLOR;
-        }
+        const lineFadeNear = getNumberPropertyValueSafe(technique.lineFadeNear, fadeNear, env);
+        const lineFadeFar = getNumberPropertyValueSafe(technique.lineFadeFar, fadeFar, env);
 
         return {
             color,

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -9,7 +9,6 @@ import {
     composeTechniqueTextureName,
     DecodedTile,
     getFeatureId,
-    getPropertyValue,
     ImageTexture,
     isLineMarkerTechnique,
     isPoiTechnique,
@@ -20,6 +19,7 @@ import {
 import { ContextualArabicConverter } from "@here/harp-text-canvas";
 import { assert, assertExists, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+import { getNumberPropertyValueSafe } from "../DecodedTileHelpers";
 import { MapView } from "../MapView";
 import { TextElement } from "../text/TextElement";
 import { DEFAULT_TEXT_DISTANCE_SCALE } from "../text/TextElementsRenderer";
@@ -500,23 +500,23 @@ export class PoiManager {
         const env = this.mapView.env;
         const fadeNear =
             technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, env)
-                : technique.fadeNear;
+                ? getNumberPropertyValueSafe(technique.fadeNear, undefined, env)
+                : undefined;
         const fadeFar =
             technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, env)
-                : technique.fadeFar;
-        const xOffset = getPropertyValue(technique.xOffset, env);
-        const yOffset = getPropertyValue(technique.yOffset, env);
+                ? getNumberPropertyValueSafe(technique.fadeFar, undefined, env)
+                : undefined;
+        const xOffset = getNumberPropertyValueSafe(technique.xOffset, 0, env);
+        const yOffset = getNumberPropertyValueSafe(technique.yOffset, 0, env);
 
         const textElement: TextElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             positions,
             textElementsRenderer.styleCache.getRenderStyle(tile, technique),
             textElementsRenderer.styleCache.getLayoutStyle(tile, technique),
-            getPropertyValue(priority, env),
-            xOffset !== undefined ? xOffset : 0.0,
-            yOffset !== undefined ? yOffset : 0.0,
+            getNumberPropertyValueSafe(priority, 0, env),
+            xOffset,
+            yOffset,
             featureId,
             technique.style,
             fadeNear,

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Env, getPropertyValue, ImageTexture } from "@here/harp-datasource-protocol";
+import { Env, ImageTexture } from "@here/harp-datasource-protocol";
 import { IconMaterial } from "@here/harp-materials";
 import { MemoryUsage, TextCanvas } from "@here/harp-text-canvas";
 import { assert, LoggerManager, Math2D } from "@here/harp-utils";
 import * as THREE from "three";
 
 import { ColorCache } from "../ColorCache";
+import { getNumberPropertyValueSafe } from "../DecodedTileHelpers";
 import { ImageItem } from "../image/Image";
 import { MapView } from "../MapView";
 import { ScreenCollisions } from "../ScreenCollisions";
@@ -347,11 +348,11 @@ export class PoiRenderer {
         const width = poiInfo.computedWidth! * scale;
         const height = poiInfo.computedHeight! * scale;
         const technique = poiInfo.technique;
-        const iconXOffset = getPropertyValue(technique.iconXOffset, env);
-        const iconYOffset = getPropertyValue(technique.iconYOffset, env);
+        const iconXOffset = getNumberPropertyValueSafe(technique.iconXOffset, 0, env);
+        const iconYOffset = getNumberPropertyValueSafe(technique.iconYOffset, 0, env);
 
-        const centerX = screenPosition.x + (typeof iconXOffset === "number" ? iconXOffset : 0);
-        const centerY = screenPosition.y + (typeof iconYOffset === "number" ? iconYOffset : 0);
+        const centerX = screenPosition.x + iconXOffset;
+        const centerY = screenPosition.y + iconYOffset;
 
         screenBox.x = centerX - width / 2;
         screenBox.y = centerY - height / 2;
@@ -611,12 +612,12 @@ export class PoiRenderer {
         // maxT += 0.5 / imageHeight;
 
         // By default, iconScaleV should be equal to iconScaleH, whatever is set in the style.
-        const screenWidth = getPropertyValue(technique.screenWidth, env);
+        const screenWidth = getNumberPropertyValueSafe(technique.screenWidth, undefined, env);
         if (screenWidth !== undefined) {
             iconScaleV = iconScaleH = screenWidth / iconWidth;
         }
 
-        const screenHeight = getPropertyValue(technique.screenHeight, env);
+        const screenHeight = getNumberPropertyValueSafe(technique.screenHeight, undefined, env);
         if (screenHeight !== undefined) {
             iconScaleV = screenHeight / iconHeight;
             if (screenWidth !== undefined) {

--- a/@here/harp-mapview/test/DecodedTileHelpersTest.ts
+++ b/@here/harp-mapview/test/DecodedTileHelpersTest.ts
@@ -7,9 +7,17 @@
 import { assert } from "chai";
 import * as THREE from "three";
 
-import { MapEnv, SolidLineTechnique } from "@here/harp-datasource-protocol";
+import { Expr, GeometryType, MapEnv, SolidLineTechnique } from "@here/harp-datasource-protocol";
 import { SolidLineMaterial } from "@here/harp-materials";
-import { applyBaseColorToMaterial, createMaterial } from "../lib/DecodedTileHelpers";
+import { LoggerManager } from "@here/harp-utils";
+import {
+    applyBaseColorToMaterial,
+    createMaterial,
+    getColorPropertyValueSafe,
+    getEnumPropertyValueSafe,
+    getNumberPropertyValueSafe
+} from "../lib/DecodedTileHelpers";
+import { MapViewEventNames } from "../lib/MapView";
 
 // tslint:disable:only-arrow-functions
 
@@ -71,5 +79,138 @@ describe("DecodedTileHelpers", function() {
         assert.equal(material.blending, THREE.NormalBlending);
         assert.equal(material.color.getHex(), 0xff00ff);
         assert.equal(material.transparent, false);
+    });
+    describe("getXXPropertySafe", function() {
+        before(function() {
+            LoggerManager.instance.enable("DecodedTileHelpers", false);
+            LoggerManager.instance.enable("InterpolatedProperty", false);
+        });
+        after(function() {
+            LoggerManager.instance.enable("DecodedTileHelpers", true);
+            LoggerManager.instance.enable("InterpolatedProperty", true);
+        });
+
+        const nullReturningExpr = Expr.fromJSON(["get", "fooBar"]);
+        const throwingReturningExpr = Expr.fromJSON(["/", "fooBar", null]);
+
+        describe("#getNumberPropertyValueSafe", function() {
+            it("returns proper literal values as is", function() {
+                assert.strictEqual(getNumberPropertyValueSafe(-1, 13, env), -1);
+                assert.strictEqual(getNumberPropertyValueSafe(-0, 14, env), -0);
+                assert.strictEqual(getNumberPropertyValueSafe(333, 14, env), 333);
+            });
+            it("falls back to default on non-numbers", function() {
+                assert.strictEqual(getNumberPropertyValueSafe("aa", 13, env), 13);
+                assert.strictEqual(getNumberPropertyValueSafe(null, 14, env), 14);
+                assert.strictEqual(getNumberPropertyValueSafe(false, 15, env), 15);
+                assert.strictEqual(getNumberPropertyValueSafe(undefined, 16, env), 16);
+            });
+            it("evaluates proper expressions", function() {
+                assert.equal(getNumberPropertyValueSafe(Expr.fromJSON(["number", 22]), 0, env), 22);
+                assert.equal(getNumberPropertyValueSafe(Expr.fromJSON(["+", 33, 44]), 0, env), 77);
+            });
+            it("supports expr-s evaluating to null or error", function() {
+                assert.strictEqual(getNumberPropertyValueSafe(nullReturningExpr, 13, env), 13);
+                assert.strictEqual(getNumberPropertyValueSafe(throwingReturningExpr, 13, env), 13);
+            });
+        });
+        describe("#getColorPropertyValueSafe", function() {
+            it("returns proper literal values as is", function() {
+                assert.strictEqual(getColorPropertyValueSafe("#f0f7", undefined, env), -1996553985);
+                assert.strictEqual(getColorPropertyValueSafe("#f0f", undefined, env), 0xff00ff);
+                assert.strictEqual(getColorPropertyValueSafe(0, undefined, env), 0);
+            });
+            it("evaluates proper expressions", function() {
+                assert.equal(
+                    getColorPropertyValueSafe(Expr.fromJSON(["string", "#f0f"]), 0, env),
+                    0xff00ff
+                );
+                assert.equal(
+                    getColorPropertyValueSafe(Expr.fromJSON(["rgba", 255, 0, 255, 1]), 0, env),
+                    0xff00ff
+                );
+            });
+            it("falls back to default on non-numbers", function() {
+                assert.strictEqual(getColorPropertyValueSafe("aa", 0, env), 0);
+                assert.strictEqual(getColorPropertyValueSafe(null, 0xff00ff, env), 0xff00ff);
+                assert.strictEqual(getColorPropertyValueSafe(false, undefined, env), undefined);
+                assert.strictEqual(getColorPropertyValueSafe(undefined, "#f0f", env), "#f0f");
+            });
+            it("supports expr-s evaluating to null or error", function() {
+                assert.strictEqual(getColorPropertyValueSafe(nullReturningExpr, 13, env), 13);
+                assert.strictEqual(getColorPropertyValueSafe(throwingReturningExpr, 13, env), 13);
+            });
+        });
+        describe("#getEnumPropertyValueSafe", function() {
+            it("parses correct values into enum values", function() {
+                assert.equal(
+                    getEnumPropertyValueSafe("Point", GeometryType, undefined, env),
+                    GeometryType.Point
+                );
+                assert.equal(
+                    getEnumPropertyValueSafe("Unspecified", GeometryType, undefined, env),
+                    GeometryType.Unspecified
+                );
+                assert.equal(
+                    getEnumPropertyValueSafe("Other", GeometryType, undefined, env),
+                    GeometryType.Other
+                );
+
+                assert.equal(
+                    getEnumPropertyValueSafe("AfterRender", MapViewEventNames, undefined, env),
+                    MapViewEventNames.AfterRender
+                );
+                assert.equal(
+                    getEnumPropertyValueSafe(
+                        Expr.fromJSON(["string", "Point"]),
+                        GeometryType,
+                        GeometryType.Unspecified,
+                        env
+                    ),
+                    GeometryType.Point
+                );
+            });
+            it("falls back to default for invalid values", function() {
+                assert.equal(
+                    getEnumPropertyValueSafe(
+                        "PointXX",
+                        GeometryType,
+                        GeometryType.Unspecified,
+                        env
+                    ),
+                    GeometryType.Unspecified
+                );
+                assert.equal(
+                    getEnumPropertyValueSafe(
+                        Expr.fromJSON(["string", "baz"]),
+                        GeometryType,
+                        GeometryType.Unspecified,
+                        env
+                    ),
+                    GeometryType.Unspecified
+                );
+            });
+
+            it("supports expr-s evaluating to null or error", function() {
+                assert.strictEqual(
+                    getEnumPropertyValueSafe(
+                        nullReturningExpr,
+                        GeometryType,
+                        GeometryType.Point,
+                        env
+                    ),
+                    GeometryType.Point
+                );
+                assert.strictEqual(
+                    getEnumPropertyValueSafe(
+                        nullReturningExpr,
+                        GeometryType,
+                        GeometryType.Object3D,
+                        env
+                    ),
+                    GeometryType.Object3D
+                );
+            });
+        });
     });
 });

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DecodedTile, GeometryType, IndexedTechnique } from "@here/harp-datasource-protocol";
+import {
+    DecodedTile,
+    Env,
+    GeometryType,
+    IndexedTechnique,
+    MapEnv
+} from "@here/harp-datasource-protocol";
 import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import {
     mercatorProjection,
@@ -25,6 +31,10 @@ class FakeMapView {
 
     get zoomLevel(): number {
         return 0;
+    }
+
+    get env(): Env {
+        return new MapEnv({ $zoom: 0 });
     }
 
     get viewRanges(): ViewRanges {

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -377,6 +377,7 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
     static DEFAULT_COLOR: number = 0xff0000;
     static DEFAULT_WIDTH: number = 1.0;
     static DEFAULT_OUTLINE_WIDTH: number = 0.0;
+    static DEFAULT_OUTLINE_COLOR: number = SolidLineMaterial.DEFAULT_COLOR;
     static DEFAULT_OPACITY: number = 1.0;
     static DEFAULT_DRAW_RANGE_START: number = 0.0;
     static DEFAULT_DRAW_RANGE_END: number = 1.0;
@@ -436,7 +437,7 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
                     diffuse: new THREE.Uniform(new THREE.Color(SolidLineMaterial.DEFAULT_COLOR)),
                     dashColor: new THREE.Uniform(new THREE.Color(SolidLineMaterial.DEFAULT_COLOR)),
                     outlineColor: new THREE.Uniform(
-                        new THREE.Color(SolidLineMaterial.DEFAULT_COLOR)
+                        new THREE.Color(SolidLineMaterial.DEFAULT_OUTLINE_COLOR)
                     ),
                     lineWidth: new THREE.Uniform(SolidLineMaterial.DEFAULT_WIDTH),
                     outlineWidth: new THREE.Uniform(SolidLineMaterial.DEFAULT_OUTLINE_WIDTH),

--- a/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
+++ b/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
@@ -3,9 +3,9 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { getPropertyValue, isTextTechnique } from "@here/harp-datasource-protocol";
+import { isTextTechnique } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils/lib/tiling/TileKey";
-import { DataSource, TextElement } from "@here/harp-mapview";
+import { DataSource, getNumberPropertyValueSafe, TextElement } from "@here/harp-mapview";
 import { debugContext } from "@here/harp-mapview/lib/DebugContext";
 import {
     ContextualArabicConverter,
@@ -90,8 +90,6 @@ export class OmvDebugLabelsTile extends OmvTile {
 
         tileGeometryCreator.createTextElements(this, decodedTile);
 
-        const colorMap = new Map<number, THREE.Color>();
-
         // allow limiting to specific names and/or index. There can be many paths with the same text
         const textFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.TEXT");
         const indexFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.INDEX");
@@ -125,12 +123,6 @@ export class OmvDebugLabelsTile extends OmvTile {
                 const technique = decodedTile.techniques[textPath.technique];
                 if (!isTextTechnique(technique)) {
                     continue;
-                }
-                if (technique.color !== undefined) {
-                    colorMap.set(
-                        textPath.technique,
-                        new THREE.Color(getPropertyValue(technique.color, env))
-                    );
                 }
 
                 baseVertex = linePositions.length / 3;
@@ -188,7 +180,7 @@ export class OmvDebugLabelsTile extends OmvTile {
                                     new THREE.Vector3(x + worldOffsetX, y, z),
                                     textRenderStyle,
                                     textLayoutStyle,
-                                    getPropertyValue(technique.priority || 0, env),
+                                    getNumberPropertyValueSafe(technique.priority, 0, env),
                                     technique.xOffset || 0.0,
                                     technique.yOffset || 0.0
                                 );


### PR DESCRIPTION
As dynamic expression may return invalid value (bad type, null, error),
we have to guard places when style expressions/values are used.

This patch protects against style / Expr yielding:
 - [x] null
 - [x] invalid type for numeric attributes
 - [x] invalid type or format for color attributes
 - [x] errors thrown while evaluating expressions

Also improves type safety around dynamic properties (by getting rid of `any`)

by falling back to default value for given attribute.

Related-to: HARP-8515