### PR TITLE
Fix animated exposure of building footprint.

### DIFF
--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -49,6 +49,14 @@ export interface ExtrusionFeatureParameters {
      * Ratio of the extruded objects, where `1.0` is the default value
      */
     extrusionRatio?: number;
+
+    /**
+     * Enable z-fighting workaround that doesn't animate buildings with `height <
+     * [[ExtrusionFeatureDefs.MIN_BUILDING_HEIGHT]]`.
+     *
+     * Should be applied to `polygon` materials using this feature.
+     */
+    zFightingWorkaround?: boolean;
 }
 
 /**
@@ -874,6 +882,10 @@ export class ExtrusionFeatureMixin implements ExtrusionFeature {
         assert(this.shaderDefines !== undefined);
         assert(this.shaderUniforms !== undefined);
 
+        if (params && params.zFightingWorkaround === true) {
+            this.shaderDefines.ZFIGHTING_WORKAROUND = "";
+        }
+
         // Create uniform with default value, this ensures that it is always created,
         // so no need for checks in setters.
         this.shaderUniforms!.extrusionRatio = new THREE.Uniform(
@@ -939,7 +951,7 @@ export class MapMeshBasicMaterial extends THREE.MeshBasicMaterial
         ExtrusionFeature.patchGlobalShaderChunks();
 
         this.addExtrusionProperties();
-        this.applyExtrusionParameters(params);
+        this.applyExtrusionParameters({ ...params, zFightingWorkaround: true });
 
         this.addDisplacementProperties();
         this.applyDisplacementParameters(params);
@@ -1075,7 +1087,7 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
         ExtrusionFeature.patchGlobalShaderChunks();
 
         this.addExtrusionProperties();
-        this.applyExtrusionParameters(params);
+        this.applyExtrusionParameters({ ...params, zFightingWorkaround: true });
     }
 
     clone(): this {

--- a/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
@@ -15,15 +15,19 @@ export default {
 attribute vec4 extrusionAxis;
 uniform float extrusionRatio;
 varying vec4 vExtrusionAxis;
+#ifdef ZFIGHTING_WORKAROUND
 varying float vExtrusionRatio;
-
+#endif
 `,
     extrusion_vertex: `
+#ifdef ZFIGHTING_WORKAROUND
 // Cancel extrusionRatio (meaning, force to 1) if extrusionAxisLen < MIN_BUILDING_HEIGHT.
 const float MIN_BUILDING_HEIGHT_SQUARED = ${MIN_BUILDING_HEIGHT_SQUARED};
 float extrusionAxisLenSquared = dot(extrusionAxis.xyz, extrusionAxis.xyz);
 vExtrusionRatio = (extrusionAxisLenSquared < MIN_BUILDING_HEIGHT_SQUARED) ? 1.0 : extrusionRatio;
-
+#else
+float vExtrusionRatio = extrusionRatio;
+#endif
 transformed = transformed + extrusionAxis.xyz * (vExtrusionRatio - 1.0);
 vExtrusionAxis = vec4(normalMatrix * extrusionAxis.xyz, extrusionAxis.w);
 `,
@@ -62,10 +66,17 @@ vExtrusionAxis = vec4(normalMatrix * extrusionAxis.xyz, extrusionAxis.w);
 vec3 geometryNormal = normal;
 `,
     extrusion_pars_fragment: `
+#ifdef ZFIGHTING_WORKAROUND
 varying float vExtrusionRatio;
+#else
+uniform float extrusionRatio;
+#endif
 varying vec4 vExtrusionAxis;
 `,
     extrusion_fragment: `
+#ifndef ZFIGHTING_WORKAROUND
+float vExtrusionRatio = extrusionRatio;
+#endif
 gl_FragColor.a *= smoothstep( 0.0, 0.25, vExtrusionRatio );
 `
 };


### PR DESCRIPTION
Disable "z-figthing workaround" for EdgeMaterial.

PR #1179 introduced workaround to prevent z-fighting of small buildings
(height ~ 0).  This workaround is viable for translucent polygons, but
not for lines ... esp. lines that are always on z=0 such as footprints.
As result #1179, accidentaly completly disabled "animated exposure"
of footprints, causing them to be visible with opacity=1 from frame 1,
only to be clobbered by other geometry few frames later, effectively
producing annoying flicker.

Related-to: HARP-8448