### PR TITLE
Ensure style expressions are compiled for road picking.

### DIFF
--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -13,6 +13,7 @@ import {
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
     isInterpolatedProperty,
+    isJsonExpr,
     isShaderTechnique,
     isStandardTechnique,
     isTerrainTechnique,
@@ -698,6 +699,28 @@ export function evaluateColorProperty(value: Value, zoomLevel?: number): number 
     }
 
     throw new Error(`Unsupported color format: '${value}'`);
+}
+
+/**
+ * Compile expressions in techniques as they were received from decoder.
+ */
+export function compileTechniques(techniques: Technique[]) {
+    techniques.forEach((technique: any) => {
+        for (const propertyName in technique) {
+            if (!technique.hasOwnProperty(propertyName)) {
+                continue;
+            }
+            const value = technique[propertyName];
+            if (isJsonExpr(value) && propertyName !== "kind") {
+                // "kind" is reserved.
+                try {
+                    technique[propertyName] = Expr.fromJSON(value);
+                } catch (error) {
+                    logger.error("#compileTechniques: Failed to compile expression:", error);
+                }
+            }
+        }
+    });
 }
 
 /**

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -13,6 +13,7 @@ import {
 import { Expr } from "@here/harp-datasource-protocol/lib/Expr";
 import { assert, LoggerManager, Math2D } from "@here/harp-utils";
 import * as THREE from "three";
+import { compileTechniques } from "./DecodedTileHelpers";
 import { MapView } from "./MapView";
 import { PickObjectType, PickResult } from "./PickHandler";
 import { RoadIntersectionData, Tile } from "./Tile";
@@ -61,6 +62,8 @@ export class RoadPicker {
 
         const widths: RoadIntersectionData["widths"] = [];
         widths.length = lineFeatures.numFeatures;
+
+        compileTechniques(extendedTileInfo.techniqueCatalog);
 
         const mapView = this.m_mapView;
         for (let i = 0; i < lineFeatures.numFeatures; i++) {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -20,7 +20,6 @@ import {
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
     isFillTechnique,
-    isJsonExpr,
     isLineMarkerTechnique,
     isLineTechnique,
     isPoiTechnique,
@@ -59,6 +58,7 @@ import { ColorCache } from "../ColorCache";
 import {
     applyBaseColorToMaterial,
     applySecondaryColorToMaterial,
+    compileTechniques,
     createMaterial,
     getBufferAttribute,
     getObjectConstructor
@@ -173,22 +173,7 @@ export class TileGeometryCreator {
         }
 
         // compile the dynamic expressions.
-        decodedTile.techniques.forEach((technique: any) => {
-            for (const propertyName in technique) {
-                if (!technique.hasOwnProperty(propertyName)) {
-                    continue;
-                }
-                const value = technique[propertyName];
-                if (isJsonExpr(value) && propertyName !== "kind") {
-                    // "kind" is reserved.
-                    try {
-                        technique[propertyName] = Expr.fromJSON(value);
-                    } catch (error) {
-                        logger.error("#initDecodedTile: Failed to compile expression:", error);
-                    }
-                }
-            }
-        });
+        compileTechniques(decodedTile.techniques);
     }
 
     /**


### PR DESCRIPTION
Since #1135, we need to compile technique expressions before passing
to `getPropertyValue` and friends.

Related-to: HARP-8531

