### PR TITLE
Use Env for dynamic expressions.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -80,9 +80,7 @@ export function evaluateTechniqueAttr<T = Value>(
             evaluated = undefined;
         }
     } else if (isInterpolatedProperty(attrValue)) {
-        const storageLevel =
-            context instanceof Env ? (context.lookup("$zoom") as number) : context.zoomLevel;
-        evaluated = getPropertyValue(attrValue, storageLevel) as any;
+        evaluated = getPropertyValue(attrValue, context instanceof Env ? context : context.env);
     } else {
         evaluated = (attrValue as unknown) as Value;
     }

--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -6,7 +6,7 @@
 
 import { CallExpr, ExprScope, LiteralExpr, NumberLiteralExpr, Value } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
-import { createInterpolatedProperty, getPropertyValue } from "../InterpolatedProperty";
+import { createInterpolatedProperty, evaluateInterpolatedProperty } from "../InterpolatedProperty";
 import { InterpolatedProperty, InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
 
 type InterpolateCallExpr = CallExpr & {
@@ -313,7 +313,7 @@ const operators = {
                 }
             }
 
-            return getPropertyValue(interpolatedProperty, context.env);
+            return evaluateInterpolatedProperty(interpolatedProperty, context.env);
         }
     },
     step: {
@@ -356,7 +356,7 @@ const operators = {
                 }
             }
 
-            return getPropertyValue(interpolatedProperty, context.env);
+            return evaluateInterpolatedProperty(interpolatedProperty, context.env);
         }
     }
 };

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -52,6 +52,10 @@ describe("ExprEvaluator", function() {
         };
     }
 
+    function envForZoom(zoom: number) {
+        return new MapEnv({ $zoom: zoom });
+    }
+
     describe("Operator 'all'", function() {
         it("evaluate", function() {
             assert.isTrue(
@@ -686,14 +690,14 @@ describe("ExprEvaluator", function() {
             const interpolation = evaluate(["step", ["zoom"], "#ff0000", 13, "#000000"]);
             for (let zoom = 0; zoom < 13; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#ff0000", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#ff0000", envForZoom(zoom))
                 );
             }
             for (let zoom = 13; zoom < 20; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#000000", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#000000", envForZoom(zoom))
                 );
             }
         });
@@ -710,20 +714,20 @@ describe("ExprEvaluator", function() {
             ]);
 
             assert.strictEqual(
-                getPropertyValue(interpolation, -1),
-                getPropertyValue("#ff0000", -1)
+                getPropertyValue(interpolation, envForZoom(-1)),
+                getPropertyValue("#ff0000", envForZoom(-1))
             );
 
             for (let zoom = 0; zoom < 13; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#00ff00", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#00ff00", envForZoom(zoom))
                 );
             }
             for (let zoom = 13; zoom < 20; ++zoom) {
                 assert.strictEqual(
-                    getPropertyValue(interpolation, zoom),
-                    getPropertyValue("#000000", zoom)
+                    getPropertyValue(interpolation, envForZoom(zoom)),
+                    getPropertyValue("#000000", envForZoom(zoom))
                 );
             }
         });
@@ -1056,7 +1060,7 @@ describe("ExprEvaluator", function() {
         ]);
 
         for (let zoom = 0; zoom < 7; zoom += 0.5) {
-            const value = getPropertyValue(interp, zoom);
+            const value = getPropertyValue(interp, envForZoom(zoom));
             if (zoom < 4) {
                 assert.strictEqual(value, 0);
             } else {

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -8,7 +8,8 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
-import { getPropertyValue } from "../lib/InterpolatedProperty";
+import { MapEnv } from "../lib/Env";
+import { evaluateInterpolatedProperty } from "../lib/InterpolatedProperty";
 import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
@@ -40,104 +41,108 @@ const enumProperty: InterpolatedProperty = {
     values: ["Enum0", "Enum1", "Enum2"]
 };
 
+function evaluateInterpolatedPropertyZoom(property: InterpolatedProperty, level: number) {
+    return evaluateInterpolatedProperty(property, new MapEnv({ $zoom: level }));
+}
+
 describe("Interpolation", function() {
     it("Discrete", () => {
-        assert.strictEqual(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.strictEqual(getPropertyValue(numberProperty, 0), 0);
-        assert.strictEqual(getPropertyValue(numberProperty, 2.5), 0);
-        assert.strictEqual(getPropertyValue(numberProperty, 5), 100);
-        assert.strictEqual(getPropertyValue(numberProperty, 7.5), 100);
-        assert.strictEqual(getPropertyValue(numberProperty, 10), 500);
-        assert.strictEqual(getPropertyValue(numberProperty, Infinity), 500);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 0);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 100);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.strictEqual(getPropertyValue(booleanProperty, -Infinity), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, 0), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, 2.5), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, 5), false);
-        assert.strictEqual(getPropertyValue(booleanProperty, 7.5), false);
-        assert.strictEqual(getPropertyValue(booleanProperty, 10), true);
-        assert.strictEqual(getPropertyValue(booleanProperty, Infinity), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, -Infinity), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 0), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 2.5), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 5), false);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 7.5), false);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, 10), true);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(booleanProperty, Infinity), true);
 
