### PR TITLE
HARP-8971: Fix wrong computation of fullFrameTime (hence fps)

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2709,34 +2709,36 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Renders the current frame.
      */
-    private render(time: number): void {
+    private render(frameStartTime: number): void {
         if (this.m_drawing) {
             return;
         }
-        ++this.m_frameNumber;
 
-        const stats = PerformanceStatistics.instance;
-        const gatherStatistics: boolean = stats.enabled;
-
-        const frameStartTime = time;
-
-        RENDER_EVENT.time = time;
+        RENDER_EVENT.time = frameStartTime;
         this.dispatchEvent(RENDER_EVENT);
 
-        let currentFrameEvent: FrameStats | undefined;
+        ++this.m_frameNumber;
 
+        let currentFrameEvent: FrameStats | undefined;
+        const stats = PerformanceStatistics.instance;
+        const gatherStatistics: boolean = stats.enabled;
         if (gatherStatistics) {
             currentFrameEvent = stats.currentFrame;
-            currentFrameEvent.setValue("renderCount.frameNumber", this.m_frameNumber);
 
             if (this.m_previousFrameTimeStamp !== undefined) {
+                // In contrast to fullFrameTime we also measure the application code
+                // for the FPS. This means FPS != 1000 / fullFrameTime.
                 const timeSincePreviousFrame = frameStartTime - this.m_previousFrameTimeStamp;
-                if (gatherStatistics) {
-                    currentFrameEvent.setValue("render.fullFrameTime", timeSincePreviousFrame);
-                    // For convenience and easy readability
-                    currentFrameEvent.setValue("render.fps", 1000 / timeSincePreviousFrame);
-                }
+                currentFrameEvent.setValue("render.fps", 1000 / timeSincePreviousFrame);
             }
+
+            // We store the last frame statistics at the beginning of the next frame b/c additional
+            // work (i.e. geometry creation) is done outside of the animation frame but still needs
+            // to be added to the `fullFrameTime` (see [[TileGeometryLoader]]).
+            stats.storeAndClearFrameInfo();
+
+            currentFrameEvent = currentFrameEvent as FrameStats;
+            currentFrameEvent.setValue("renderCount.frameNumber", this.m_frameNumber);
         }
 
         this.m_previousFrameTimeStamp = frameStartTime;
@@ -2847,7 +2849,7 @@ export class MapView extends THREE.EventDispatcher {
             });
         }
 
