### PR TITLE
UrlUtils: URI reference resolution cross-platform

### DIFF
--- a/@here/harp-utils/lib/UrlUtils.ts
+++ b/@here/harp-utils/lib/UrlUtils.ts
@@ -47,7 +47,7 @@ export function resolveReferenceUri(parentUri: string | undefined, childUri: str
     }
 }
 
-const absoluteUrlWithOriginRe = new RegExp("^(?:[a-z]+:)?//", "i");
+const absoluteUrlWithOriginRe = /^(?:[a-z]+:)?(\/\/|\\\\?)/i;
 
 /**
  * Returns base URL of given resource URL.

--- a/@here/harp-utils/test/UrlUtilsTest.ts
+++ b/@here/harp-utils/test/UrlUtilsTest.ts
@@ -58,6 +58,8 @@ describe("UrlUtils", function() {
                 "https://bar.com/foo"
             );
             assert.equal(resolveReferenceUri("https://bar.com", "//bar.com/foo"), "//bar.com/foo");
+            assert.equal(resolveReferenceUri("https://bar.com", "C:\\bar.com\\foo"), "C:\\bar.com\\foo");
+            assert.equal(resolveReferenceUri("https://bar.com", "\\\\bar.com\\foo"), "\\\\bar.com\\foo");
         });
     });
 


### PR DESCRIPTION
In order to determine if a path of a referenced resource in a scheme (or child
URI) is absolute, the string is tested against a regular expression which only
covered non-Windows paths. This led to problems when actually working with
resource paths on Windows.

This change allows to detect absolute paths in a Windows-format as well

Signed-off-by: ESTIB <jose.vega@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
