### PR TITLE
Honor $EXTRA_TSC_ARGS when building

### DIFF
--- a/@here/harp-atlas-tools/package.json
+++ b/@here/harp-atlas-tools/package.json
@@ -8,7 +8,7 @@
         "harp-sprites-generator": "lib/cli-sprites-generator.js"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "watch": "tsc -w",
         "generateAtlas": "ts-node src/cli-atlas-generator.ts",
         "generateSprites": "ts-node src/cli-sprites-generator.ts",

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS",
         "generate-json-schema": "ts-json-schema-generator -c -p ./lib/Theme.ts -t Theme -k defaultSnippets > theme.schema.json"
     },

--- a/@here/harp-datasource-protocol/test/ThemeTypingsTest.ts
+++ b/@here/harp-datasource-protocol/test/ThemeTypingsTest.ts
@@ -70,10 +70,10 @@ function validate(type: string, response: any, validationExpectedToFail: boolean
     assert.strictEqual(!result, validationExpectedToFail);
 }
 
-describeOnlyNode("Theme typings test", function() {
+describeOnlyNode("Theme typings test", function(this: Mocha.Suite) {
     this.timeout(30000);
 
-    it("syntax test for properly defined Theme object", function() {
+    it("syntax test for properly defined Theme object", function(this: Mocha.Context) {
         this.timeout(30000);
 
         const ProperTheme = {
@@ -99,7 +99,8 @@ describeOnlyNode("Theme typings test", function() {
         validate("Theme", ProperTheme);
     });
 
-    it("syntax test for improperly defined Theme object (excessive properties)", function() {
+    // tslint:disable-next-line: max-line-length
+    it("syntax test for improperly defined Theme object (excessive properties)", function(this: Mocha.Context) {
         this.timeout(30000);
 
         const ImproperTheme = {

--- a/@here/harp-debug-datasource/package.json
+++ b/@here/harp-debug-datasource/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-features-datasource/package.json
+++ b/@here/harp-features-datasource/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-fetch/package.json
+++ b/@here/harp-fetch/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-geojson-datasource/package.json
+++ b/@here/harp-geojson-datasource/package.json
@@ -9,7 +9,7 @@
         "main": "index-worker.js"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-geometry/package.json
+++ b/@here/harp-geometry/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
@@ -35,7 +35,7 @@ class TransverseMercatorProjection extends Projection {
      * So, in transverse we need to compute distnce to poles, and clamp if
      * radius is exceeded
      */
-    static clampGeoPoint(geoPoint: GeoCoordinatesLike, unitScale: number) {
+    static clampGeoPoint(geoPoint: GeoCoordinatesLike, _unitScale: number) {
         const lat = geoPoint.latitude;
         const lon = geoPoint.longitude;
 

--- a/@here/harp-geoutils/package.json
+++ b/@here/harp-geoutils/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-lines/package.json
+++ b/@here/harp-lines/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-lines/test/rendering/RenderLines.ts
+++ b/@here/harp-lines/test/rendering/RenderLines.ts
@@ -281,12 +281,12 @@ describe("Rendering lines: ", function() {
         await ibct.assertCanvasMatchesReference(canvas, `${name}`);
     }
 
-    it("renders solid lines - lineWidth: 1", async function() {
+    it("renders solid lines - lineWidth: 1", async function(this: Mocha.Context) {
         const lineStyle = { lineWidth: 1, color: "#FFF" };
         await renderLines(linesConfig, this, "solid-lines-1px", lineStyle);
     });
 
-    it("renders undisplaced solid lines - perspective camera", async function() {
+    it("renders undisplaced solid lines - perspective camera", async function(this: Mocha.Context) {
         const config = displacedLinesConfig;
         const { width, height } = getCanvasSize(config);
         const camera = createPerspectiveCamera(width, height);
@@ -298,7 +298,7 @@ describe("Rendering lines: ", function() {
         await renderLines(config, this, "undisplaced-solid-lines-persective", lineStyle, camera);
     });
 
-    it("renders displaced solid lines - perspective camera", async function() {
+    it("renders displaced solid lines - perspective camera", async function(this: Mocha.Context) {
         const config = displacedLinesConfig;
         const { width, height } = getCanvasSize(config);
         const camera = createPerspectiveCamera(width, height);
@@ -312,17 +312,18 @@ describe("Rendering lines: ", function() {
         await renderLines(config, this, "displaced-solid-lines-persective", lineStyle, camera);
     });
 
-    it("renders solid lines - lineWidth: 20", async function() {
+    it("renders solid lines - lineWidth: 20", async function(this: Mocha.Context) {
         const lineStyle = { lineWidth: 20, color: "#FFF" };
         await renderLines(linesConfig, this, "solid-lines-20px", lineStyle);
     });
 
-    it("renders solid lines with outline - outlineWidth: 5", async function() {
+    it("renders solid lines with outline - outlineWidth: 5", async function(this: Mocha.Context) {
         const lineStyle = { lineWidth: 10, color: "#F00", outlineWidth: 5, outlineColor: "#0F0" };
         await renderLines(linesConfig, this, "solid-lines-outline", lineStyle);
     });
 
-    it("renders dashed lines with outline - outlineWidth: 3, dashSize: 4", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines with outline - outlineWidth: 3, dashSize: 4", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 4,
             color: "#F00",
@@ -335,7 +336,7 @@ describe("Rendering lines: ", function() {
         await renderLines(linesConfig, this, "dashed-lines-outline", lineStyle);
     });
 
-    it("renders dashed lines with outline - transparent", async function() {
+    it("renders dashed lines with outline - transparent", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 4,
             color: "#F00",
@@ -347,12 +348,13 @@ describe("Rendering lines: ", function() {
         await renderLines(linesConfig, this, "dashed-lines-outline-alpha", lineStyle);
     });
 
-    it("renders dashed lines - lineWidth: 1, gapSize: 2, dashSize: 2", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines - lineWidth: 1, gapSize: 2, dashSize: 2", async function(this: Mocha.Context) {
         const lineStyle = { lineWidth: 1, color: "#FFF", gapSize: 2, dashSize: 2 };
         await renderLines(linesConfig, this, "dashed-lines-1px", lineStyle);
     });
 
-    it("renders dashed lines with dashColor: #F00", async function() {
+    it("renders dashed lines with dashColor: #F00", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 1,
             color: "#FFF",
@@ -363,17 +365,18 @@ describe("Rendering lines: ", function() {
         await renderLines(linesConfig, this, "dashed-lines-color", lineStyle);
     });
 
-    it("renders dashed lines - lineWidth: 20,gapSize: 2, dashSize: 2", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines - lineWidth: 20,gapSize: 2, dashSize: 2", async function(this: Mocha.Context) {
         const lineStyle = { lineWidth: 20, color: "#FFF", gapSize: 2, dashSize: 2 };
         await renderLines(linesConfig, this, "dashed-lines-20px", lineStyle);
     });
 
-    it("renders solid lines - overdraw check", async function() {
+    it("renders solid lines - overdraw check", async function(this: Mocha.Context) {
         const lineStyle = { lineWidth: 20, color: "#FFF", opacity: 0.5, transparent: true };
         await renderLines(checkOverDrawLines, this, "solid-lines-overdraw-20px", lineStyle);
     });
 
-    it("renders dashed lines - overdraw check", async function() {
+    it("renders dashed lines - overdraw check", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 20,
             color: "#FFF",
@@ -385,7 +388,8 @@ describe("Rendering lines: ", function() {
         await renderLines(checkOverDrawLines, this, "dashed-lines-overdraw-20px", lineStyle);
     });
 
-    it("renders dashed lines with round dashes - no outline, dashSize: 16", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines with round dashes - no outline, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Round",
             lineWidth: 8,
@@ -402,7 +406,8 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders dashed lines with round dashes - outlineWidth: 3, dashSize: 16", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines with round dashes - outlineWidth: 3, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Round",
             lineWidth: 8,
@@ -421,7 +426,8 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders dashed lines with diamond dashes - no outline, dashSize: 16", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines with diamond dashes - no outline, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Diamond",
             lineWidth: 8,
@@ -438,7 +444,8 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders dashed lines w/ diamond dashes - outlineWidth: 3, dashSize: 16", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("renders dashed lines w/ diamond dashes - outlineWidth: 3, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Diamond",
             lineWidth: 8,
@@ -457,7 +464,7 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders dashed lines with stretched diamond dashes", async function() {
+    it("renders dashed lines with stretched diamond dashes", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Diamond",
             lineWidth: 8,
@@ -474,7 +481,7 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders solid lines - caps check round", async function() {
+    it("renders solid lines - caps check round", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 20,
             color: "#FFF",
@@ -490,7 +497,7 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders solid lines - caps check none", async function() {
+    it("renders solid lines - caps check none", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 20,
             color: "#FFF",
@@ -506,7 +513,7 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders solid lines - caps check square", async function() {
+    it("renders solid lines - caps check square", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 20,
             color: "#FFF",
@@ -522,7 +529,7 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders solid lines - caps check triangle out", async function() {
+    it("renders solid lines - caps check triangle out", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 20,
             color: "#FFF",
@@ -538,7 +545,7 @@ describe("Rendering lines: ", function() {
         );
     });
 
-    it("renders solid lines - caps check triangle in", async function() {
+    it("renders solid lines - caps check triangle in", async function(this: Mocha.Context) {
         const lineStyle = {
             lineWidth: 20,
             color: "#FFF",

--- a/@here/harp-lrucache/package.json
+++ b/@here/harp-lrucache/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-map-controls/package.json
+++ b/@here/harp-map-controls/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-map-theme/package.json
+++ b/@here/harp-map-theme/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare-icons": "ts-node ./scripts/prepareIcons.ts",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS && ts-node ./scripts/prepack.ts"
     },

--- a/@here/harp-mapview-decoder/package.json
+++ b/@here/harp-mapview-decoder/package.json
@@ -13,7 +13,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-mapview/package.json
+++ b/@here/harp-mapview/package.json
@@ -17,7 +17,7 @@
         "test": "test"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -159,7 +159,8 @@ describe("map-view#Utils", function() {
         expect(objSize.gpuSize).to.be.equal(1584); // see previous test
     });
 
-    it("estimate size of world with 1000 cubes (BufferGeometry)", async function() {
+    // tslint:disable-next-line: max-line-length
+    it("estimate size of world with 1000 cubes (BufferGeometry)", async function(this: Mocha.Context) {
         this.timeout(4000);
         const scene: THREE.Scene = new THREE.Scene();
         for (let i = 0; i < 1000; i++) {

--- a/@here/harp-materials/package.json
+++ b/@here/harp-materials/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-olp-utils/package.json
+++ b/@here/harp-olp-utils/package.json
@@ -4,7 +4,7 @@
     "description": "HERE OLP utilities",
     "main": "index.js",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-omv-datasource/package.json
+++ b/@here/harp-omv-datasource/package.json
@@ -12,7 +12,7 @@
         "test": "test"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/OmvTest.js",
         "gen-decoder": "pbjs -t static-module -w commonjs --no-encode --no-verify --no-create lib/proto/vector_tile.proto -o lib/proto/vector_tile.js && pbts lib/proto/vector_tile.js -o lib/proto/vector_tile.d.ts",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"

--- a/@here/harp-test-utils/lib/TestUtils.ts
+++ b/@here/harp-test-utils/lib/TestUtils.ts
@@ -249,7 +249,7 @@ function reportAsyncFailuresAfterTestEnd(this: any) {
 }
 
 if (typeof beforeEach !== "undefined") {
-    beforeEach(function() {
+    beforeEach(function(this: Mocha.Context) {
         // Save current test so willEventually && waitForEvent can check that current test is still
         // executing.
         mochaCurrentTest = this.currentTest;

--- a/@here/harp-test-utils/package.json
+++ b/@here/harp-test-utils/package.json
@@ -6,7 +6,7 @@
     "browser": "index.web.js",
     "typings": "index.web",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-text-canvas/package.json
+++ b/@here/harp-text-canvas/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-text-canvas/test/rendering/TextCanvasRenderingTest.ts
+++ b/@here/harp-text-canvas/test/rendering/TextCanvasRenderingTest.ts
@@ -67,7 +67,7 @@ describe("TextCanvas", function() {
         await ibct.assertCanvasMatchesReference(canvas, params.testName);
     }
 
-    it("renders hello world text", async function() {
+    it("renders hello world text", async function(this: Mocha.Context) {
         await basicRenderTest(
             {
                 test: this,
@@ -100,7 +100,7 @@ describe("TextCanvas", function() {
             }
         );
     });
-    it("renders ß", async function() {
+    it("renders ß", async function(this: Mocha.Context) {
         await basicRenderTest(
             {
                 test: this,
@@ -133,7 +133,7 @@ describe("TextCanvas", function() {
             }
         );
     });
-    it("renders ß with dashes", async function() {
+    it("renders ß with dashes", async function(this: Mocha.Context) {
         await basicRenderTest(
             {
                 test: this,
@@ -170,7 +170,7 @@ describe("TextCanvas", function() {
         );
     });
 
-    it("renders rotated hello world text", async function() {
+    it("renders rotated hello world text", async function(this: Mocha.Context) {
         await basicRenderTest(
             {
                 test: this,
@@ -218,7 +218,7 @@ describe("TextCanvas", function() {
         );
     });
 
-    it("renders hello world on path", async function() {
+    it("renders hello world on path", async function(this: Mocha.Context) {
         await basicRenderTest(
             {
                 test: this,

--- a/@here/harp-transfer-manager/package.json
+++ b/@here/harp-transfer-manager/package.json
@@ -10,7 +10,7 @@
     },
     "scripts": {
         "test": "cross-env mocha  --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-utils/package.json
+++ b/@here/harp-utils/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "browser": "index.web.js",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },

--- a/@here/harp-webpack-utils/package.json
+++ b/@here/harp-webpack-utils/package.json
@@ -3,7 +3,7 @@
     "version": "0.12.0",
     "description": "harp.gl webpack utilities",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },
     "repository": {

--- a/@here/harp-webtile-datasource/package.json
+++ b/@here/harp-webtile-datasource/package.json
@@ -8,7 +8,7 @@
         "test": "test"
     },
     "scripts": {
-        "build": "tsc",
+        "build": "tsc $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/WebTileTest.js",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
     },


### PR DESCRIPTION
Allows us to pass extra options to tsc when running from within e.g.
lerna. Good to try out new compiler options.

Also fixed some super strict linter warnings.