-        if (this.m_movementDetector.checkCameraMoved(this, time)) {
+        if (this.m_movementDetector.checkCameraMoved(this, frameStartTime)) {
             const { yaw, pitch, roll } = MapViewUtils.extractAttitude(this, this.camera);
             const { latitude, longitude, altitude } = this.geoCenter;
             this.dispatchEvent({
@@ -2866,7 +2868,7 @@ export class MapView extends THREE.EventDispatcher {
         const camera = this.m_pointOfView !== undefined ? this.m_pointOfView : this.m_rteCamera;
 
         if (this.renderLabels) {
-            this.prepareRenderTextElements(time);
+            this.prepareRenderTextElements(frameStartTime);
         }
 
         if (gatherStatistics) {
@@ -2899,10 +2901,10 @@ export class MapView extends THREE.EventDispatcher {
             this.m_firstFrameRendered = true;
 
             if (gatherStatistics) {
-                stats.appResults.set("firstFrame", time);
+                stats.appResults.set("firstFrame", frameStartTime);
             }
 
-            FIRST_FRAME_EVENT.time = time;
+            FIRST_FRAME_EVENT.time = frameStartTime;
             this.dispatchEvent(FIRST_FRAME_EVENT);
         }
 
@@ -2919,18 +2921,33 @@ export class MapView extends THREE.EventDispatcher {
         if (currentFrameEvent !== undefined) {
             endTime = PerformanceTimer.now();
 
+            const frameRenderTime = endTime - frameStartTime;
+
             currentFrameEvent.setValue("render.setupTime", setupTime! - frameStartTime);
             currentFrameEvent.setValue("render.cullTime", cullTime! - setupTime!);
             currentFrameEvent.setValue("render.textPlacementTime", textPlacementTime! - cullTime!);
             currentFrameEvent.setValue("render.drawTime", drawTime! - textPlacementTime!);
             currentFrameEvent.setValue("render.textDrawTime", textDrawTime! - drawTime!);
             currentFrameEvent.setValue("render.cleanupTime", endTime - textDrawTime!);
-            currentFrameEvent.setValue("render.frameRenderTime", endTime - frameStartTime);
+            currentFrameEvent.setValue("render.frameRenderTime", frameRenderTime);
 
-            PerformanceStatistics.instance.storeFrameInfo(this.m_renderer.info);
+            // Initialize the fullFrameTime with the frameRenderTime If we also create geometry in
+            // this frame, this number will be increased in the TileGeometryLoader.
+            currentFrameEvent.setValue("render.fullFrameTime", frameRenderTime);
+            currentFrameEvent.setValue("render.geometryCreationTime", 0);
+
+            // Add THREE.js statistics
+            stats.addWebGLInfo(this.m_renderer.info);
+
+            // Add memory statistics
+            // FIXME:
+            // This will only measure the memory of the rendering and not of the geometry creation.
+            // Assuming the garbage collector is not kicking in immediately we will at least see
+            // the geometry creation memory consumption acounted in the next frame.
+            stats.addMemoryInfo();
         }
 
-        DID_RENDER_EVENT.time = time;
+        DID_RENDER_EVENT.time = frameStartTime;
         this.dispatchEvent(DID_RENDER_EVENT);
 
         // After completely rendering this frame, it is checked if this frame was the first complete
@@ -2946,10 +2963,10 @@ export class MapView extends THREE.EventDispatcher {
             this.m_firstFrameComplete = true;
 
             if (gatherStatistics) {
-                stats.appResults.set("firstFrameComplete", time);
+                stats.appResults.set("firstFrameComplete", frameStartTime);
             }
 
-            FRAME_COMPLETE_EVENT.time = time;
+            FRAME_COMPLETE_EVENT.time = frameStartTime;
             this.dispatchEvent(FRAME_COMPLETE_EVENT);
         }
     }

--- a/@here/harp-mapview/lib/Statistics.ts
+++ b/@here/harp-mapview/lib/Statistics.ts
@@ -1017,55 +1017,51 @@ export class PerformanceStatistics {
     }
 
     /**
-     * Stores the current frame events into the array of events. Uses [[THREE.WebGLInfo]] to add the
-     * render state information to the current frame.
-     *
+     * Add the render state information from [[THREE.WebGLInfo]] to the current frame.
      * @param {THREE.WebGLInfo} webGlInfo
-     * @returns {boolean} Returns `false` if the maximum number of storable frames has been reached.
-     * @memberof PerformanceStatistics
      */
-    storeFrameInfo(webGlInfo?: THREE.WebGLInfo): boolean {
-        if (this.m_frameEvents.length >= this.maxNumFrames) {
-            return false;
+    addWebGLInfo(webGlInfo: THREE.WebGLInfo) {
+        if (webGlInfo.render !== undefined) {
+            this.currentFrame.setValue(
+                "gl.numCalls",
+                webGlInfo.render.calls === null ? 0 : webGlInfo.render.calls
+            );
+            this.currentFrame.setValue(
+                "gl.numPoints",
+                webGlInfo.render.points === null ? 0 : webGlInfo.render.points
+            );
+            this.currentFrame.setValue(
+                "gl.numLines",
+                webGlInfo.render.lines === null ? 0 : webGlInfo.render.lines
+            );
+            this.currentFrame.setValue(
+                "gl.numTriangles",
+                webGlInfo.render.triangles === null ? 0 : webGlInfo.render.triangles
+            );
         }
-
-        if (webGlInfo !== undefined) {
-            if (webGlInfo.render !== undefined) {
-                this.currentFrame.setValue(
-                    "gl.numCalls",
-                    webGlInfo.render.calls === null ? 0 : webGlInfo.render.calls
-                );
-                this.currentFrame.setValue(
-                    "gl.numPoints",
-                    webGlInfo.render.points === null ? 0 : webGlInfo.render.points
-                );
-                this.currentFrame.setValue(
-                    "gl.numLines",
-                    webGlInfo.render.lines === null ? 0 : webGlInfo.render.lines
-                );
-                this.currentFrame.setValue(
-                    "gl.numTriangles",
-                    webGlInfo.render.triangles === null ? 0 : webGlInfo.render.triangles
-                );
-            }
-            if (webGlInfo.memory !== undefined) {
-                this.currentFrame.setValue(
-                    "gl.numGeometries",
-                    webGlInfo.memory.geometries === null ? 0 : webGlInfo.memory.geometries
-                );
-                this.currentFrame.setValue(
-                    "gl.numTextures",
-                    webGlInfo.memory.textures === null ? 0 : webGlInfo.memory.textures
-                );
-            }
-            if (webGlInfo.programs !== undefined) {
-                this.currentFrame.setValue(
-                    "gl.numPrograms",
-                    webGlInfo.programs === null ? 0 : webGlInfo.programs.length
-                );
-            }
+        if (webGlInfo.memory !== undefined) {
+            this.currentFrame.setValue(
+                "gl.numGeometries",
+                webGlInfo.memory.geometries === null ? 0 : webGlInfo.memory.geometries
+            );
+            this.currentFrame.setValue(
+                "gl.numTextures",
+                webGlInfo.memory.textures === null ? 0 : webGlInfo.memory.textures
+            );
         }
+        if (webGlInfo.programs !== undefined) {
+            this.currentFrame.setValue(
+                "gl.numPrograms",
+                webGlInfo.programs === null ? 0 : webGlInfo.programs.length
+            );
+        }
+    }
 
+    /**
+     * Add memory statistics to the current frame if available.
+     * @note Currently only supported on Chrome
+     */
+    addMemoryInfo() {
         if (window !== undefined && window.performance !== undefined) {
             const memory = (window.performance as any).memory as ChromeMemoryInfo;
             if (memory !== undefined) {
@@ -1073,6 +1069,18 @@ export class PerformanceStatistics {
                 this.currentFrame.setValue("memory.usedJSHeapSize", memory.usedJSHeapSize);
                 this.currentFrame.setValue("memory.jsHeapSizeLimit", memory.jsHeapSizeLimit);
             }
+        }
+    }
+
+    /**
+     * Stores the current frame events into the array of events and clears all values.
+     *
+     * @returns {boolean} Returns `false` if the maximum number of storable frames has been reached.
+     * @memberof PerformanceStatistics
+     */
+    storeAndClearFrameInfo(): boolean {
+        if (this.m_frameEvents.length >= this.maxNumFrames) {
+            return false;
         }
 
         this.m_frameEvents.addFrame(this.currentFrame);

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -319,6 +319,11 @@ export class SimpleTileGeometryLoader implements TileGeometryLoader {
             if (stats.enabled) {
                 const geometryCreationTime = PerformanceTimer.now() - now;
                 const currentFrame = stats.currentFrame;
+
+                // Account for the geometry creation in the current frame.
+                currentFrame.addValue("render.fullFrameTime", geometryCreationTime);
+                currentFrame.addValue("render.geometryCreationTime", geometryCreationTime);
+
                 currentFrame.addValue("geometry.geometryCreationTime", geometryCreationTime);
                 currentFrame.addValue("geometryCount.numGeometries", decodedTile.geometries.length);
                 currentFrame.addValue("geometryCount.numTechniques", decodedTile.techniques.length);

--- a/@here/harp-mapview/test/StatisticsTest.ts
+++ b/@here/harp-mapview/test/StatisticsTest.ts
@@ -436,14 +436,14 @@ describe("mapview-statistics", function() {
             a: 100
         });
 
-        stats.storeFrameInfo();
+        stats.storeAndClearFrameInfo();
 
         addFrameValues({
             a: 150,
             b: 200
         });
 
-        stats.storeFrameInfo();
+        stats.storeAndClearFrameInfo();
 
         const frameEvents = stats.frameEvents;
         assert.equal(frameEvents.length, 2);


### PR DESCRIPTION
Previously the fullFrameTime was computed by subtracting the last frame start time from the current frame start time.
This was done to make sure we also measure the time we spend outside the current animation frame (i.e. geometry creation time).
Unfortunately with this approach we also measure everything the application/test is doing.

With this change the fullFrameTime is explicitly computed by adding the geometry creation time to the current frame.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
