### PR TITLE
HARP-8768: Fix cancellation handling in OlpDataProvider.

### DIFF
--- a/@here/harp-olp-utils/package.json
+++ b/@here/harp-olp-utils/package.json
@@ -26,6 +26,7 @@
         "@here/olp-sdk-dataservice-read": "^1.2.0"
     },
     "devDependencies": {
+        "@here/harp-fetch": "^0.12.0",
         "@here/harp-test-utils": "^0.12.0",
         "@types/chai": "^4.1.2",
         "@types/mocha": "^5.2.7",

--- a/@here/harp-olp-utils/test/OlpDataProviderTest.ts
+++ b/@here/harp-olp-utils/test/OlpDataProviderTest.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import * as sinon from "sinon";
+
+import "@here/harp-fetch";
+import { TileKey } from "@here/harp-geoutils";
+import { assertRejected } from "@here/harp-test-utils";
+import { VersionedLayerClient } from "@here/olp-sdk-dataservice-read";
+import { OlpDataProvider } from "../lib/OlpDataProvider";
+
+describe("OlpDataProvider", function() {
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.createSandbox();
+    });
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    it("#getData doesn't swallow AbortError", async function() {
+        // Check that OlpDataProvider doesn't swallow AbortError.
+
+        // Setup stub VersionedLayerClient.getData to always throw AbortError
+        sandbox.stub(VersionedLayerClient.prototype, "getData").callsFake(async () => {
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    const error = new Error("Aborted");
+                    error.name = "AbortError";
+                    reject(error);
+                }, 1);
+            });
+        });
+
+        const dataProvider = new OlpDataProvider({
+            hrn: "hrn:test:data:::test",
+            layerId: "testLayer",
+            getToken: async () => "token123",
+            version: 333
+        });
+        await dataProvider.connect();
+        const tileKey = TileKey.fromRowColumnLevel(2, 2, 2);
+
+        // Assert that OlpProvider reports `AbortError`
+        await assertRejected(async () => dataProvider.getTile(tileKey), /Aborted/);
+    });
+
+    it("#getData obeys `abortSignal`", async function() {
+        // Check that OlpDataProvider obeys abort signal despite fake successfull
+        // Response.
+
+        // Setup stub VersionedLayerClient.getData to always throw AbortError
+
+        sandbox.stub(VersionedLayerClient.prototype, "getData").callsFake(async () => {
+            return new Promise<Response>((resolve, reject) => {
+                setTimeout(() => {
+                    const fakeResponse: Partial<Response> = {
+                        status: 200
+                    };
+                    resolve(fakeResponse as Response);
+                }, 2);
+            });
+        });
+
+        const dataProvider = new OlpDataProvider({
+            hrn: "hrn:test:data:::test",
+            layerId: "testLayer",
+            getToken: async () => "token123",
+            version: 333
+        });
+        await dataProvider.connect();
+        const tileKey = TileKey.fromRowColumnLevel(2, 2, 2);
+        const abortController = new AbortController();
+
+        // dispatch `abort` to our to our signal
+        setTimeout(() => {
+            abortController.abort();
+        }, 0);
+
+        // Assert that OlpProvider reports `AbortError` when signaled.
+        await assertRejected(
+            async () => dataProvider.getTile(tileKey, abortController.signal),
+            /Aborted/
+        );
+    });
+});


### PR DESCRIPTION
Don't handle `AbortError` in OlpDataProvider.getTile as this should
be loaded up in call chain by `TileLoader`.

Related-to: HARP-8768
