### PR TITLE
MINOR: Fix phased loading default value interpretation.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -524,8 +524,13 @@ export interface MapViewOptions extends TextElementsRendererOptions {
     maxFps?: number;
 
     /**
-     * Enable phased loading. If `false`, the geometry on a [[Tile]] is always being created in a
-     * single step, instead of (potentially) over multiple frames to smoothen animations.
+     * Enable phased loading.
+     *
+     * Enabling this feature allows to minimize performance overhead by distributing geometry
+     * creation over multiple frames, thus decreasing CPU load at single frame for smoother
+     * application feedback and animations.
+     * If `false` or undefined, the geometry on a [[Tile]] is always being created in a single
+     * step, instead of (potentially) over multiple frames.
      *
      * @default `false`
      */
@@ -1744,10 +1749,10 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Returns 'true' if the phased loading is currently enabled.
      *
-     * @default true.
+     * @default `false`.
      */
     get phasedLoadingEnabled(): boolean {
-        return this.m_options.enablePhasedLoading !== false;
+        return this.m_options.enablePhasedLoading === true;
     }
 
     /**


### PR DESCRIPTION
The phased loading in options is interpreted as 'false' by default, such
as it is disabled when the option is undefined.
Fix getter implementation to comply with options interpretation.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
