### PR TITLE
HARP-8604: Fix for multiple time tile loading using setTimeout() call.

### DIFF
--- a/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { DecodedTile } from "@here/harp-datasource-protocol";
+import {
+    TileKey,
+    TilingScheme,
+    webMercatorProjection,
+    webMercatorTilingScheme
+} from "@here/harp-geoutils";
+import { DataSource, MapView, Statistics, Tile } from "@here/harp-mapview";
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+const { expect } = chai;
+import { TileGeometryCreator } from "@here/harp-mapview/lib/geometry/TileGeometryCreator";
+import { SimpleTileGeometryLoader } from "@here/harp-mapview/lib/geometry/TileGeometryLoader";
+import { willEventually } from "@here/harp-test-utils";
+import * as sinon from "sinon";
+
+class FakeVisibleTileSet {
+    // tslint:disable-next-line: no-empty
+    disposeTile(tile: Tile) {}
+}
+
+class MockDataSource extends DataSource {
+    /** @override */
+    getTilingScheme(): TilingScheme {
+        return webMercatorTilingScheme;
+    }
+
+    /** @override */
+    getTile(tileKey: TileKey): Tile | undefined {
+        // Create a tile which is by default visible for test purposes.
+        const tile = new Tile(this, tileKey);
+        tile.isVisible = true;
+        return tile;
+    }
+}
+
+function createFakeMapView() {
+    return ({
+        projection: webMercatorProjection,
+        // tslint:disable-next-line:no-empty
+        getDataSourceByName() {},
+        statistics: new Statistics(),
+        frameNumber: 5, // must be higher then 0, for tile visibility check
+        visibleTileSet: new FakeVisibleTileSet(),
+        theme: {}
+    } as any) as MapView;
+}
+
+function createFakeDecodedTile(): DecodedTile {
+    return {
+        techniques: [],
+        geometries: []
+    };
+}
+
+const wait = (ms: number = 0) => new Promise(res => setTimeout(res, ms));
+
+describe("SimpleTileGeometryLoader", function() {
+    let tileKey: TileKey;
+    let tile: Tile;
+    let dataSource: DataSource;
+    let mapView: MapView;
+    let geometryLoader: SimpleTileGeometryLoader;
+    let sandbox: any;
+
+    before(function() {
+        tileKey = TileKey.fromRowColumnLevel(0, 0, 0);
+        mapView = createFakeMapView();
+        dataSource = new MockDataSource();
+        dataSource.attach(mapView);
+    });
+
+    beforeEach(function() {
+        tile = dataSource.getTile(tileKey)!;
+        geometryLoader = new SimpleTileGeometryLoader(tile);
+        tile.tileGeometryLoader = geometryLoader;
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe("tile preprocessing", function() {
+        it("should not load geometry before update", function() {
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.basicGeometryLoaded).to.be.false;
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.allGeometryLoaded).to.be.false;
+
+            // tslint:disable-next-line: no-unused-expression
+            return expect(geometryLoader.isFinished).to.be.false;
+        });
+
+        it("should not load geometry before tile is decoded", function() {
+            geometryLoader.update(undefined, undefined);
+            geometryLoader.update(undefined, undefined);
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.geometryCreationPending).to.be.false;
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.basicGeometryLoaded).to.be.false;
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.allGeometryLoaded).to.be.false;
+
+            // tslint:disable-next-line: no-unused-expression
+            return expect(geometryLoader.isFinished).to.be.false;
+        });
+
+        it("should start load geometry for decoded tile", async function() {
+            // Mimic the tile is being decoded.
+            tile.decodedTile = createFakeDecodedTile();
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.isFinished).to.be.false;
+
+            geometryLoader!.update(undefined, undefined);
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.geometryCreationPending).to.be.true;
+
+            await willEventually(() => {
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should not start geometry loading for invisible tile", async function() {
+            // Mimic the tile is being decoded.
+            tile.decodedTile = createFakeDecodedTile();
+            tile.isVisible = false;
+
+            geometryLoader!.update(undefined, undefined);
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.geometryCreationPending).to.be.false;
+
+            await willEventually(() => {
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should not start geometry loading for disposed tile", async function() {
+            // Mimic the tile is being decoded.
+            tile.decodedTile = createFakeDecodedTile();
+            tile.dispose();
+
+            geometryLoader!.update(undefined, undefined);
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.geometryCreationPending).to.be.false;
+
+            await willEventually(() => {
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+    });
+
+    describe("tile geometry creation", function() {
+        it("should not start geometry creation for invisible tile", async function() {
+            tile.decodedTile = createFakeDecodedTile();
+            tile.isVisible = false;
+
+            const geometryCreator = TileGeometryCreator.instance;
+            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
+            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
+
+            expect(spyProcessTechniques.callCount).equal(0);
+            expect(spyCreateGeometries.callCount).equal(0);
+
+            geometryLoader!.update(undefined, undefined);
+
+            expect(spyProcessTechniques.callCount).equal(0);
+            expect(spyCreateGeometries.callCount).equal(0);
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.geometryCreationPending).to.be.false;
+
+            await willEventually(() => {
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should not start geometry creation for disposed tile", async function() {
+            tile.decodedTile = createFakeDecodedTile();
+            tile.dispose();
+
+            const geometryCreator = TileGeometryCreator.instance;
+            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
+            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
+
+            expect(spyProcessTechniques.callCount).equal(0);
+            expect(spyCreateGeometries.callCount).equal(0);
+
+            geometryLoader!.update(undefined, undefined);
+
+            expect(spyProcessTechniques.callCount).equal(0);
+            expect(spyCreateGeometries.callCount).equal(0);
+
+            // tslint:disable-next-line: no-unused-expression
+            expect(geometryLoader.geometryCreationPending).to.be.false;
+
+            await willEventually(() => {
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should start processing geometry for decoded tile only once", async function() {
+            tile.decodedTile = createFakeDecodedTile();
+
+            const geometryCreator = TileGeometryCreator.instance;
+            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
+            const spySetDecodedTile = sandbox.spy(geometryLoader, "setDecodedTile") as any;
+            expect(spyProcessTechniques.callCount).equal(0);
+            expect(spySetDecodedTile.callCount).equal(0);
+
+            // Mimic multiple frame updates.
+            geometryLoader!.update(undefined, undefined);
+            await wait();
+            geometryLoader!.update(undefined, undefined);
+            await wait();
+            geometryLoader!.update(undefined, undefined);
+            await wait();
+
+            expect(spySetDecodedTile.callCount).equal(1);
+            expect(spyProcessTechniques.callCount).equal(1);
+
+            await willEventually(() => {
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should create geometry for decoded tile only once (via timeout)", async function() {
+            tile.decodedTile = createFakeDecodedTile();
+
+            const geometryCreator = TileGeometryCreator.instance;
+            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
+            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
+            expect(spyCreateGeometries.callCount).equal(0);
+            expect(spyProcessTechniques.callCount).equal(0);
+
+            // Mimic multiple frame updates.
+            geometryLoader!.update(undefined, undefined);
+            await wait();
+            geometryLoader!.update(undefined, undefined);
+            await wait();
+            geometryLoader!.update(undefined, undefined);
+            await wait();
+
+            await willEventually(() => {
+                expect(spyProcessTechniques.callCount).equal(1);
+                expect(spyCreateGeometries.callCount).equal(1);
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should not create geometry for invisible tile while in timeout", async function() {
+            tile.decodedTile = createFakeDecodedTile();
+
+            const geometryCreator = TileGeometryCreator.instance;
+            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
+            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
+            expect(spyCreateGeometries.callCount).equal(0);
+            expect(spyProcessTechniques.callCount).equal(0);
+
+            // Mimic multiple frame updates.
+            geometryLoader!.update(undefined, undefined);
+            // Make immediately invisible - if flaky remove this test.
+            tile.isVisible = false;
+            await wait();
+
+            await willEventually(() => {
+                expect(spyProcessTechniques.callCount).equal(1);
+                expect(spyCreateGeometries.callCount).equal(0);
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+
+        it("should not create geometry for disposed tile while in timeout", async function() {
+            tile.decodedTile = createFakeDecodedTile();
+
+            const geometryCreator = TileGeometryCreator.instance;
+            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
+            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
+            expect(spyCreateGeometries.callCount).equal(0);
+            expect(spyProcessTechniques.callCount).equal(0);
+
+            geometryLoader!.update(undefined, undefined);
+            // Make immediately disposed - if flaky remove this test.
+            tile.dispose();
+
+            await willEventually(() => {
+                expect(spyProcessTechniques.callCount).equal(1);
+                expect(spyCreateGeometries.callCount).equal(0);
+                // tslint:disable-next-line: no-unused-expression
+                expect(geometryLoader.isFinished).to.be.true;
+            });
+        });
+    });
+});

--- a/@here/harp-mapview/lib/geometry/PhasedTileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/PhasedTileGeometryLoader.ts
@@ -291,13 +291,20 @@ export class PhasedTileGeometryLoader implements TileGeometryLoader {
         this.m_currentPhaseIndex = 0;
     }
 
+    private finish() {
+        this.m_decodedTile = undefined;
+        this.m_tile.loadingFinished();
+        this.m_tile.removeDecodedTile();
+        this.m_isFinished = true;
+    }
+
     /**
      * Increment the current phase to activate the next phase of geometries.
      *
      * @returns {(number | undefined)} The index into the now active current pase, or `undefined` if
      *      the last phase has been reached.
      */
-    protected nextPhase(): number | undefined {
+    private nextPhase(): number | undefined {
         if (this.m_currentPhaseIndex < this.m_loadPhaseDefinitions.length) {
             this.m_currentPhaseIndex++;
         }
@@ -313,7 +320,7 @@ export class PhasedTileGeometryLoader implements TileGeometryLoader {
      * @param {TileGeometryCreator} geometryCreator
      * @param {GeometryKind} kindToCreate
      */
-    protected createKind(geometryCreator: TileGeometryCreator, kindToCreate: GeometryKind): void {
+    private createKind(geometryCreator: TileGeometryCreator, kindToCreate: GeometryKind): void {
         if (this.m_geometryKindsLoaded.has(kindToCreate)) {
             return;
         }
@@ -364,12 +371,5 @@ export class PhasedTileGeometryLoader implements TileGeometryLoader {
 
             geometryCreator.preparePois(tile, decodedTile);
         }
-    }
-
-    private finish() {
-        this.m_decodedTile = undefined;
-        this.m_tile.loadingFinished();
-        this.m_tile.removeDecodedTile();
-        this.m_isFinished = true;
     }
 }

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -164,6 +164,8 @@ export class TileGeometryCreator {
                 continue;
             }
 
+            // Technique is enabled only if enabledKinds is defined and technique belongs to that set or
+            // if that's not the case, disabledKinds must be undefined or technique does not belong to it.
             technique.enabled =
                 !(disabledKinds !== undefined && disabledKinds.hasOrIntersects(technique.kind)) ||
                 (enabledKinds !== undefined && enabledKinds.hasOrIntersects(technique.kind));


### PR DESCRIPTION
The decoded tiles geometry was loaded/generated multiple times, both with
techniques processing in SimpleTileGeometryLoader.
This patchset fixes the flow so the request for tile load after decoding is
processed only once.
It also adds some sanity checks that ensures us that disposed or unvisible
tiles are no longer loaded/processed.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