-        assert.strictEqual(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.strictEqual(getPropertyValue(colorProperty, 0), 0xff0000);
-        assert.strictEqual(getPropertyValue(colorProperty, 2.5), 0xff0000);
-        assert.strictEqual(getPropertyValue(colorProperty, 5), 0x00ff00);
-        assert.strictEqual(getPropertyValue(colorProperty, 7.5), 0x00ff00);
-        assert.strictEqual(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.strictEqual(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0xff0000);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x00ff00);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
 
-        assert.strictEqual(getPropertyValue(enumProperty, -Infinity), "Enum0");
-        assert.strictEqual(getPropertyValue(enumProperty, 0), "Enum0");
-        assert.strictEqual(getPropertyValue(enumProperty, 2.5), "Enum0");
-        assert.strictEqual(getPropertyValue(enumProperty, 5), "Enum1");
-        assert.strictEqual(getPropertyValue(enumProperty, 7.5), "Enum1");
-        assert.strictEqual(getPropertyValue(enumProperty, 10), "Enum2");
-        assert.strictEqual(getPropertyValue(enumProperty, Infinity), "Enum2");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, -Infinity), "Enum0");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 0), "Enum0");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 2.5), "Enum0");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 5), "Enum1");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 7.5), "Enum1");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, 10), "Enum2");
+        assert.strictEqual(evaluateInterpolatedPropertyZoom(enumProperty, Infinity), "Enum2");
     });
     it("Linear", () => {
         numberProperty.interpolationMode = InterpolationMode.Linear;
         colorProperty.interpolationMode = InterpolationMode.Linear;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 50);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 300);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 50);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 300);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
         // rgb: [ 0.5, 0.5, 0 ]
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0x7f7f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0x7f7f00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
         // rgb: [ 0, 0.5, 0.5 ]
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x007f7f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x007f7f);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Cubic", () => {
         numberProperty.interpolationMode = InterpolationMode.Cubic;
         colorProperty.interpolationMode = InterpolationMode.Cubic;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 31.25);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 281.25);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 31.25);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 281.25);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
         // rgb: [ 0.4375, 0.625, 0 ]
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0x6f9f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0x6f9f00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
         // rgb: [ 0, 0.625, 0.4375 ]
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x009f6f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x009f6f);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
     it("Exponential", () => {
         numberProperty.interpolationMode = InterpolationMode.Exponential;
         colorProperty.interpolationMode = InterpolationMode.Exponential;
 
-        assert.equal(getPropertyValue(numberProperty, -Infinity), 0);
-        assert.equal(getPropertyValue(numberProperty, 0), 0);
-        assert.equal(getPropertyValue(numberProperty, 2.5), 25);
-        assert.equal(getPropertyValue(numberProperty, 5), 100);
-        assert.equal(getPropertyValue(numberProperty, 7.5), 200);
-        assert.equal(getPropertyValue(numberProperty, 10), 500);
-        assert.equal(getPropertyValue(numberProperty, Infinity), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, -Infinity), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 0), 0);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 2.5), 25);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 5), 100);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 7.5), 200);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, 10), 500);
+        assert.equal(evaluateInterpolatedPropertyZoom(numberProperty, Infinity), 500);
 
-        assert.equal(getPropertyValue(colorProperty, -Infinity), 0xff0000);
-        assert.equal(getPropertyValue(colorProperty, 0), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, -Infinity), 0xff0000);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 0), 0xff0000);
         // rgb: [ 0.75, 0.25, 0 ]
