### PR TITLE
PoC: Revamp material updates

### DIFF
--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -80,84 +80,39 @@ export function isInterpolatedProperty(p: any): p is InterpolatedProperty {
 }
 
 /**
- * A temp [[Env]] containing the arguments passed to `getPropertyValue`.
- *
- * [[dynamicPropertiesTempEnv]] is used when `getPropertyValue` is
- * invoked with explicit values for `zoom` and `pixelToMeters` instead
- * of with an [[Env]].
- *
- * @hidden
- */
-const dynamicPropertiesTempEnv = new MapEnv({
-    $zoom: 0,
-    $pixelToMeters: 1
-});
+* Get the value of the specified property in given `env`.
 
-/**
- * Get the value of the specified property at the given zoom level.
- *
- * @param property Property of a technique.
- * @param env The [[Env]] used to evaluate the property.
- */
+* @param property Property of a technique.
+* @param env The [[Env]] used to evaluate the property
+*/
 export function getPropertyValue(
     property: Value | Expr | InterpolatedProperty | undefined,
     env: Env
-): any;
-
-/**
- * Get the value of the specified property at the given zoom level.
- *
- * @param property Property of a technique.
- * @param level Display level the property should be rendered at.
- * @param pixelToMeters Optional pixels to meters conversion factor (needed for proper
- * interpolation of `length` values).
- *
- */
-export function getPropertyValue(
-    property: Value | Expr | InterpolatedProperty | undefined,
-    level: number,
-    pixelToMeters?: number
-): any;
-
-export function getPropertyValue(
-    property: Value | Expr | InterpolatedProperty | undefined,
-    envOrLevel: number | Env,
-    pixelToMeters: number = 1.0
 ): any {
     if (Expr.isExpr(property)) {
-        let env: Env;
-
-        if (typeof envOrLevel === "number") {
-            dynamicPropertiesTempEnv.entries.$zoom = envOrLevel;
-            dynamicPropertiesTempEnv.entries.$pixelToMeters = pixelToMeters;
-            env = dynamicPropertiesTempEnv;
-        } else {
-            env = envOrLevel;
-        }
-
         return property.evaluate(env, ExprScope.Dynamic);
     }
 
-    let level: number;
-
-    if (typeof envOrLevel === "number") {
-        level = envOrLevel;
-    } else {
-        level = envOrLevel.lookup("$zoom") as number;
-        pixelToMeters = envOrLevel.lookup("$pixelToMeters") as number;
+    if (isInterpolatedProperty(property)) {
+        return evaluateInterpolatedProperty(property, env);
     }
 
-    // Non-interpolated property parsing
-    if (!isInterpolatedProperty(property)) {
-        if (typeof property !== "string") {
-            // Property in numeric or array, etc. format
-            return property;
-        } else {
-            const value = parseStringEncodedNumeral(property, pixelToMeters);
-            return value !== undefined ? value : property;
-        }
-        // Interpolated property
-    } else if (property._stringEncodedNumeralType !== undefined) {
+    if (typeof property !== "string") {
+        // Property in numeric or array, etc. format
+        return property;
+    } else {
+        // Non-interpolated string encoded numeral parsing
+        const pixelToMeters = (env.lookup("$pixelToMeters") as number) || 1;
+        const value = parseStringEncodedNumeral(property, pixelToMeters);
+        return value !== undefined ? value : property;
+    }
+}
+
+export function evaluateInterpolatedProperty(property: InterpolatedProperty, env: Env): any {
+    const level = env.lookup("$zoom") as number;
+    const pixelToMeters = env.lookup("$pixelToMeters") as number;
+
+    if (property._stringEncodedNumeralType !== undefined) {
         switch (property._stringEncodedNumeralType) {
             case StringEncodedNumeralType.Meters:
             case StringEncodedNumeralType.Pixels:

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -80,9 +80,7 @@ export function evaluateTechniqueAttr<T = Value>(
             evaluated = undefined;
         }
     } else if (isInterpolatedProperty(attrValue)) {
-        const storageLevel =
-            context instanceof Env ? (context.lookup("$zoom") as number) : context.zoomLevel;
-        evaluated = getPropertyValue(attrValue, storageLevel) as any;
+        evaluated = getPropertyValue(attrValue, context instanceof Env ? context : context.env);
     } else {
         evaluated = (attrValue as unknown) as Value;
     }

--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -6,7 +6,7 @@
 
 import { CallExpr, ExprScope, LiteralExpr, NumberLiteralExpr, Value } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
-import { createInterpolatedProperty, getPropertyValue } from "../InterpolatedProperty";
+import { createInterpolatedProperty, evaluateInterpolatedProperty } from "../InterpolatedProperty";
 import { InterpolatedProperty, InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
 
 type InterpolateCallExpr = CallExpr & {
@@ -313,7 +313,7 @@ const operators = {
                 }
             }
 
-            return getPropertyValue(interpolatedProperty, context.env);
+            return evaluateInterpolatedProperty(interpolatedProperty, context.env);
         }
     },
     step: {
@@ -356,7 +356,7 @@ const operators = {
                 }
             }
 
-            return getPropertyValue(interpolatedProperty, context.env);
+            return evaluateInterpolatedProperty(interpolatedProperty, context.env);
         }
     }
 };

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -52,6 +52,10 @@ describe("ExprEvaluator", function() {
         };
     }
 
+    function envForZoom(zoom: number) {
+        return new MapEnv({ $zoom: zoom });
+    }
+
     describe("Operator 'all'", function() {
         it("evaluate", function() {
             assert.isTrue(
@@ -686,14 +690,14 @@ describe("ExprEvaluator", function() {
             const interpolation = evaluate(["step", ["zoom"], "#ff0000", 13, "#000000"]);
             for (let zoom = 0; zoom < 13; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#ff0000", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#ff0000", envForZoom(zoom))
                 );
             }
             for (let zoom = 13; zoom < 20; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#000000", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#000000", envForZoom(zoom))
                 );
             }
         });
@@ -710,20 +714,20 @@ describe("ExprEvaluator", function() {
             ]);
 
             assert.strictEqual(
-                getPropertyValue(interpolation, -1),
-                getPropertyValue("#ff0000", -1)
+                getPropertyValue(interpolation, envForZoom(-1)),
+                getPropertyValue("#ff0000", envForZoom(-1))
             );
 
             for (let zoom = 0; zoom < 13; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#00ff00", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#00ff00", envForZoom(zoom))
                 );
             }
             for (let zoom = 13; zoom < 20; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#000000", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#000000", envForZoom(zoom))
                 );
             }
         });
@@ -1056,7 +1060,7 @@ describe("ExprEvaluator", function() {
         ]);
 
         for (let zoom = 0; zoom < 7; zoom += 0.5) {
-            const value = getPropertyValue(interp, zoom);
+            const value = getPropertyValue(interp, envForZoom(zoom));
             if (zoom < 4) {
                 assert.strictEqual(value, 0);
             } else {

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -8,7 +8,8 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
-import { getPropertyValue } from "../lib/InterpolatedProperty";
+import { MapEnv } from "../lib/Env";
+import { evaluateInterpolatedProperty } from "../lib/InterpolatedProperty";
 import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
@@ -40,104 +41,108 @@ const enumProperty: InterpolatedProperty = {
     values: ["Enum0", "Enum1", "Enum2"]
 };
 
+function evaluateInterpolatedPropertyZoom(property: InterpolatedProperty, level: number) {
+    return evaluateInterpolatedProperty(property, new MapEnv({ $zoom: level }));
+}
+
 describe("Interpolation", function() {
     it("Discrete", () => {
-        assert.strictEqual(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.strictEqual(getPropertyValue(numberProperty, 0), 0);
-        assert.strictEqual(getPropertyValue(numberProperty, 2.5), 0);
-        assert.strictEqual(getPropertyValue(numberProperty, 5), 100);
-        assert.strictEqual(getPropertyValue(numberProperty, 7.5), 100);
-        assert.strictEqual(getPropertyValue(numberProperty, 10), 500);
-        assert.strictEqual(getPropertyValue(numberProperty, Infinity), 500);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 0);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 100);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.strictEqual(getPropertyValue(booleanProperty, -Infinity), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, 0), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, 2.5), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, 5), false);
-        assert.strictEqual(getPropertyValue(booleanProperty, 7.5), false);
-        assert.strictEqual(getPropertyValue(booleanProperty, 10), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, Infinity), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, -Infinity), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 0), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 2.5), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 5), false);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 7.5), false);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 10), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, Infinity), true);
 
