### PR TITLE
HARP-8521: Fix terrain overlay.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -1358,7 +1358,9 @@ export class TileGeometryCreator {
         technique: Technique,
         object: THREE.Object3D
     ) {
-        const hasObjInfos = (srcGeometry.objInfos?.length ?? 0) > 0;
+        if ((srcGeometry.objInfos?.length ?? 0) === 0) {
+            return;
+        }
 
         if (isTerrainTechnique(technique)) {
             assert(
@@ -1366,14 +1368,10 @@ export class TileGeometryCreator {
                 "Unexpected user data in terrain object"
             );
 
-            if (typeof srcGeometry.objInfos![0] === "number") {
-                assert(false, "Wrong attribute map type for terrain geometry");
-                return;
-            }
-
-            if (!hasObjInfos) {
-                return;
-            }
+            assert(
+                typeof srcGeometry.objInfos![0] === "object",
+                "Wrong attribute map type for terrain geometry"
+            );
 
             const displacementMap = (srcGeometry.objInfos as DisplacementMap[])[0];
             const tileDisplacementMap: TileDisplacementMap = {
@@ -1388,10 +1386,9 @@ export class TileGeometryCreator {
                 displacementMap
             };
             object.userData = tileDisplacementMap;
-        } else if (
-            (hasObjInfos || isCirclesTechnique(technique) || isSquaresTechnique(technique)) &&
-            !isSolidLineTechnique(technique)
-        ) {
+        } else if (isSolidLineTechnique(technique)) {
+            object.userData = srcGeometry.objInfos!;
+        } else {
             // Set the feature data for picking with `MapView.intersectMapObjects()` except for
             // solid-line which uses tile-based picking.
             const featureData: TileFeatureData = {
@@ -1401,8 +1398,6 @@ export class TileGeometryCreator {
             };
             object.userData.feature = featureData;
             object.userData.technique = technique;
-        } else if (hasObjInfos) {
-            object.userData = srcGeometry.objInfos!;
         }
     }
 

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -4,20 +4,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DecodedTile } from "@here/harp-datasource-protocol";
+import { DecodedTile, GeometryType } from "@here/harp-datasource-protocol";
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import {
     mercatorProjection,
     TileKey,
     TilingScheme,
     webMercatorTilingScheme
 } from "@here/harp-geoutils";
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
 import { DataSource } from "../lib/DataSource";
+import { DisplacementMap } from "../lib/DisplacementMap";
 import { TileGeometryCreator } from "../lib/geometry/TileGeometryCreator";
 import { Tile } from "../lib/Tile";
 
+class FakeMapView {
+    private m_scene = new THREE.Scene();
+
+    get zoomLevel(): number {
+        return 0;
+    }
+
+    get viewRanges(): ViewRanges {
+        return { near: 0, far: 0, minimum: 0, maximum: 0 };
+    }
+
+    get clearColor(): number {
+        return 0;
+    }
+
+    get animatedExtrusionHandler() {
+        return undefined;
+    }
+
+    get scene() {
+        return this.m_scene;
+    }
+}
 class MockDataSource extends DataSource {
     /** @override */
     getTilingScheme(): TilingScheme {
@@ -29,19 +54,28 @@ class MockDataSource extends DataSource {
     }
 }
 
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
 describe("TileGeometryCreator", () => {
-    it("add label blocking elements", () => {
-        const mockDatasource = sinon.createStubInstance(MockDataSource);
+    let mockDatasource: sinon.SinonStubbedInstance<MockDataSource>;
+    let newTile: Tile;
+    const tgc = TileGeometryCreator.instance;
+    const mapView = new FakeMapView();
+
+    before(function() {
+        mockDatasource = sinon.createStubInstance(MockDataSource);
 
         mockDatasource.getTilingScheme.callsFake(() => webMercatorTilingScheme);
         sinon.stub(mockDatasource, "projection").get(() => mercatorProjection);
-
-        const tgc = TileGeometryCreator.instance;
-        const newTile = new Tile(
+        sinon.stub(mockDatasource, "mapView").get(() => mapView);
+        newTile = new Tile(
             (mockDatasource as unknown) as DataSource,
             TileKey.fromRowColumnLevel(0, 0, 0)
         );
+    });
 
+    it("add label blocking elements", () => {
         const decodedTile: DecodedTile = {
             pathGeometries: [{ path: [new THREE.Vector3(1, 1, 1), new THREE.Vector3(2, 2, 2)] }],
             geometries: [],
@@ -51,5 +85,37 @@ describe("TileGeometryCreator", () => {
         // There should one line with two points.
         assert.equal(newTile.blockingElements.length, 1);
         assert.equal(newTile.blockingElements[0].points.length, 2);
+    });
+
+    it("terrain tile gets tile displacement map as user data", () => {
+        const decodedDisplacementMap: DisplacementMap = {
+            xCountVertices: 2,
+            yCountVertices: 3,
+            buffer: new Float32Array()
+        };
+        const decodedTile: DecodedTile = {
+            geometries: [
+                {
+                    type: GeometryType.Polygon,
+                    vertexAttributes: [],
+                    groups: [{ start: 0, count: 1, technique: 0, createdOffsets: [] }],
+                    objInfos: [decodedDisplacementMap]
+                }
+            ],
+            techniques: [{ name: "terrain", renderOrder: 0 }]
+        };
+        tgc.createObjects(newTile, decodedTile);
+        assert.equal(newTile.objects.length, 1);
+        const userData = newTile.objects[0].userData;
+        expect(userData).to.be.an("object");
+
+        expect(userData).to.have.property("displacementMap");
+        assert.strictEqual(userData.displacementMap, decodedDisplacementMap);
+
+        expect(userData).to.have.property("texture");
+        expect(userData.texture).to.be.an.instanceOf(THREE.DataTexture);
+        const imageData: ImageData = (userData.texture as THREE.DataTexture).image;
+        assert.equal(imageData.width, decodedDisplacementMap.xCountVertices);
+        assert.equal(imageData.height, decodedDisplacementMap.yCountVertices);
     });
 });


### PR DESCRIPTION
TileDisplacementMap was not being set as user data
for terrain objects in TileGeometryCreator.
Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
