### PR TITLE
HARP-8523: Fix zoom level jitter and tiles flickering.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1726,6 +1726,7 @@ export class MapView extends THREE.EventDispatcher {
         return this.m_zoomLevel;
     }
     set zoomLevel(zoomLevel: number) {
+        zoomLevel = MapViewUtils.roundZoomLevel(zoomLevel);
         this.m_zoomLevel = THREE.MathUtils.clamp(
             zoomLevel,
             this.m_minZoomLevel,

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -6,16 +6,10 @@
 
 import * as THREE from "three";
 
-import {
-    GeoCoordinates,
-    MathUtils,
-    Projection,
-    ProjectionType,
-    TileKey
-} from "@here/harp-geoutils";
+import { GeoCoordinates, Projection, ProjectionType, TileKey } from "@here/harp-geoutils";
 import { EarthConstants } from "@here/harp-geoutils/lib/projection/EarthConstants";
 import { MapMeshBasicMaterial, MapMeshStandardMaterial } from "@here/harp-materials";
-import { assert, LoggerManager } from "@here/harp-utils";
+import { assert, LoggerManager, MathUtils } from "@here/harp-utils";
 import { MapView, MAX_TILT_ANGLE } from "./MapView";
 import { getFeatureDataSize, TileFeatureData } from "./Tile";
 
@@ -450,7 +444,7 @@ export namespace MapViewUtils {
             mapView.projection.type === ProjectionType.Spherical
                 ? cache.vector3[0].copy(mapView.camera.position).normalize()
                 : cache.vector3[0].set(0, 0, 1),
-            MathUtils.degToRad(-deltaYawDeg)
+            THREE.MathUtils.degToRad(-deltaYawDeg)
         );
         mapView.camera.updateMatrixWorld();
 
@@ -860,8 +854,9 @@ export namespace MapViewUtils {
             options.maxZoomLevel
         );
         // Round to avoid modify the zoom level without distance change, with the imprecision
-        // introduced by raycasting.
-        return Math.round(zoomLevel * 10e15) / 10e15;
+        // introduced by ray-casting and distance calculus.
+        // NOTE: Using 10 fractional digits as rounding precision solves HARP-8523.
+        return roundZoomLevel(zoomLevel);
     }
 
     /**
@@ -965,6 +960,26 @@ export namespace MapViewUtils {
         screenSize: number
     ): number {
         return (distance * screenSize) / focalLength;
+    }
+
+    /**
+     * Function performs zoom level rounding to 10-th place after comma.
+     *
+     * Inaccuracies on the 13-th fractional digit may be observed when doing small
+     * tilt changes, thus causing the zoom level to be discretized to smaller value then real
+     * one, for example when acquiring tiles storage level or visibility level.
+     * This causes zoom level jitter and displaying wrong tile set (with different zoom level)
+     * for a certain camera arrangements (angles).
+     *
+     * @note Rounding function is used to limit zoom level jitter and fluctuations.
+     *
+     * @param zoomLevel Input zoom level from based on camera distance.
+     * @return The resulting zoom level rounded to 10-th place after comma.
+     */
+    export function roundZoomLevel(zoomLevel: number) {
+        // Here 10 digits gives quite big safety margin, yet still giving enough precision for
+        // zoom level based interpolations.
+        return MathUtils.roundFraction(zoomLevel, 10);
     }
 
     /**

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -103,7 +103,8 @@ describe("map-view#Utils", function() {
                     mapViewMock,
                     distance
                 );
-                expect(zoomLevel).to.be.closeTo(calculatedZoomLevel, 1e-14);
+                // Expect accuracy till 10-th fractional digit (10-th place after comma).
+                expect(zoomLevel).to.be.closeTo(calculatedZoomLevel, 1e-10);
             }
         });
     });

--- a/@here/harp-utils/lib/MathUtils.ts
+++ b/@here/harp-utils/lib/MathUtils.ts
@@ -1,3 +1,5 @@
+import { assert } from "./assert";
+
 /*
  * Copyright (C) 2017-2019 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
@@ -162,5 +164,45 @@ export namespace MathUtils {
         const timeValue =
             time < 0.5 ? 4 * time * time * time : (time - 1) * (2 * time - 2) * (2 * time - 2) + 1;
         return startValue + (endValue - startValue) * timeValue;
+    }
+
+    /**
+     * Round number to a specified number of fractional digits, using 'round to nearest' convention.
+     *
+     * Midpoint values of less significant fraction digit (digit on position 'digits + 1' after
+     * comma) are promoting - increase previous digit - if they are greater or equal to 5.
+     *
+     * @note Function accepts negative values using correct arithmetic rounding, such as the correct
+     * numbers for `roundFraction(-0.5, 0)` will be `-1` and for `roundFraction(-1.55, 1)` will
+     * be `-1.6`.
+     * @note If you accidentally pass floating point number (with fraction) to @param digits
+     * this value will be _truncated_, but negative number of digits is not allowed.
+     *
+     * @param value The floating point value to be rounded.
+     * @param digits The number of fractional digits to leave (accuracy after comma).
+     */
+    export function roundFraction(value: number, digitsNum: number = 10) {
+        assert(digitsNum >= 0, "Number of digits must be higher then 0!");
+        // Make sure digits are specified as discreet number.
+        const digits = Math.trunc(digitsNum);
+        // Calculate mantissa factor for truncation.
+        const mantissaCut = Math.pow(10, digits);
+        let fraction = value * mantissaCut;
+        let result = Math.trunc(fraction);
+        fraction = fraction - result;
+        const sign: number = Math.sign(value);
+        // Value has no more then 'digitsNum' fractional digits.
+        if (fraction === 0) {
+            return value;
+        }
+        // Last digit promotes fractional part up.
+        else if (fraction * sign >= 0.5) {
+            result = (result + sign) / mantissaCut;
+        }
+        // Just cut digits further then 'digitsNum'
+        else {
+            result = result / mantissaCut;
+        }
+        return result;
     }
 }

