### PR TITLE
Don't create dynamic strings in 'hot' asserts.

### DIFF
--- a/@here/harp-datasource-protocol/lib/ColorUtils.ts
+++ b/@here/harp-datasource-protocol/lib/ColorUtils.ts
@@ -113,7 +113,7 @@ export namespace ColorUtils {
      * point from 0 to 1 inclusively.
      */
     export function getRgbaFromHex(hex: number): { r: number; g: number; b: number; a: number } {
-        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format");
         return {
             r: ((hex >> SHIFT_RED) & HEX_FULL_CHANNEL) / HEX_FULL_CHANNEL,
             g: ((hex >> SHIFT_GREEN) & HEX_FULL_CHANNEL) / HEX_FULL_CHANNEL,
@@ -131,7 +131,7 @@ export namespace ColorUtils {
      * @returns True if color has transparency defined.
      */
     export function hasAlphaInHex(hex: number): boolean {
-        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format");
         return hex >> SHIFT_TRANSPARENCY !== 0;
     }
 
@@ -143,7 +143,7 @@ export namespace ColorUtils {
      * @returns The floating point alpha component in <0, 1> range.
      */
     export function getAlphaFromHex(hex: number): number {
-        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format");
         return (
             ((HEX_FULL_CHANNEL - (hex >> SHIFT_TRANSPARENCY)) & HEX_FULL_CHANNEL) / HEX_FULL_CHANNEL
         );
@@ -157,7 +157,7 @@ export namespace ColorUtils {
      * @returns number coded color value representable as 0xRRGGBB in hex.
      */
     export function removeAlphaFromHex(hex: number): number {
-        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format: #" + hex.toString(16));
+        assert((hex & ~HEX_TRGB_MASK) === 0, "Wrong hex format");
         return hex & HEX_RGB_MASK;
     }
 }

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -69,7 +69,7 @@ const StringEncodedHex: StringEncodedNumeralFormat = {
         // Only few sizes are possible for given reg-exp.
         assert(
             size === 3 || size === 4 || size === 6 || size === 8,
-            `Matched incorrect hex format: ${encodedValue}`
+            `Matched incorrect hex color format`
         );
         // Note that we simply ignore alpha channel value.
         // TODO: To be resolved with HARP-7517


### PR DESCRIPTION
Our toolchain is unable to remove `assert` calls yet, and JIT is unable to skip creation of assert arguments (observed in profiler), so don't create dynamic strings in assert arguments.

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>