### PR TITLE
Better handling of olp data

### DIFF
--- a/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
@@ -39,6 +39,11 @@ export interface OlpCopyrightProviderParams {
      * @default `"copyright_suppliers_here"`
      */
     partition?: string;
+
+    /**
+     * Version of the catalog
+     */
+    version: number;
 }
 
 const DEFAULT_LAYER = "copyright";
@@ -79,7 +84,9 @@ export class OlpCopyrightProvider extends CopyrightCoverageProvider {
                 settings
             );
             const partition = await client.getData(
-                new DataRequest().withPartitionId(this.m_params.partition ?? DEFAULT_PARTITION)
+                new DataRequest()
+                    .withPartitionId(this.m_params.partition ?? DEFAULT_PARTITION)
+                    .withVersion(this.m_params.version)
             );
             const json = await partition.json();
             this.m_cachedCopyrightResponse = json[this.m_params.baseScheme ?? "normal"];

--- a/@here/harp-olp-utils/lib/OlpDataProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpDataProvider.ts
@@ -103,10 +103,17 @@ export class OlpDataProvider implements DataProvider {
                 abortSignal
             )
             .then(response => {
-                // 204 - NO CONTENT, no data exists at the given tile. Do nothing.
-                return response.status === 204 ? Promise.resolve({}) : response.arrayBuffer();
+                if (response.status !== 200) {
+                    throw new Error(response.statusText);
+                }
+                return response.arrayBuffer();
             })
             .catch(error => {
+                // 204 - NO CONTENT, no data exists at the given tile.
+                if (error.name === "HttpError" && error.status === 204) {
+                    return {};
+                }
+
                 logger.error(
                     `Error loading tile ${tileKey.mortonCode()} for catalog ${
                         this.params.hrn


### PR DESCRIPTION
http/204 errors are now propagated as exceptions, not as replies.
Also handle the version in OlpCopyrightProvider as the license might
change between catalog versions.