### PR TITLE
HARP-8615: Add support for reading flat themes.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -110,6 +110,19 @@ export interface Theme {
 }
 
 /**
+ * A type representing HARP themes with all the styleset declarations
+ * grouped in one [[Array]].
+ *
+ * @internal This type will merge with [[Theme]].
+ */
+export type FlatTheme = Omit<Theme, "styles"> & {
+    /**
+     * The style rules used to render the map.
+     */
+    styles?: StyleSet;
+};
+
+/**
  * Checks if the given definition implements the [[BoxedDefinition]] interface.
  */
 export function isBoxedDefinition(def: Definition): def is BoxedDefinition {
@@ -251,7 +264,7 @@ export type BoxedDefinition =
 /**
  * Possible values for `definitions` element of [Theme].
  */
-export type Definition = LiteralValue | JsonExpr | BoxedDefinition | JsonExpr | StyleDeclaration;
+export type Definition = LiteralValue | JsonExpr | BoxedDefinition | StyleDeclaration;
 
 /**
  * An array of [[Definition]]s.
@@ -376,6 +389,11 @@ export interface BaseStyle {
      * Human readable description.
      */
     description?: string;
+
+    /**
+     * The style set referenced by this styling rule.
+     */
+    styleSet?: string;
 
     /**
      * Technique name. See the classes extending from this class to determine what possible

--- a/@here/harp-mapview/test/ThemeLoaderTest.ts
+++ b/@here/harp-mapview/test/ThemeLoaderTest.ts
@@ -17,6 +17,7 @@ const URL = typeof window !== "undefined" ? window.URL : nodeUrl.URL;
 
 import {
     BoxedSelectorDefinition,
+    FlatTheme,
     ResolvedStyleSet,
     SolidLineStyle,
     StyleSelector,
@@ -473,6 +474,142 @@ describe("ThemeLoader", function() {
                 )
             );
             assert.isTrue(loggerMock.warn.calledWith("styles.tilezen[1]: invalid style, ignored"));
+        });
+    });
+
+    describe("flat themes", function() {
+        it("load flat theme", async () => {
+            const flatTheme: FlatTheme = {
+                styles: [
+                    {
+                        styleSet: "tilezen",
+                        when: ["boolean", true],
+                        technique: "none"
+                    },
+                    {
+                        styleSet: "terrain",
+                        when: ["boolean", false],
+                        technique: "none"
+                    },
+                    {
+                        styleSet: "tilezen",
+                        when: ["boolean", false],
+                        technique: "solid-line",
+                        attr: {
+                            lineWidth: 2
+                        }
+                    }
+                ]
+            };
+
+            const theme = await ThemeLoader.load(flatTheme);
+
+            assert.isDefined(theme.styles);
+            assert.isArray(theme.styles!.tilezen);
+            const tilezen: ResolvedStyleSet = theme.styles!.tilezen as any;
+            assert.strictEqual(tilezen.length, 2);
+            assert.strictEqual(tilezen[0].technique, "none");
+            assert.strictEqual(tilezen[1].technique, "solid-line");
+
+            assert.isArray(theme.styles!.terrain);
+            const terrain: ResolvedStyleSet = theme.styles!.terrain as any;
+            assert.strictEqual(terrain.length, 1);
+            assert.strictEqual(terrain[0].technique, "none");
+        });
+    });
+
+    describe("merge style sets", function() {
+        it("merge themes", async () => {
+            const baseTheme: Theme = {
+                styles: {
+                    tilezen: [
+                        {
+                            when: ["boolean", true],
+                            technique: "none"
+                        }
+                    ],
+                    terrain: [
+                        {
+                            when: ["boolean", false],
+                            technique: "none"
+                        }
+                    ]
+                }
+            };
+
+            const source: Theme = {
+                extends: [baseTheme],
+                styles: {
+                    tilezen: [
+                        {
+                            when: ["boolean", false],
+                            technique: "solid-line",
+                            attr: {
+                                lineWidth: 2
+                            }
+                        }
+                    ]
+                }
+            };
+
+            const theme = await ThemeLoader.load(source);
+
+            assert.isDefined(theme.styles);
+            assert.isArray(theme.styles!.tilezen);
+            const tilezen: ResolvedStyleSet = theme.styles!.tilezen as any;
+            assert.strictEqual(tilezen.length, 2);
+            assert.strictEqual(tilezen[0].technique, "none");
+            assert.strictEqual(tilezen[1].technique, "solid-line");
+
+            assert.isArray(theme.styles!.terrain);
+            const terrain: ResolvedStyleSet = theme.styles!.terrain as any;
+            assert.strictEqual(terrain.length, 1);
+            assert.strictEqual(terrain[0].technique, "none");
+        });
+
+        it("merge flat themes", async () => {
+            const baseTheme: FlatTheme = {
+                styles: [
+                    {
+                        styleSet: "tilezen",
+                        when: ["boolean", true],
+                        technique: "none"
+                    },
+                    {
+                        styleSet: "terrain",
+                        when: ["boolean", false],
+                        technique: "none"
+                    }
+                ]
+            };
+
+            const source: FlatTheme = {
+                extends: [baseTheme],
+                styles: [
+                    {
+                        styleSet: "tilezen",
+                        when: ["boolean", false],
+                        technique: "solid-line",
+                        attr: {
+                            lineWidth: 2
+                        }
+                    }
+                ]
+            };
+
+            const theme = await ThemeLoader.load(source);
+
+            assert.isDefined(theme.styles);
+            assert.isArray(theme.styles!.tilezen);
+            const tilezen: ResolvedStyleSet = theme.styles!.tilezen as any;
+            assert.strictEqual(tilezen.length, 2);
+            assert.strictEqual(tilezen[0].technique, "none");
+            assert.strictEqual(tilezen[1].technique, "solid-line");
+
+            assert.isArray(theme.styles!.terrain);
+            const terrain: ResolvedStyleSet = theme.styles!.terrain as any;
+            assert.strictEqual(terrain.length, 1);
+            assert.strictEqual(terrain[0].technique, "none");
         });
     });
 });


### PR DESCRIPTION
Flat themes are HARP themes where all the style declarations
are flattened in one single array. This change adds initial
support for loading flat themes by converting them to
HARP themes. The conversion is done so we can start experimenting
with this new file format without changing too much the HARP code base.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
