### PR TITLE
[WIP] Refactor technique handling to separate modules

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
@@ -58,7 +58,7 @@ export interface TechniqueDescriptor<T> {
 }
 
 type OneThatMatches<T, P> = T extends P ? T : never;
-type TechniqueByName<K extends Technique["name"]> = OneThatMatches<Technique, { name: K }>;
+export type TechniqueByName<K extends Technique["name"]> = OneThatMatches<Technique, { name: K }>;
 
 export type TechniqueDescriptorRegistry = {
     [P in Technique["name"]]?: TechniqueDescriptor<TechniqueByName<P>>;

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -173,24 +173,31 @@ export class AnimatedExtrusionTileHandler {
 
     constructor(
         private m_tile: Tile,
-        extrudedObjects: Array<{ object: THREE.Object3D; materialFeature: boolean }>,
+        extrudedObjects: THREE.Object3D[],
         private m_animatedExtrusionDuration: number
     ) {
         this.m_mapView = m_tile.mapView;
         this.m_animatedExtrusionHandler = this.m_mapView.animatedExtrusionHandler;
 
         extrudedObjects.forEach(extrudedObject => {
-            this.m_extrudedObjects.push(extrudedObject.object);
+            this.m_extrudedObjects.push(extrudedObject);
         });
 
         this.startExtrusionAnimationIfNeeded(this.m_animatedExtrusionHandler.zoomDirection);
     }
 
+    add(extrudedObjects: THREE.Object3D[]) {
+        this.m_extrudedObjects.push(...extrudedObjects);
+    }
+
     /**
-     * Set an extrusion ratio value for the materials [[MapMeshBasicMaterial]]
+     * Extrusion ratio value for the materials [[MapMeshBasicMaterial]]
      * and [[EdgeMaterial]]. Controlled by [[AnimatedExtrusionHandler]]
      * for extrusion animation effect.
      */
+    get extrusionRatio() {
+        return this.m_animatedExtrusionRatio;
+    }
     set extrusionRatio(value: number) {
         this.m_animatedExtrusionRatio = value;
 

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -563,7 +563,7 @@ function applyTechniqueToMaterial(
  * @param techniqueAttrValue technique property value which will be applied to material attribute
  * @param zoomLevel optional tile zoom level.
  */
-function applyTechniquePropertyToMaterial(
+export function applyTechniquePropertyToMaterial(
     material: THREE.Material,
     propertyName: string,
     techniqueAttrValue: Value,

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -60,6 +60,7 @@ import { ScreenCollisions, ScreenCollisionsDebug } from "./ScreenCollisions";
 import { ScreenProjector } from "./ScreenProjector";
 import { SkyBackground } from "./SkyBackground";
 import { FrameStats, PerformanceStatistics } from "./Statistics";
+import { TechniqueUpdateContext } from "./techniques/TechniqueHandler";
 import { FontCatalogLoader } from "./text/FontCatalogLoader";
 import { MapViewState } from "./text/MapViewState";
 import { TextCanvasFactory } from "./text/TextCanvasFactory";
@@ -800,6 +801,7 @@ export class MapView extends THREE.EventDispatcher {
     private m_animatedExtrusionHandler: AnimatedExtrusionHandler;
 
     private m_env: MapEnv = new MapEnv({});
+    private m_techniqueUpdateContext: TechniqueUpdateContext;
 
     private m_enableMixedLod: boolean | undefined;
 
@@ -899,6 +901,13 @@ export class MapView extends THREE.EventDispatcher {
             this.m_collisionDebugCanvas = this.m_options.collisionDebugCanvas;
             this.m_screenCollisions = new ScreenCollisionsDebug(this.m_collisionDebugCanvas);
         }
+
+        this.m_techniqueUpdateContext = {
+            env: this.m_env,
+            frameNumber: -1,
+            projection: this.projection,
+            viewRanges: this.viewRanges
+        };
 
         this.handleRequestAnimationFrame = this.renderFunc.bind(this);
         this.handlePostponedAnimationFrame = this.postponedAnimationFrame.bind(this);
@@ -1521,6 +1530,7 @@ export class MapView extends THREE.EventDispatcher {
         const headingDeg = -THREE.MathUtils.radToDeg(attitude.yaw);
 
         this.m_visibleTileSetOptions.projection = projection;
+        this.m_techniqueUpdateContext.projection = projection;
         this.updatePolarDataSource();
         this.clearTileCache();
         this.textElementsRenderer.clearRenderStates();
@@ -1741,6 +1751,15 @@ export class MapView extends THREE.EventDispatcher {
      */
     get env(): Env {
         return this.m_env;
+    }
+
+    /**
+     * Technique update context.
+     *
+     * Updated with each frame.
+     */
+    get techniqueUpdateContext(): TechniqueUpdateContext {
+        return this.m_techniqueUpdateContext;
     }
 
     /**
@@ -2587,6 +2606,9 @@ export class MapView extends THREE.EventDispatcher {
         this.m_env.entries.$pixelToMeters = this.pixelToWorld;
 
         this.m_env.entries.$frameNumber = this.m_frameNumber;
+
+        this.m_techniqueUpdateContext.frameNumber = this.frameNumber;
+        this.m_techniqueUpdateContext.viewRanges = this.viewRanges;
     }
 
     /**
@@ -2796,16 +2818,23 @@ export class MapView extends THREE.EventDispatcher {
         const renderList = this.m_visibleTiles.dataSourceTileList;
 
         // no need to check everything if we're not going to create text renderer.
+
         renderList.forEach(({ zoomLevel, renderedTiles }) => {
             renderedTiles.forEach(tile => {
-                this.renderTileObjects(tile, zoomLevel);
-
                 //We know that rendered tiles are visible (in the view frustum), so we update the
                 //frame number, note we don't do this for the visibleTiles because some may still be
                 //loading (and therefore aren't visible in the sense of being seen on the screen).
                 //Note also, this number isn't currently used anywhere so should be considered to be
                 //removed in the future (though could be good for debugging purposes).
+                // Also, important to mark them now, so Tile.updateDynamicTechniques know that this
+                // tiles objects need to be updated.
                 tile.frameNumLastVisible = this.m_frameNumber;
+            });
+
+            // Since we share materials between tiles, it's important that all updates of
+            // `tile.frameNumLastVisible` are done before we try to update techniques.
+            renderedTiles.forEach(tile => {
+                this.renderTileObjects(tile, zoomLevel);
             });
         });
 
@@ -2975,7 +3004,14 @@ export class MapView extends THREE.EventDispatcher {
     private renderTileObjects(tile: Tile, zoomLevel: number) {
         const worldOffsetX = tile.computeWorldOffsetX();
         if (tile.willRender(zoomLevel)) {
+            tile.updateDynamicTechniques(this.m_techniqueUpdateContext);
+
             for (const object of tile.objects) {
+                // Don't add completly transparent objects.
+                if (!object.visible) {
+                    continue;
+                }
+
                 object.position.copy(tile.center);
                 if (object.displacement !== undefined) {
                     object.position.add(object.displacement);

--- a/@here/harp-mapview/lib/techniques/ExtrudedPolygonTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/ExtrudedPolygonTechniqueHandler.ts
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import {
+    BufferAttribute,
+    Expr,
+    ExtrudedPolygonTechnique,
+    Geometry,
+    getPropertyValue,
+    Group
+} from "@here/harp-datasource-protocol";
+import {
+    EdgeMaterial,
+    EdgeMaterialParameters,
+    MapMeshBasicMaterial,
+    MapMeshStandardMaterial
+} from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import { AnimatedExtrusionTileHandler } from "../AnimatedExtrusionHandler";
+import { applyBaseColorToMaterial, getBufferAttribute } from "../DecodedTileHelpers";
+import {
+    createDepthPrePassMesh,
+    isRenderDepthPrePassEnabled,
+    setDepthPrePassStencil
+} from "../DepthPrePass";
+import { Tile } from "../Tile";
+import { techniqueHandlers, TechniqueUpdateContext, TileWorldSpaceEntry } from "./TechniqueHandler";
+import { TechniqueHandlerCommon, WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+export class ExtrudedPolygonTechniqueHandler extends WorldSpaceTechniqueHandlerBase<
+    ExtrudedPolygonTechnique
+> {
+    static isAnimatedExtrusionEnabled(technique: ExtrudedPolygonTechnique, tile: Tile) {
+        const animatedExtrusionHandler = tile.mapView.animatedExtrusionHandler;
+        if (!animatedExtrusionHandler) {
+            return false;
+        }
+        let animateExtrusionValue = getPropertyValue(
+            technique.animateExtrusion,
+            tile.mapView.env // TODO: discrete env!
+        );
+        if (animateExtrusionValue !== undefined) {
+            animateExtrusionValue =
+                typeof animateExtrusionValue === "boolean"
+                    ? animateExtrusionValue
+                    : typeof animateExtrusionValue === "number"
+                    ? animateExtrusionValue !== 0
+                    : false;
+        }
+        return animateExtrusionValue !== undefined &&
+            animatedExtrusionHandler.forceEnabled === false
+            ? animateExtrusionValue
+            : animatedExtrusionHandler.enabled;
+    }
+
+    private mainMaterial: MapMeshStandardMaterial;
+
+    private edgeMaterial?: EdgeMaterial;
+
+    /**
+     * Meshes with `mainMaterial` (+depth pre-pass mesh) with visibility that depends on
+     * dynamic `opacity`.
+     */
+    private mainObjects: TileWorldSpaceEntry[] = [];
+
+    /**
+     * Meshes with `edgeMaterial` with visibility that depends on dynamic `opacity`.
+     */
+    private edgeObjects: TileWorldSpaceEntry[] = [];
+
+    private extrusionAnimationEnabled: boolean = false;
+    private extrusionAnimationDuration?: number;
+
+    constructor(technique: ExtrudedPolygonTechnique, tile: Tile, context: TechniqueUpdateContext) {
+        super(technique, tile.mapView);
+
+        this.mainMaterial = this.createMaterial(technique, context) as MapMeshStandardMaterial;
+        assert(
+            this.mainMaterial instanceof MapMeshBasicMaterial ||
+                this.mainMaterial instanceof MapMeshStandardMaterial
+        );
+
+        if (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateBaseColor.bind(
+                    undefined,
+                    this.mainMaterial,
+                    this.mainObjects,
+                    technique
+                )
+            );
+        }
+
+        const fadingParams = TechniqueHandlerCommon.getPolygonFadingParams(technique, context.env);
+        if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParams)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateFadingParams.bind(
+                    undefined,
+                    this.mainMaterial,
+                    fadingParams
+                )
+            );
+        }
+
+        if (Expr.isExpr(technique.emissive)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.genericMaterialUpdater.bind(
+                    undefined,
+                    this.mainMaterial,
+                    this.technique,
+                    "emissive"
+                )
+            );
+        }
+
+        if (
+            Expr.isExpr(technique.lineWidth) ||
+            (typeof technique.lineWidth === "number" && technique.lineWidth > 0)
+        ) {
+            const materialParams: EdgeMaterialParameters = {
+                color: fadingParams.color,
+                colorMix: fadingParams.colorMix,
+                fadeNear: fadingParams.lineFadeNear,
+                fadeFar: fadingParams.lineFadeFar
+            };
+            this.edgeMaterial = new EdgeMaterial(materialParams);
+            this.materials.push(this.edgeMaterial);
+
+            if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParams)) {
+                this.updaters.push(
+                    TechniqueHandlerCommon.updateEdgeFadingParams.bind(
+                        undefined,
+                        this.edgeMaterial,
+                        fadingParams
+                    )
+                );
+            }
+
+            if (Expr.isExpr(technique.lineColor) || Expr.isExpr(technique.opacity)) {
+                this.updaters.push(this.updateEdgeColor.bind(this));
+            }
+        }
+
+        this.extrusionAnimationEnabled = ExtrudedPolygonTechniqueHandler.isAnimatedExtrusionEnabled(
+            technique,
+            tile
+        );
+
+        if (this.extrusionAnimationEnabled) {
+            const animatedExtrusionHandler = tile.mapView.animatedExtrusionHandler;
+            this.extrusionAnimationDuration =
+                this.technique.animateExtrusionDuration !== undefined &&
+                animatedExtrusionHandler.forceEnabled === false
+                    ? technique.animateExtrusionDuration
+                    : animatedExtrusionHandler.duration;
+        }
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group?: Group) {
+        const bufferGeometry = TechniqueHandlerCommon.createGenericBufferGeometry(
+            this.technique,
+            srcGeometry,
+            group
+        );
+        const mainObject = new THREE.Mesh(bufferGeometry, this.mainMaterial);
+
+        TechniqueHandlerCommon.setupUserData(srcGeometry, this.technique, mainObject);
+
+        mainObject.renderOrder = this.technique.renderOrder;
+
+        const result: THREE.Object3D[] = [];
+
+        result.push(mainObject);
+
+        this.mainObjects.push({ object: mainObject, tile });
+        this.registerObject(tile, mainObject);
+
+        const renderDepthPrePass = isRenderDepthPrePassEnabled(this.technique);
+
+        if (renderDepthPrePass) {
+            const depthPassMesh = createDepthPrePassMesh(mainObject as THREE.Mesh);
+            result.push(depthPassMesh);
+            this.registerObject(tile, depthPassMesh);
+            this.mainObjects.push({ tile, object: depthPassMesh });
+
+            setDepthPrePassStencil(depthPassMesh, mainObject);
+        }
+
+        if (this.edgeMaterial && srcGeometry.edgeIndex) {
+            const edgeGeometry = new THREE.BufferGeometry();
+            edgeGeometry.setAttribute("position", bufferGeometry.getAttribute("position"));
+
+            const colorAttribute = bufferGeometry.getAttribute("color");
+            if (colorAttribute !== undefined) {
+                edgeGeometry.setAttribute("color", colorAttribute);
+            }
+
+            const extrusionAttribute = bufferGeometry.getAttribute("extrusionAxis");
+            if (extrusionAttribute !== undefined) {
+                edgeGeometry.setAttribute("extrusionAxis", extrusionAttribute);
+            }
+
+            const normalAttribute = bufferGeometry.getAttribute("normal");
+            if (normalAttribute !== undefined) {
+                edgeGeometry.setAttribute("normal", normalAttribute);
+            }
+
+            const uvAttribute = bufferGeometry.getAttribute("uv");
+            if (uvAttribute !== undefined) {
+                edgeGeometry.setAttribute("uv", uvAttribute);
+            }
+
+            edgeGeometry.setIndex(getBufferAttribute(srcGeometry.edgeIndex! as BufferAttribute));
+
+            const edgeObject = new THREE.LineSegments(edgeGeometry, this.edgeMaterial);
+            edgeObject.renderOrder = mainObject.renderOrder + 0.1;
+
+            this.edgeObjects.push({ tile, object: edgeObject });
+            this.registerObject(tile, edgeObject);
+            result.push(edgeObject);
+        }
+
+        if (this.extrusionAnimationEnabled) {
+            if (tile.animatedExtrusionTileHandler === undefined) {
+                tile.animatedExtrusionTileHandler = new AnimatedExtrusionTileHandler(
+                    tile,
+                    result,
+                    this.extrusionAnimationDuration!
+                );
+                tile.mapView.animatedExtrusionHandler.add(tile.animatedExtrusionTileHandler);
+            } else {
+                tile.animatedExtrusionTileHandler.add(result);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @override
+     */
+    removeTileObjects(tile: Tile) {
+        this.mainObjects = this.mainObjects.filter(entry => entry.tile !== tile);
+        this.edgeObjects = this.edgeObjects.filter(entry => entry.tile !== tile);
+
+        super.removeTileObjects(tile);
+    }
+
+    private updateEdgeColor(context: TechniqueUpdateContext) {
+        assert(this.edgeMaterial !== undefined);
+
+        const lastOpacity = this.edgeMaterial!.opacity;
+        applyBaseColorToMaterial(
+            this.edgeMaterial!,
+            this.edgeMaterial!.color,
+            this.technique,
+            this.technique.lineColor!,
+            context.env
+        );
+
+        if (lastOpacity !== this.edgeMaterial!.opacity) {
+            TechniqueHandlerCommon.forEachTileObject(this.edgeObjects, context, object => {
+                object.visible = this.edgeMaterial!.opacity > 0;
+            });
+        }
+    }
+}
+
+techniqueHandlers["extruded-polygon"] = ExtrudedPolygonTechniqueHandler;

--- a/@here/harp-mapview/lib/techniques/FillTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/FillTechniqueHandler.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import { Expr, FillTechnique, Geometry, Group } from "@here/harp-datasource-protocol";
+import { EdgeMaterial, EdgeMaterialParameters, MapMeshBasicMaterial } from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import { applyBaseColorToMaterial, getBufferAttribute } from "../DecodedTileHelpers";
+import { Tile } from "../Tile";
+import { techniqueHandlers, TechniqueUpdateContext, TileWorldSpaceEntry } from "./TechniqueHandler";
+import { TechniqueHandlerCommon, WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+export class FillTechniqueHandler extends WorldSpaceTechniqueHandlerBase<FillTechnique> {
+    private mainMaterial: MapMeshBasicMaterial;
+    private outlineMaterial?: EdgeMaterial;
+
+    private mainObjects: TileWorldSpaceEntry[] = [];
+    private outlineObjects: TileWorldSpaceEntry[] = [];
+
+    constructor(technique: FillTechnique, tile: Tile, context: TechniqueUpdateContext) {
+        // this.technique = fillDefaults(techniqe)
+        super(technique, tile.mapView);
+        this.mainMaterial = this.createMaterial(technique, context) as MapMeshBasicMaterial;
+        assert(this.mainMaterial instanceof MapMeshBasicMaterial);
+
+        if (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateBaseColor.bind(
+                    undefined,
+                    this.mainMaterial,
+                    this.mainObjects,
+                    technique
+                )
+            );
+        }
+
+        const fadingParams = TechniqueHandlerCommon.getPolygonFadingParams(technique, context.env);
+        if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParams)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateFadingParams.bind(
+                    undefined,
+                    this.mainMaterial,
+                    fadingParams
+                )
+            );
+        }
+
+        if (
+            Expr.isExpr(technique.lineWidth) ||
+            (typeof technique.lineWidth === "number" && technique.lineWidth > 0)
+        ) {
+            const materialParams: EdgeMaterialParameters = {
+                color: fadingParams.color,
+                colorMix: fadingParams.colorMix,
+                fadeNear: fadingParams.lineFadeNear,
+                fadeFar: fadingParams.lineFadeFar
+            };
+            this.outlineMaterial = new EdgeMaterial(materialParams);
+            this.materials.push(this.outlineMaterial);
+
+            if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParams)) {
+                this.updaters.push(
+                    TechniqueHandlerCommon.updateEdgeFadingParams.bind(
+                        undefined,
+                        this.outlineMaterial,
+                        fadingParams
+                    )
+                );
+            }
+
+            if (Expr.isExpr(technique.lineColor) || Expr.isExpr(technique.opacity)) {
+                this.updaters.push(this.updateOutlineColor.bind(this));
+            }
+        }
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group?: Group) {
+        const mainObject = this.createObject(
+            tile,
+            srcGeometry,
+            group,
+            THREE.Mesh,
+            this.mainMaterial
+        );
+
+        TechniqueHandlerCommon.setupUserData(srcGeometry, this.technique, mainObject);
+
+        this.mainObjects.push({ object: mainObject, tile });
+        this.objects.push({ object: mainObject, tile });
+
+        if (this.outlineMaterial && srcGeometry.edgeIndex) {
+            const bufferGeometry = mainObject.geometry as THREE.BufferGeometry;
+            const outlineGeometry = new THREE.BufferGeometry();
+            outlineGeometry.setAttribute("position", bufferGeometry.getAttribute("position"));
+            outlineGeometry.setIndex(getBufferAttribute(srcGeometry.edgeIndex!));
+
+            const outlineObject = new THREE.LineSegments(outlineGeometry, this.outlineMaterial);
+
+            outlineObject.renderOrder = mainObject.renderOrder + 0.1;
+
+            this.outlineObjects.push({ object: outlineObject, tile });
+            this.registerObject(tile, outlineObject);
+
+            return [mainObject, outlineObject];
+        }
+        return [mainObject];
+    }
+
+    /**
+     * @override
+     */
+    removeTileObjects(tile: Tile) {
+        super.removeTileObjects(tile);
+
+        this.mainObjects = this.mainObjects.filter(entry => entry.tile !== tile);
+        this.outlineObjects = this.outlineObjects.filter(entry => entry.tile !== tile);
+    }
+
+    private updateOutlineColor(context: TechniqueUpdateContext) {
+        assert(this.outlineMaterial !== undefined);
+
+        const lastOpacity = this.outlineMaterial!.opacity;
+        applyBaseColorToMaterial(
+            this.outlineMaterial!,
+            this.outlineMaterial!.color,
+            this.technique,
+            this.technique.lineColor!,
+            context.env
+        );
+
+        if (lastOpacity !== this.outlineMaterial!.opacity) {
+            TechniqueHandlerCommon.forEachTileObject(this.outlineObjects, context, object => {
+                object.visible = this.outlineMaterial!!.opacity > 0;
+            });
+        }
+    }
+}
+
+techniqueHandlers.fill = FillTechniqueHandler;