-        assert.equal(getPropertyValue(colorProperty, 2.5), 0xbf3f00);
-        assert.equal(getPropertyValue(colorProperty, 5), 0x00ff00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 2.5), 0xbf3f00);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 5), 0x00ff00);
         // rgb: [ 0, 0.75, 0.25 ]
-        assert.equal(getPropertyValue(colorProperty, 7.5), 0x00bf3f);
-        assert.equal(getPropertyValue(colorProperty, 10), 0x0000ff);
-        assert.equal(getPropertyValue(colorProperty, Infinity), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 7.5), 0x00bf3f);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, 10), 0x0000ff);
+        assert.equal(evaluateInterpolatedPropertyZoom(colorProperty, Infinity), 0x0000ff);
     });
 });

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -6,6 +6,7 @@
 
 import {
     DecodedTile,
+    Env,
     getPropertyValue,
     isPoiTechnique,
     isTextTechnique,
@@ -126,7 +127,7 @@ export class GeoJsonTile extends Tile {
      *
      * @param decodedTile The decoded tile received by the [[GeoJsonDecoder]].
      */
-    createTextElements(decodedTile: DecodedTile, zoomLevel: number) {
+    createTextElements(decodedTile: DecodedTile, env: Env) {
         const tileGeometryCreator = TileGeometryCreator.instance;
         const worldOffsetX = this.computeWorldOffsetX();
 
@@ -135,7 +136,7 @@ export class GeoJsonTile extends Tile {
                 const techniqueIndex = geometry.technique!;
                 const technique = decodedTile.techniques[techniqueIndex];
                 if (isPoiTechnique(technique)) {
-                    this.addPois(geometry, technique, zoomLevel, worldOffsetX);
+                    this.addPois(geometry, technique, env, worldOffsetX);
                 }
             }
         }
@@ -227,7 +228,7 @@ export class GeoJsonTile extends Tile {
             path,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.env),
             xOffset,
             yOffset,
             featureId
@@ -308,7 +309,7 @@ export class GeoJsonTile extends Tile {
             position,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, this.mapView.env),
             xOffset,
             yOffset,
             featureId
@@ -342,7 +343,7 @@ export class GeoJsonTile extends Tile {
     private addPois(
         geometry: PoiGeometry,
         technique: PoiTechnique,
-        zoomLevel: number,
+        env: Env,
         worldOffsetX: number
     ) {
         const attribute = getBufferAttribute(geometry.positions);
@@ -357,7 +358,7 @@ export class GeoJsonTile extends Tile {
             );
             const properties =
                 geometry.objInfos !== undefined ? geometry.objInfos[index] : undefined;
-            this.addPoi(currentVertexCache, technique, zoomLevel, properties);
+            this.addPoi(currentVertexCache, technique, env, properties);
         }
     }
 
@@ -371,14 +372,14 @@ export class GeoJsonTile extends Tile {
     private addPoi(
         position: THREE.Vector3,
         technique: PoiTechnique,
-        zoomLevel: number,
+        env: Env,
         geojsonProperties?: {}
     ) {
         const label = DEFAULT_LABELED_ICON.label;
         const priority =
             technique.priority === undefined ? DEFAULT_LABELED_ICON.priority : technique.priority;
-        const xOffset = getPropertyValue(technique.xOffset, zoomLevel);
-        const yOffset = getPropertyValue(technique.yOffset, zoomLevel);
+        const xOffset = getPropertyValue(technique.xOffset, env);
+        const yOffset = getPropertyValue(technique.yOffset, env);
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
@@ -388,7 +389,7 @@ export class GeoJsonTile extends Tile {
             position,
             styleCache.getRenderStyle(this, technique),
             styleCache.getLayoutStyle(this, technique),
-            getPropertyValue(priority, this.mapView.zoomLevel),
+            getPropertyValue(priority, env),
             xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : xOffset,
             yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : yOffset,
             featureId

--- a/@here/harp-geojson-datasource/test/GeoJsonTest.ts
+++ b/@here/harp-geojson-datasource/test/GeoJsonTest.ts
@@ -321,7 +321,7 @@ describe("@here-geojson-datasource", () => {
         mapView.addDataSource(datasource);
 
         const tile = new FakeGeoJsonTile(datasource, new TileKey(1, 1, 5));
-        tile.createTextElements(decodedTile, 6);
+        tile.createTextElements(decodedTile, mapView.env);
         const userTextElements = tile.userTextElements;
 
         // Text element for points.

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
+    Env,
     GeometryKind,
     GradientSky,
     ImageTexture,
     Light,
+    MapEnv,
     PostEffects,
     Sky,
     Theme
@@ -795,6 +797,8 @@ export class MapView extends THREE.EventDispatcher {
     private m_languages: string[] | undefined;
     private m_copyrightInfo: CopyrightInfo[] = [];
     private m_animatedExtrusionHandler: AnimatedExtrusionHandler;
+
+    private m_env: MapEnv = new MapEnv({});
 
     private m_enableMixedLod: boolean | undefined;
 
@@ -1725,6 +1729,13 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
+     * Environment used to evaluate dynamic scene expressions.
+     */
+    get env(): Env {
+        return this.m_env;
+    }
+
+    /**
      * Returns the storage level for the given camera setup.
      * Actual storage level of the rendered data also depends on [[DataSource.storageLevelOffset]].
      */
@@ -2558,6 +2569,19 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
+     * Update `Env` instance used for style `Expr` evaluations.
+     */
+    private updateEnv() {
+        this.m_env.entries.$zoom = this.m_zoomLevel;
+
+        // This one introduces unnecessary calculation of pixelToWorld, even if it's barely
+        // used in our styles.
+        this.m_env.entries.$pixelToMeters = this.pixelToWorld;
+
+        this.m_env.entries.$frameNumber = this.m_frameNumber;
+    }
+
+    /**
      * Returns the height of the camera above the earths surface.
      *
      * If there is an ElevationProvider, this is used. Otherwise the projection is used to determine
@@ -2729,6 +2753,8 @@ export class MapView extends THREE.EventDispatcher {
         }
 
         this.updateCameras();
+        this.updateEnv();
+
         this.m_renderer.clear();
 
         // clear the scene

--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -115,7 +115,7 @@ export class PolarTileDataSource extends DataSource {
         const techniques = styleSetEvaluator.getMatchingTechniques(env);
 
         return techniques.length !== 0
-            ? createMaterial({ technique: techniques[0], level: 1 })
+            ? createMaterial({ technique: techniques[0], env })
             : undefined;
     }
 

--- a/@here/harp-mapview/lib/RoadPicker.ts
+++ b/@here/harp-mapview/lib/RoadPicker.ts
@@ -83,11 +83,7 @@ export class RoadPicker {
                               const unitFactor =
                                   technique.metricUnit === "Pixel" ? mapView.pixelToWorld : 1.0;
                               return (
-                                  getPropertyValue(
-                                      technique.lineWidth,
-                                      mapView.zoomLevel,
-                                      mapView.pixelToWorld
-                                  ) *
+                                  getPropertyValue(technique.lineWidth, mapView.env) *
                                   unitFactor *
                                   0.5
                               );

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -497,24 +497,24 @@ export class PoiManager {
         // The current zoomlevel of mapview. Since this method is called for all tiles in the
         // VisibleTileSet we can be sure that the current zoomlevel matches the zoomlevel where
         // the tile should be shown.
-        const displayZoomLevel = this.mapView.zoomLevel;
+        const env = this.mapView.env;
         const fadeNear =
             technique.fadeNear !== undefined
-                ? getPropertyValue(technique.fadeNear, displayZoomLevel)
+                ? getPropertyValue(technique.fadeNear, env)
                 : technique.fadeNear;
         const fadeFar =
             technique.fadeFar !== undefined
-                ? getPropertyValue(technique.fadeFar, displayZoomLevel)
+                ? getPropertyValue(technique.fadeFar, env)
                 : technique.fadeFar;
-        const xOffset = getPropertyValue(technique.xOffset, displayZoomLevel);
-        const yOffset = getPropertyValue(technique.yOffset, displayZoomLevel);
+        const xOffset = getPropertyValue(technique.xOffset, env);
+        const yOffset = getPropertyValue(technique.yOffset, env);
 
         const textElement: TextElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             positions,
             textElementsRenderer.styleCache.getRenderStyle(tile, technique),
             textElementsRenderer.styleCache.getLayoutStyle(tile, technique),
-            getPropertyValue(priority, displayZoomLevel),
+            getPropertyValue(priority, env),
             xOffset !== undefined ? xOffset : 0.0,
             yOffset !== undefined ? yOffset : 0.0,
             featureId,

--- a/@here/harp-mapview/lib/text/MapViewState.ts
+++ b/@here/harp-mapview/lib/text/MapViewState.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeometryKindSet } from "@here/harp-datasource-protocol";
+import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { Projection } from "@here/harp-geoutils";
 import { ElevationProvider } from "../ElevationProvider";
 import { MapView } from "../MapView";
@@ -30,6 +30,9 @@ export class MapViewState implements ViewState {
     }
     get zoomLevel(): number {
         return this.m_mapView.zoomLevel;
+    }
+    get env(): Env {
+        return this.m_mapView.env;
     }
     get frameNumber(): number {
         return this.m_mapView.frameNumber;

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Env } from "@here/harp-datasource-protocol";
 import { ProjectionType } from "@here/harp-geoutils";
 import {
     HorizontalAlignment,
@@ -255,7 +256,7 @@ export enum PlacementResult {
  * @param screenPosition Screen position of the icon.
  * @param scaleFactor Scaling factor to apply to the icon dimensions.
  * @param screenCollisions Used to check the icon visibility and collisions.
- * @param zoomLevel Current zoom level.
+ * @param env Current map env.
  * @returns `PlacementResult.Ok` if icon can be placed, `PlacementResult.Rejected` if there's
  * a collision, `PlacementResult.Invisible` if it's not visible.
  */
@@ -264,10 +265,10 @@ export function placeIcon(
     poiInfo: PoiInfo,
     screenPosition: THREE.Vector2,
     scaleFactor: number,
-    zoomLevel: number,
+    env: Env,
     screenCollisions: ScreenCollisions
 ): PlacementResult {
-    PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scaleFactor, zoomLevel, tmp2DBox);
+    PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scaleFactor, env, tmp2DBox);
     if (!screenCollisions.isVisible(tmp2DBox)) {
         return PlacementResult.Invisible;
     }

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1575,8 +1575,7 @@ export class TextElementsRenderer {
             textDistance,
             this.m_viewState.lookAtDistance
         );
-        const iconReady =
-            renderIcon && poiRenderer.prepareRender(pointLabel, this.m_viewState.zoomLevel);
+        const iconReady = renderIcon && poiRenderer.prepareRender(pointLabel, this.m_viewState.env);
 
         if (iconReady) {
             const result = placeIcon(
@@ -1584,7 +1583,7 @@ export class TextElementsRenderer {
                 poiInfo!,
                 tempPoiScreenPosition,
                 distanceScaleFactor,
-                this.m_viewState.zoomLevel,
+                this.m_viewState.env,
                 this.m_screenCollisions
             );
             if (result === PlacementResult.Invisible) {
@@ -1689,7 +1688,7 @@ export class TextElementsRenderer {
                     distanceScaleFactor,
                     allocateSpace,
                     opacity,
-                    this.m_viewState.zoomLevel
+                    this.m_viewState.env
                 );
 
                 if (placementStats) {
@@ -1739,7 +1738,7 @@ export class TextElementsRenderer {
         const poiInfo = lineMarkerLabel.poiInfo!;
         if (
             path.length === 0 ||
-            !poiRenderer.prepareRender(lineMarkerLabel, this.m_viewState.zoomLevel)
+            !poiRenderer.prepareRender(lineMarkerLabel, this.m_viewState.env)
         ) {
             return;
         }

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -9,6 +9,7 @@ import {
     getPropertyValue,
     IndexedTechniqueParams,
     LineMarkerTechnique,
+    MapEnv,
     PoiTechnique,
     Technique,
     TextStyleDefinition,
@@ -303,11 +304,14 @@ export class TextStyleCache {
         const mapView = tile.mapView;
         const dataSource = tile.dataSource;
         const zoomLevel = mapView.zoomLevel;
-        const zoomLevelInt = Math.floor(zoomLevel);
+        const discreteZoomLevel = Math.floor(zoomLevel);
 
-        const cacheId = computeStyleCacheId(dataSource.name, technique, zoomLevelInt);
+        const cacheId = computeStyleCacheId(dataSource.name, technique, discreteZoomLevel);
         let renderStyle = this.m_textRenderStyleCache.get(cacheId);
         if (renderStyle === undefined) {
+            // Environment with $zoom forced to integer to achieve stable interpolated values.
+            const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.env);
+
             const defaultRenderParams = this.m_defaultStyle.renderParams;
 
             // Sets opacity to 1.0 if default and technique attribute are undefined.
@@ -315,13 +319,13 @@ export class TextStyleCache {
             // Interpolate opacity but only on discreet zoom levels (step interpolation).
             let opacity = getPropertyValue(
                 getOptionValue(technique.opacity, defaultOpacity),
-                zoomLevelInt
+                discreteZoomEnv
             );
 
             let color: THREE.Color | undefined;
             // Store color (RGB) in cache and multiply opacity value with the color alpha channel.
             if (technique.color !== undefined) {
-                let hexColor = evaluateColorProperty(technique.color, zoomLevelInt);
+                let hexColor = evaluateColorProperty(technique.color, discreteZoomEnv);
                 if (ColorUtils.hasAlphaInHex(hexColor)) {
                     const alpha = ColorUtils.getAlphaFromHex(hexColor);
                     opacity = opacity * alpha;
@@ -337,7 +341,7 @@ export class TextStyleCache {
             );
             const backgroundSize = getPropertyValue(
                 getOptionValue(technique.backgroundSize, defaultBackgroundSize),
-                zoomLevelInt
+                discreteZoomEnv
             );
 
             const hasBackgroundDefined =
@@ -358,13 +362,13 @@ export class TextStyleCache {
                     technique.backgroundOpacity,
                     hasBackgroundDefined ? 1.0 : defaultBackgroundOpacity
                 ),
-                zoomLevelInt
+                discreteZoomEnv
             );
 
             let backgroundColor: THREE.Color | undefined;
             // Store background color (RGB) in cache and multiply backgroundOpacity by its alpha.
             if (technique.backgroundColor !== undefined) {
-                let hexBgColor = evaluateColorProperty(technique.backgroundColor, zoomLevelInt);
+                let hexBgColor = evaluateColorProperty(technique.backgroundColor, discreteZoomEnv);
                 if (ColorUtils.hasAlphaInHex(hexBgColor)) {
                     const alpha = ColorUtils.getAlphaFromHex(hexBgColor);
                     backgroundOpacity = backgroundOpacity * alpha;
@@ -379,7 +383,7 @@ export class TextStyleCache {
                     unit: FontUnit.Pixel,
                     size: getPropertyValue(
                         getOptionValue(technique.size, defaultRenderParams.fontSize!.size),
-                        zoomLevelInt
+                        discreteZoomEnv
                     ),
                     backgroundSize
                 },
@@ -434,20 +438,24 @@ export class TextStyleCache {
         tile: Tile,
         technique: TextTechnique | PoiTechnique | LineMarkerTechnique
     ): TextLayoutStyle {
+        const mapView = tile.mapView;
         const floorZoomLevel = Math.floor(tile.mapView.zoomLevel);
         const cacheId = computeStyleCacheId(tile.dataSource.name, technique, floorZoomLevel);
         let layoutStyle = this.m_textLayoutStyleCache.get(cacheId);
 
         if (layoutStyle === undefined) {
+            // Environment with $zoom forced to integer to achieve stable interpolated values.
+            const discreteZoomEnv = new MapEnv({ $zoom: floorZoomLevel }, mapView.env);
+
             const defaultLayoutParams = this.m_defaultStyle.layoutParams;
 
-            const hAlignment = getPropertyValue(technique.hAlignment, floorZoomLevel) as
+            const hAlignment = getPropertyValue(technique.hAlignment, discreteZoomEnv) as
                 | string
                 | undefined;
-            const vAlignment = getPropertyValue(technique.vAlignment, floorZoomLevel) as
+            const vAlignment = getPropertyValue(technique.vAlignment, discreteZoomEnv) as
                 | string
                 | undefined;
-            const wrapping = getPropertyValue(technique.wrappingMode, floorZoomLevel) as
+            const wrapping = getPropertyValue(technique.wrappingMode, discreteZoomEnv) as
                 | string
                 | undefined;
 
@@ -463,22 +471,22 @@ export class TextStyleCache {
 
             const layoutParams = {
                 tracking:
-                    getPropertyValue(technique.tracking, floorZoomLevel) ??
+                    getPropertyValue(technique.tracking, discreteZoomEnv) ??
                     defaultLayoutParams.tracking,
                 leading:
-                    getPropertyValue(technique.leading, floorZoomLevel) ??
+                    getPropertyValue(technique.leading, discreteZoomEnv) ??
                     defaultLayoutParams.leading,
                 maxLines:
-                    getPropertyValue(technique.maxLines, floorZoomLevel) ??
+                    getPropertyValue(technique.maxLines, discreteZoomEnv) ??
                     defaultLayoutParams.maxLines,
                 lineWidth:
-                    getPropertyValue(technique.lineWidth, floorZoomLevel) ??
+                    getPropertyValue(technique.lineWidth, discreteZoomEnv) ??
                     defaultLayoutParams.lineWidth,
                 canvasRotation:
-                    getPropertyValue(technique.canvasRotation, floorZoomLevel) ??
+                    getPropertyValue(technique.canvasRotation, discreteZoomEnv) ??
                     defaultLayoutParams.canvasRotation,
                 lineRotation:
-                    getPropertyValue(technique.lineRotation, floorZoomLevel) ??
+                    getPropertyValue(technique.lineRotation, discreteZoomEnv) ??
                     defaultLayoutParams.lineRotation,
                 wrappingMode:
                     wrapping === "None" || wrapping === "Character" || wrapping === "Word"

--- a/@here/harp-mapview/lib/text/ViewState.ts
+++ b/@here/harp-mapview/lib/text/ViewState.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeometryKindSet } from "@here/harp-datasource-protocol";
+import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { Projection } from "@here/harp-geoutils";
 import { ElevationProvider } from "../ElevationProvider";
 
@@ -16,6 +16,7 @@ export interface ViewState {
     cameraIsMoving: boolean; // Whether view's camera is currently moving.
     maxVisibilityDist: number; // Maximum far plane distance.
     zoomLevel: number; // View's zoom level.
+    env: Env;
     frameNumber: number; // Current frame number.
     lookAtDistance: number; // Distance to the lookAt point.
     isDynamic: boolean; // Whether a new frame for the view is already requested.

--- a/@here/harp-mapview/test/DecodedTileHelpersTest.ts
+++ b/@here/harp-mapview/test/DecodedTileHelpersTest.ts
@@ -7,13 +7,14 @@
 import { assert } from "chai";
 import * as THREE from "three";
 
-import { SolidLineTechnique } from "@here/harp-datasource-protocol";
+import { MapEnv, SolidLineTechnique } from "@here/harp-datasource-protocol";
 import { SolidLineMaterial } from "@here/harp-materials";
 import { applyBaseColorToMaterial, createMaterial } from "../lib/DecodedTileHelpers";
 
 // tslint:disable:only-arrow-functions
 
 describe("DecodedTileHelpers", function() {
+    const env = new MapEnv({ $zoom: 10 });
     describe("#createMaterial", function() {
         it("supports #rgba in base material colors", function() {
             const technique: SolidLineTechnique = {
@@ -22,7 +23,7 @@ describe("DecodedTileHelpers", function() {
                 renderOrder: 0,
                 color: "#f0f7"
             };
-            const material = createMaterial({ technique, level: 10 })! as SolidLineMaterial;
+            const material = createMaterial({ technique, env })! as SolidLineMaterial;
             assert.exists(material);
 
             assert.approximately(material.opacity, 7 / 15, 0.00001);
@@ -38,7 +39,7 @@ describe("DecodedTileHelpers", function() {
                 color: "#f0f",
                 secondaryColor: "#f0f7"
             };
-            const material = createMaterial({ technique, level: 10 })! as SolidLineMaterial;
+            const material = createMaterial({ technique, env })! as SolidLineMaterial;
             assert.exists(material);
 
             assert.equal(material.opacity, 1);
@@ -56,7 +57,7 @@ describe("DecodedTileHelpers", function() {
             renderOrder: 0,
             color: "#f0f7"
         };
-        applyBaseColorToMaterial(material, material.color, technique, technique.color, 10);
+        applyBaseColorToMaterial(material, material.color, technique, technique.color, env);
 
         assert.approximately(material.opacity, 7 / 15, 0.00001);
         assert.equal(material.blending, THREE.CustomBlending);
@@ -64,7 +65,7 @@ describe("DecodedTileHelpers", function() {
         assert.equal(material.transparent, false);
 
         technique.color = "#f0f";
-        applyBaseColorToMaterial(material, material.color, technique, technique.color, 10);
+        applyBaseColorToMaterial(material, material.color, technique, technique.color, env);
 
         assert.equal(material.opacity, 1);
         assert.equal(material.blending, THREE.NormalBlending);

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Theme } from "@here/harp-datasource-protocol";
+import { MapEnv, Theme } from "@here/harp-datasource-protocol";
 import { identityProjection, TileKey } from "@here/harp-geoutils";
 import { TextCanvas } from "@here/harp-text-canvas";
 import { assert, expect } from "chai";
@@ -50,6 +50,7 @@ function createViewState(worldCenter: THREE.Vector3, sandbox: sinon.SinonSandbox
         maxVisibilityDist: 10000,
         // This level affects the distance tolerance applied to find label replacement by location.
         zoomLevel: 20,
+        env: new MapEnv({ $zoom: 20 }),
         frameNumber: 0,
         lookAtDistance: 0,
         isDynamic: false,

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -6,7 +6,7 @@
 
 // tslint:disable:only-arrow-functions
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
-import { ShaderTechnique } from "@here/harp-datasource-protocol";
+import { MapEnv, ShaderTechnique } from "@here/harp-datasource-protocol";
 import { assert } from "chai";
 import * as THREE from "three";
 import { createMaterial, getObjectConstructor } from "./../lib/DecodedTileHelpers";
@@ -26,8 +26,8 @@ describe("Tile Creation", function() {
             },
             renderOrder: 0
         };
-        const level = 14;
-        const shaderMaterial = createMaterial({ technique, level });
+        const env = new MapEnv({ $zoom: 14 });
+        const shaderMaterial = createMaterial({ technique, env });
         assert.isTrue(
             shaderMaterial instanceof THREE.ShaderMaterial,
             "expected a THREE.ShaderMaterial"

--- a/@here/harp-mapview/test/stubPoiRenderer.ts
+++ b/@here/harp-mapview/test/stubPoiRenderer.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Env } from "@here/harp-datasource-protocol";
 import { Math2D } from "@here/harp-utils";
 import * as sinon from "sinon";
 import * as THREE from "three";
@@ -38,13 +39,13 @@ export function stubPoiRenderer(
             scale: number,
             allocateScreenSpace: boolean,
             opacity: number,
-            zoomLevel: number
+            env: Env
         ) => {
             // TODO: HARP-7648 Refactor PoiRenderer.renderPoi, to take out
             // bbox computation(already done during placement) and screen allocation (should
             // be done during placement instead).
             const bbox = new Math2D.Box();
-            PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scale, zoomLevel, bbox);
+            PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scale, env, bbox);
             if (allocateScreenSpace) {
                 screenCollisions.allocate(bbox);
             }

--- a/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
+++ b/@here/harp-omv-datasource/lib/OmvDebugLabelsTile.ts
@@ -95,7 +95,7 @@ export class OmvDebugLabelsTile extends OmvTile {
         // allow limiting to specific names and/or index. There can be many paths with the same text
         const textFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.TEXT");
         const indexFilter = debugContext.getValue("DEBUG_TEXT_PATHS.FILTER.INDEX");
-        const zoomLevel = this.mapView.zoomLevel;
+        const env = this.mapView.env;
 
         if (decodedTile.textPathGeometries !== undefined) {
             this.preparedTextPaths = tileGeometryCreator.prepareTextPaths(
@@ -129,7 +129,7 @@ export class OmvDebugLabelsTile extends OmvTile {
                 if (technique.color !== undefined) {
                     colorMap.set(
                         textPath.technique,
-                        new THREE.Color(getPropertyValue(technique.color, zoomLevel))
+                        new THREE.Color(getPropertyValue(technique.color, env))
                     );
                 }
 
@@ -188,7 +188,7 @@ export class OmvDebugLabelsTile extends OmvTile {
                                     new THREE.Vector3(x + worldOffsetX, y, z),
                                     textRenderStyle,
                                     textLayoutStyle,
-                                    getPropertyValue(technique.priority || 0, zoomLevel),
+                                    getPropertyValue(technique.priority || 0, env),
                                     technique.xOffset || 0.0,
                                     technique.yOffset || 0.0
                                 );


### PR DESCRIPTION
Use `Env` in invocations of `getPropertyValue` to support other dynamic
properties than `zoomLevel` only.

