### PR TITLE
Add support for dynamic properties.

### DIFF
--- a/@here/harp-datasource-protocol/StyleExpressions.md
+++ b/@here/harp-datasource-protocol/StyleExpressions.md
@@ -67,6 +67,21 @@ Returns a `boolean` indicating if the current `feature` or the given
 ["!has", name, object]
 ```
 
+## dynamic-properties
+
+Gets the properties that are evaluated at rendering time.
+
+``javascript
+// returns an object containing the dynamic properties.
+["dynamic-properties"]
+
+// gets the value of the dynamic property `animating`
+["get", "animating", ["dynamic-properties"]]
+
+// `true` if `animating` is a dynamic property.
+["has", "animating", ["dynamic-properties"]]
+```
+
 ## in
 
 Returns a `boolean` indicating if the `value` is contained in the list of `elements`.

--- a/@here/harp-datasource-protocol/lib/Env.ts
+++ b/@here/harp-datasource-protocol/lib/Env.ts
@@ -21,6 +21,15 @@ export interface ValueMap {
  */
 export class Env {
     /**
+     * Returns `true` if the given object is an instance of [[Env]].
+     *
+     * @param object The object to test.
+     */
+    static isEnv(object: any): object is Env {
+        return object instanceof Env;
+    }
+
+    /**
      * Returns property in [[Env]] by name.
      *
      * @param name Name of property.

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -41,11 +41,6 @@ export class ExprDependencies {
      * The properties needed to evaluate the [[Expr]].
      */
     readonly properties = new Set<string>();
-
-    /**
-     * `true` if the [[Expr]] depends on zoom level. Default is `false`.
-     */
-    zoom?: boolean;
 }
 
 class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
@@ -97,11 +92,7 @@ class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
     }
 
     visitCallExpr(expr: CallExpr, context: ExprDependencies): void {
-        if (expr.op === "zoom" && expr.args.length === 0) {
-            context.zoom = true;
-        } else {
-            expr.args.forEach(childExpr => childExpr.accept(this, context));
-        }
+        expr.args.forEach(childExpr => childExpr.accept(this, context));
     }
 
     visitMatchExpr(expr: MatchExpr, context: ExprDependencies): void {

--- a/@here/harp-datasource-protocol/lib/ExprInstantiator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprInstantiator.ts
@@ -140,7 +140,7 @@ export class ExprInstantiator implements ExprVisitor<Expr, InstantiationContext>
         for (const [condition, branch] of expr.branches) {
             const newCondition = condition.accept(this, context);
             const deps = newCondition.dependencies();
-            if (!deps.zoom && deps.properties.size === 0) {
+            if (!condition.isDynamic() && deps.properties.size === 0) {
                 if (Boolean(newCondition.evaluate(emptyEnv, ExprScope.Condition))) {
                     return branch.accept(this, context);
                 }

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -722,7 +722,7 @@ export class StyleSetEvaluator {
             if (Expr.isExpr(attrValue)) {
                 const deps = attrValue.dependencies();
 
-                if (!deps.zoom && deps.properties.size === 0) {
+                if (deps.properties.size === 0 && !attrValue.isDynamic()) {
                     // no data-dependencies detected.
                     attrValue = attrValue.evaluate(this.m_emptyEnv);
                 }

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -45,10 +45,13 @@ describe("ExprEvaluator", function() {
     }
 
     function dependencies(json: JsonValue) {
-        const deps = Expr.fromJSON(json).dependencies();
+        const expr = Expr.fromJSON(json);
+        const dynamic = expr.isDynamic();
+        const deps = expr.dependencies();
+        const properties = Array.from(deps.properties).sort();
         return {
-            properties: Array.from(deps.properties).sort(),
-            zoom: deps.zoom || false
+            properties: Array.from(properties).sort(),
+            dynamic
         };
     }
 
@@ -174,6 +177,42 @@ describe("ExprEvaluator", function() {
             assert.isFalse(evaluate(["!has", "z", ["literal", object]]));
             assert.isFalse(evaluate(["!has", "k", ["literal", object]]));
             assert.isTrue(evaluate(["!has", "w", ["literal", object]]));
+        });
+    });
+
+    describe("Operator 'dynamic-properties'", function() {
+        it("evaluation scope", function() {
+            // the ["dynamic-properties"] in a dynamic scope should return the current environment.
+            assert.isTrue(
+                Env.isEnv(evaluate(["dynamic-properties"], undefined, ExprScope.Dynamic))
+            );
+
+            // the ["dynamic-properties"] in a static scope should return itself.
+            assert.isTrue(
+                Expr.isExpr(evaluate(["dynamic-properties"], undefined, ExprScope.Value))
+            );
+
+            // the ["dynamic-properties"] in a condition scope should return itself.
+            assert.isTrue(
+                Expr.isExpr(evaluate(["dynamic-properties"], undefined, ExprScope.Condition))
+            );
+        });
+
+        it("get", function() {
+            const values: ValueMap = { x: 123 };
+
+            assert.strictEqual(
+                evaluate(["get", "x", ["dynamic-properties"]], values, ExprScope.Dynamic),
+                123
+            );
+
+            assert.isTrue(
+                evaluate(["has", "x", ["dynamic-properties"]], values, ExprScope.Dynamic)
+            );
+
+            assert.isFalse(
+                evaluate(["has", "y", ["dynamic-properties"]], values, ExprScope.Dynamic)
+            );
         });
     });
 
@@ -790,23 +829,23 @@ describe("ExprEvaluator", function() {
     });
 
     it("Dependencies", function() {
-        assert.deepEqual(dependencies(true), { properties: [], zoom: false });
-        assert.deepEqual(dependencies(["get", "x"]), { properties: ["x"], zoom: false });
-        assert.deepEqual(dependencies(["has", "x"]), { properties: ["x"], zoom: false });
+        assert.deepEqual(dependencies(true), { properties: [], dynamic: false });
+        assert.deepEqual(dependencies(["get", "x"]), { properties: ["x"], dynamic: false });
+        assert.deepEqual(dependencies(["has", "x"]), { properties: ["x"], dynamic: false });
 
         assert.deepEqual(
             dependencies(["interpolate", ["exponential", 2], ["zoom"], 0, 0, 1, 1, ["get", "max"]]),
-            { properties: ["max"], zoom: true }
+            { properties: ["max"], dynamic: true }
         );
 
         assert.deepEqual(dependencies(["step", ["zoom"], "default", 5, "a", 10, "b"]), {
             properties: [],
-            zoom: true
+            dynamic: true
         });
 
         assert.deepEqual(dependencies(["match", ["get", "two"], [0, 1], false, 2, true, false]), {
             properties: ["two"],
-            zoom: false
+            dynamic: false
         });
 
         assert.deepEqual(
@@ -820,7 +859,7 @@ describe("ExprEvaluator", function() {
             ]),
             {
                 properties: ["fallback-value", "x"],
-                zoom: true
+                dynamic: true
             }
         );
     });
@@ -1173,6 +1212,12 @@ describe("ExprEvaluator", function() {
             assert.deepStrictEqual(instantiate(["in", ["get", "two"], ["aa", "bb"]]), false);
 
             assert.deepStrictEqual(instantiate(["in", ["get", "y"], [123, 321]]), true);
+
+            assert.deepStrictEqual(instantiate(["get", "x", ["dynamic-properties"]]), [
+                "get",
+                "x",
+                ["dynamic-properties"]
+            ]);
         });
     });
 


### PR DESCRIPTION
Dynamic properties are properties that are resolved at rendering
time.

This change also removes the special handling of ["zoom"] when
computing the dependencies of an expression.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