--- a/@here/harp-mapview/lib/techniques/GenericWorldSpaceTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/GenericWorldSpaceTechniqueHandler.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import {
+    Expr,
+    Geometry,
+    Group,
+    isExtrudedLineTechnique,
+    isLineTechnique,
+    isSegmentsTechnique,
+    Technique
+} from "@here/harp-datasource-protocol";
+import { getObjectConstructor } from "../DecodedTileHelpers";
+import { Tile } from "../Tile";
+import { TechniqueUpdateContext } from "./TechniqueHandler";
+import { TechniqueHandlerCommon, WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+/**
+ * Generic world space technique handler.
+ *
+ * Fallback to create objects for "generic" techniques that doesn't need special handling.
+ *
+ * Responsible for creation of materials and scene objects for this technique as well as updating,
+ * them if they are dynamic.
+ *
+ * Supported for [[ExtrudedLineTechnique]], [[LineTechnique]], [[SegmentsTechnique]].
+ *
+ * Supports fading features and color & opactity interpolation and hiding of completly transparent
+ * objects.
+ */
+export class GenericWorldSpaceTechniqueHandler extends WorldSpaceTechniqueHandlerBase<Technique> {
+    material: THREE.Material;
+
+    constructor(technique: Technique, tile: Tile, context: TechniqueUpdateContext) {
+        super(technique, tile.mapView);
+        this.material = this.createMaterial(technique, context);
+
+        const fadingParams = TechniqueHandlerCommon.getFadingParams(technique, context.env);
+        if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParams)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateFadingParams.bind(
+                    undefined,
+                    this.material,
+                    fadingParams
+                )
+            );
+        }
+
+        if (
+            isLineTechnique(technique) ||
+            isSegmentsTechnique(technique) ||
+            isExtrudedLineTechnique(technique)
+        ) {
+            if (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity)) {
+                this.updaters.push(
+                    TechniqueHandlerCommon.updateBaseColor.bind(
+                        undefined,
+                        this.material as any,
+                        this.objects,
+                        technique
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group?: Group) {
+        const ObjectConstructor = getObjectConstructor(this.technique);
+        if (ObjectConstructor === undefined) {
+            throw new Error(`Unknown technique ${this.technique.name}`);
+        }
+        const object = this.createObject(
+            tile,
+            srcGeometry,
+            group,
+            ObjectConstructor,
+            this.material
+        );
+
+        TechniqueHandlerCommon.setupUserData(srcGeometry, this.technique, object);
+
+        return [object];
+    }
+}

--- a/@here/harp-mapview/lib/techniques/PointTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/PointTechniqueHandler.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import {
+    CirclesTechnique,
+    Expr,
+    Geometry,
+    Group,
+    isCirclesTechnique,
+    SquaresTechnique
+} from "@here/harp-datasource-protocol";
+import { CirclePointsMaterial } from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import { Circles, Squares } from "../MapViewPoints";
+import { Tile } from "../Tile";
+import { techniqueHandlers, TechniqueUpdateContext } from "./TechniqueHandler";
+import { TechniqueHandlerCommon, WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+type PointTechnique = CirclesTechnique | SquaresTechnique;
+
+/**
+ * [[CirclesTechnique]] and [[SquaresTechnique]] rendering handler.
+ *
+ * Responsible for creation of materials and scene objects for this technique as well as updating
+ * them if they are dynamic.
+ */
+export class PointTechniqueHandler extends WorldSpaceTechniqueHandlerBase<PointTechnique> {
+    material: CirclePointsMaterial | THREE.PointsMaterial;
+
+    constructor(technique: PointTechnique, tile: Tile, context: TechniqueUpdateContext) {
+        super(technique, tile.mapView);
+        this.material = this.createMaterial(technique, context) as
+            | CirclePointsMaterial
+            | THREE.PointsMaterial;
+        assert(
+            this.material instanceof CirclePointsMaterial ||
+                this.material instanceof THREE.PointsMaterial
+        );
+
+        if (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateBaseColor.bind(
+                    undefined,
+                    this.material,
+                    this.objects,
+                    technique
+                )
+            );
+        }
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group?: Group) {
+        const ObjectConstructor = isCirclesTechnique(this.technique) ? Circles : Squares;
+        const object = this.createObject(
+            tile,
+            srcGeometry,
+            group,
+            ObjectConstructor,
+            this.material
+        );
+
+        if (this.technique.enablePicking !== undefined) {
+            object.enableRayTesting = this.technique.enablePicking;
+        }
+
+        TechniqueHandlerCommon.setupUserData(srcGeometry, this.technique, object);
+
+        return [object];
+    }
+}
+
+techniqueHandlers.squares = PointTechniqueHandler;
+techniqueHandlers.circles = PointTechniqueHandler;

--- a/@here/harp-mapview/lib/techniques/SolidLineTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/SolidLineTechniqueHandler.ts
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import {
+    Expr,
+    Geometry,
+    getPropertyValue,
+    Group,
+    SolidLineTechnique
+} from "@here/harp-datasource-protocol";
+import { ProjectionType } from "@here/harp-geoutils";
+import { setShaderMaterialDefine, SolidLineMaterial } from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import { applyBaseColorToMaterial } from "../DecodedTileHelpers";
+import { Tile } from "../Tile";
+import { techniqueHandlers, TechniqueUpdateContext, TileWorldSpaceEntry } from "./TechniqueHandler";
+import { TechniqueHandlerCommon, WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+const tmpVector3 = new THREE.Vector3();
+const tmpVector2 = new THREE.Vector2();
+
+/**
+ * [[SolidLineTechnique]] rendering handler.
+ *
+ * Responsible for creation of materials and scene objects for this technique as well as updating
+ * them if they are dynamic.
+ *
+ * Shareable for same techniques (and tile level if clipping is anabled and projection is planar).
+ */
+export class SolidLineTechniqueHandler extends WorldSpaceTechniqueHandlerBase<SolidLineTechnique> {
+    private mainMaterial: SolidLineMaterial;
+
+    private secondaryMaterial?: SolidLineMaterial;
+
+    private mainObjects: TileWorldSpaceEntry[] = [];
+    private secondaryObjects: TileWorldSpaceEntry[] = [];
+
+    private metricUnitIsPixel: boolean;
+
+    constructor(technique: SolidLineTechnique, tile: Tile, context: TechniqueUpdateContext) {
+        super(technique, tile.mapView);
+
+        this.mainMaterial = this.createMaterial(technique, context) as SolidLineMaterial;
+        assert(this.mainMaterial instanceof SolidLineMaterial);
+
+        if (technique.clipping !== false && context.projection.type === ProjectionType.Planar) {
+            tile.boundingBox.getSize(tmpVector3);
+            tmpVector2.set(tmpVector3.x, tmpVector3.y);
+            this.mainMaterial.clipTileSize = tmpVector2;
+        }
+
+        if (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateBaseColor.bind(
+                    undefined,
+                    this.mainMaterial,
+                    this.mainObjects,
+                    technique
+                )
+            );
+        }
+
+        this.metricUnitIsPixel = technique.metricUnit === "Pixel";
+
+        if (Expr.isExpr(technique.lineWidth) || this.metricUnitIsPixel) {
+            this.updaters.push(this.updateLineWidth.bind(this));
+        }
+
+        if (Expr.isExpr(technique.outlineWidth) || this.metricUnitIsPixel) {
+            this.updaters.push(this.updateOutlineWidth.bind(this));
+        }
+
+        if (Expr.isExpr(technique.dashSize) || this.metricUnitIsPixel) {
+            this.updaters.push(this.updateDashSize.bind(this));
+        }
+
+        if (Expr.isExpr(technique.gapSize) || this.metricUnitIsPixel) {
+            this.updaters.push(this.updateGapSize.bind(this));
+        }
+
+        // TODO:
+        // Now, with new approach, we don't install handlers for non-interpolated props, so
+        // static widths/heights/gaps will not have unitFactor or 0.5 applied.
+        // Call them manually or invent better, `createMaterial`
+
+        if (this.technique.lineWidth !== undefined) {
+            this.updateLineWidth(context);
+        }
+        if (this.technique.outlineWidth !== undefined) {
+            this.updateOutlineWidth(context);
+        }
+        if (this.technique.dashSize !== undefined) {
+            this.updateDashSize(context);
+        }
+        if (this.technique.gapSize !== undefined) {
+            this.updateGapSize(context);
+        }
+
+        const fadingParam = TechniqueHandlerCommon.getFadingParams(technique, context.env);
+        if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParam)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateFadingParams.bind(
+                    undefined,
+                    this.mainMaterial,
+                    fadingParam
+                )
+            );
+        }
+
+        if (technique.secondaryWidth !== undefined) {
+            this.secondaryMaterial = this.mainMaterial.clone();
+            this.materials.push(this.secondaryMaterial);
+
+            applyBaseColorToMaterial(
+                this.secondaryMaterial,
+                this.secondaryMaterial.color,
+                this.technique,
+                this.technique.secondaryColor ?? 0xff0000,
+                context.env
+            );
+
+            if (technique.secondaryCaps !== undefined) {
+                this.secondaryMaterial.caps = technique.secondaryCaps;
+            }
+
+            if (Expr.isExpr(technique.secondaryColor) || Expr.isExpr(technique.opacity)) {
+                this.updaters.push(this.updateSecondaryColor.bind(this));
+            }
+
+            if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParam)) {
+                this.updaters.push(
+                    TechniqueHandlerCommon.updateFadingParams.bind(
+                        undefined,
+                        this.secondaryMaterial,
+                        fadingParam
+                    )
+                );
+            }
+
+            if (
+                Expr.isExpr(technique.secondaryWidth) ||
+                Expr.isExpr(technique.secondaryColor) ||
+                Expr.isExpr(technique.opacity) ||
+                this.metricUnitIsPixel
+            ) {
+                this.updaters.push(this.updateSecondaryWidth.bind(this));
+            }
+
+            if (technique.secondaryWidth !== undefined) {
+                this.updateSecondaryWidth(context);
+            }
+        }
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group: Group) {
+        const bufferGeometry = TechniqueHandlerCommon.createGenericBufferGeometry(
+            this.technique,
+            srcGeometry,
+            group
+        );
+        const mainObject = new THREE.Mesh(bufferGeometry, this.mainMaterial);
+
+        mainObject.renderOrder = this.technique.renderOrder;
+
+        this.registerObject(tile, mainObject);
+        tile.objects.push(mainObject);
+        this.mainObjects.push({ object: mainObject, tile });
+
+        // NOTE: this is copied wholesale from TechiqueGeometryCreator
+        {
+            // TODO: candidate for removal, we don't generate buffer geometries with color anywhere
+            if (bufferGeometry.getAttribute("color")) {
+                setShaderMaterialDefine(this.mainMaterial, "USE_COLOR", true);
+            }
+        }
+
+        if (this.secondaryMaterial) {
+            const secondaryObject = new THREE.Mesh(bufferGeometry, this.secondaryMaterial);
+
+            secondaryObject.renderOrder =
+                this.technique.secondaryRenderOrder !== undefined
+                    ? this.technique.secondaryRenderOrder
+                    : this.technique.renderOrder - 0.0000001;
+            tile.objects.push(secondaryObject);
+            this.registerObject(tile, secondaryObject);
+            this.secondaryObjects.push({ object: mainObject, tile });
+
+            return [mainObject, secondaryObject];
+        }
+        TechniqueHandlerCommon.setupUserData(srcGeometry, this.technique, mainObject);
+        return [mainObject];
+    }
+
+    /**
+     * @override
+     */
+    removeTileObjects(tile: Tile) {
+        super.removeTileObjects(tile);
+
+        this.mainObjects = this.mainObjects.filter(entry => entry.tile !== tile);
+        this.secondaryObjects = this.secondaryObjects.filter(entry => entry.tile !== tile);
+    }
+
+    private updateLineWidth(context: TechniqueUpdateContext) {
+        const unitFactor = this.getUnitFactor(context);
+
+        this.mainMaterial.lineWidth =
+            getPropertyValue(this.technique.lineWidth, context.env) * unitFactor * 0.5;
+    }
+
+    private updateOutlineWidth(context: TechniqueUpdateContext) {
+        const unitFactor = this.getUnitFactor(context);
+
+        this.mainMaterial.outlineWidth =
+            getPropertyValue(this.technique.outlineWidth, context.env) * unitFactor;
+    }
+
+    private updateDashSize(context: TechniqueUpdateContext) {
+        const unitFactor = this.getUnitFactor(context);
+
+        this.mainMaterial.dashSize =
+            getPropertyValue(this.technique.dashSize, context.env) * unitFactor * 0.5;
+    }
+
+    private updateGapSize(context: TechniqueUpdateContext) {
+        const unitFactor = this.getUnitFactor(context);
+
+        this.mainMaterial.gapSize =
+            getPropertyValue(this.technique.gapSize, context.env) * unitFactor * 0.5;
+    }
+
+    private updateSecondaryColor(context: TechniqueUpdateContext) {
+        assert(this.secondaryMaterial !== undefined);
+
+        const lastOpacity = this.secondaryMaterial!.opacity;
+        applyBaseColorToMaterial(
+            this.secondaryMaterial!,
+            this.secondaryMaterial!.color,
+            this.technique,
+            this.technique.secondaryColor!,
+            context.env
+        );
+
+        if (lastOpacity !== this.secondaryMaterial!.opacity) {
+            for (const entry of this.secondaryObjects) {
+                if (entry.tile.frameNumLastVisible === context.frameNumber) {
+                    entry.object.visible = this.secondaryMaterial!.opacity > 0;
+                }
+            }
+        }
+    }
+
+    private updateSecondaryWidth(context: TechniqueUpdateContext) {
+        const secondaryMaterial = this.secondaryMaterial!;
+        assert(this.secondaryMaterial !== undefined);
+
+        const opacity = this.mainMaterial.opacity;
+
+        const unitFactor = this.getUnitFactor(context);
+
+        // Note, we assume that main materials lineWidth has been already updated
+        // if dynamic.
+        const techniqueLineWidth = this.mainMaterial.lineWidth;
+        const techniqueSecondaryWidth =
+            getPropertyValue(this.technique.secondaryWidth!, context.env) * unitFactor * 0.5;
+
+        const actualLineWidth =
+            techniqueSecondaryWidth <= techniqueLineWidth &&
+            (opacity === undefined || opacity === 1)
+                ? 0
+                : techniqueSecondaryWidth;
+        secondaryMaterial.lineWidth = actualLineWidth;
+    }
+
+    private getUnitFactor(context: TechniqueUpdateContext): number {
+        return this.metricUnitIsPixel ? this.getPixelToWorld(context) : 1.0;
+    }
+
+    private getPixelToWorld(context: TechniqueUpdateContext): number {
+        return (context.env.lookup("$pixelToWorld") as number) ?? 1.0;
+    }
+}
+
+// Note: This `as any` is needed probably because `SolidLineTechnique.name` is alternative.
+(techniqueHandlers["solid-line"] as any) = SolidLineTechniqueHandler;
+(techniqueHandlers["dashed-line"] as any) = SolidLineTechniqueHandler;