--- a/@here/harp-utils/test/MathUtilsTest.ts
+++ b/@here/harp-utils/test/MathUtilsTest.ts
@@ -35,5 +35,91 @@ describe("MathUtils", () => {
             assert.isFalse(MathUtils.isClamped(5, undefined, 2));
             assert.isFalse(MathUtils.isClamped(0, 1, undefined));
         });
+        it("roundFraction", () => {
+            assert.equal(MathUtils.roundFraction(1, 0), 1);
+            assert.equal(MathUtils.roundFraction(5, 0), 5);
+            assert.equal(MathUtils.roundFraction(99, 0), 99);
+
+            assert.equal(MathUtils.roundFraction(1.1, 0), 1);
+            assert.equal(MathUtils.roundFraction(1.4, 0), 1);
+            assert.equal(MathUtils.roundFraction(1.4999999999, 0), 1);
+            assert.equal(MathUtils.roundFraction(1.5, 0), 2);
+
+            assert.equal(MathUtils.roundFraction(5.1, 0), 5);
+            assert.equal(MathUtils.roundFraction(5.4, 0), 5);
+            assert.equal(MathUtils.roundFraction(5.4999999999, 0), 5);
+            assert.equal(MathUtils.roundFraction(5.5, 0), 6);
+            assert.equal(MathUtils.roundFraction(5.9999999999, 0), 6);
+
+            assert.equal(MathUtils.roundFraction(99.1, 0), 99);
+            assert.equal(MathUtils.roundFraction(99.4, 0), 99);
+            assert.equal(MathUtils.roundFraction(99.499999999, 0), 99);
+            assert.equal(MathUtils.roundFraction(99.5, 0), 100);
+            assert.equal(MathUtils.roundFraction(99.999999999, 0), 100);
+
+            assert.equal(MathUtils.roundFraction(1.1, 1), 1.1);
+            assert.equal(MathUtils.roundFraction(1.11, 1), 1.1);
+            assert.equal(MathUtils.roundFraction(1.1000000001, 1), 1.1);
+            assert.equal(MathUtils.roundFraction(1.14, 1), 1.1);
+            assert.equal(MathUtils.roundFraction(1.1499999999, 1), 1.1);
+
+            assert.equal(MathUtils.roundFraction(1.15, 1), 1.2);
+            assert.equal(MathUtils.roundFraction(1.19, 1), 1.2);
+            assert.equal(MathUtils.roundFraction(1.1999999999, 1), 1.2);
+
+            assert.equal(MathUtils.roundFraction(1.1, 2), 1.1);
+            assert.equal(MathUtils.roundFraction(1.101, 2), 1.1);
+            assert.equal(MathUtils.roundFraction(1.1049999999, 2), 1.1);
+            assert.equal(MathUtils.roundFraction(1.105, 2), 1.11);
+
+            assert.equal(MathUtils.roundFraction(1.15, 2), 1.15);
+            assert.equal(MathUtils.roundFraction(1.15, 10), 1.15);
+            assert.equal(MathUtils.roundFraction(1.15000000001, 10), 1.15);
+            assert.equal(MathUtils.roundFraction(1.15000000001, 11), 1.15000000001);
+
+            assert.equal(MathUtils.roundFraction(99.001, 2), 99);
+            assert.equal(MathUtils.roundFraction(99.005, 2), 99.01);
+            assert.equal(MathUtils.roundFraction(99.0005, 2), 99);
+            assert.equal(MathUtils.roundFraction(99.499999, 2), 99.5);
+            assert.equal(MathUtils.roundFraction(99.495, 2), 99.5);
+            assert.equal(MathUtils.roundFraction(99.999999, 2), 100);
+
+            // Test negative numbers
+            assert.equal(MathUtils.roundFraction(-0.1, 0), 0);
+            assert.equal(MathUtils.roundFraction(-0.5, 0), -1);
+            assert.equal(MathUtils.roundFraction(-0.9, 0), -1);
+
+            assert.equal(MathUtils.roundFraction(-1.1, 0), -1);
+            assert.equal(MathUtils.roundFraction(-1.4, 0), -1);
+            assert.equal(MathUtils.roundFraction(-1.4999999999, 0), -1);
+            assert.equal(MathUtils.roundFraction(-1.5, 0), -2);
+            assert.equal(MathUtils.roundFraction(-9.5, 0), -10);
+
+            assert.equal(MathUtils.roundFraction(-0.45, 1), -0.5);
+            assert.equal(MathUtils.roundFraction(-0.45, 2), -0.45);
+            assert.equal(MathUtils.roundFraction(-0.55, 1), -0.6);
+            assert.equal(MathUtils.roundFraction(-0.555, 2), -0.56);
+
+            assert.equal(MathUtils.roundFraction(-1.4999999999, 1), -1.5);
+            assert.equal(MathUtils.roundFraction(-1.4999999999, 2), -1.5);
+            assert.equal(MathUtils.roundFraction(-1.495, 2), -1.5);
+
+            assert.equal(MathUtils.roundFraction(-9.5, 1), -9.5);
+            assert.equal(MathUtils.roundFraction(-9.555, 1), -9.6);
+            assert.equal(MathUtils.roundFraction(-9.999, 1), -10);
+
+            // Allows to pass digits number as float, should remove fraction part then.
+            assert.equal(MathUtils.roundFraction(1.2345, 1.5), 1.2);
+            assert.equal(MathUtils.roundFraction(1.2345, 2.5), 1.23);
+            assert.equal(MathUtils.roundFraction(1.2345, 3.9), 1.235);
+
+            // Test wrong argument for digits num.
+            assert.throws(() => {
+                MathUtils.roundFraction(10.1, -1);
+            }, "Number of digits must be higher then 0!");
+            assert.throws(() => {
+                MathUtils.roundFraction(10.12, -2.4);
+            }, "Number of digits must be higher then 0!");
+        });
     });
 });


### PR DESCRIPTION
Inaccuracies on the 13-th fractional digit of zoom level calculation
may be observed when doing small tilt changes, thus causing the zoom level
to be discretized to smaller value then real one, especially when
calculating tiles' storage or visibility level.
This causes displaying wrong tile set (with different zoom level) for
a certain camera arrangement (angles).

The change introduces zoom level rounding above 10-th fractional digit,
giving enough safety margin for inaccurate zoom level from distance
calculus and quite good precision for zoom level based interpolations.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
