### PR TITLE
HARP-8523: Fix zoom level jitter and tiles flickering.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1726,6 +1726,7 @@ export class MapView extends THREE.EventDispatcher {
         return this.m_zoomLevel;
     }
     set zoomLevel(zoomLevel: number) {
+        zoomLevel = MapViewUtils.roundZoomLevel(zoomLevel);
         this.m_zoomLevel = THREE.MathUtils.clamp(
             zoomLevel,
             this.m_minZoomLevel,

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -103,7 +103,8 @@ describe("map-view#Utils", function() {
                     mapViewMock,
                     distance
                 );
-                expect(zoomLevel).to.be.closeTo(calculatedZoomLevel, 1e-14);
+                // Expect accuracy till 10-th fractional digit (10-th place after comma).
+                expect(zoomLevel).to.be.closeTo(calculatedZoomLevel, 1e-10);
             }
         });
     });


### PR DESCRIPTION
Inaccuracies on the 13-th fractional digit of zoom level calculation
may be observed when doing small tilt changes, thus causing the zoom level
to be discretized to smaller value then real one, especially when
calculating tiles' storage or visibility level.
This causes displaying wrong tile set (with different zoom level) for
a certain camera arrangement (angles).

The change introduces zoom level rounding above 10-th fractional digit,
giving enough safety margin for inaccurate zoom level from distance
calculus and quite good precision for zoom level based interpolations.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