--- a/@here/harp-mapview/lib/techniques/StandardTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/StandardTechniqueHandler.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import { Expr, Geometry, Group, StandardTechnique } from "@here/harp-datasource-protocol";
+import { MapMeshStandardMaterial } from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import { applySecondaryColorToMaterial } from "../DecodedTileHelpers";
+import { Tile } from "../Tile";
+import { techniqueHandlers, TechniqueUpdateContext } from "./TechniqueHandler";
+import { TechniqueHandlerCommon, WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+/**
+ * [[StandardTechnique]] rendering handler.
+ *
+ * Responsible for creation of materials and scene objects for this technique as well as updating
+ * them if they are dynamic.
+ *
+ * Shareable for same techniques (and tile level if clipping is anabled and projection is planar).
+ *
+ * TODO: This almost same as [[GenericWorldSpaceTechniqueHandler]] module emissive ...
+ */
+export class StandardTechniqueHandler extends WorldSpaceTechniqueHandlerBase<StandardTechnique> {
+    private mainMaterial: MapMeshStandardMaterial;
+
+    constructor(technique: StandardTechnique, tile: Tile, context: TechniqueUpdateContext) {
+        super(technique, tile.mapView);
+
+        this.mainMaterial = this.createMaterial(technique, context) as MapMeshStandardMaterial;
+        assert(this.mainMaterial instanceof MapMeshStandardMaterial);
+
+        this.installUpdaters(context);
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group?: Group) {
+        const object = this.createObject(tile, srcGeometry, group, THREE.Mesh, this.mainMaterial);
+        TechniqueHandlerCommon.setupUserData(srcGeometry, this.technique, object);
+        return [object];
+    }
+
+    private installUpdaters(context: TechniqueUpdateContext) {
+        const technique = this.technique;
+        if (Expr.isExpr(technique.color) || Expr.isExpr(technique.opacity)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateBaseColor.bind(
+                    undefined,
+                    this.mainMaterial,
+                    this.objects,
+                    technique
+                )
+            );
+        }
+
+        const fadingParams = TechniqueHandlerCommon.getFadingParams(technique, context.env);
+        if (TechniqueHandlerCommon.isFadingFeatureEnabled(fadingParams)) {
+            this.updaters.push(
+                TechniqueHandlerCommon.updateFadingParams.bind(
+                    undefined,
+                    this.mainMaterial,
+                    fadingParams
+                )
+            );
+        }
+
+        if (Expr.isExpr(technique.emissive)) {
+            this.updaters.push(this.updateEmissive.bind(this));
+        }
+    }
+
+    private updateEmissive(context: TechniqueUpdateContext) {
+        assert(this.mainMaterial instanceof MapMeshStandardMaterial);
+
+        applySecondaryColorToMaterial(
+            (this.mainMaterial as MapMeshStandardMaterial).emissive,
+            this.technique.emissive!,
+            context.env
+        );
+    }
+}
+
+techniqueHandlers.standard = StandardTechniqueHandler;

