### PR TITLE
MINOR: Remove logging to console and check with spy instead

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileLoader.ts
+++ b/@here/harp-mapview-decoder/lib/TileLoader.ts
@@ -17,6 +17,9 @@ import { LoggerManager } from "@here/harp-utils";
 
 import { DataProvider } from "./DataProvider";
 
+/**
+ * Logger to write to console etc.
+ */
 const logger = LoggerManager.instance.create("TileLoader");
 
 /**

--- a/@here/harp-mapview/test/CopyrightProvidersTest.ts
+++ b/@here/harp-mapview/test/CopyrightProvidersTest.ts
@@ -13,6 +13,7 @@ import * as sinon from "sinon";
 import { GeoBox, GeoCoordinates } from "@here/harp-geoutils";
 import { getTestResourceUrl } from "@here/harp-test-utils";
 import { TransferManager } from "@here/harp-transfer-manager";
+import { LoggerManager } from "@here/harp-utils";
 import { CopyrightInfo } from "../lib/copyrights/CopyrightInfo";
 import { UrlCopyrightProvider } from "../lib/copyrights/UrlCopyrightProvider";
 
@@ -24,14 +25,24 @@ describe("CopyrightProviders", function() {
         }
 
         describe("#init", function() {
+            let provider: UrlCopyrightProvider;
+            this.beforeEach(() => {
+                provider = new UrlCopyrightProvider("", "normal");
+                LoggerManager.instance.update("CopyrightCoverageProvider", { enabled: false });
+            });
+            this.afterEach(() => {
+                LoggerManager.instance.update("CopyrightCoverageProvider", { enabled: true });
+            });
             it("Should return default copyrights if failed to load data", async function() {
                 const fakeJson = sinon.fake.rejects(new Error("error"));
 
                 sinon.replace(TransferManager.prototype, "downloadJson", fakeJson);
-                const copyrights = await getCopyrights(
+
+                const copyrights = await provider.getCopyrights(
                     new GeoBox(new GeoCoordinates(2, 2), new GeoCoordinates(3, 3)),
                     10
                 );
+
                 sinon.restore();
 
                 expect(copyrights).to.deep.equal([]);
@@ -41,7 +52,6 @@ describe("CopyrightProviders", function() {
                 const fakeJson = sinon.fake.rejects(new Error("error"));
                 sinon.replace(TransferManager.prototype, "downloadJson", fakeJson);
 
-                const provider = new UrlCopyrightProvider("", "normal");
                 const geoBox = new GeoBox(new GeoCoordinates(2, 2), new GeoCoordinates(3, 3));
                 const firstResult = await provider.getCopyrights(geoBox, 10);
                 const secondResult = await provider.getCopyrights(geoBox, 5);


### PR DESCRIPTION
Removes the errors from the console, i.e.:

```
TileLoader: [anonymous-datasource#5]: failed to load tile 1 Error: No connection.
    at MockDataProvider.getTile (/home/travis/build/heremaps/harp.gl/@here/harp-mapview-decoder/test/TileLoaderTest.ts:50:35)
    at TileLoader.startLoading (/home/travis/build/heremaps/harp.gl/@here/harp-mapview-decoder/lib/TileLoader.ts:87:9)
    at TileLoader.loadAndDecode (/home/travis/build/heremaps/harp.gl/@here/harp-mapview-decoder/lib/TileLoader.ts:26:6)
    at Context.<anonymous> (/home/travis/build/heremaps/harp.gl/@here/harp-mapview-decoder/test/TileLoaderTest.ts:194:44)
```

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
