### PR TITLE
HARP-9079: Fix the styling data driven example.

### DIFF
--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -47,7 +47,7 @@ export namespace DataDrivenThemeExample {
                     }
                 },
                 styles: {
-                    tilezen: [
+                    population: [
                         ["ref", "countryBorderOutline"],
                         ["ref", "waterPolygons"],
                         {
@@ -100,7 +100,7 @@ export namespace DataDrivenThemeExample {
             urlParams: {
                 access_token: accessToken
             },
-            styleSetName: "tilezen",
+            styleSetName: "population",
             maxZoomLevel: 17,
             copyrightInfo
         });


### PR DESCRIPTION
This particular example demonstrates how to create a new style set
by importing rules from an existing theme. Unfortunately, instead of
creating a new style set this example was simply appending rules to the
imported style set named 'tilezen' defined in berlin_tilezen_base.json

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