-        assert.strictEqual(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.strictEqual(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.strictEqual(getPropertyValue(colorProperty, 2.5), 0xff0000);
-        assert.strictEqual(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.strictEqual(getPropertyValue(colorProperty, 7.5), 0x00ff00);
-        assert.strictEqual(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.strictEqual(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0xff0000);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x00ff00);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
 
-        assert.strictEqual(getPropertyValue(enumProperty, -Infinity), "Enum0");
-        assert.strictEqual(getPropertyValue(enumProperty, 0), "Enum0");
-        assert.strictEqual(getPropertyValue(enumProperty, 2.5), "Enum0");
-        assert.strictEqual(getPropertyValue(enumProperty, 5), "Enum1");
-        assert.strictEqual(getPropertyValue(enumProperty, 7.5), "Enum1");
-        assert.strictEqual(getPropertyValue(enumProperty, 10), "Enum2");
-        assert.strictEqual(getPropertyValue(enumProperty, Infinity), "Enum2");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, -Infinity), "Enum0");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 0), "Enum0");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 2.5), "Enum0");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 5), "Enum1");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 7.5), "Enum1");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 10), "Enum2");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, Infinity), "Enum2");
     });
     it("Linear", () => {
         numberProperty.interpolationMode = InterpolationMode.Linear;
         colorProperty.interpolationMode = InterpolationMode.Linear;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 50);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 300);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 50);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 300);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
         // rgb: [ 0.5, 0.5, 0 ]
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0x7f7f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0x7f7f00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
         // rgb: [ 0, 0.5, 0.5 ]
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x007f7f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x007f7f);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Cubic", () => {
         numberProperty.interpolationMode = InterpolationMode.Cubic;
         colorProperty.interpolationMode = InterpolationMode.Cubic;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 31.25);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 281.25);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 31.25);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 281.25);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
         // rgb: [ 0.4375, 0.625, 0 ]
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0x6f9f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0x6f9f00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
         // rgb: [ 0, 0.625, 0.4375 ]
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x009f6f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x009f6f);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Exponential", () => {
         numberProperty.interpolationMode = InterpolationMode.Exponential;
         colorProperty.interpolationMode = InterpolationMode.Exponential;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 25);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 200);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 25);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 200);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
         // rgb: [ 0.75, 0.25, 0 ]
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xbf3f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0xbf3f00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
         // rgb: [ 0, 0.75, 0.25 ]
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00bf3f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x00bf3f);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
 });

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -6,6 +6,7 @@
 
 import {
     DecodedTile,
+    Env,
     getPropertyValue,
     isPoiTechnique,
     isTextTechnique,
@@ -126,7 +127,7 @@ export class GeoJsonTile extends Tile {
      *
      * @param decodedTile The decoded tile received by the [[GeoJsonDecoder]].
      */
-    createTextElements(decodedTile: DecodedTile, zoomLevel: number) {
+    createTextElements(decodedTile: DecodedTile, env: Env) {
         const tileGeometryCreator = TileGeometryCreator.instance;
         const worldOffsetX = this.computeWorldOffsetX();
 
@@ -135,7 +136,7 @@ export class GeoJsonTile extends Tile {
                 const techniqueIndex = geometry.technique!;
                 const technique = decodedTile.techniques[techniqueIndex];
                 if (isPoiTechnique(technique)) {
-                    this.addPois(geometry, technique, zoomLevel, worldOffsetX);
+                    this.addPois(geometry, technique, env, worldOffsetX);
                 }
             }
         }
@@ -227,7 +228,7 @@ export class GeoJsonTile extends Tile {
             path,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.mapEnv),
             xOffset,
             yOffset,
             featureId
@@ -308,7 +309,7 @@ export class GeoJsonTile extends Tile {
             position,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.mapEnv),
             xOffset,
             yOffset,
             featureId
@@ -342,7 +343,7 @@ export class GeoJsonTile extends Tile {
     private addPois(
         geometry: PoiGeometry,
         technique: PoiTechnique,
-        zoomLevel: number,
+        env: Env,
         worldOffsetX: number
     ) {
         const attribute = getBufferAttribute(geometry.positions);
@@ -357,7 +358,7 @@ export class GeoJsonTile extends Tile {
             );
             const properties =
                 geometry.objInfos !== undefined ? geometry.objInfos[index] : undefined;
-            this.addPoi(currentVertexCache, technique, zoomLevel, properties);
+            this.addPoi(currentVertexCache, technique, env, properties);
         }
     }
 
@@ -371,14 +372,14 @@ export class GeoJsonTile extends Tile {
     private addPoi(
         position: THREE.Vector3,
         technique: PoiTechnique,
-        zoomLevel: number,
+        env: Env,
         geojsonProperties?: {}
     ) {
         const label = DEFAULT_LABELED_ICON.label;
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
-        const xOffset = getPropertyValue(technique.xOffset, zoomLevel);
-        const yOffset = getPropertyValue(technique.yOffset, zoomLevel);
+        const xOffset = getPropertyValue(technique.xOffset, env);
+        const yOffset = getPropertyValue(technique.yOffset, env);
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
@@ -388,7 +389,7 @@ export class GeoJsonTile extends Tile {
             position,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, env),
             xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : xOffset,
             yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : yOffset,
             featureId

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -684,7 +684,7 @@ function evaluateProperty(value: any, env?: Env): any {
  * @param value the value of color property defined in technique
  * @param zoomLevel zoom level used for interpolation.
  */
-export function evaluateColorProperty(value: Value, env?: Env): number {
+export function evaluateColorProperty(value: Value | Expr, env?: Env): number {
     value = evaluateProperty(value, env);
 
     if (typeof value === "number") {

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -8,6 +8,7 @@ import {
     GradientSky,
     ImageTexture,
     Light,
+    MapEnv,
     PostEffects,
     Sky,
     Theme
@@ -790,6 +791,8 @@ export class MapView extends THREE.EventDispatcher {
     private m_languages: string[] | undefined;
     private m_copyrightInfo: CopyrightInfo[] = [];
     private m_animatedExtrusionHandler: AnimatedExtrusionHandler;
+
+    private m_env: MapEnv = new MapEnv({});
 
     private m_enableMixedLod: boolean | undefined;
 
@@ -1711,6 +1714,10 @@ export class MapView extends THREE.EventDispatcher {
         this.update();
     }
 
+    get mapEnv(): MapEnv {
+        return this.m_env;
+    }
+
     /**
      * Returns the storage level for the given camera setup.
      * Actual storage level of the rendered data also depends on [[DataSource.storageLevelOffset]].
@@ -2545,6 +2552,19 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
+     * Update `Env` instance used for style `Expr` evaluations.
+     */
+    private updateEnv() {
+        this.m_env.entries.$zoom = this.m_zoomLevel;
+
+        // This one introduces unnecessary calculation of pixelToWorld, even if it's barely
+        // used in our styles.
+        this.m_env.entries.$pixelToMeters = this.pixelToWorld;
+
+        this.m_env.entries.$frameNumber = this.m_frameNumber;
+    }
+
+    /**
      * Returns the height of the camera above the earths surface.
      *
      * If there is an ElevationProvider, this is used. Otherwise the projection is used to determine
@@ -2716,6 +2736,8 @@ export class MapView extends THREE.EventDispatcher {
         }
 
         this.updateCameras();
+        this.updateEnv();
+
         this.m_renderer.clear();
 
         // clear the scene

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2935,7 +2935,14 @@ export class MapView extends THREE.EventDispatcher {
     private renderTileObjects(tile: Tile, zoomLevel: number) {
         const worldOffsetX = tile.computeWorldOffsetX();
         if (tile.willRender(zoomLevel)) {
+            tile.updateDynamicObjects();
+
             for (const object of tile.objects) {
+                // Don't add completly transparent objects.
+                if (!object.visible) {
+                    continue;
+                }
+
                 object.position.copy(tile.center);
                 if (object.displacement !== undefined) {
                     object.position.add(object.displacement);

--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -115,7 +115,7 @@ export class PolarTileDataSource extends DataSource {
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
 
         return techniques.length !== 0
-            ? createMaterial({ technique: techniques[0], level: 1 })
+            ? createMaterial({ technique: techniques[0], env })
             : undefined;
     }
 

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -83,11 +83,7 @@ export class RoadPicker {
                               const unitFactor =
                                   technique.metricUnit === "Pixel" ? mapView.pixelToWorld : 1.0;
                               return (
-                                  getPropertyValue(
-                                      technique.lineWidth,
-                                      mapView.zoomLevel,
-                                      mapView.pixelToWorld
-                                  ) *
+                                  getPropertyValue(technique.lineWidth, mapView.mapEnv) *
                                   unitFactor *
                                   0.5
                               );

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -7,6 +7,7 @@ import {
     BaseTechniqueParams,
     BufferAttribute,
     DecodedTile,
+    Env,
     Expr,
     ExtrudedPolygonTechnique,
     FillTechnique,
@@ -29,6 +30,7 @@ import {
     isTerrainTechnique,
     isTextTechnique,
     MakeTechniqueAttrs,
+    MapEnv,
     needsVertexNormals,
     SolidLineTechnique,
     StandardExtrudedLineTechnique,
@@ -349,8 +351,10 @@ export class TileGeometryCreator {
     ) {
         const mapView = tile.mapView;
         const textElementsRenderer = mapView.textElementsRenderer;
-        const displayZoomLevel = Math.floor(mapView.zoomLevel);
         const worldOffsetX = tile.computeWorldOffsetX();
+
+        const discreteZoomLevel = Math.floor(mapView.zoomLevel);
+        const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.mapEnv);
 
         if (decodedTile.textPathGeometries !== undefined) {
             const textPathGeometries = this.prepareTextPaths(
@@ -384,15 +388,15 @@ export class TileGeometryCreator {
                 // Make sorting stable.
                 const priority =
                     technique.priority !== undefined
-                        ? getPropertyValue(technique.priority, displayZoomLevel)
+                        ? getPropertyValue(technique.priority, discreteZoomEnv)
                         : 0;
                 const fadeNear =
                     technique.fadeNear !== undefined
-                        ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                        ? getPropertyValue(technique.fadeNear, discreteZoomEnv)
                         : technique.fadeNear;
                 const fadeFar =
                     technique.fadeFar !== undefined
-                        ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                        ? getPropertyValue(technique.fadeFar, discreteZoomEnv)
                         : technique.fadeFar;
                 const userData = textPath.objInfos;
                 const featureId = getFeatureId(userData);
@@ -461,15 +465,15 @@ export class TileGeometryCreator {
 
                 const priority =
                     technique.priority !== undefined
-                        ? getPropertyValue(technique.priority, displayZoomLevel)
+                        ? getPropertyValue(technique.priority, discreteZoomEnv)
                         : 0;
                 const fadeNear =
                     technique.fadeNear !== undefined
-                        ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                        ? getPropertyValue(technique.fadeNear, discreteZoomEnv)
                         : technique.fadeNear;
                 const fadeFar =
                     technique.fadeFar !== undefined
-                        ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                        ? getPropertyValue(technique.fadeFar, discreteZoomEnv)
                         : technique.fadeFar;
 
                 for (let i = 0; i < numPositions; ++i) {
@@ -540,7 +544,8 @@ export class TileGeometryCreator {
         const materials: THREE.Material[] = [];
         const mapView = tile.mapView;
         const dataSource = tile.dataSource;
-        const displayZoomLevel = Math.floor(mapView.zoomLevel);
+        const discreteZoomLevel = Math.floor(mapView.zoomLevel);
+        const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.mapEnv);
         const objects = tile.objects;
         const viewRanges = mapView.viewRanges;
 
@@ -599,7 +604,7 @@ export class TileGeometryCreator {
                     material = createMaterial(
                         {
                             technique,
-                            level: displayZoomLevel,
+                            env: mapView.mapEnv,
                             fog: mapView.scene.fog !== null
                         },
                         onMaterialUpdated
@@ -712,7 +717,7 @@ export class TileGeometryCreator {
                 if (isLineTechnique(technique) || isSegmentsTechnique(technique)) {
                     const hasDynamicColor =
                         Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity);
-                    const fadingParams = this.getFadingParams(displayZoomLevel, technique);
+                    const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
                     FadingFeature.addRenderHelper(
                         object,
                         viewRanges,
@@ -727,7 +732,7 @@ export class TileGeometryCreator {
                                       lineMaterial.color,
                                       technique,
                                       technique.color,
-                                      mapView.zoomLevel
+                                      mapView.mapEnv
                                   );
                               }
                             : undefined
@@ -737,7 +742,8 @@ export class TileGeometryCreator {
                 if (isSolidLineTechnique(technique)) {
                     const hasDynamicColor =
                         Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity);
-                    const fadingParams = this.getFadingParams(displayZoomLevel, technique);
+                    const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
+
                     FadingFeature.addRenderHelper(
                         object,
                         viewRanges,
@@ -755,46 +761,31 @@ export class TileGeometryCreator {
                                     lineMaterial.color,
                                     technique,
                                     technique.color,
-                                    mapView.zoomLevel
+                                    mapView.mapEnv
                                 );
                             }
 
                             lineMaterial.lineWidth =
-                                getPropertyValue(
-                                    technique.lineWidth,
-                                    mapView.zoomLevel,
-                                    mapView.pixelToWorld
-                                ) *
+                                getPropertyValue(technique.lineWidth, mapView.mapEnv) *
                                 unitFactor *
                                 0.5;
 
                             if (technique.outlineWidth !== undefined) {
                                 lineMaterial.outlineWidth =
-                                    getPropertyValue(
-                                        technique.outlineWidth,
-                                        mapView.zoomLevel,
-                                        mapView.pixelToWorld
-                                    ) * unitFactor;
+                                    getPropertyValue(technique.outlineWidth, mapView.mapEnv) *
+                                    unitFactor;
                             }
 
                             if (technique.dashSize !== undefined) {
                                 lineMaterial.dashSize =
-                                    getPropertyValue(
-                                        technique.dashSize,
-                                        mapView.zoomLevel,
-                                        mapView.pixelToWorld
-                                    ) *
+                                    getPropertyValue(technique.dashSize, mapView.mapEnv) *
                                     unitFactor *
                                     0.5;
                             }
 
                             if (technique.gapSize !== undefined) {
                                 lineMaterial.gapSize =
-                                    getPropertyValue(
-                                        technique.gapSize,
-                                        mapView.zoomLevel,
-                                        mapView.pixelToWorld
-                                    ) *
+                                    getPropertyValue(technique.gapSize, mapView.mapEnv) *
                                     unitFactor *
                                     0.5;
                             }
@@ -809,7 +800,7 @@ export class TileGeometryCreator {
                     // dynamic properties is defined.
                     if (technique.fadeFar !== undefined || hasDynamicColor) {
                         const fadingParams = this.getFadingParams(
-                            displayZoomLevel,
+                            mapView.mapEnv,
                             technique as StandardExtrudedLineTechnique
                         );
 
@@ -830,7 +821,7 @@ export class TileGeometryCreator {
                                           extrudedMaterial.color,
                                           technique,
                                           technique.color!,
-                                          mapView.zoomLevel
+                                          mapView.mapEnv
                                       );
                                   }
                                 : undefined
@@ -850,7 +841,7 @@ export class TileGeometryCreator {
                     const hasDynamicColor = hasDynamicPrimaryColor || hasDynamicSecondaryColor;
 
                     if (technique.fadeFar !== undefined || hasDynamicColor) {
-                        const fadingParams = this.getFadingParams(displayZoomLevel, technique);
+                        const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
                         FadingFeature.addRenderHelper(
                             object,
                             viewRanges,
@@ -869,7 +860,7 @@ export class TileGeometryCreator {
                                               polygonMaterial.color,
                                               technique,
                                               technique.color!,
-                                              mapView.zoomLevel
+                                              mapView.mapEnv
                                           );
                                       }
 
@@ -883,7 +874,7 @@ export class TileGeometryCreator {
                                           applySecondaryColorToMaterial(
                                               standardMat.emissive,
                                               technique.emissive!,
-                                              mapView.zoomLevel
+                                              mapView.mapEnv
                                           );
                                       }
                                   }
@@ -912,7 +903,7 @@ export class TileGeometryCreator {
                 ) {
                     let animateExtrusionValue = getPropertyValue(
                         technique.animateExtrusion,
-                        displayZoomLevel
+                        discreteZoomEnv
                     );
                     if (animateExtrusionValue !== undefined) {
                         animateExtrusionValue =
@@ -985,7 +976,7 @@ export class TileGeometryCreator {
                     const extrudedPolygonTechnique = technique as ExtrudedPolygonTechnique;
 
                     const fadingParams = this.getPolygonFadingParams(
-                        displayZoomLevel,
+                        discreteZoomEnv,
                         extrudedPolygonTechnique
                     );
 
@@ -1016,7 +1007,7 @@ export class TileGeometryCreator {
                                       edgeMaterial.color,
                                       extrudedPolygonTechnique,
                                       extrudedPolygonTechnique.lineColor!,
-                                      mapView.zoomLevel
+                                      mapView.mapEnv
                                   );
                               }
                             : undefined
@@ -1066,10 +1057,7 @@ export class TileGeometryCreator {
 
                     const fillTechnique = technique as FillTechnique;
 
-                    const fadingParams = this.getPolygonFadingParams(
-                        displayZoomLevel,
-                        fillTechnique
-                    );
+                    const fadingParams = this.getPolygonFadingParams(mapView.mapEnv, fillTechnique);
 
                     // Configure the edge material based on the theme values.
                     const materialParams: EdgeMaterialParameters = {
@@ -1097,7 +1085,7 @@ export class TileGeometryCreator {
                                       edgeMaterial.color,
                                       fillTechnique,
                                       fillTechnique.lineColor!,
-                                      mapView.zoomLevel
+                                      mapView.mapEnv
                                   );
                               }
                             : undefined
@@ -1116,7 +1104,7 @@ export class TileGeometryCreator {
                         outlineMaterial.color,
                         outlineTechnique,
                         outlineTechnique.secondaryColor ?? 0x000000,
-                        mapView.zoomLevel
+                        discreteZoomEnv
                     );
                     if (outlineTechnique.secondaryCaps !== undefined) {
                         outlineMaterial.caps = outlineTechnique.secondaryCaps;
@@ -1132,7 +1120,7 @@ export class TileGeometryCreator {
                         outlineObj.renderOrder += group.renderOrderOffset;
                     }
 
-                    const fadingParams = this.getFadingParams(displayZoomLevel, technique);
+                    const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
                     FadingFeature.addRenderHelper(
                         outlineObj,
                         viewRanges,
@@ -1153,24 +1141,22 @@ export class TileGeometryCreator {
                                     lineMaterial.color,
                                     outlineTechnique,
                                     outlineTechnique.secondaryColor,
-                                    mapView.zoomLevel
+                                    mapView.mapEnv
                                 );
                             }
 
                             if (outlineTechnique.secondaryWidth !== undefined) {
                                 const techniqueLineWidth = getPropertyValue(
                                     outlineTechnique.lineWidth!,
-                                    mapView.zoomLevel,
-                                    mapView.pixelToWorld
+                                    mapView.mapEnv
                                 );
                                 const techniqueSecondaryWidth = getPropertyValue(
                                     outlineTechnique.secondaryWidth!,
-                                    mapView.zoomLevel,
-                                    mapView.pixelToWorld
+                                    mapView.mapEnv
                                 );
                                 const techniqueOpacity = getPropertyValue(
                                     outlineTechnique.opacity,
-                                    mapView.zoomLevel
+                                    mapView.mapEnv
                                 );
                                 // hide outline when it's equal or smaller then line to avoid subpixel contour
                                 const lineWidth =
@@ -1405,16 +1391,16 @@ export class TileGeometryCreator {
      * Gets the fading parameters for several kinds of objects.
      */
     private getFadingParams(
-        displayZoomLevel: number,
+        env: Env,
         technique: MakeTechniqueAttrs<BaseTechniqueParams>
     ): FadingParameters {
         const fadeNear =
             technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                ? getPropertyValue(technique.fadeNear, env)
                 : FadingFeature.DEFAULT_FADE_NEAR;
         const fadeFar =
             technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                ? getPropertyValue(technique.fadeFar, env)
                 : FadingFeature.DEFAULT_FADE_FAR;
         return {
             fadeNear,
@@ -1426,14 +1412,14 @@ export class TileGeometryCreator {
      * Gets the fading parameters for several kinds of objects.
      */
     private getPolygonFadingParams(
-        displayZoomLevel: number,
+        env: Env,
         technique: FillTechnique | ExtrudedPolygonTechnique
     ): PolygonFadingParameters {
         let color: string | number | undefined;
         let colorMix = EdgeMaterial.DEFAULT_COLOR_MIX;
 
         if (technique.lineColor !== undefined) {
-            color = getPropertyValue(technique.lineColor, displayZoomLevel);
+            color = getPropertyValue(technique.lineColor, env);
             if (isExtrudedPolygonTechnique(technique)) {
                 const extrudedPolygonTechnique = technique as ExtrudedPolygonTechnique;
                 colorMix =
@@ -1445,20 +1431,20 @@ export class TileGeometryCreator {
 
         const fadeNear =
             technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                ? getPropertyValue(technique.fadeNear, env)
                 : FadingFeature.DEFAULT_FADE_NEAR;
         const fadeFar =
             technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                ? getPropertyValue(technique.fadeFar, env)
                 : FadingFeature.DEFAULT_FADE_FAR;
 
         const lineFadeNear =
             technique.lineFadeNear !== undefined
-                ? getPropertyValue(technique.lineFadeNear, displayZoomLevel)
+                ? getPropertyValue(technique.lineFadeNear, env)
                 : fadeNear;
         const lineFadeFar =
             technique.lineFadeFar !== undefined
-                ? getPropertyValue(technique.lineFadeFar, displayZoomLevel)
+                ? getPropertyValue(technique.lineFadeFar, env)
                 : fadeFar;
 
         if (color === undefined) {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -33,7 +33,7 @@ import {
     MapEnv,
     needsVertexNormals,
     SolidLineTechnique,
-    StandardExtrudedLineTechnique,
+    StandardTechniqueParams,
     Technique,
     TerrainTechnique,
     TextPathGeometry
@@ -42,6 +42,7 @@ import {
 import { SphericalGeometrySubdivisionModifier } from "@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier";
 import { EarthConstants, GeoCoordinates, ProjectionType } from "@here/harp-geoutils";
 import {
+    cameraToWorldDistance,
     EdgeMaterial,
     EdgeMaterialParameters,
     FadingFeature,
@@ -414,6 +415,7 @@ export class TileGeometryCreator {
                     fadeFar,
                     tile.offset
                 );
+
                 textElement.pathLengthSqr = textPath.pathLengthSqr;
                 textElement.minZoomLevel =
                     technique.minZoomLevel !== undefined
@@ -547,7 +549,6 @@ export class TileGeometryCreator {
         const discreteZoomLevel = Math.floor(mapView.zoomLevel);
         const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.mapEnv);
         const objects = tile.objects;
-        const viewRanges = mapView.viewRanges;
 
         for (const srcGeometry of decodedTile.geometries) {
             const groups = srcGeometry.groups;
@@ -592,32 +593,22 @@ export class TileGeometryCreator {
                     continue;
                 }
 
-                let material: THREE.Material | undefined = materials[techniqueIndex];
+                const dynamicBaseColor =
+                    (isSolidLineTechnique(technique) ||
+                        isFillTechnique(technique) ||
+                        isExtrudedPolygonTechnique(technique) ||
+                        isLineTechnique(technique) ||
+                        isSegmentsTechnique(technique) ||
+                        isExtrudedLineTechnique(technique)) &&
+                    (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity));
 
+                let material: THREE.Material | undefined = materials[techniqueIndex];
                 if (material === undefined) {
-                    const onMaterialUpdated = (texture: THREE.Texture) => {
-                        dataSource.requestUpdate();
-                        if (texture !== undefined) {
-                            tile.addOwnedTexture(texture);
-                        }
-                    };
-                    material = createMaterial(
-                        {
-                            technique,
-                            env: mapView.mapEnv,
-                            fog: mapView.scene.fog !== null
-                        },
-                        onMaterialUpdated
-                    );
-                    if (material === undefined) {
+                    material = this.createMainMaterial(tile, technique);
+                    if (!material) {
                         continue;
                     }
                     materials[techniqueIndex] = material;
-                }
-
-                // Modify the standard textured shader to support height-based coloring.
-                if (isTerrainTechnique(technique)) {
-                    this.setupTerrainMaterial(technique, material, tile.mapView.clearColor);
                 }
 
                 const bufferGeometry = new THREE.BufferGeometry();
@@ -677,14 +668,6 @@ export class TileGeometryCreator {
                     // TODO: Unify access to shader defines via SolidLineMaterial setters
                     assert(!isHighPrecisionLineMaterial(material));
                     const lineMaterial = material as SolidLineMaterial;
-                    if (
-                        technique.clipping !== false &&
-                        tile.projection.type === ProjectionType.Planar
-                    ) {
-                        tile.boundingBox.getSize(tmpVector3);
-                        tmpVector2.set(tmpVector3.x, tmpVector3.y);
-                        lineMaterial.clipTileSize = tmpVector2;
-                    }
 
                     if (bufferGeometry.getAttribute("color")) {
                         setShaderMaterialDefine(lineMaterial, "USE_COLOR", true);
@@ -696,6 +679,15 @@ export class TileGeometryCreator {
                     isSolidLineTechnique(technique) && technique.secondaryWidth !== undefined;
 
                 const object = new ObjectCtor(bufferGeometry, material);
+
+                if (dynamicBaseColor) {
+                    tile.addUpdater(() => {
+                        object.visible = material!.opacity > 0;
+                    });
+                } else {
+                    object.visible = material.opacity > 0;
+                }
+
                 object.renderOrder = technique.renderOrder!;
 
                 if (group.renderOrderOffset !== undefined) {
@@ -714,174 +706,7 @@ export class TileGeometryCreator {
                     (object as MapViewPoints).enableRayTesting = technique.enablePicking!;
                 }
 
-                if (isLineTechnique(technique) || isSegmentsTechnique(technique)) {
-                    const hasDynamicColor =
-                        Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity);
-                    const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
-                    FadingFeature.addRenderHelper(
-                        object,
-                        viewRanges,
-                        fadingParams.fadeNear,
-                        fadingParams.fadeFar,
-                        false,
-                        hasDynamicColor
-                            ? (renderer, mat) => {
-                                  const lineMaterial = mat as THREE.LineBasicMaterial;
-                                  applyBaseColorToMaterial(
-                                      lineMaterial,
-                                      lineMaterial.color,
-                                      technique,
-                                      technique.color,
-                                      mapView.mapEnv
-                                  );
-                              }
-                            : undefined
-                    );
-                }
-
-                if (isSolidLineTechnique(technique)) {
-                    const hasDynamicColor =
-                        Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity);
-                    const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
-
-                    FadingFeature.addRenderHelper(
-                        object,
-                        viewRanges,
-                        fadingParams.fadeNear,
-                        fadingParams.fadeFar,
-                        false,
-                        (renderer, mat) => {
-                            const lineMaterial = mat as SolidLineMaterial;
-                            const unitFactor =
-                                technique.metricUnit === "Pixel" ? mapView.pixelToWorld : 1.0;
-
-                            if (hasDynamicColor) {
-                                applyBaseColorToMaterial(
-                                    lineMaterial,
-                                    lineMaterial.color,
-                                    technique,
-                                    technique.color,
-                                    mapView.mapEnv
-                                );
-                            }
-
-                            lineMaterial.lineWidth =
-                                getPropertyValue(technique.lineWidth, mapView.mapEnv) *
-                                unitFactor *
-                                0.5;
-
-                            if (technique.outlineWidth !== undefined) {
-                                lineMaterial.outlineWidth =
-                                    getPropertyValue(technique.outlineWidth, mapView.mapEnv) *
-                                    unitFactor;
-                            }
-
-                            if (technique.dashSize !== undefined) {
-                                lineMaterial.dashSize =
-                                    getPropertyValue(technique.dashSize, mapView.mapEnv) *
-                                    unitFactor *
-                                    0.5;
-                            }
-
-                            if (technique.gapSize !== undefined) {
-                                lineMaterial.gapSize =
-                                    getPropertyValue(technique.gapSize, mapView.mapEnv) *
-                                    unitFactor *
-                                    0.5;
-                            }
-                        }
-                    );
-                }
-
-                if (isExtrudedLineTechnique(technique)) {
-                    const hasDynamicColor =
-                        Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity);
-                    // extruded lines are normal meshes, and need transparency only when fading or
-                    // dynamic properties is defined.
-                    if (technique.fadeFar !== undefined || hasDynamicColor) {
-                        const fadingParams = this.getFadingParams(
-                            mapView.mapEnv,
-                            technique as StandardExtrudedLineTechnique
-                        );
-
-                        FadingFeature.addRenderHelper(
-                            object,
-                            viewRanges,
-                            fadingParams.fadeNear,
-                            fadingParams.fadeFar,
-                            true,
-                            hasDynamicColor
-                                ? (renderer, mat) => {
-                                      const extrudedMaterial = mat as
-                                          | MapMeshStandardMaterial
-                                          | MapMeshBasicMaterial;
-
-                                      applyBaseColorToMaterial(
-                                          extrudedMaterial,
-                                          extrudedMaterial.color,
-                                          technique,
-                                          technique.color!,
-                                          mapView.mapEnv
-                                      );
-                                  }
-                                : undefined
-                        );
-                    }
-                }
-
                 this.addUserData(tile, srcGeometry, technique, object);
-
-                if (isExtrudedPolygonTechnique(technique) || isFillTechnique(technique)) {
-                    // filled polygons are normal meshes, and need transparency only when fading or
-                    // dynamic properties is defined.
-                    const hasDynamicPrimaryColor =
-                        Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity);
-                    const hasDynamicSecondaryColor =
-                        isExtrudedPolygonTechnique(technique) && Expr.isExpr(technique.emissive);
-                    const hasDynamicColor = hasDynamicPrimaryColor || hasDynamicSecondaryColor;
-
-                    if (technique.fadeFar !== undefined || hasDynamicColor) {
-                        const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
-                        FadingFeature.addRenderHelper(
-                            object,
-                            viewRanges,
-                            fadingParams.fadeNear,
-                            fadingParams.fadeFar,
-                            true,
-                            hasDynamicColor
-                                ? (renderer, mat) => {
-                                      const polygonMaterial = mat as
-                                          | MapMeshBasicMaterial
-                                          | MapMeshStandardMaterial;
-
-                                      if (hasDynamicPrimaryColor) {
-                                          applyBaseColorToMaterial(
-                                              polygonMaterial,
-                                              polygonMaterial.color,
-                                              technique,
-                                              technique.color!,
-                                              mapView.mapEnv
-                                          );
-                                      }
-
-                                      if (
-                                          hasDynamicSecondaryColor &&
-                                          // Just to omit compiler warnings
-                                          isExtrudedPolygonTechnique(technique)
-                                      ) {
-                                          const standardMat = mat as MapMeshStandardMaterial;
-
-                                          applySecondaryColorToMaterial(
-                                              standardMat.emissive,
-                                              technique.emissive!,
-                                              mapView.mapEnv
-                                          );
-                                      }
-                                  }
-                                : undefined
-                        );
-                    }
-                }
 
                 const extrudedObjects: Array<{
                     object: THREE.Object3D;
@@ -934,6 +759,12 @@ export class TileGeometryCreator {
                         extrudedObjects.push({
                             object: depthPassMesh,
                             materialFeature: true
+                        });
+                    }
+
+                    if (dynamicBaseColor) {
+                        tile.addUpdater(() => {
+                            depthPassMesh.visible = material!.opacity > 0 && material!.opacity < 1;
                         });
                     }
 
@@ -993,25 +824,24 @@ export class TileGeometryCreator {
                     // Set the correct render order.
                     edgeObj.renderOrder = object.renderOrder + 0.1;
 
-                    FadingFeature.addRenderHelper(
-                        edgeObj,
-                        viewRanges,
-                        fadingParams.lineFadeNear,
-                        fadingParams.lineFadeFar,
-                        false,
-                        extrudedPolygonTechnique.lineColor !== undefined &&
-                            Expr.isExpr(extrudedPolygonTechnique.lineColor)
-                            ? () => {
-                                  applyBaseColorToMaterial(
-                                      edgeMaterial,
-                                      edgeMaterial.color,
-                                      extrudedPolygonTechnique,
-                                      extrudedPolygonTechnique.lineColor!,
-                                      mapView.mapEnv
-                                  );
-                              }
-                            : undefined
+                    this.addFadingUpdaterIfNeeded(
+                        tile,
+                        edgeMaterial,
+                        fadingParams.fadeNear,
+                        fadingParams.fadeFar
                     );
+                    if (Expr.isExpr(technique.lineColor) || Expr.isExpr(technique.opacity)) {
+                        tile.addUpdater(() => {
+                            applyBaseColorToMaterial(
+                                edgeMaterial,
+                                edgeMaterial.color,
+                                extrudedPolygonTechnique,
+                                extrudedPolygonTechnique.lineColor!,
+                                mapView.mapEnv
+                            );
+                            edgeObj.visible = edgeMaterial.opacity > 0;
+                        });
+                    }
 
                     if (extrusionAnimationEnabled) {
                         extrudedObjects.push({
@@ -1057,7 +887,10 @@ export class TileGeometryCreator {
 
                     const fillTechnique = technique as FillTechnique;
 
-                    const fadingParams = this.getPolygonFadingParams(mapView.mapEnv, fillTechnique);
+                    const fadingParams = this.getPolygonFadingParams(
+                        discreteZoomEnv,
+                        fillTechnique
+                    );
 
                     // Configure the edge material based on the theme values.
                     const materialParams: EdgeMaterialParameters = {
@@ -1070,26 +903,25 @@ export class TileGeometryCreator {
                     const outlineObj = new THREE.LineSegments(outlineGeometry, outlineMaterial);
                     outlineObj.renderOrder = object.renderOrder + 0.1;
 
-                    FadingFeature.addRenderHelper(
-                        outlineObj,
-                        viewRanges,
+                    this.addFadingUpdaterIfNeeded(
+                        tile,
+                        outlineMaterial,
                         fadingParams.lineFadeNear,
-                        fadingParams.lineFadeFar,
-                        false,
-                        fillTechnique.lineColor !== undefined &&
-                            Expr.isExpr(fillTechnique.lineColor)
-                            ? (renderer, mat) => {
-                                  const edgeMaterial = mat as EdgeMaterial;
-                                  applyBaseColorToMaterial(
-                                      edgeMaterial,
-                                      edgeMaterial.color,
-                                      fillTechnique,
-                                      fillTechnique.lineColor!,
-                                      mapView.mapEnv
-                                  );
-                              }
-                            : undefined
+                        fadingParams.lineFadeFar
                     );
+
+                    if (Expr.isExpr(technique.lineColor) || Expr.isExpr(technique.opacity)) {
+                        tile.addUpdater(() => {
+                            applyBaseColorToMaterial(
+                                outlineMaterial,
+                                outlineMaterial.color,
+                                fillTechnique,
+                                fillTechnique.lineColor!,
+                                mapView.mapEnv
+                            );
+                            outlineObj.visible = outlineMaterial.opacity > 0;
+                        });
+                    }
 
                     this.registerTileObject(tile, outlineObj, technique.kind);
                     objects.push(outlineObj);
@@ -1121,53 +953,61 @@ export class TileGeometryCreator {
                     }
 
                     const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
-                    FadingFeature.addRenderHelper(
-                        outlineObj,
-                        viewRanges,
+                    this.addFadingUpdaterIfNeeded(
+                        tile,
+                        outlineMaterial,
                         fadingParams.fadeNear,
-                        fadingParams.fadeFar,
-                        false,
-                        (renderer, mat) => {
-                            const lineMaterial = mat as SolidLineMaterial;
-
-                            const unitFactor =
-                                outlineTechnique.metricUnit === "Pixel"
-                                    ? mapView.pixelToWorld
-                                    : 1.0;
-
-                            if (outlineTechnique.secondaryColor !== undefined) {
-                                applyBaseColorToMaterial(
-                                    lineMaterial,
-                                    lineMaterial.color,
-                                    outlineTechnique,
-                                    outlineTechnique.secondaryColor,
-                                    mapView.mapEnv
-                                );
-                            }
-
-                            if (outlineTechnique.secondaryWidth !== undefined) {
-                                const techniqueLineWidth = getPropertyValue(
-                                    outlineTechnique.lineWidth!,
-                                    mapView.mapEnv
-                                );
-                                const techniqueSecondaryWidth = getPropertyValue(
-                                    outlineTechnique.secondaryWidth!,
-                                    mapView.mapEnv
-                                );
-                                const techniqueOpacity = getPropertyValue(
-                                    outlineTechnique.opacity,
-                                    mapView.mapEnv
-                                );
-                                // hide outline when it's equal or smaller then line to avoid subpixel contour
-                                const lineWidth =
-                                    techniqueSecondaryWidth <= techniqueLineWidth &&
-                                    (techniqueOpacity === undefined || techniqueOpacity === 1)
-                                        ? 0
-                                        : techniqueSecondaryWidth;
-                                lineMaterial.lineWidth = lineWidth * unitFactor * 0.5;
-                            }
-                        }
+                        fadingParams.fadeFar
                     );
+                    if (
+                        Expr.isExpr(outlineTechnique.secondaryColor) ||
+                        Expr.isExpr(outlineTechnique.opacity)
+                    ) {
+                        tile.addUpdater(() => {
+                            applyBaseColorToMaterial(
+                                outlineMaterial,
+                                outlineMaterial.color,
+                                outlineTechnique,
+                                outlineTechnique.secondaryColor!,
+                                mapView.mapEnv
+                            );
+                            outlineObj.visible = outlineMaterial.opacity > 0;
+                        });
+                    }
+
+                    const metricUnitIsPixel = outlineTechnique.metricUnit === "Pixel";
+
+                    if (
+                        Expr.isExpr(outlineTechnique.secondaryWidth) ||
+                        Expr.isExpr(outlineTechnique.secondaryColor) ||
+                        Expr.isExpr(outlineTechnique.opacity) ||
+                        metricUnitIsPixel
+                    ) {
+                        tile.addUpdater(() => {
+                            const mainLineMaterial = material as SolidLineMaterial;
+                            // NOTE! we assume that _effective_ opacity and lineWidth was calculated
+                            // by previous updater!
+                            const opacity = outlineMaterial.opacity;
+
+                            if (opacity === 0) {
+                                return;
+                            }
+
+                            const unitFactor = metricUnitIsPixel ? mapView.pixelToWorld : 1.0;
+
+                            const actualSecondaryWidth =
+                                getPropertyValue(outlineTechnique.secondaryWidth!, mapView.mapEnv) *
+                                unitFactor *
+                                0.5;
+                            const actualMainWitdh = mainLineMaterial.lineWidth;
+                            if (actualSecondaryWidth < actualMainWitdh) {
+                                outlineObj.visible = false;
+                            } else {
+                                outlineObj.visible = true;
+                                outlineMaterial.lineWidth = actualSecondaryWidth;
+                            }
+                        });
+                    }
 
                     this.registerTileObject(tile, outlineObj, technique.kind);
                     objects.push(outlineObj);
@@ -1259,6 +1099,138 @@ export class TileGeometryCreator {
             this.registerTileObject(tile, groundPlane, GeometryKind.Background);
             tile.objects.push(groundPlane);
         }
+    }
+
+    private createMainMaterial(tile: Tile, technique: Technique) {
+        const mapView = tile.mapView;
+
+        const discreteZoomLevel = Math.floor(mapView.zoomLevel);
+        const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.mapEnv);
+
+        const onMaterialUpdated = (texture: THREE.Texture) => {
+            tile.dataSource.requestUpdate();
+            if (texture !== undefined) {
+                tile.addOwnedTexture(texture);
+            }
+        };
+        const material = createMaterial(
+            {
+                technique,
+                env: mapView.mapEnv,
+                fog: mapView.scene.fog !== null
+            },
+            onMaterialUpdated
+        );
+        if (material === undefined) {
+            return undefined;
+        }
+
+        // fading updater
+        if (
+            isSolidLineTechnique(technique) ||
+            isFillTechnique(technique) ||
+            isExtrudedPolygonTechnique(technique) ||
+            isLineTechnique(technique) ||
+            isSegmentsTechnique(technique) ||
+            isExtrudedLineTechnique(technique)
+        ) {
+            const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
+            this.addFadingUpdaterIfNeeded(
+                tile,
+                material,
+                fadingParams.fadeNear,
+                fadingParams.fadeFar
+            );
+        }
+
+        const dynamicBaseColor =
+            (isSolidLineTechnique(technique) ||
+                isFillTechnique(technique) ||
+                isExtrudedPolygonTechnique(technique) ||
+                isLineTechnique(technique) ||
+                isSegmentsTechnique(technique) ||
+                isExtrudedLineTechnique(technique)) &&
+            (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity));
+
+        // base color updater
+        if (dynamicBaseColor) {
+            tile.addUpdater(() => {
+                const theMaterial = material as SolidLineMaterial | THREE.MeshBasicMaterial;
+                applyBaseColorToMaterial(
+                    theMaterial,
+                    theMaterial.color,
+                    technique,
+                    (technique as StandardTechniqueParams).color!,
+                    mapView.mapEnv
+                );
+            });
+        }
+
+        // custom updaters
+        if (isSolidLineTechnique(technique)) {
+            const lineMaterial = material as SolidLineMaterial;
+
+            const metricUnitIsPixel = technique.metricUnit === "Pixel";
+
+            if (Expr.isExpr(technique.lineWidth) || metricUnitIsPixel) {
+                tile.addUpdater(() => {
+                    const unitFactor = metricUnitIsPixel ? mapView.pixelToWorld : 1.0;
+                    lineMaterial.lineWidth =
+                        getPropertyValue(technique.lineWidth, mapView.mapEnv) * unitFactor * 0.5;
+                });
+            }
+
+            if (Expr.isExpr(technique.outlineWidth) || metricUnitIsPixel) {
+                tile.addUpdater(() => {
+                    const unitFactor = metricUnitIsPixel ? mapView.pixelToWorld : 1.0;
+                    lineMaterial.outlineWidth =
+                        getPropertyValue(technique.outlineWidth, mapView.mapEnv) * unitFactor;
+                });
+            }
+
+            if (Expr.isExpr(technique.dashSize) || metricUnitIsPixel) {
+                tile.addUpdater(() => {
+                    const unitFactor = metricUnitIsPixel ? mapView.pixelToWorld : 1.0;
+
+                    lineMaterial.dashSize =
+                        getPropertyValue(technique.dashSize, mapView.mapEnv) * unitFactor * 0.5;
+                });
+            }
+
+            if (Expr.isExpr(technique.gapSize) || metricUnitIsPixel) {
+                tile.addUpdater(() => {
+                    const unitFactor = metricUnitIsPixel ? mapView.pixelToWorld : 1.0;
+
+                    lineMaterial.gapSize =
+                        getPropertyValue(technique.gapSize, mapView.mapEnv) * unitFactor * 0.5;
+                });
+            }
+
+            if (technique.clipping !== false && tile.projection.type === ProjectionType.Planar) {
+                tile.boundingBox.getSize(tmpVector3);
+                tmpVector2.set(tmpVector3.x, tmpVector3.y);
+                lineMaterial.clipTileSize = tmpVector2;
+            }
+        }
+
+        if (isExtrudedPolygonTechnique(technique) && Expr.isExpr(technique.emissive)) {
+            tile.addUpdater(() => {
+                const standardMat = material as MapMeshStandardMaterial;
+
+                applySecondaryColorToMaterial(
+                    standardMat.emissive,
+                    technique.emissive!,
+                    mapView.mapEnv
+                );
+            });
+        }
+
+        // Modify the standard textured shader to support height-based coloring.
+        if (isTerrainTechnique(technique)) {
+            this.setupTerrainMaterial(technique, material, tile.mapView.clearColor);
+        }
+
+        return material;
     }
 
     private setupTerrainMaterial(
@@ -1385,6 +1357,33 @@ export class TileGeometryCreator {
             object.userData.feature = featureData;
             object.userData.technique = technique;
         }
+    }
+
+    private addFadingUpdaterIfNeeded(
+        tile: Tile,
+        material: FadingFeature,
+        fadeNear: number | undefined,
+        fadeFar: number | undefined
+    ) {
+        if (fadeNear === FadingFeature.DEFAULT_FADE_NEAR) {
+            fadeNear = undefined;
+        }
+        if (fadeFar === FadingFeature.DEFAULT_FADE_FAR) {
+            fadeFar = undefined;
+        }
+
+        if (fadeNear === undefined && fadeFar === undefined) {
+            return;
+        }
+        tile.addUpdater(() => {
+            const viewRanges = tile.mapView.viewRanges;
+            if (fadeNear !== undefined) {
+                material.fadeNear = cameraToWorldDistance(fadeNear, viewRanges);
+            }
+            if (fadeFar !== undefined) {
+                material.fadeFar = cameraToWorldDistance(fadeFar, viewRanges);
+            }
+        });
     }
 
     /**

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -497,24 +497,24 @@ export class PoiManager {
         // The current zoomlevel of mapview. Since this method is called for all tiles in the
         // VisibleTileSet we can be sure that the current zoomlevel matches the zoomlevel where
         // the tile should be shown.
-        const displayZoomLevel = this.mapView.zoomLevel;
+        const env = this.mapView.mapEnv;
         const fadeNear =
             technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                ? getPropertyValue(technique.fadeNear, env)
                 : technique.fadeNear;
         const fadeFar =
             technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                ? getPropertyValue(technique.fadeFar, env)
                 : technique.fadeFar;
-        const xOffset = getPropertyValue(technique.xOffset, displayZoomLevel);
-        const yOffset = getPropertyValue(technique.yOffset, displayZoomLevel);
+        const xOffset = getPropertyValue(technique.xOffset, env);
+        const yOffset = getPropertyValue(technique.yOffset, env);
 
         const textElement: TextElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             positions,
             textElementsRenderer.styleCache.getRenderStyle(tile, technique),
             textElementsRenderer.styleCache.getLayoutStyle(tile, technique),
-            getPropertyValue(priority, displayZoomLevel),
+            getPropertyValue(priority, env),
             xOffset !== undefined ? xOffset : 0.0,
             yOffset !== undefined ? yOffset : 0.0,
             featureId,

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -476,7 +476,7 @@ export class PoiRenderer {
      */
     private preparePoi(pointLabel: TextElement, env: Env): void {
         const poiInfo = pointLabel.poiInfo;
-        if (poiInfo === undefined || !pointLabel.visible) {
+        if (poiInfo === undefined || !pointLabel.reallyVisible) {
             return;
         }
 
@@ -487,7 +487,7 @@ export class PoiRenderer {
 
         if (poiInfo.poiTableName !== undefined) {
             if (this.mapView.poiManager.updatePoiFromPoiTable(pointLabel)) {
-                if (!pointLabel.visible) {
+                if (!pointLabel.reallyVisible) {
                     // PoiTable set this POI to not visible.
                     return;
                 }

--- a/@here/harp-mapview/lib/text/MapViewState.ts
+++ b/@here/harp-mapview/lib/text/MapViewState.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeometryKindSet } from "@here/harp-datasource-protocol";
+import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { MapView } from "../MapView";
 import { ViewState } from "./ViewState";
 
@@ -28,6 +28,9 @@ export class MapViewState implements ViewState {
     }
     get zoomLevel(): number {
         return this.m_mapView.zoomLevel;
+    }
+    get env(): Env {
+        return this.m_mapView.mapEnv;
     }
     get frameNumber(): number {
         return this.m_mapView.frameNumber;

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Env } from "@here/harp-datasource-protocol";
 import { ProjectionType } from "@here/harp-geoutils";
 import {
     HorizontalAlignment,
@@ -257,7 +258,7 @@ export enum PlacementResult {
  * @param screenPosition Screen position of the icon.
  * @param scaleFactor Scaling factor to apply to the icon dimensions.
  * @param screenCollisions Used to check the icon visibility and collisions.
- * @param zoomLevel Current zoom level.
+ * @param env Current map env.
  * @returns `PlacementResult.Ok` if icon can be placed, `PlacementResult.Rejected` if there's
  * a collision, `PlacementResult.Invisible` if it's not visible.
  */
@@ -266,10 +267,10 @@ export function placeIcon(
     poiInfo: PoiInfo,
     screenPosition: THREE.Vector2,
     scaleFactor: number,
-    zoomLevel: number,
+    env: Env,
     screenCollisions: ScreenCollisions
 ): PlacementResult {
-    PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scaleFactor, zoomLevel, tmp2DBox);
+    PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scaleFactor, env, tmp2DBox);
     if (!screenCollisions.isVisible(tmp2DBox)) {
         return PlacementResult.Invisible;
     }

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -144,7 +144,7 @@ export function checkReadyForPlacement(
 ): { result: PrePlacementResult; viewDistance: number | undefined } {
     let viewDistance: number | undefined;
 
-    if (!textElement.visible) {
+    if (!textElement.reallyVisible) {
         return { result: PrePlacementResult.Invisible, viewDistance };
     }
 
@@ -159,7 +159,7 @@ export function checkReadyForPlacement(
     // Text element visibility and zoom level ranges must be checked after calling
     // updatePoiFromPoiTable, since that function may change those values.
     if (
-        !textElement.visible ||
+        !textElement.reallyVisible ||
         !MathUtils.isClamped(
             viewState.zoomLevel,
             textElement.minZoomLevel,
@@ -308,6 +308,13 @@ export function placePointLabel(
     outScreenPosition: THREE.Vector3
 ): PlacementResult {
     const label = labelState.element;
+
+    if (label.lastUpdated !== (label.renderStyle as any).lastUpdated) {
+        label.bounds = undefined;
+        label.textBufferObject = undefined;
+
+        label.lastUpdated = (label.renderStyle as any).lastUpdated;
+    }
 
     if (label.bounds === undefined) {
         label.bounds = new THREE.Box2();

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -319,11 +319,14 @@ export class TextElement {
 
     type: TextElementType;
 
+    lastUpdated?: number;
+
     private m_poiInfo?: PoiInfo;
 
     private m_renderStyle?: TextRenderStyle;
 
     private m_layoutStyle?: TextLayoutStyle;
+
 
     /**
      * Creates a new `TextElement`.
@@ -464,6 +467,13 @@ export class TextElement {
      */
     set layoutStyle(style: TextLayoutStyle | undefined) {
         this.m_layoutStyle = style;
+    }
+
+    get reallyVisible() {
+        return (
+            this.visible &&
+            (typeof this.renderParams.opacity === "undefined" || this.renderParams.opacity > 0)
+        );
     }
 
     hasFeatureId(): boolean {

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1565,8 +1565,7 @@ export class TextElementsRenderer {
             textDistance,
             this.m_viewState.lookAtDistance
         );
-        const iconReady =
-            renderIcon && poiRenderer.prepareRender(pointLabel, this.m_viewState.zoomLevel);
+        const iconReady = renderIcon && poiRenderer.prepareRender(pointLabel, this.m_viewState.env);
 
         if (iconReady) {
             const result = placeIcon(
@@ -1574,7 +1573,7 @@ export class TextElementsRenderer {
                 poiInfo!,
                 tempPoiScreenPosition,
                 distanceScaleFactor,
-                this.m_viewState.zoomLevel,
+                this.m_viewState.env,
                 this.m_screenCollisions
             );
             if (result === PlacementResult.Invisible) {
@@ -1679,7 +1678,7 @@ export class TextElementsRenderer {
                     distanceScaleFactor,
                     allocateSpace,
                     opacity,
-                    this.m_viewState.zoomLevel
+                    this.m_viewState.env
                 );
 
                 if (placementStats) {
@@ -1729,7 +1728,7 @@ export class TextElementsRenderer {
         const poiInfo = lineMarkerLabel.poiInfo!;
         if (
             path.length === 0 ||
-            !poiRenderer.prepareRender(lineMarkerLabel, this.m_viewState.zoomLevel)
+            !poiRenderer.prepareRender(lineMarkerLabel, this.m_viewState.env)
         ) {
             return;
         }

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -9,6 +9,7 @@ import {
     getPropertyValue,
     IndexedTechniqueParams,
     LineMarkerTechnique,
+    MapEnv,
     PoiTechnique,
     Technique,
     TextStyleDefinition,
@@ -303,11 +304,13 @@ export class TextStyleCache {
         const mapView = tile.mapView;
         const dataSource = tile.dataSource;
         const zoomLevel = mapView.zoomLevel;
-        const zoomLevelInt = Math.floor(zoomLevel);
+        const discreteZoomLevel = Math.floor(zoomLevel);
 
-        const cacheId = computeStyleCacheId(dataSource.name, technique, zoomLevelInt);
+        const cacheId = computeStyleCacheId(dataSource.name, technique, discreteZoomLevel);
         let renderStyle = this.m_textRenderStyleCache.get(cacheId);
         if (renderStyle === undefined) {
+            const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.mapEnv);
+
             const defaultRenderParams = this.m_defaultStyle.renderParams;
 
             // Sets opacity to 1.0 if default and technique attribute are undefined.
@@ -315,13 +318,13 @@ export class TextStyleCache {
             // Interpolate opacity but only on discreet zoom levels (step interpolation).
             let opacity = getPropertyValue(
                 getOptionValue(technique.opacity, defaultOpacity),
-                zoomLevelInt
+                discreteZoomEnv
             );
 
             let color: THREE.Color | undefined;
             // Store color (RGB) in cache and multiply opacity value with the color alpha channel.
             if (technique.color !== undefined) {
-                let hexColor = evaluateColorProperty(technique.color, zoomLevelInt);
+                let hexColor = evaluateColorProperty(technique.color, discreteZoomEnv);
                 if (ColorUtils.hasAlphaInHex(hexColor)) {
                     const alpha = ColorUtils.getAlphaFromHex(hexColor);
                     opacity = opacity * alpha;
@@ -337,7 +340,7 @@ export class TextStyleCache {
             );
             const backgroundSize = getPropertyValue(
                 getOptionValue(technique.backgroundSize, defaultBackgroundSize),
-                zoomLevelInt
+                discreteZoomEnv
             );
 
             const hasBackgroundDefined =
@@ -358,13 +361,13 @@ export class TextStyleCache {
                     technique.backgroundOpacity,
                     hasBackgroundDefined ? 1.0 : defaultBackgroundOpacity
                 ),
-                zoomLevelInt
+                discreteZoomEnv
             );
 
             let backgroundColor: THREE.Color | undefined;
             // Store background color (RGB) in cache and multiply backgroundOpacity by its alpha.
             if (technique.backgroundColor !== undefined) {
-                let hexBgColor = evaluateColorProperty(technique.backgroundColor, zoomLevelInt);
+                let hexBgColor = evaluateColorProperty(technique.backgroundColor, discreteZoomEnv);
                 if (ColorUtils.hasAlphaInHex(hexBgColor)) {
                     const alpha = ColorUtils.getAlphaFromHex(hexBgColor);
                     backgroundOpacity = backgroundOpacity * alpha;
@@ -379,7 +382,7 @@ export class TextStyleCache {
                     unit: FontUnit.Pixel,
                     size: getPropertyValue(
                         getOptionValue(technique.size, defaultRenderParams.fontSize!.size),
-                        zoomLevelInt
+                        discreteZoomEnv
                     ),
                     backgroundSize
                 },
@@ -434,20 +437,22 @@ export class TextStyleCache {
         tile: Tile,
         technique: TextTechnique | PoiTechnique | LineMarkerTechnique
     ): TextLayoutStyle {
+        const mapView = tile.mapView;
         const floorZoomLevel = Math.floor(tile.mapView.zoomLevel);
         const cacheId = computeStyleCacheId(tile.dataSource.name, technique, floorZoomLevel);
         let layoutStyle = this.m_textLayoutStyleCache.get(cacheId);
 
         if (layoutStyle === undefined) {
+            const discreteZoomEnv = new MapEnv({ $zoom: floorZoomLevel }, mapView.mapEnv);
             const defaultLayoutParams = this.m_defaultStyle.layoutParams;
 
-            const hAlignment = getPropertyValue(technique.hAlignment, floorZoomLevel) as
+            const hAlignment = getPropertyValue(technique.hAlignment, discreteZoomEnv) as
                 | string
                 | undefined;
-            const vAlignment = getPropertyValue(technique.vAlignment, floorZoomLevel) as
+            const vAlignment = getPropertyValue(technique.vAlignment, discreteZoomEnv) as
                 | string
                 | undefined;
-            const wrapping = getPropertyValue(technique.wrappingMode, floorZoomLevel) as
+            const wrapping = getPropertyValue(technique.wrappingMode, discreteZoomEnv) as
                 | string
                 | undefined;
 
@@ -463,22 +468,22 @@ export class TextStyleCache {
 
             const layoutParams = {
                 tracking:
-                    getPropertyValue(technique.tracking, floorZoomLevel) ??
+                    getPropertyValue(technique.tracking, discreteZoomEnv) ??
                     defaultLayoutParams.tracking,
                 leading:
-                    getPropertyValue(technique.leading, floorZoomLevel) ??
+                    getPropertyValue(technique.leading, discreteZoomEnv) ??
                     defaultLayoutParams.leading,
                 maxLines:
-                    getPropertyValue(technique.maxLines, floorZoomLevel) ??
+                    getPropertyValue(technique.maxLines, discreteZoomEnv) ??
                     defaultLayoutParams.maxLines,
                 lineWidth:
-                    getPropertyValue(technique.lineWidth, floorZoomLevel) ??
+                    getPropertyValue(technique.lineWidth, discreteZoomEnv) ??
                     defaultLayoutParams.lineWidth,
                 canvasRotation:
-                    getPropertyValue(technique.canvasRotation, floorZoomLevel) ??
+                    getPropertyValue(technique.canvasRotation, discreteZoomEnv) ??
                     defaultLayoutParams.canvasRotation,
                 lineRotation:
-                    getPropertyValue(technique.lineRotation, floorZoomLevel) ??
+                    getPropertyValue(technique.lineRotation, discreteZoomEnv) ??
                     defaultLayoutParams.lineRotation,
                 wrappingMode:
                     wrapping === "None" || wrapping === "Character" || wrapping === "Word"

--- a/@here/harp-mapview/lib/text/ViewState.ts
+++ b/@here/harp-mapview/lib/text/ViewState.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeometryKindSet } from "@here/harp-datasource-protocol";
+import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 
 /**
  * State parameters of a view that are required by the text renderer.
@@ -14,6 +14,7 @@ export interface ViewState {
     cameraIsMoving: boolean; // Whether view's camera is currently moving.
     maxVisibilityDist: number; // Maximum far plane distance.
     zoomLevel: number; // View's zoom level.
+    env: Env;
     frameNumber: number; // Current frame number.
     lookAtDistance: number; // Distance to the lookAt point.
     isDynamic: boolean; // Whether a new frame for the view is already requested.

--- a/@here/harp-mapview/test/DecodedTileHelpersTest.ts
+++ b/@here/harp-mapview/test/DecodedTileHelpersTest.ts
@@ -7,13 +7,14 @@
 import { assert } from "chai";
 import * as THREE from "three";
 
-import { SolidLineTechnique } from "@here/harp-datasource-protocol";
+import { MapEnv, SolidLineTechnique } from "@here/harp-datasource-protocol";
 import { SolidLineMaterial } from "@here/harp-materials";
 import { applyBaseColorToMaterial, createMaterial } from "../lib/DecodedTileHelpers";
 
 // tslint:disable:only-arrow-functions
 
 describe("DecodedTileHelpers", function() {
+    const env = new MapEnv({ $zoom: 10 });
     describe("#createMaterial", function() {
         it("supports #rgba in base material colors", function() {
             const technique: SolidLineTechnique = {
@@ -22,7 +23,7 @@ describe("DecodedTileHelpers", function() {
                 renderOrder: 0,
                 color: "#f0f7"
             };
-            const material = createMaterial({ technique, level: 10 })! as SolidLineMaterial;
+            const material = createMaterial({ technique, env })! as SolidLineMaterial;
             assert.exists(material);
 
             assert.approximately(material.opacity, 7 / 15, 0.00001);
@@ -38,7 +39,7 @@ describe("DecodedTileHelpers", function() {
                 color: "#f0f",
                 secondaryColor: "#f0f7"
             };
-            const material = createMaterial({ technique, level: 10 })! as SolidLineMaterial;
+            const material = createMaterial({ technique, env })! as SolidLineMaterial;
             assert.exists(material);
 
             assert.equal(material.opacity, 1);
@@ -56,7 +57,7 @@ describe("DecodedTileHelpers", function() {
             renderOrder: 0,
             color: "#f0f7"
         };
-        applyBaseColorToMaterial(material, material.color, technique, technique.color, 10);
+        applyBaseColorToMaterial(material, material.color, technique, technique.color, env);
 
         assert.approximately(material.opacity, 7 / 15, 0.00001);
         assert.equal(material.blending, THREE.CustomBlending);
@@ -64,7 +65,7 @@ describe("DecodedTileHelpers", function() {
         assert.equal(material.transparent, false);
 
         technique.color = "#f0f";
-        applyBaseColorToMaterial(material, material.color, technique, technique.color, 10);
+        applyBaseColorToMaterial(material, material.color, technique, technique.color, env);
 
         assert.equal(material.opacity, 1);
         assert.equal(material.blending, THREE.NormalBlending);

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Theme } from "@here/harp-datasource-protocol";
+import { MapEnv, Theme } from "@here/harp-datasource-protocol";
 import { mercatorProjection, Projection, TileKey } from "@here/harp-geoutils";
 import { TextCanvas } from "@here/harp-text-canvas";
 import { assert, expect } from "chai";
@@ -45,6 +45,7 @@ function createViewState(worldCenter: THREE.Vector3): ViewState {
         maxVisibilityDist: 10000,
         // This level affects the distance tolerance applied to find label replacement by location.
         zoomLevel: 20,
+        env: new MapEnv({ $zoom: 20 }),
         frameNumber: 0,
         lookAtDistance: 0,
         isDynamic: false,

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -6,7 +6,7 @@
 
 // tslint:disable:only-arrow-functions
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
-import { ShaderTechnique } from "@here/harp-datasource-protocol";
+import { MapEnv, ShaderTechnique } from "@here/harp-datasource-protocol";
 import { assert } from "chai";
 import * as THREE from "three";
 import { createMaterial, getObjectConstructor } from "./../lib/DecodedTileHelpers";
@@ -26,8 +26,8 @@ describe("Tile Creation", function() {
             },
             renderOrder: 0
         };
-        const level = 14;
-        const shaderMaterial = createMaterial({ technique, level });
+        const env = new MapEnv({ $zoom: 14 });
+        const shaderMaterial = createMaterial({ technique, env });
         assert.isTrue(
             shaderMaterial instanceof THREE.ShaderMaterial,
             "expected a THREE.ShaderMaterial"

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -140,7 +140,7 @@ interface MixinShaderProperties {
  * @param visibilityRange object describing maximum and minimum visibility range - distances
  * from camera at which objects won't be rendered anymore.
  */
-function cameraToWorldDistance(distance: number, visibilityRange: ViewRanges): number {
+export function cameraToWorldDistance(distance: number, visibilityRange: ViewRanges): number {
     return distance * visibilityRange.maximum;
 }
 
@@ -522,63 +522,6 @@ export namespace FadingFeature {
             "fog_fragment",
             "fading_fragment",
             true
-        );
-    }
-
-    /**
-     * As three.js is rendering the transparent objects last (internally), regardless of their
-     * renderOrder value, we set the transparent value to false in the [[onAfterRenderCall]]. In
-     * [[onBeforeRender]], the function [[calculateDepthFromCameraDistance]] sets it to true if the
-     * fade distance value is less than 1.
-     *
-     * @param object [[THREE.Object3D]] to prepare for rendering.
-     * @param viewRanges The visibility ranges (clip planes and maximum visible distance) for
-     * actual camera setup.
-     * @param fadeNear The fadeNear value to set in the material.
-     * @param fadeFar The fadeFar value to set in the material.
-     * @param updateUniforms If `true`, the fading uniforms are set. Not required if material is
-     *          handling the uniforms already, like in a [[THREE.ShaderMaterial]].
-     * @param additionalCallback If defined, this function will be called before the function will
-     *          return.
-     */
-    export function addRenderHelper(
-        object: THREE.Object3D,
-        viewRanges: ViewRanges,
-        fadeNear: number | undefined,
-        fadeFar: number | undefined,
-        updateUniforms: boolean,
-        additionalCallback?: (
-            renderer: THREE.WebGLRenderer,
-            material: THREE.Material & FadingFeature
-        ) => void
-    ) {
-        // tslint:disable-next-line:no-unused-variable
-        object.onBeforeRender = chainCallbacks(
-            object.onBeforeRender,
-            (
-                renderer: THREE.WebGLRenderer,
-                scene: THREE.Scene,
-                camera: THREE.Camera,
-                geometry: THREE.Geometry | THREE.BufferGeometry,
-                material: THREE.Material & FadingFeature,
-                group: THREE.Group
-            ) => {
-                const fadingMaterial = material as FadingFeature;
-
-                fadingMaterial.fadeNear =
-                    fadeNear === undefined || fadeNear === FadingFeature.DEFAULT_FADE_NEAR
-                        ? FadingFeature.DEFAULT_FADE_NEAR
-                        : cameraToWorldDistance(fadeNear, viewRanges);
-
-                fadingMaterial.fadeFar =
-                    fadeFar === undefined || fadeFar === FadingFeature.DEFAULT_FADE_FAR
-                        ? FadingFeature.DEFAULT_FADE_FAR
-                        : cameraToWorldDistance(fadeFar, viewRanges);
-
-                if (additionalCallback !== undefined) {
-                    additionalCallback(renderer, material);
-                }
-            }
         );
     }
 }

--- a/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
+++ b/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
@@ -95,7 +95,7 @@ export class OmvDebugLabelsTile extends OmvTile {
         // allow limiting to specific names and/or index. There can be many paths with the same text
         const textFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.TEXT");
         const indexFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.INDEX");
-        const zoomLevel = this.mapView.zoomLevel;
+        const env = this.mapView.mapEnv;
 
         if (decodedTile.textPathGeometries !== undefined) {
             this.preparedTextPaths = tileGeometryCreator.prepareTextPaths(
@@ -129,7 +129,7 @@ export class OmvDebugLabelsTile extends OmvTile {
                 if (technique.color !== undefined) {
                     colorMap.set(
                         textPath.technique,
-                        new THREE.Color(getPropertyValue(technique.color, zoomLevel))
+                        new THREE.Color(getPropertyValue(technique.color, env))
                     );
                 }
 
@@ -188,7 +188,7 @@ export class OmvDebugLabelsTile extends OmvTile {
                                     new THREE.Vector3(x + worldOffsetX, y, z),
                                     textRenderStyle,
                                     textLayoutStyle,
-                                    getPropertyValue(technique.priority || 0, zoomLevel),
+                                    getPropertyValue(technique.priority || 0, env),
                                     technique.xOffset || 0.0,
                                     technique.yOffset || 0.0
                                 );


### PR DESCRIPTION
*work-in-progress*

This is "no chains" fork of #1271 to experiment with directions on how to efficiently update materials, TextElements and objects.
Should be split into several PRs of course (includes #1282)

--

* Tile: add updateDynamicObjects callback that shall be called by
  MapView to update dynamic objects explicitly

* MapView: Call `updateDynamicObjects` on all rendered tiles and then don't add
  completly transparent objects to scene

* TileGeometryCreator Refactor most of `onBeforeRender` callbacks so they are executed
  in controlled (in scope of `Tile.updateDynamicObjects`)
* TextStyleCache to use `Tile.addUpdater` to support full interpolation some of `TextElement` props

* Refactor fading render helper to use `Tile.addUpdater` Don't install fading render helper at all if fading is disabled
