### PR TITLE
HARP-8531: Fix styling rgba(...) expression encoder.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -118,7 +118,7 @@ const StringEncodedRGBA: StringEncodedNumeralFormat = {
         target[0] = parseInt(channels[1], 10) / 255;
         target[1] = parseInt(channels[2], 10) / 255;
         target[2] = parseInt(channels[3], 10) / 255;
-        target[3] = parseInt(channels[4], 10);
+        target[3] = parseFloat(channels[4]);
         return true;
     }
 };
@@ -218,6 +218,7 @@ export function parseStringEncodedNumeral(
                         tmpBuffer[2],
                         tmpBuffer[3]
                     );
+                    break;
                 case StringEncodedNumeralType.RGB:
                 case StringEncodedNumeralType.HSL:
                     result = ColorUtils.getHexFromRgb(tmpBuffer[0], tmpBuffer[1], tmpBuffer[2]);


### PR DESCRIPTION
There was a bug that encoded alpha channel as integer value.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