--- a/@here/harp-mapview/lib/techniques/TechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/TechniqueHandler.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    Env,
+    Expr,
+    Geometry,
+    Group,
+    IndexedTechnique,
+    PoiGeometry,
+    Technique,
+    TextGeometry,
+    TextPathGeometry,
+    Value
+} from "@here/harp-datasource-protocol";
+import { TechniqueByName } from "@here/harp-datasource-protocol/lib/TechniqueDescriptor";
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
+import { Projection } from "@here/harp-geoutils";
+import { TextElement } from "../text/TextElement";
+import { Tile } from "../Tile";
+
+export interface TechniqueUpdateContext {
+    /**
+     * Current frame number.
+     *
+     * Use to skip re-evaluation of properties that are stable across frame.
+     */
+    frameNumber: number;
+
+    /**
+     * Current [[ViewRanges]].
+     *
+     * Used to calculate actual fading params of materials.
+     */
+    viewRanges: ViewRanges;
+
+    /**
+     * Projection used current [[MapView]].
+     */
+    projection: Projection;
+
+    /**
+     * Expression evaluation environment containing variable bindings.
+     */
+    env: Env;
+
+    /**
+     * Optional, cache of expression results.
+     *
+     * @see [[Expr.evaluate]]
+     */
+    cachedExprResults?: Map<Expr, Value>;
+}
+
+export type TechniqueUpdater = (context: TechniqueUpdateContext) => void;
+
+export interface TileObjectEntry<T> {
+    tile: Tile;
+    object: T;
+}
+
+export type TileWorldSpaceEntry = TileObjectEntry<THREE.Object3D>;
+export type TileScreenSpaceEntry = TileObjectEntry<TextElement>;
+
+export interface TechniqueHandler {
+    technique: Technique;
+
+    isDynamic: boolean;
+
+    /**
+     * Update dynamic properties of objects (material, text styles, visibilty status, etc.)
+     * managed by this technique.
+     *
+     * @param context
+     */
+    update(context: TechniqueUpdateContext): void;
+
+    /**
+     * Dispose of resources managed by this technique.
+     */
+    dispose(): void;
+
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group: Group): THREE.Object3D[];
+
+    addScreenSpaceObject(
+        tile: Tile,
+        text: TextGeometry | TextPathGeometry | PoiGeometry
+    ): TextElement[];
+
+    /**
+     * Unregister tile objects associated with particular [[Tile]] instance.
+     */
+    removeTileObjects(tile: Tile): void;
+}
+
+export class TechniqueHandlerSet {
+    readonly techniqueHandlers: TechniqueHandler[] = [];
+    readonly dynamicTechniqueHandlers: TechniqueHandler[] = [];
+
+    constructor(readonly tile: Tile) {}
+
+    getTechniqueHandler(
+        technique: IndexedTechnique,
+        fallbackHandler?: TechniqueHandlerConstructor
+    ) {
+        const tile = this.tile;
+        let techniqueHandler = this.techniqueHandlers[technique._index];
+        if (techniqueHandler === undefined) {
+            const techniqueHandlerCtor =
+                ((techniqueHandlers[technique.name] as unknown) as TechniqueHandlerConstructor) ??
+                fallbackHandler;
+            if (!techniqueHandlerCtor) {
+                throw new Error(`unknown technique ${technique.name}`);
+            }
+            techniqueHandler = new techniqueHandlerCtor(
+                technique,
+                tile,
+                tile.mapView.techniqueUpdateContext
+            );
+            if (techniqueHandler.isDynamic) {
+                this.dynamicTechniqueHandlers.push(techniqueHandler);
+            }
+            this.techniqueHandlers[technique._index] = techniqueHandler;
+        }
+        return techniqueHandler;
+    }
+
+    update(context: TechniqueUpdateContext) {
+        for (const techniqueHandler of this.dynamicTechniqueHandlers) {
+            techniqueHandler.update(context);
+        }
+    }
+
+    clear() {
+        for (const techniqueHandler of this.techniqueHandlers) {
+            techniqueHandler.removeTileObjects(this.tile);
+        }
+        this.techniqueHandlers.length = 0;
+    }
+}
+
+export type TechniqueHandlerConstructor<T extends Technique = Technique> = new (
+    technique: T,
+    tile: Tile,
+    context: TechniqueUpdateContext
+) => TechniqueHandler;
+
+export type TechniqueHandlerRegistry = {
+    [P in Technique["name"]]?: TechniqueHandlerConstructor<TechniqueByName<P>>;
+};
+
+export const techniqueHandlers: TechniqueHandlerRegistry = {};

