### PR TITLE
Optimize interpolants usage.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -9,8 +9,10 @@ import { ExprEvaluator, ExprEvaluatorContext, OperatorDescriptor } from "./ExprE
 import { ExprInstantiator, InstantiationContext } from "./ExprInstantiator";
 import { ExprParser } from "./ExprParser";
 import { ExprPool } from "./ExprPool";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
-import { interpolatedPropertyDefinitionToJsonExpr } from "./InterpolatedPropertyDefs";
+import {
+    interpolatedPropertyDefinitionToJsonExpr,
+    isInterpolatedPropertyDefinition
+} from "./InterpolatedPropertyDefs";
 import { Definitions, isBoxedDefinition, isLiteralDefinition } from "./Theme";
 
 export * from "./Env";

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -34,60 +34,42 @@ const interpolants = [
 const tmpBuffer = new Array<number>(StringEncodedNumeralFormatMaxSize);
 
 /**
- * Property which value is interpolated across different zoom levels.
+ * @hidden
+ *
+ * Runtime representation of [[InterpolatedPropertyDefs]].
+ *
+ * Created by [[createInterpolatedProperty]].
+ *
+ * Evaluate results with [[getPropertyValue]].
  */
 export interface InterpolatedProperty {
     /**
-     * Interpolation mode that should be used for this property.
+     * Main interpolant for this property.
      */
-    interpolationMode: InterpolationMode;
-
-    /**
-     * Zoom level keys array.
-     */
-    zoomLevels: Float32Array;
-
-    /**
-     * Property values array.
-     */
-    values: ArrayLike<any>;
-
-    /**
-     * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
-     */
-    exponent?: number;
+    interpolant: THREE.Interpolant;
 
     /**
      * @hidden
-     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
+     *
+     * Type of string encoded numeral this property contains.
+     * @see [[StringEncodedNumeralType]]
      */
-    _stringEncodedNumeralType?: StringEncodedNumeralType;
+    stringEncodedNumeralType?: StringEncodedNumeralType;
 
     /**
-     * @hidden
-     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
-     * [[StringEncodedNumeral]]s.
+     * Auxiliary interpolant for mask that tells if `pixelToWorld` has to be applied to result of
+     * main interpolant.
+     *
+     * Used only for interpolated _metric_ numerals based on `pixelToWorld` parameter.
      */
-    _stringEncodedNumeralDynamicMask?: Float32Array;
+    maskInterpolant?: THREE.Interpolant;
 }
 
 /**
  * Type guard to check if an object is an instance of `InterpolatedProperty`.
  */
 export function isInterpolatedProperty(p: any): p is InterpolatedProperty {
-    if (
-        p &&
-        p.interpolationMode !== undefined &&
-        p.zoomLevels instanceof Float32Array &&
-        p.values !== undefined &&
-        p.values.length > 0 &&
-        (p.zoomLevels.length === p.values.length / 4 ||
-            p.zoomLevels.length === p.values.length / 3 ||
-            p.zoomLevels.length === p.values.length)
-    ) {
-        return true;
-    }
-    return false;
+    return p && typeof p.interpolant === "object" && p.interpolant !== null;
 }
 
 /**
@@ -105,66 +87,39 @@ export function getPropertyValue(property: Value | Expr | undefined, env: Env): 
         // Property in numeric or array, etc. format
         return property;
     } else {
-        // Non-interpolated string encoded numeral parsing
-        const pixelToMeters = (env.lookup("$pixelToMeters") as number) || 1;
-        const value = parseStringEncodedNumeral(property, pixelToMeters);
+        const value = parseStringEncodedNumeral(property, env);
         return value !== undefined ? value : property;
     }
 }
 
 export function evaluateInterpolatedProperty(property: InterpolatedProperty, env: Env): any {
-    const level = env.lookup("$zoom") as number;
-    const pixelToMeters = env.lookup("$pixelToMeters") as number;
-
-    if (property._stringEncodedNumeralType !== undefined) {
-        switch (property._stringEncodedNumeralType) {
+    if (property.stringEncodedNumeralType !== undefined) {
+        switch (property.stringEncodedNumeralType) {
             case StringEncodedNumeralType.Meters:
             case StringEncodedNumeralType.Pixels:
-                return getInterpolatedMetric(property, level, pixelToMeters);
+                return getInterpolatedMetric(property, env);
             case StringEncodedNumeralType.Hex:
             case StringEncodedNumeralType.RGB:
             case StringEncodedNumeralType.RGBA:
             case StringEncodedNumeralType.HSL:
-                return getInterpolatedColor(property, level);
+                return getInterpolatedColor(property, env);
         }
     }
-    return getInterpolatedMetric(property, level, pixelToMeters);
+    return getInterpolatedMetric(property, env);
 }
 
-function getInterpolatedMetric(
-    property: InterpolatedProperty,
-    level: number,
-    pixelToMeters: number
-): number {
-    const nChannels = property.values.length / property.zoomLevels.length;
-    const interpolant = new interpolants[property.interpolationMode](
-        property.zoomLevels,
-        property.values,
-        nChannels
-    );
-    if (
-        property.interpolationMode === InterpolationMode.Exponential &&
-        property.exponent !== undefined
-    ) {
-        (interpolant as ExponentialInterpolant).exponent = property.exponent;
-    }
+function getInterpolatedMetric(property: InterpolatedProperty, env: Env): number {
+    const level = env.lookup("$zoom") as number;
+    const interpolant = property.interpolant;
+
     interpolant.evaluate(level);
 
-    if (property._stringEncodedNumeralDynamicMask === undefined) {
+    if (property.maskInterpolant === undefined) {
         return interpolant.resultBuffer[0];
     } else {
-        const maskInterpolant = new interpolants[property.interpolationMode](
-            property.zoomLevels,
-            property._stringEncodedNumeralDynamicMask,
-            1
-        );
-        if (
-            property.interpolationMode === InterpolationMode.Exponential &&
-            property.exponent !== undefined
-        ) {
-            (maskInterpolant as ExponentialInterpolant).exponent = property.exponent;
-        }
+        const maskInterpolant = property.maskInterpolant!;
         maskInterpolant.evaluate(level);
+        const pixelToMeters = env.lookup("$pixelToMeters") as number;
 
         return (
             interpolant.resultBuffer[0] *
@@ -173,20 +128,12 @@ function getInterpolatedMetric(
     }
 }
 
-function getInterpolatedColor(property: InterpolatedProperty, level: number): number {
-    const nChannels = property.values.length / property.zoomLevels.length;
-    const interpolant = new interpolants[property.interpolationMode](
-        property.zoomLevels,
-        property.values,
-        nChannels
-    );
-    if (
-        property.interpolationMode === InterpolationMode.Exponential &&
-        property.exponent !== undefined
-    ) {
-        (interpolant as ExponentialInterpolant).exponent = property.exponent;
-    }
+function getInterpolatedColor(property: InterpolatedProperty, env: Env): number {
+    const level = env.lookup("$zoom") as number;
+
+    const interpolant = property.interpolant;
     interpolant.evaluate(level);
+    const nChannels = interpolant.resultBuffer.length;
 
     assert(nChannels === 3 || nChannels === 4);
     // ColorUtils.getHexFromRgba() does not clamp the values which may be out of
@@ -228,12 +175,12 @@ export function createInterpolatedProperty(
         default:
         case "number":
         case "boolean":
-            return {
+            return createInterpolatedPropertyInt({
                 interpolationMode,
                 zoomLevels,
                 values: new Float32Array(prop.values as any),
                 exponent: prop.exponent
-            };
+            });
         case "string":
             // TODO: Minimize effort for pre-matching the numeral format.
             const matchedFormat = StringEncodedNumeralFormats.find(format =>
@@ -242,11 +189,11 @@ export function createInterpolatedProperty(
 
             if (matchedFormat === undefined) {
                 if (interpolationMode === InterpolationMode.Discrete) {
-                    return {
+                    return createInterpolatedPropertyInt({
                         interpolationMode,
                         zoomLevels,
                         values: prop.values
-                    };
+                    });
                 }
 
                 logger.error(`No StringEncodedNumeralFormat matched ${firstValue}.`);
@@ -264,15 +211,97 @@ export function createInterpolatedProperty(
                 maskValues
             );
 
-            return {
+            return createInterpolatedPropertyInt({
                 interpolationMode,
                 zoomLevels,
                 values: propValues,
                 exponent: prop.exponent,
-                _stringEncodedNumeralType: matchedFormat.type,
-                _stringEncodedNumeralDynamicMask: needsMask ? maskValues : undefined
-            };
+                stringEncodedNumeralType: matchedFormat.type,
+                stringEncodedNumeralDynamicMask: needsMask ? maskValues : undefined
+            });
     }
+}
+
+/**
+ * @hidden
+ *
+ * Internal representation of [[InterpoolatedPropertyDefs]] with support for
+ * string ecoded numerals.
+ *
+ * For use with [[createInterpolatedPropertyInt]] and [[createInterpolant]].
+ */
+export interface InterpolatedPropertyParams {
+    /**
+     * Interpolation mode that should be used for this property.
+     */
+    interpolationMode: InterpolationMode;
+
+    /**
+     * Zoom level keys array.
+     */
+    zoomLevels: Float32Array;
+
+    /**
+     * Property values array.
+     */
+    values: ArrayLike<any>;
+
+    /**
+     * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
+     */
+    exponent?: number;
+
+    /**
+     * @hidden
+     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
+     */
+    stringEncodedNumeralType?: StringEncodedNumeralType;
+
+    /**
+     * @hidden
+     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
+     * [[StringEncodedNumeral]]s.
+     */
+    stringEncodedNumeralDynamicMask?: Float32Array;
+}
+
+/**
+ * @hidden
+ *
+ * Create [[InterpolatedProperty]] from [[InterpolatedPropertyParams]].
+ */
+export function createInterpolatedPropertyInt(
+    params: InterpolatedPropertyParams
+): InterpolatedProperty {
+    const result: InterpolatedProperty = {
+        interpolant: createInterpolant(params),
+        stringEncodedNumeralType: params.stringEncodedNumeralType
+    };
+    if (params.stringEncodedNumeralDynamicMask) {
+        result.maskInterpolant = createInterpolant({
+            interpolationMode: params.interpolationMode,
+            zoomLevels: params.zoomLevels,
+            values: params.stringEncodedNumeralDynamicMask,
+            exponent: params.exponent
+        });
+    }
+    return result;
+}
+
+function createInterpolant(params: InterpolatedPropertyParams) {
+    const nChannels = params.values.length / params.zoomLevels.length;
+    const interpolant = new interpolants[params.interpolationMode](
+        params.zoomLevels,
+        params.values,
+        nChannels
+    );
+    if (
+        params.interpolationMode === InterpolationMode.Exponential &&
+        params.exponent !== undefined
+    ) {
+        (interpolant as ExponentialInterpolant).exponent = params.exponent;
+    }
+    return interpolant;
 }
 
 function removeDuplicatePropertyValues<T>(p: InterpolatedPropertyDefinition<T>) {

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -11,11 +11,7 @@ import { ColorUtils } from "./ColorUtils";
 import { Env } from "./Env";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
 import { Expr, ExprScope, Value } from "./Expr";
-import {
-    InterpolatedProperty,
-    InterpolatedPropertyDefinition,
-    InterpolationMode
-} from "./InterpolatedPropertyDefs";
+import { InterpolatedPropertyDefinition, InterpolationMode } from "./InterpolatedPropertyDefs";
 import {
     parseStringEncodedNumeral,
     StringEncodedColorFormats,
@@ -38,26 +34,41 @@ const interpolants = [
 const tmpBuffer = new Array<number>(StringEncodedNumeralFormatMaxSize);
 
 /**
- * Checks if a property is interpolated.
- * @param p property to be checked
+ * Property which value is interpolated across different zoom levels.
  */
-export function isInterpolatedPropertyDefinition<T>(
-    p: any
-): p is InterpolatedPropertyDefinition<T> {
-    if (
-        p &&
-        p.interpolationMode === undefined &&
-        Array.isArray(p.values) &&
-        p.values.length > 0 &&
-        p.values[0] !== undefined &&
-        Array.isArray(p.zoomLevels) &&
-        p.zoomLevels.length > 0 &&
-        p.zoomLevels[0] !== undefined &&
-        p.values.length === p.zoomLevels.length
-    ) {
-        return true;
-    }
-    return false;
+export interface InterpolatedProperty {
+    /**
+     * Interpolation mode that should be used for this property.
+     */
+    interpolationMode: InterpolationMode;
+
+    /**
+     * Zoom level keys array.
+     */
+    zoomLevels: Float32Array;
+
+    /**
+     * Property values array.
+     */
+    values: ArrayLike<any>;
+
+    /**
+     * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
+     */
+    exponent?: number;
+
+    /**
+     * @hidden
+     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
+     */
+    _stringEncodedNumeralType?: StringEncodedNumeralType;
+
+    /**
+     * @hidden
+     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
+     * [[StringEncodedNumeral]]s.
+     */
+    _stringEncodedNumeralDynamicMask?: Float32Array;
 }
 
 /**
@@ -85,16 +96,9 @@ export function isInterpolatedProperty(p: any): p is InterpolatedProperty {
 * @param property Property of a technique.
 * @param env The [[Env]] used to evaluate the property
 */
-export function getPropertyValue(
-    property: Value | Expr | InterpolatedProperty | undefined,
-    env: Env
-): any {
+export function getPropertyValue(property: Value | Expr | undefined, env: Env): any {
     if (Expr.isExpr(property)) {
         return property.evaluate(env, ExprScope.Dynamic);
-    }
-
-    if (isInterpolatedProperty(property)) {
-        return evaluateInterpolatedProperty(property, env);
     }
 
     if (typeof property !== "string") {

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -5,7 +5,6 @@
  */
 
 import { JsonExpr } from "./Expr";
-import { StringEncodedNumeralType } from "./StringEncodedNumeral";
 
 /**
  * Interpolation mode used when computing a [[InterpolatedProperty]] value for a given zoom level.
@@ -36,41 +35,26 @@ export interface InterpolatedPropertyDefinition<T> {
 }
 
 /**
- * Property which value is interpolated across different zoom levels.
+ * Checks if a property is interpolated.
+ * @param p property to be checked
  */
-export interface InterpolatedProperty {
-    /**
-     * Interpolation mode that should be used for this property.
-     */
-    interpolationMode: InterpolationMode;
-
-    /**
-     * Zoom level keys array.
-     */
-    zoomLevels: Float32Array;
-
-    /**
-     * Property values array.
-     */
-    values: ArrayLike<any>;
-
-    /**
-     * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
-     */
-    exponent?: number;
-
-    /**
-     * @hidden
-     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
-     */
-    _stringEncodedNumeralType?: StringEncodedNumeralType;
-
-    /**
-     * @hidden
-     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
-     * [[StringEncodedNumeral]]s.
-     */
-    _stringEncodedNumeralDynamicMask?: Float32Array;
+export function isInterpolatedPropertyDefinition<T>(
+    p: any
+): p is InterpolatedPropertyDefinition<T> {
+    if (
+        p &&
+        p.interpolationMode === undefined &&
+        Array.isArray(p.values) &&
+        p.values.length > 0 &&
+        p.values[0] !== undefined &&
+        Array.isArray(p.zoomLevels) &&
+        p.zoomLevels.length > 0 &&
+        p.zoomLevels[0] !== undefined &&
+        p.values.length === p.zoomLevels.length
+    ) {
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -6,6 +6,7 @@
 import { assert } from "@here/harp-utils";
 import { Color } from "three";
 import { ColorUtils } from "./ColorUtils";
+import { Env } from "./Env";
 
 const tmpColor = new Color();
 
@@ -192,14 +193,11 @@ const tmpBuffer: number[] = new Array(StringEncodedNumeralFormatMaxSize);
  * Parse string encoded numeral values using all known [[StringEncodedNumeralFormats]].
  *
  * @param numeral The string representing numeric value.
- * @param pixelToMeters The ratio used to convert from meters to pixels (default 1.0).
+ * @param env [[Env]] instance to evaluate scene dependent numerals
  * @returns Number parsed or __undefined__ if non of the numeral patterns matches the expression
  * provided in [[numeral]].
  */
-export function parseStringEncodedNumeral(
-    numeral: string,
-    pixelToMeters: number = 1.0
-): number | undefined {
+export function parseStringEncodedNumeral(numeral: string, env?: Env): number | undefined {
     let result: number | undefined;
     const formatMatch = (format: StringEncodedNumeralFormat) => {
         if (format.decoder(numeral, tmpBuffer)) {
@@ -208,6 +206,7 @@ export function parseStringEncodedNumeral(
                     result = tmpBuffer[0];
                     break;
                 case StringEncodedNumeralType.Pixels:
+                    const pixelToMeters = (env?.lookup("$pixelToMeters") as number) ?? 1;
                     result = tmpBuffer[0] * pixelToMeters;
                     break;
                 case StringEncodedNumeralType.Hex:

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -27,8 +27,11 @@ import {
     VarExpr
 } from "./Expr";
 import { ExprPool } from "./ExprPool";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
-import { interpolatedPropertyDefinitionToJsonExpr } from "./InterpolatedPropertyDefs";
+import {} from "./InterpolatedProperty";
+import {
+    interpolatedPropertyDefinitionToJsonExpr,
+    isInterpolatedPropertyDefinition
+} from "./InterpolatedPropertyDefs";
 import { AttrScope, mergeTechniqueDescriptor } from "./TechniqueDescriptor";
 import { IndexedTechnique, Technique, techniqueDescriptors } from "./Techniques";
 import {

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -6,8 +6,6 @@
 
 import { LoggerManager } from "@here/harp-utils";
 import { Env, Expr, ExprScope, MapEnv, Value } from "./Expr";
-import { getPropertyValue, isInterpolatedProperty } from "./InterpolatedProperty";
-import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
 
 const logger = LoggerManager.instance.create("TechniqueAttr");
 
@@ -46,7 +44,7 @@ export interface AttrEvaluationContext {
  */
 export function evaluateTechniqueAttr<T = Value>(
     context: Env | AttrEvaluationContext,
-    attrValue: T | Expr | InterpolatedProperty | undefined
+    attrValue: T | Expr | undefined
 ): T | undefined;
 
 /**
@@ -56,13 +54,13 @@ export function evaluateTechniqueAttr<T = Value>(
  */
 export function evaluateTechniqueAttr<T = Value>(
     context: Env | AttrEvaluationContext,
-    attrValue: T | Expr | InterpolatedProperty | undefined,
+    attrValue: T | Expr | undefined,
     defaultValue: T
 ): T;
 
 export function evaluateTechniqueAttr<T = Value>(
     context: Env | AttrEvaluationContext,
-    attrValue: T | Expr | InterpolatedProperty | undefined,
+    attrValue: T | Expr | undefined,
     defaultValue?: T
 ): T | undefined {
     const env = context instanceof Env ? context : context.env;
@@ -79,8 +77,6 @@ export function evaluateTechniqueAttr<T = Value>(
             logger.error(`failed to evaluate expression '${JSON.stringify(attrValue)}': ${error}`);
             evaluated = undefined;
         }
-    } else if (isInterpolatedProperty(attrValue)) {
-        evaluated = getPropertyValue(attrValue, context instanceof Env ? context : context.env);
     } else {
         evaluated = (attrValue as unknown) as Value;
     }

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -25,7 +25,7 @@ import {
 } from "./TechniqueParams";
 
 import { Expr, JsonExpr } from "./Expr";
-import { InterpolatedProperty, InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
+import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 import {
     AttrScope,
     mergeTechniqueDescriptor,
@@ -66,7 +66,7 @@ export type RemoveJsonExpr<T> = T | JsonExpr extends T ? Exclude<T, JsonExpr> : 
  */
 export type MakeTechniqueAttrs<T> = {
     [P in keyof T]: T[P] | JsonExpr extends T[P]
-        ? RemoveInterpolatedPropDef<RemoveJsonExpr<T[P]>> | Expr | InterpolatedProperty
+        ? RemoveInterpolatedPropDef<RemoveJsonExpr<T[P]>> | Expr
         : T[P];
 };
 

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -6,7 +6,7 @@
 
 import { Vector3Like } from "@here/harp-geoutils/lib/math/Vector3Like";
 import { isJsonExpr, JsonExpr } from "./Expr";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
+import { isInterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 import {
     BaseTechniqueParams,
     BasicExtrudedLineTechniqueParams,

--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -6,8 +6,12 @@
 
 import { CallExpr, ExprScope, LiteralExpr, NumberLiteralExpr, Value } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
-import { createInterpolatedProperty, evaluateInterpolatedProperty } from "../InterpolatedProperty";
-import { InterpolatedProperty, InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
+import {
+    createInterpolatedProperty,
+    evaluateInterpolatedProperty,
+    InterpolatedProperty
+} from "../InterpolatedProperty";
+import { InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
 
 type InterpolateCallExpr = CallExpr & {
     _mode?: InterpolatedPropertyDefinition<any>["interpolation"];

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -9,8 +9,8 @@
 
 import { assert } from "chai";
 import { MapEnv } from "../lib/Env";
-import { evaluateInterpolatedProperty } from "../lib/InterpolatedProperty";
-import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
+import { evaluateInterpolatedProperty, InterpolatedProperty } from "../lib/InterpolatedProperty";
+import { InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
 const levels = new Float32Array([0, 5, 10]);

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -9,34 +9,35 @@
 
 import { assert } from "chai";
 import { MapEnv } from "../lib/Env";
-import { evaluateInterpolatedProperty, InterpolatedProperty } from "../lib/InterpolatedProperty";
+import {
+    createInterpolatedPropertyInt,
+    evaluateInterpolatedProperty,
+    InterpolatedProperty,
+    InterpolatedPropertyParams
+} from "../lib/InterpolatedProperty";
 import { InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
 const levels = new Float32Array([0, 5, 10]);
 
-const numberProperty: InterpolatedProperty = {
-    interpolationMode: InterpolationMode.Discrete,
+const numberPropertyDef: Omit<InterpolatedPropertyParams, "interpolationMode"> = {
     zoomLevels: levels,
     values: [0, 100, 500]
 };
 
-const booleanProperty: InterpolatedProperty = {
-    interpolationMode: InterpolationMode.Discrete,
+const booleanPropertyDef: Omit<InterpolatedPropertyParams, "interpolationMode"> = {
     zoomLevels: levels,
     values: [true, false, true]
 };
 
-const colorProperty: InterpolatedProperty = {
-    interpolationMode: InterpolationMode.Discrete,
+const colorPropertyDef: Omit<InterpolatedPropertyParams, "interpolationMode"> = {
     zoomLevels: levels,
     // [r0, g0, b0, r1, g1, b1, ...]
     values: [1, 0, 0, 0, 1, 0, 0, 0, 1],
-    _stringEncodedNumeralType: StringEncodedNumeralType.Hex
+    stringEncodedNumeralType: StringEncodedNumeralType.Hex
 };
 
-const enumProperty: InterpolatedProperty = {
-    interpolationMode: InterpolationMode.Discrete,
+const enumPropertyDef: Omit<InterpolatedPropertyParams, "interpolationMode"> = {
     zoomLevels: levels,
     values: ["Enum0", "Enum1", "Enum2"]
 };
@@ -47,6 +48,23 @@ function evaluateInterpolatedPropertyZoom(property: InterpolatedProperty, level:
 
 describe("Interpolation", function() {
     it("Discrete", () => {
+        const numberProperty = createInterpolatedPropertyInt({
+            ...numberPropertyDef,
+            interpolationMode: InterpolationMode.Discrete
+        });
+        const booleanProperty = createInterpolatedPropertyInt({
+            ...booleanPropertyDef,
+            interpolationMode: InterpolationMode.Discrete
+        });
+        const colorProperty = createInterpolatedPropertyInt({
+            ...colorPropertyDef,
+            interpolationMode: InterpolationMode.Discrete
+        });
+        const enumProperty = createInterpolatedPropertyInt({
+            ...enumPropertyDef,
+            interpolationMode: InterpolationMode.Discrete
+        });
+
         assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
         assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
         assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 0);
@@ -80,8 +98,14 @@ describe("Interpolation", function() {
         assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, Infinity), "Enum2");
     });
     it("Linear", () => {
-        numberProperty.interpolationMode = InterpolationMode.Linear;
-        colorProperty.interpolationMode = InterpolationMode.Linear;
+        const numberProperty = createInterpolatedPropertyInt({
+            ...numberPropertyDef,
+            interpolationMode: InterpolationMode.Linear
+        });
+        const colorProperty = createInterpolatedPropertyInt({
+            ...colorPropertyDef,
+            interpolationMode: InterpolationMode.Linear
+        });
 
         assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
         assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
@@ -102,8 +126,14 @@ describe("Interpolation", function() {
         assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Cubic", () => {
-        numberProperty.interpolationMode = InterpolationMode.Cubic;
-        colorProperty.interpolationMode = InterpolationMode.Cubic;
+        const numberProperty = createInterpolatedPropertyInt({
+            ...numberPropertyDef,
+            interpolationMode: InterpolationMode.Cubic
+        });
+        const colorProperty = createInterpolatedPropertyInt({
+            ...colorPropertyDef,
+            interpolationMode: InterpolationMode.Cubic
+        });
 
         assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
         assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
@@ -124,8 +154,14 @@ describe("Interpolation", function() {
         assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Exponential", () => {
-        numberProperty.interpolationMode = InterpolationMode.Exponential;
-        colorProperty.interpolationMode = InterpolationMode.Exponential;
+        const numberProperty = createInterpolatedPropertyInt({
+            ...numberPropertyDef,
+            interpolationMode: InterpolationMode.Exponential
+        });
+        const colorProperty = createInterpolatedPropertyInt({
+            ...colorPropertyDef,
+            interpolationMode: InterpolationMode.Exponential
+        });
 
         assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
         assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);


### PR DESCRIPTION
Optimize InteprolatedProperty to reuse Interpolant instances across
evaluations.

THREE.JS interpolants cache last interpolation range, so assuming that
we usually render value on similar zoom levels, we don't have search for
interpolation range on every frame.

Time impact: O(1) complexity of most of interpolations [1].

Mem impact: don't allocate interpolant + one array internally on each
evaluation.

Based on #1332, review only last commit.

[1] https://threejs.org/docs/#api/en/math/Interpolant