### PR TITLE
Sync chromedriver version with actual chrome in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ branches:
     - master
     - release
 
+env:
+  - DETECT_CHROMEDRIVER_VERSION=true
+
 # upgrade yarn to a more recent version
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@types/express": "^4.17.2",
         "@types/fs-extra": "^8.0.0",
         "chai": "^4.2.0",
-        "chromedriver": "^78.0.0",
+        "chromedriver": "^80.0.0",
         "commander": "^4.0.1",
         "express": "^4.17.1",
         "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,6 +231,11 @@
     highlight.js "^9.15.6"
     marked "^0.6.1"
 
+"@testim/chrome-version@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
+  integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
+
 "@tweenjs/tween.js@^17.4.0":
   version "17.4.0"
   resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-17.4.0.tgz#2e9ab3f2111906b30dfe1ef3259a9781dd211d35"
@@ -1460,11 +1465,12 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@^78.0.0:
-  version "78.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-78.0.1.tgz#2db3425a2cba6fcaf1a41d9538b16c3d06fa74a8"
-  integrity sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==
+chromedriver@^80.0.0:
+  version "80.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-80.0.0.tgz#f9e2af4c2117e7e07dc4558cf9496a70ad6c3ddc"
+  integrity sha512-W4tIbaOve7HeGFLnbbZMV4AUlnBaapL+H41fvDFKOXCmUvgPhxVN9y/c3EgmsOcokLQkqxpOC/txEujms1eT0w==
   dependencies:
+    "@testim/chrome-version" "^1.0.7"
     del "^4.1.1"
     extract-zip "^1.6.7"
     mkdirp "^0.5.1"


### PR DESCRIPTION
Travis CI always uses "current stable" version of chrome, and `chromedriver` has very limited compatibility (usually 1 or 2 major versions max).

Detect actual chrome version on system and upgrade chromedriver used for browser integration testing.