--- a/@here/harp-mapview/lib/techniques/TechniqueHandlerCommon.ts
+++ b/@here/harp-mapview/lib/techniques/TechniqueHandlerCommon.ts
@@ -1,0 +1,421 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import {
+    BaseTechniqueParams,
+    BufferAttribute,
+    Env,
+    Expr,
+    ExtrudedPolygonTechnique,
+    FillTechnique,
+    Geometry,
+    getArrayConstructor,
+    getPropertyValue,
+    Group,
+    InterpolatedProperty,
+    isExtrudedPolygonTechnique,
+    isSolidLineTechnique,
+    isTerrainTechnique,
+    MakeTechniqueAttrs,
+    needsVertexNormals,
+    Technique,
+    TextGeometry,
+    TextPathGeometry
+} from "@here/harp-datasource-protocol";
+import { cameraToWorldDistance, EdgeMaterial, FadingFeature } from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import {
+    applyBaseColorToMaterial,
+    applyTechniquePropertyToMaterial,
+    createMaterial,
+    getBufferAttribute
+} from "../DecodedTileHelpers";
+import { FadingParameters, PolygonFadingParameters } from "../geometry/TileGeometryCreator";
+import { MapView } from "../MapView";
+import { TextElement } from "../text/TextElement";
+import { Tile, TileFeatureData, TileObject } from "../Tile";
+import {
+    TechniqueHandler,
+    TechniqueUpdateContext,
+    TechniqueUpdater,
+    TileObjectEntry,
+    TileWorldSpaceEntry
+} from "./TechniqueHandler";
+
+export abstract class WorldSpaceTechniqueHandlerBase<T extends Technique>
+    implements TechniqueHandler {
+    readonly technique: T;
+
+    protected objects: TileWorldSpaceEntry[] = [];
+    protected materials: THREE.Material[] = [];
+    protected textures: THREE.Texture[] = [];
+
+    protected mapView: MapView;
+
+    protected updaters: TechniqueUpdater[] = [];
+
+    private disposed: boolean = false;
+    private lastUpdateFrameNumber: number = -1;
+
+    constructor(technique: T, mapView: MapView) {
+        this.technique = technique;
+        this.mapView = mapView;
+    }
+
+    get isDynamic() {
+        return this.updaters.length > 0;
+    }
+
+    /**
+     * Dispose of this handler.
+     *
+     * Due to fact, that this is called during theme reset, we dispose only mark that we can be
+     * disposed and perform real disposal of resources in [[removeTileObjects]].
+     */
+    dispose() {
+        this.disposed = true;
+    }
+
+    removeTileObjects(tile: Tile) {
+        this.objects = this.objects.filter(entry => entry.tile !== tile);
+        if (this.objects.length === 0 && this.disposed) {
+            this.reallyDispose();
+        }
+    }
+
+    update(context: TechniqueUpdateContext): void {
+        if (context.frameNumber === this.lastUpdateFrameNumber) {
+            return;
+        }
+        this.lastUpdateFrameNumber = context.frameNumber;
+
+        for (const updater of this.updaters) {
+            updater(context);
+        }
+    }
+
+    abstract addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group: Group): THREE.Object3D[];
+
+    addScreenSpaceObject(tile: Tile, text: TextGeometry | TextPathGeometry): TextElement[] {
+        assert(false, `addTextElement not supported by ${this.constructor.name}`);
+        return [];
+    }
+
+    protected createMaterial(technique: Technique, context: TechniqueUpdateContext) {
+        const onTextureReady = (texture: THREE.Texture) => {
+            this.textures.push(texture);
+            this.mapView.update();
+        };
+        const material = createMaterial({ technique, env: context.env }, onTextureReady);
+        if (material === undefined) {
+            throw new Error(`#createMaterial unknown technique ${technique.name}`);
+        }
+        this.materials.push(material);
+        return material;
+    }
+
+    protected createObject<OT extends THREE.Object3D>(
+        tile: Tile,
+        srcGeometry: Geometry,
+        group: Group | undefined,
+        constructor: new (...args: any[]) => OT,
+        material: THREE.Material
+    ): OT {
+        const bufferGeometry = TechniqueHandlerCommon.createGenericBufferGeometry(
+            this.technique,
+            srcGeometry,
+            group
+        );
+        const object = new constructor(bufferGeometry, material);
+
+        object.renderOrder = this.technique.renderOrder;
+
+        this.registerObject(tile, object);
+        return object;
+    }
+
+    protected registerObject(tile: Tile, object: THREE.Object3D): TileObject {
+        const tileObject = object as TileObject;
+        tileObject.techniqueHandler = this;
+        this.objects.push({ tile, object });
+        return tileObject;
+    }
+
+    protected reallyDispose() {
+        for (const texture of this.textures) {
+            texture.dispose();
+        }
+
+        for (const material of this.materials) {
+            material.dispose();
+        }
+    }
+}
+
+export namespace TechniqueHandlerCommon {
+    type MaterialWithBaseColor = THREE.Material & {
+        color: THREE.Color;
+    };
+
+    interface TechniqueWithColor {
+        color?: string | number | Expr | InterpolatedProperty;
+        opacity?: number | Expr | InterpolatedProperty;
+    }
+
+    export function forEachTileObject<T>(
+        objects: Array<TileObjectEntry<T>>,
+        context: TechniqueUpdateContext,
+        callback: (target: T) => void
+    ) {
+        for (const entry of objects) {
+            if (entry.tile.frameNumLastVisible === context.frameNumber) {
+                callback(entry.object);
+            }
+        }
+    }
+
+    export function updateBaseColor(
+        material: MaterialWithBaseColor,
+        objects: TileWorldSpaceEntry[],
+        technique: Technique & TechniqueWithColor,
+        context: TechniqueUpdateContext
+    ) {
+        const lastOpacity = material.opacity;
+        applyBaseColorToMaterial(
+            material,
+            material.color,
+            technique,
+            technique.color!,
+            context.env
+        );
+        if (lastOpacity !== material.opacity) {
+            forEachTileObject(objects, context, target => {
+                target.visible = material.opacity > 0;
+            });
+        }
+    }
+
+    export function genericMaterialUpdater(
+        material: THREE.Material,
+        technique: Technique,
+        attrName: string,
+        context: TechniqueUpdateContext
+    ) {
+        applyTechniquePropertyToMaterial(
+            material,
+            attrName as string,
+            (technique as any)[attrName],
+            context.env
+        );
+    }
+
+    export function getFadingParams(
+        technique: MakeTechniqueAttrs<BaseTechniqueParams>,
+        env: Env
+    ): FadingParameters {
+        const fadeNear =
+            technique.fadeNear !== undefined
+                ? getPropertyValue(technique.fadeNear, env)
+                : FadingFeature.DEFAULT_FADE_NEAR;
+        const fadeFar =
+            technique.fadeFar !== undefined
+                ? getPropertyValue(technique.fadeFar, env)
+                : FadingFeature.DEFAULT_FADE_FAR;
+        return {
+            fadeNear,
+            fadeFar
+        };
+    }
+
+    export function getPolygonFadingParams(
+        technique: FillTechnique | ExtrudedPolygonTechnique,
+        env: Env
+    ): PolygonFadingParameters {
+        let color: string | number | undefined;
+        let colorMix = EdgeMaterial.DEFAULT_COLOR_MIX;
+
+        if (technique.lineColor !== undefined) {
+            color = getPropertyValue(technique.lineColor, env);
+            if (isExtrudedPolygonTechnique(technique)) {
+                const extrudedPolygonTechnique = technique as ExtrudedPolygonTechnique;
+                colorMix =
+                    extrudedPolygonTechnique.lineColorMix !== undefined
+                        ? extrudedPolygonTechnique.lineColorMix
+                        : EdgeMaterial.DEFAULT_COLOR_MIX;
+            }
+        }
+
+        const fadeNear =
+            technique.fadeNear !== undefined
+                ? getPropertyValue(technique.fadeNear, env)
+                : FadingFeature.DEFAULT_FADE_NEAR;
+        const fadeFar =
+            technique.fadeFar !== undefined
+                ? getPropertyValue(technique.fadeFar, env)
+                : FadingFeature.DEFAULT_FADE_FAR;
+
+        const lineFadeNear =
+            technique.lineFadeNear !== undefined
+                ? getPropertyValue(technique.lineFadeNear, env)
+                : fadeNear;
+        const lineFadeFar =
+            technique.lineFadeFar !== undefined
+                ? getPropertyValue(technique.lineFadeFar, env)
+                : fadeFar;
+
+        if (color === undefined) {
+            color = EdgeMaterial.DEFAULT_COLOR;
+        }
+
+        return {
+            color,
+            colorMix,
+            fadeNear,
+            fadeFar,
+            lineFadeNear,
+            lineFadeFar
+        };
+    }
+
+    export function isFadingFeatureEnabled(fadingParameters: FadingParameters) {
+        let { fadeFar, fadeNear } = fadingParameters;
+
+        if (fadeNear === FadingFeature.DEFAULT_FADE_NEAR) {
+            fadeNear = undefined;
+        }
+        if (fadeFar === FadingFeature.DEFAULT_FADE_FAR) {
+            fadeFar = undefined;
+        }
+
+        return fadeNear !== undefined || fadeFar !== undefined;
+    }
+
+    export function updateFadingParams(
+        material: FadingFeature,
+        fadingParameters: FadingParameters,
+        context: TechniqueUpdateContext
+    ) {
+        const { fadeFar, fadeNear } = fadingParameters;
+
+        if (fadeNear !== undefined) {
+            material.fadeNear = cameraToWorldDistance(fadeNear, context.viewRanges);
+        }
+        if (fadeFar !== undefined) {
+            material.fadeFar = cameraToWorldDistance(fadeFar, context.viewRanges);
+        }
+    }
+
+    export function updateEdgeFadingParams(
+        material: FadingFeature,
+        fadingParameters: PolygonFadingParameters,
+        context: TechniqueUpdateContext
+    ) {
+        const fadeFar = fadingParameters.lineFadeFar;
+        const fadeNear = fadingParameters.lineFadeNear;
+
+        if (fadeNear !== undefined) {
+            material.fadeNear = cameraToWorldDistance(fadeNear, context.viewRanges);
+        }
+        if (fadeFar !== undefined) {
+            material.fadeFar = cameraToWorldDistance(fadeFar, context.viewRanges);
+        }
+    }
+
+    export function createGenericBufferGeometry(
+        technique: Technique,
+        srcGeometry: Geometry,
+        group?: Group
+    ) {
+        const bufferGeometry = new THREE.BufferGeometry();
+
+        srcGeometry.vertexAttributes.forEach((vertexAttribute: BufferAttribute) => {
+            const buffer = getBufferAttribute(vertexAttribute);
+            bufferGeometry.setAttribute(vertexAttribute.name, buffer);
+        });
+
+        if (srcGeometry.interleavedVertexAttributes !== undefined) {
+            srcGeometry.interleavedVertexAttributes.forEach(
+                (attr: {
+                    type: any;
+                    buffer: any;
+                    stride: any;
+                    attributes: {
+                        forEach: (
+                            arg0: (interleavedAttr: {
+                                itemSize: any;
+                                offset: any;
+                                name: any;
+                            }) => void
+                        ) => void;
+                    };
+                }) => {
+                    const ArrayCtor = getArrayConstructor(attr.type);
+                    const buffer = new THREE.InterleavedBuffer(
+                        new ArrayCtor(attr.buffer),
+                        attr.stride
+                    );
+                    attr.attributes.forEach(
+                        (interleavedAttr: { itemSize: any; offset: any; name: any }) => {
+                            const attribute = new THREE.InterleavedBufferAttribute(
+                                buffer,
+                                interleavedAttr.itemSize,
+                                interleavedAttr.offset,
+                                false
+                            );
+                            bufferGeometry.setAttribute(interleavedAttr.name, attribute);
+                        }
+                    );
+                }
+            );
+        }
+
+        if (srcGeometry.index) {
+            bufferGeometry.setIndex(getBufferAttribute(srcGeometry.index));
+        }
+
+        if (!bufferGeometry.getAttribute("normal") && needsVertexNormals(technique)) {
+            bufferGeometry.computeVertexNormals();
+        }
+
+        if (group !== undefined) {
+            bufferGeometry.addGroup(group.start, group.count);
+        }
+        return bufferGeometry;
+    }
+
+    export function setupUserData(
+        srcGeometry: Geometry,
+        technique: Technique,
+        object: THREE.Object3D
+    ) {
+        if (srcGeometry.uuid !== undefined) {
+            object.userData.geometryId = srcGeometry.uuid;
+        }
+
+        if ((srcGeometry.objInfos?.length ?? 0) === 0) {
+            return;
+        }
+
+        if (isTerrainTechnique(technique)) {
+            // TODO: why terrain technique retrofits something strange into objInfos?
+            return;
+        } else if (isSolidLineTechnique(technique)) {
+            object.userData = srcGeometry.objInfos!;
+        } else {
+            // Set the feature data for picking with `MapView.intersectMapObjects()` except for
+            // solid-line which uses tile-based picking.
+            const featureData: TileFeatureData = {
+                geometryType: srcGeometry.type,
+                starts: srcGeometry.featureStarts,
+                objInfos: srcGeometry.objInfos
+            };
+            object.userData.feature = featureData;
+            object.userData.technique = technique;
+        }
+    }
+}

