### PR TITLE
Skip completly transparent objects.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2955,7 +2955,17 @@ export class MapView extends THREE.EventDispatcher {
     private renderTileObjects(tile: Tile, zoomLevel: number) {
         const worldOffsetX = tile.computeWorldOffsetX();
         if (tile.willRender(zoomLevel)) {
+            tile.updateDynamicObjects();
+
             for (const object of tile.objects) {
+                // Don't add completly transparent objects.
+                if ("material" in object && (object as any).material instanceof THREE.Material) {
+                    const material: THREE.Material = (object as any).material;
+                    if (material.opacity === 0) {
+                        continue;
+                    }
+                }
+
                 object.position.copy(tile.center);
                 if (object.displacement !== undefined) {
                     object.position.add(object.displacement);

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -476,7 +476,7 @@ export class PoiRenderer {
      */
     private preparePoi(pointLabel: TextElement, env: Env): void {
         const poiInfo = pointLabel.poiInfo;
-        if (poiInfo === undefined || !pointLabel.visible) {
+        if (poiInfo === undefined || !pointLabel.reallyVisible) {
             return;
         }
 
@@ -487,7 +487,7 @@ export class PoiRenderer {
 
         if (poiInfo.poiTableName !== undefined) {
             if (this.mapView.poiManager.updatePoiFromPoiTable(pointLabel)) {
-                if (!pointLabel.visible) {
+                if (!pointLabel.reallyVisible) {
                     // PoiTable set this POI to not visible.
                     return;
                 }

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -142,7 +142,7 @@ export function checkReadyForPlacement(
 ): { result: PrePlacementResult; viewDistance: number | undefined } {
     let viewDistance: number | undefined;
 
-    if (!textElement.visible) {
+    if (!textElement.reallyVisible) {
         return { result: PrePlacementResult.Invisible, viewDistance };
     }
 
@@ -157,7 +157,7 @@ export function checkReadyForPlacement(
     // Text element visibility and zoom level ranges must be checked after calling
     // updatePoiFromPoiTable, since that function may change those values.
     if (
-        !textElement.visible ||
+        !textElement.reallyVisible ||
         !MathUtils.isClamped(
             viewState.zoomLevel,
             textElement.minZoomLevel,

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -471,6 +471,13 @@ export class TextElement {
         this.m_layoutStyle = style;
     }
 
+    get reallyVisible() {
+        return (
+            this.visible &&
+            (typeof this.renderParams.opacity === "undefined" || this.renderParams.opacity > 0)
+        );
+    }
+
     hasFeatureId(): boolean {
         return this.featureId !== undefined && this.featureId !== 0;
     }

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -148,7 +148,7 @@ interface MixinShaderProperties {
  * @param visibilityRange object describing maximum and minimum visibility range - distances
  * from camera at which objects won't be rendered anymore.
  */
-function cameraToWorldDistance(distance: number, visibilityRange: ViewRanges): number {
+export function cameraToWorldDistance(distance: number, visibilityRange: ViewRanges): number {
     return distance * visibilityRange.maximum;
 }
 
@@ -530,63 +530,6 @@ export namespace FadingFeature {
             "fog_fragment",
             "fading_fragment",
             true
-        );
-    }
-
-    /**
-     * As three.js is rendering the transparent objects last (internally), regardless of their
-     * renderOrder value, we set the transparent value to false in the [[onAfterRenderCall]]. In
-     * [[onBeforeRender]], the function [[calculateDepthFromCameraDistance]] sets it to true if the
-     * fade distance value is less than 1.
-     *
-     * @param object [[THREE.Object3D]] to prepare for rendering.
-     * @param viewRanges The visibility ranges (clip planes and maximum visible distance) for
-     * actual camera setup.
-     * @param fadeNear The fadeNear value to set in the material.
-     * @param fadeFar The fadeFar value to set in the material.
-     * @param updateUniforms If `true`, the fading uniforms are set. Not required if material is
-     *          handling the uniforms already, like in a [[THREE.ShaderMaterial]].
-     * @param additionalCallback If defined, this function will be called before the function will
-     *          return.
-     */
-    export function addRenderHelper(
-        object: THREE.Object3D,
-        viewRanges: ViewRanges,
-        fadeNear: number | undefined,
-        fadeFar: number | undefined,
-        updateUniforms: boolean,
-        additionalCallback?: (
-            renderer: THREE.WebGLRenderer,
-            material: THREE.Material & FadingFeature
-        ) => void
-    ) {
-        // tslint:disable-next-line:no-unused-variable
-        object.onBeforeRender = chainCallbacks(
-            object.onBeforeRender,
-            (
-                renderer: THREE.WebGLRenderer,
-                scene: THREE.Scene,
-                camera: THREE.Camera,
-                geometry: THREE.Geometry | THREE.BufferGeometry,
-                material: THREE.Material & FadingFeature,
-                group: THREE.Group
-            ) => {
-                const fadingMaterial = material as FadingFeature;
-
-                fadingMaterial.fadeNear =
-                    fadeNear === undefined || fadeNear === FadingFeature.DEFAULT_FADE_NEAR
-                        ? FadingFeature.DEFAULT_FADE_NEAR
-                        : cameraToWorldDistance(fadeNear, viewRanges);
-
-                fadingMaterial.fadeFar =
-                    fadeFar === undefined || fadeFar === FadingFeature.DEFAULT_FADE_FAR
-                        ? FadingFeature.DEFAULT_FADE_FAR
-                        : cameraToWorldDistance(fadeFar, viewRanges);
-
-                if (additionalCallback !== undefined) {
-                    additionalCallback(renderer, material);
-                }
-            }
         );
     }
 }


### PR DESCRIPTION
Skip completly transparent objects, so then don't land in render
pipeline if opacity===0.

* Tile: add updateDynamicObjects callback that shall be called by
  MapView to update dynamic objects explicitly

* MapView: Call `updateDynamicObjects` on all rendered tiles and then don't add
  completly transparent objects to scene

* TileGeometryCreator Refactor most of `onBeforeRender` callbacks so they are executed
  in controlled (in scope of `Tile.updateDynamicObjects`)

* Unrelated - don't install fading render helper at all if fading is
  disabled

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>
