### PR TITLE
Remove the usages of Technique._keys.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -852,7 +852,6 @@ export class StyleSetEvaluator {
 
         technique._index = this.m_techniques.length;
         technique._styleSetIndex = style._styleSetIndex!;
-        technique._key = key;
         if (style.styleSet !== undefined) {
             technique._styleSet = style.styleSet;
         }

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -522,13 +522,6 @@ export interface IndexedTechniqueParams {
     _index: number;
 
     /**
-     * Unique technique key derived from all dynamic expressions that were input to this particular
-     * technique instance.
-     * @hidden
-     */
-    _key: string;
-
-    /**
      * Optimization: Unique [[Technique]] index of [[Style]] from which technique was derived.
      * @hidden
      */

--- a/@here/harp-datasource-protocol/test/TileInfoTest.ts
+++ b/@here/harp-datasource-protocol/test/TileInfoTest.ts
@@ -221,8 +221,7 @@ describe("ExtendedTileInfo", function() {
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const storedTechnique: IndexedTechnique = {
             name: "squares",
@@ -230,8 +229,7 @@ describe("ExtendedTileInfo", function() {
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const env = new MapEnv({
             $layer: "point_layer-" + index,
@@ -260,8 +258,7 @@ describe("ExtendedTileInfo", function() {
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const storedTechnique: IndexedTechnique = {
             name: "line",
@@ -269,8 +266,7 @@ describe("ExtendedTileInfo", function() {
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const env = new MapEnv({
             $layer: "line_layer-" + index,
@@ -298,16 +294,14 @@ describe("ExtendedTileInfo", function() {
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const storedTechnique: IndexedTechnique = {
             name: "fill",
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const env = new MapEnv({
             $layer: "fill_layer-" + index,

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -54,12 +54,14 @@ export const DEFAULT_TEXT_STYLE_CACHE_ID = "Default";
  *
  * @returns [[TextStyle]] id.
  */
-export function computeStyleCacheId(
-    datasourceName: string,
+function computeStyleCacheId(
+    tile: Tile,
     technique: Technique & Partial<IndexedTechniqueParams>,
     zoomLevel: number
 ): string {
-    return `${datasourceName}_${technique._key}_${zoomLevel}`;
+    const datasourceName = tile.dataSource.name;
+    const key = `${datasourceName}_${tile.tileKey.toHereTile()}_${technique._index}_${zoomLevel}`;
+    return key;
 }
 
 /**
@@ -301,11 +303,12 @@ export class TextStyleCache {
         technique: TextTechnique | PoiTechnique | LineMarkerTechnique
     ): TextRenderStyle {
         const mapView = tile.mapView;
-        const dataSource = tile.dataSource;
         const zoomLevel = mapView.zoomLevel;
         const zoomLevelInt = Math.floor(zoomLevel);
 
-        const cacheId = computeStyleCacheId(dataSource.name, technique, zoomLevelInt);
+        //console.log("got here", tile.decodedTile?.techniques.indexOf(technique));
+
+        const cacheId = computeStyleCacheId(tile, technique, zoomLevelInt);
         let renderStyle = this.m_textRenderStyleCache.get(cacheId);
         if (renderStyle === undefined) {
             const defaultRenderParams = this.m_defaultStyle.renderParams;
@@ -435,7 +438,7 @@ export class TextStyleCache {
         technique: TextTechnique | PoiTechnique | LineMarkerTechnique
     ): TextLayoutStyle {
         const floorZoomLevel = Math.floor(tile.mapView.zoomLevel);
-        const cacheId = computeStyleCacheId(tile.dataSource.name, technique, floorZoomLevel);
+        const cacheId = computeStyleCacheId(tile, technique, floorZoomLevel);
         let layoutStyle = this.m_textLayoutStyleCache.get(cacheId);
 
         if (layoutStyle === undefined) {

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -143,7 +143,6 @@ describe("TileGeometryCreator", () => {
                     _category: "hi-priority",
                     _index: 0,
                     _styleSetIndex: 0,
-                    _key: "key-0",
                     renderOrder: -1,
                     name: "line",
                     color: "rgb(255,0,0)",
@@ -155,7 +154,6 @@ describe("TileGeometryCreator", () => {
                     _index: 1,
                     _styleSetIndex: 0,
                     renderOrder: -1,
-                    _key: "key-0",
                     name: "circles"
                 }
             ]


### PR DESCRIPTION
This patch also modifies the cache policy of TextRenderStyle,
before this change TextRenderStyle entries where cached across
tiles created from the same datasource, with this change the
caching is limited to the tile.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