--- a/@here/harp-mapview/lib/techniques/TerrainTechniqueHandler.ts
+++ b/@here/harp-mapview/lib/techniques/TerrainTechniqueHandler.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+
+import { Geometry, Group, TerrainTechnique } from "@here/harp-datasource-protocol";
+import { EarthConstants } from "@here/harp-geoutils";
+import { MapMeshStandardMaterial } from "@here/harp-materials";
+import { assert } from "@here/harp-utils";
+import { DisplacementMap, TileDisplacementMap } from "../DisplacementMap";
+import { Tile } from "../Tile";
+import { techniqueHandlers, TechniqueUpdateContext } from "./TechniqueHandler";
+import { WorldSpaceTechniqueHandlerBase } from "./TechniqueHandlerCommon";
+
+/**
+ * [[TerrainTechnique]] rendering handler.
+ *
+ * Expects that texture is delivered in `srcGeometry.objInfos`.
+ *
+ * Not shareable across tiles.
+ */
+export class TerrainTechniqueHandler extends WorldSpaceTechniqueHandlerBase<TerrainTechnique> {
+    private material: MapMeshStandardMaterial;
+
+    constructor(technique: TerrainTechnique, tile: Tile, context: TechniqueUpdateContext) {
+        super(technique, tile.mapView);
+        this.material = this.createMaterial(technique, context) as MapMeshStandardMaterial;
+        assert(this.material instanceof MapMeshStandardMaterial);
+
+        const terrainColor = tile.mapView.clearColor;
+
+        if (technique.displacementMap === undefined) {
+            // Render terrain using the given color.
+            this.material.color.set(terrainColor);
+            return;
+        }
+
+        // Render terrain using height-based colors.
+        this.material.onBeforeCompile = (shader: THREE.Shader) => {
+            shader.fragmentShader = shader.fragmentShader.replace(
+                "#include <map_pars_fragment>",
+                `#include <map_pars_fragment>
+    uniform sampler2D displacementMap;
+    uniform float displacementScale;
+    uniform float displacementBias;`
+            );
+            shader.fragmentShader = shader.fragmentShader.replace(
+                "#include <map_fragment>",
+                `#ifdef USE_MAP
+    float minElevation = ${EarthConstants.MIN_ELEVATION.toFixed(1)};
+    float maxElevation = ${EarthConstants.MAX_ELEVATION.toFixed(1)};
+    float elevationRange = maxElevation - minElevation;
+
+    float disp = texture2D( displacementMap, vUv ).x * displacementScale + displacementBias;
+    vec4 texelColor = texture2D( map, vec2((disp - minElevation) / elevationRange, 0.0) );
+    texelColor = mapTexelToLinear( texelColor );
+    diffuseColor *= texelColor;
+#endif`
+            );
+            // We remove the displacement map from manipulating the vertices, it is
+            // however still required for the pixel shader, so it can't be directly
+            // removed.
+            shader.vertexShader = shader.vertexShader.replace(
+                "#include <displacementmap_vertex>",
+                ""
+            );
+        };
+        this.material.displacementMap!.needsUpdate = true;
+    }
+
+    /**
+     * @override
+     */
+    addWorldSpaceObject(tile: Tile, srcGeometry: Geometry, group?: Group) {
+        const object = this.createObject(tile, srcGeometry, group, THREE.Mesh, this.material);
+
+        // NOTE:
+        // This is copied wholesale from TileGeometryCreator.addUserData.
+        //
+        // TODO:
+        // Why displacementMap is retroffitted into incompatible type ???
+        // shouldn't we add specific field somewhere in Geometry/DecodedTile
+        if ((srcGeometry.objInfos?.length ?? 0) > 0) {
+            assert(
+                Object.keys(object.userData).length === 0,
+                "Unexpected user data in terrain object"
+            );
+
+            assert(
+                typeof srcGeometry.objInfos![0] === "object",
+                "Wrong attribute map type for terrain geometry"
+            );
+
+            const displacementMap = (srcGeometry.objInfos as DisplacementMap[])[0];
+            const tileDisplacementMap: TileDisplacementMap = {
+                tileKey: tile.tileKey,
+                texture: new THREE.DataTexture(
+                    displacementMap.buffer,
+                    displacementMap.xCountVertices,
+                    displacementMap.yCountVertices,
+                    THREE.LuminanceFormat,
+                    THREE.FloatType
+                ),
+                displacementMap,
+                geoBox: tile.geoBox
+            };
+            object.userData = tileDisplacementMap;
+            this.textures.push(tileDisplacementMap.texture);
+        }
+
+        return [object];
+    }
+}
+
+techniqueHandlers.terrain = TerrainTechniqueHandler;

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DecodedTile, GeometryType, IndexedTechnique } from "@here/harp-datasource-protocol";
+import {
+    DecodedTile,
+    GeometryType,
+    IndexedTechnique,
+    MapEnv
+} from "@here/harp-datasource-protocol";
 import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import {
     mercatorProjection,
@@ -18,10 +23,20 @@ import * as THREE from "three";
 import { DataSource } from "../lib/DataSource";
 import { DisplacementMap } from "../lib/DisplacementMap";
 import { TileGeometryCreator } from "../lib/geometry/TileGeometryCreator";
+import { TechniqueUpdateContext } from "../lib/techniques/TechniqueHandler";
 import { Tile } from "../lib/Tile";
 
 class FakeMapView {
     private m_scene = new THREE.Scene();
+
+    get techniqueUpdateContext(): TechniqueUpdateContext {
+        return {
+            viewRanges: this.viewRanges,
+            env: new MapEnv({ $zoom: this.zoomLevel }),
+            frameNumber: 0,
+            projection: mercatorProjection
+        };
+    }
 
     get zoomLevel(): number {
         return 0;
@@ -63,7 +78,7 @@ describe("TileGeometryCreator", () => {
     const tgc = TileGeometryCreator.instance;
     const mapView = new FakeMapView();
 
-    before(function() {
+    beforeEach(function() {
         mockDatasource = sinon.createStubInstance(MockDataSource);
 
         mockDatasource.getTilingScheme.callsFake(() => webMercatorTilingScheme);
@@ -152,7 +167,7 @@ describe("TileGeometryCreator", () => {
                     _styleSet: "tilezen",
                     _category: "low-priority",
                     _index: 1,
-                    _styleSetIndex: 0,
+                    _styleSetIndex: 1,
                     renderOrder: -1,
                     name: "circles"
                 }
@@ -173,9 +188,9 @@ describe("TileGeometryCreator", () => {
         tgc.processTechniques(newTile, undefined, undefined);
         tgc.createObjects(newTile, decodedTile as DecodedTile);
 
-        assert.strictEqual(newTile.objects.length, 3);
-        assert.strictEqual(newTile.objects[1].renderOrder, 20);
-        assert.strictEqual(newTile.objects[2].renderOrder, 10);
+        assert.strictEqual(newTile.objects.length, 2);
+        assert.strictEqual(newTile.objects[0].renderOrder, 20);
+        assert.strictEqual(newTile.objects[1].renderOrder, 10);
 
         newTile.mapView.theme = savedTheme;
     });

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -139,7 +139,7 @@ interface MixinShaderProperties {
  * @param visibilityRange object describing maximum and minimum visibility range - distances
  * from camera at which objects won't be rendered anymore.
  */
-function cameraToWorldDistance(distance: number, visibilityRange: ViewRanges): number {
+export function cameraToWorldDistance(distance: number, visibilityRange: ViewRanges): number {
     return distance * visibilityRange.maximum;
 }
 
@@ -530,63 +530,6 @@ export namespace FadingFeature {
             "fog_fragment",
             "fading_fragment",
             true
-        );
-    }
-
-    /**
-     * As three.js is rendering the transparent objects last (internally), regardless of their
-     * renderOrder value, we set the transparent value to false in the [[onAfterRenderCall]]. In
-     * [[onBeforeRender]], the function [[calculateDepthFromCameraDistance]] sets it to true if the
-     * fade distance value is less than 1.
-     *
-     * @param object [[THREE.Object3D]] to prepare for rendering.
-     * @param viewRanges The visibility ranges (clip planes and maximum visible distance) for
-     * actual camera setup.
-     * @param fadeNear The fadeNear value to set in the material.
-     * @param fadeFar The fadeFar value to set in the material.
-     * @param updateUniforms If `true`, the fading uniforms are set. Not required if material is
-     *          handling the uniforms already, like in a [[THREE.ShaderMaterial]].
-     * @param additionalCallback If defined, this function will be called before the function will
-     *          return.
-     */
-    export function addRenderHelper(
-        object: THREE.Object3D,
-        viewRanges: ViewRanges,
-        fadeNear: number | undefined,
-        fadeFar: number | undefined,
-        updateUniforms: boolean,
-        additionalCallback?: (
-            renderer: THREE.WebGLRenderer,
-            material: THREE.Material & FadingFeature
-        ) => void
-    ) {
-        // tslint:disable-next-line:no-unused-variable
-        object.onBeforeRender = chainCallbacks(
-            object.onBeforeRender,
-            (
-                renderer: THREE.WebGLRenderer,
-                scene: THREE.Scene,
-                camera: THREE.Camera,
-                geometry: THREE.Geometry | THREE.BufferGeometry,
-                material: THREE.Material & FadingFeature,
-                group: THREE.Group
-            ) => {
-                const fadingMaterial = material as FadingFeature;
-
-                fadingMaterial.fadeNear =
-                    fadeNear === undefined || fadeNear === FadingFeature.DEFAULT_FADE_NEAR
-                        ? FadingFeature.DEFAULT_FADE_NEAR
-                        : cameraToWorldDistance(fadeNear, viewRanges);
-
-                fadingMaterial.fadeFar =
-                    fadeFar === undefined || fadeFar === FadingFeature.DEFAULT_FADE_FAR
-                        ? FadingFeature.DEFAULT_FADE_FAR
-                        : cameraToWorldDistance(fadeFar, viewRanges);
-
-                if (additionalCallback !== undefined) {
-                    additionalCallback(renderer, material);
-                }
-            }
         );
     }
 }

--- a/@here/harp-utils/lib/MultiKeyMapBasic.ts
+++ b/@here/harp-utils/lib/MultiKeyMapBasic.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Very basic Map<K, V> where map is compound key.
+ *
+ * Uses linear search over values and until it finds entry with
+ * all key values `===`.
+ *
+ * To be used only with small number of entries.
+ */
+export class MultiKeyMapBasic<T, K extends any[] = any[]> {
+    /**
+     * Each entry contains []
+     */
+    entries: Array<[T, ...any[]]> = [];
+
+    getOrCreate(key: K, factory: () => T): T {
+        const entryIndex = this.findEntryIndex(key);
+        if (entryIndex !== undefined) {
+            return this.entries[entryIndex][0];
+        }
+        const newItem = factory();
+        this.entries.push([newItem, ...key]);
+        return newItem;
+    }
+
+    set(key: K, newItem: T) {
+        const entryIndex = this.findEntryIndex(key);
+        if (entryIndex !== undefined) {
+            this.entries[entryIndex][0] = newItem;
+        } else {
+            this.entries.push([newItem, ...key]);
+        }
+    }
+
+    get(key: K): T | undefined {
+        const entryIndex = this.findEntryIndex(key);
+        if (entryIndex !== undefined) {
+            return this.entries[entryIndex][0];
+        } else {
+            return undefined;
+        }
+    }
+
+    remove(key: K) {
+        const entryIndex = this.findEntryIndex(key);
+        if (entryIndex !== undefined) {
+            this.entries.splice(entryIndex, 1);
+        }
+    }
+
+    clear() {
+        this.entries.length = 0;
+    }
+
+    forEach(iteratee: (v: T) => void) {
+        for (const entry of this.entries) {
+            iteratee(entry[0]);
+        }
+    }
+
+    private findEntryIndex(key: K) {
+        for (let entryIndex = 0; entryIndex < this.entries.length; entryIndex++) {
+            const entry = this.entries[entryIndex];
+            let found = true;
+            for (let i = 0; i < key.length; i++) {
+                if (entry[i + 1] !== key[i]) {
+                    found = false;
+                    continue;
+                }
+            }
+            if (found) {
+                return entryIndex;
+            }
+        }
+        return undefined;
+    }
+}


### PR DESCRIPTION
Tear apart TileGeometryCreator into separate modules for handling particular
techniques.

It attempts to do two things:
  * separate logic of technique handling into  separate modules
  * provide coherent API for updating objects (materials, objects)
  * as PoC implements "skip rendering of invisible objects" #1271 

* Tile: add updateDynamicTechniques callback that shall be called by
  MapView to objects that depende on dynamic technique attributes

* MapView: Call `updateDynamicTechniques` on all rendered tiles and then don't add
  completly transparent objects to scene

* Extra - don't install fading render helper at all if fading is
  disabled

Follow-ups
  * Cross-tile material sharing where possible (textures example, most solid lines, fill areas etc) -> #1348
  * TechniqueHandlers concept applied to text elements and pois #1335 

What is missing
  * validation of parameters like in #1241 & #1287

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>