### PR TITLE
Remove chai from devDependencies

### DIFF
--- a/@here/harp-test-utils/package.json
+++ b/@here/harp-test-utils/package.json
@@ -43,7 +43,6 @@
         "@types/node": "^12.0.8",
         "@types/serve-static": "^1.13.2",
         "body-parser": "^1.18.3",
-        "chai": "^4.0.2",
         "cross-env": "^6.0.3",
         "express": "^4.17.1",
         "mkpath": "^1.0.0",


### PR DESCRIPTION
chai was both in dependencies and devDependencies. Since the package
seems to use chai in public API, remove the devDependency

