### PR TITLE
Add support for the style operators 'id' and 'geometry-type'

### DIFF
--- a/@here/harp-datasource-protocol/StyleExpressions.md
+++ b/@here/harp-datasource-protocol/StyleExpressions.md
@@ -27,6 +27,14 @@ Returns `true` if no sub expression evaluates to `true`.
 ["none", expr...]
 ```
 
+## id
+
+Returns the id of the current feature.
+
+```javascript
+["id"]
+```
+
 ## geometry-type
 
 Returns a `string` representing the geometry type of the current feature.

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -90,6 +90,17 @@ class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
 
     visitCallExpr(expr: CallExpr, context: ExprDependencies): void {
         expr.args.forEach(childExpr => childExpr.accept(this, context));
+
+        switch (expr.op) {
+            case "id":
+                context.properties.add("$id");
+                break;
+            case "geometry-type":
+                context.properties.add("$geometryType");
+                break;
+            default:
+                break;
+        }
     }
 
     visitMatchExpr(expr: MatchExpr, context: ExprDependencies): void {

--- a/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
@@ -23,6 +23,11 @@ const operators = {
                     return null;
             }
         }
+    },
+    id: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            return context.env.lookup("$id") ?? null;
+        }
     }
 };
 

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -764,6 +764,39 @@ describe("ExprEvaluator", function() {
             }
         });
 
+        it("Operator 'id'", function() {
+            assert.strictEqual(evaluate(["id"], { $id: 123 }), 123);
+            assert.strictEqual(evaluate(["id"], { $id: "473843" }), "473843");
+            assert.strictEqual(evaluate(["id"]), null);
+
+            assert.deepStrictEqual(dependencies(["id"]), {
+                properties: ["$id"],
+                dynamic: false
+            });
+        });
+
+        it("Operator 'geometry-type'", function() {
+            // Returns a string representing the feature type using the GoeJSON conversion,
+            // Point, LineString, or Polygon.
+
+            assert.strictEqual(evaluate(["geometry-type"], { $geometryType: "point" }), "Point");
+
+            assert.strictEqual(
+                evaluate(["geometry-type"], { $geometryType: "line" }),
+                "LineString"
+            );
+
+            assert.strictEqual(
+                evaluate(["geometry-type"], { $geometryType: "polygon" }),
+                "Polygon"
+            );
+
+            assert.deepStrictEqual(dependencies(["geometry-type"]), {
+                properties: ["$geometryType"],
+                dynamic: false
+            });
+        });
+
         it("dynamic interpolation (without step 0)", function() {
             const interpolation = evaluate(["step", ["zoom"], "#ff0000", 13, "#000000"]);
             for (let zoom = 0; zoom < 13; ++zoom) {

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -252,7 +252,7 @@ export namespace PolygonsFeaturesExample {
                 technique: "extruded-polygon",
                 when: [
                     "all",
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [">", ["to-number", ["get", propertyName]], min],
                     ["<=", ["to-number", ["get", propertyName]], max]
                 ],

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -4,7 +4,7 @@
         "extrudedBuildingsCondition": [
             "all",
             ["==", ["get", "$layer"], "buildings"],
-            ["==", ["get", "$geometryType"], "polygon"]
+            ["==", ["geometry-type"], "Polygon"]
         ],
         "defaultBuildingColor": "#EDE7E1E6",
         "waterColor": "#436981",
@@ -13,7 +13,7 @@
             "when": [
                 "all",
                 ["==", ["get", "$layer"], "water"],
-                ["==", ["get", "$geometryType"], "polygon"]
+                ["==", ["geometry-type"], "Polygon"]
             ],
             "technique": "fill",
             "attr": {
@@ -116,7 +116,7 @@
             "when": [
                 "all",
                 ["==", ["get", "$layer"], "boundaries"],
-                ["==", ["get", "$geometryType"], "line"],
+                ["==", ["geometry-type"], "LineString"],
                 ["==", ["get", "kind"], "country"]
             ],
             "technique": "solid-line",
@@ -131,7 +131,7 @@
             "when": [
                 "all",
                 ["==", ["get", "$layer"], "boundaries"],
-                ["==", ["get", "$geometryType"], "line"],
+                ["==", ["geometry-type"], "LineString"],
                 ["==", ["get", "kind"], "country"]
             ],
             "technique": "solid-line",
@@ -1245,7 +1245,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["==", ["get", "kind_detail"], "tram"]
@@ -1263,7 +1263,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     [
@@ -1284,7 +1284,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -1317,7 +1317,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -1334,7 +1334,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -1410,7 +1410,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -1477,7 +1477,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "text",
@@ -1494,7 +1494,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1587,7 +1587,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1618,7 +1618,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1663,7 +1663,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1708,7 +1708,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "text",
@@ -1724,7 +1724,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "point"]
+                    ["==", ["geometry-type"], "Point"]
                 ],
                 "technique": "text",
                 "attr": {
@@ -1741,7 +1741,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban"]
                 ],
                 "technique": "fill",
@@ -1756,7 +1756,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban_area"]
                 ],
                 "technique": "none",
@@ -1786,7 +1786,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1820,7 +1820,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "runway"]
                 ],
                 "technique": "fill",
@@ -1835,7 +1835,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "aerodrome"]
                 ],
                 "technique": "fill",
@@ -1849,7 +1849,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "national_park"]
                 ],
                 "technique": "fill",
@@ -1863,7 +1863,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "pitch"]
                 ],
                 "technique": "fill",
@@ -1877,7 +1877,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "hospital"]
                 ],
                 "technique": "fill",
@@ -1891,7 +1891,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "cemetery"]
                 ],
                 "technique": "fill",
@@ -1905,7 +1905,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "bridge"]
                 ],
                 "technique": "fill",
@@ -1919,7 +1919,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1937,7 +1937,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "religion"]
                 ],
                 "technique": "fill",
@@ -1951,7 +1951,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1969,7 +1969,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1987,7 +1987,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["any", ["==", ["get", "kind"], "beach"], ["$=", ["get", "kind"], "_site"]]
                 ],
                 "technique": "fill",
@@ -2543,7 +2543,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "point"],
+                    ["==", ["geometry-type"], "Point"],
                     ["==", ["get", "kind"], "address"]
                 ],
                 "minZoomLevel": 18,

--- a/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_day_reduced.json
@@ -791,7 +791,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["==", ["get", "kind_detail"], "tram"]
@@ -809,7 +809,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     [
@@ -830,7 +830,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -848,7 +848,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -866,7 +866,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -903,7 +903,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -956,7 +956,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "water"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "fill",
                 "attr": {
@@ -981,7 +981,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1028,7 +1028,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1073,7 +1073,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "text",
@@ -1090,7 +1090,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1183,7 +1183,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1214,7 +1214,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1259,7 +1259,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1304,7 +1304,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "text",
@@ -1318,7 +1318,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "point"]
+                    ["==", ["geometry-type"], "Point"]
                 ],
                 "technique": "text",
                 "attr": {
@@ -1335,7 +1335,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban"]
                 ],
                 "technique": "fill",
@@ -1350,7 +1350,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban_area"]
                 ],
                 "technique": "none",
@@ -1380,7 +1380,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1414,7 +1414,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "runway"]
                 ],
                 "technique": "fill",
@@ -1429,7 +1429,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "aerodrome"]
                 ],
                 "technique": "fill",
@@ -1443,7 +1443,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "national_park"]
                 ],
                 "technique": "fill",
@@ -1457,7 +1457,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "pitch"]
                 ],
                 "technique": "fill",
@@ -1471,7 +1471,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "hospital"]
                 ],
                 "technique": "fill",
@@ -1485,7 +1485,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "cemetery"]
                 ],
                 "technique": "fill",
@@ -1499,7 +1499,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "bridge"]
                 ],
                 "technique": "fill",
@@ -1513,7 +1513,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1531,7 +1531,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "religion"]
                 ],
                 "technique": "fill",
@@ -1545,7 +1545,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1563,7 +1563,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1581,7 +1581,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["any", ["==", ["get", "kind"], "beach"], ["$=", ["get", "kind"], "_site"]]
                 ],
                 "technique": "fill",
@@ -2134,7 +2134,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "extruded-polygon",
                 "minZoomLevel": 16,
@@ -2162,7 +2162,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "point"],
+                    ["==", ["geometry-type"], "Point"],
                     ["==", ["get", "kind"], "address"]
                 ],
                 "minZoomLevel": 18,

--- a/@here/harp-map-theme/resources/berlin_tilezen_effects_outlines.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_effects_outlines.json
@@ -802,7 +802,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["==", ["get", "kind_detail"], "tram"]
@@ -820,7 +820,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     [
@@ -841,7 +841,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -858,7 +858,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -875,7 +875,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -911,7 +911,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -963,7 +963,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "water"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "fill",
                 "attr": {
@@ -988,7 +988,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1035,7 +1035,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1080,7 +1080,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "text",
@@ -1097,7 +1097,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1190,7 +1190,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1221,7 +1221,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1266,7 +1266,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1311,7 +1311,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "text",
@@ -1327,7 +1327,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "point"]
+                    ["==", ["geometry-type"], "Point"]
                 ],
                 "technique": "text",
                 "attr": {
@@ -1344,7 +1344,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban"]
                 ],
                 "technique": "fill",
@@ -1359,7 +1359,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban_area"]
                 ],
                 "technique": "none",
@@ -1373,7 +1373,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1407,7 +1407,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "runway"]
                 ],
                 "technique": "fill",
@@ -1422,7 +1422,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "aerodrome"]
                 ],
                 "technique": "fill",
@@ -1436,7 +1436,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "national_park"]
                 ],
                 "technique": "fill",
@@ -1450,7 +1450,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "pitch"]
                 ],
                 "technique": "fill",
@@ -1464,7 +1464,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "hospital"]
                 ],
                 "technique": "fill",
@@ -1478,7 +1478,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "cemetery"]
                 ],
                 "technique": "fill",
@@ -1492,7 +1492,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "bridge"]
                 ],
                 "technique": "fill",
@@ -1506,7 +1506,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1524,7 +1524,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "religion"]
                 ],
                 "technique": "fill",
@@ -1538,7 +1538,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1556,7 +1556,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1574,7 +1574,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["any", ["==", ["get", "kind"], "beach"], ["$=", ["get", "kind"], "_site"]]
                 ],
                 "technique": "fill",
@@ -2094,7 +2094,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "extruded-polygon",
                 "minZoomLevel": 16,
@@ -2123,7 +2123,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "point"],
+                    ["==", ["geometry-type"], "Point"],
                     ["==", ["get", "kind"], "address"]
                 ],
                 "minZoomLevel": 18,

--- a/@here/harp-map-theme/resources/berlin_tilezen_effects_streets.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_effects_streets.json
@@ -802,7 +802,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["==", ["get", "kind_detail"], "tram"]
@@ -820,7 +820,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     [
@@ -841,7 +841,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -858,7 +858,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -875,7 +875,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -911,7 +911,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -963,7 +963,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "water"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "fill",
                 "attr": {
@@ -988,7 +988,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1035,7 +1035,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1080,7 +1080,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "text",
@@ -1097,7 +1097,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1190,7 +1190,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1221,7 +1221,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1266,7 +1266,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1311,7 +1311,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "text",
@@ -1327,7 +1327,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "point"]
+                    ["==", ["geometry-type"], "Point"]
                 ],
                 "technique": "text",
                 "attr": {
@@ -1344,7 +1344,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban"]
                 ],
                 "technique": "fill",
@@ -1359,7 +1359,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban_area"]
                 ],
                 "technique": "none",
@@ -1373,7 +1373,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1407,7 +1407,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "runway"]
                 ],
                 "technique": "fill",
@@ -1422,7 +1422,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "aerodrome"]
                 ],
                 "technique": "fill",
@@ -1436,7 +1436,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "national_park"]
                 ],
                 "technique": "fill",
@@ -1450,7 +1450,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "pitch"]
                 ],
                 "technique": "fill",
@@ -1464,7 +1464,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "hospital"]
                 ],
                 "technique": "fill",
@@ -1478,7 +1478,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "cemetery"]
                 ],
                 "technique": "fill",
@@ -1492,7 +1492,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "bridge"]
                 ],
                 "technique": "fill",
@@ -1506,7 +1506,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1524,7 +1524,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "religion"]
                 ],
                 "technique": "fill",
@@ -1538,7 +1538,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1556,7 +1556,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1574,7 +1574,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["any", ["==", ["get", "kind"], "beach"], ["$=", ["get", "kind"], "_site"]]
                 ],
                 "technique": "fill",
@@ -2094,7 +2094,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "extruded-polygon",
                 "minZoomLevel": 16,
@@ -2123,7 +2123,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "point"],
+                    ["==", ["geometry-type"], "Point"],
                     ["==", ["get", "kind"], "address"]
                 ],
                 "technique": "text",

--- a/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_night_reduced.json
@@ -795,7 +795,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["==", ["get", "kind_detail"], "tram"]
@@ -813,7 +813,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     [
@@ -834,7 +834,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -852,7 +852,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -870,7 +870,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["!", ["get", "is_tunnel"]]
@@ -907,7 +907,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "roads"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "rail"],
                     ["in", ["get", "kind_detail"], ["literal", ["rail", "light_rail", "tram"]]],
                     ["get", "is_tunnel"]
@@ -960,7 +960,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "water"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "fill",
                 "attr": {
@@ -985,7 +985,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1032,7 +1032,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "solid-line",
@@ -1077,7 +1077,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "country"]
                 ],
                 "technique": "text",
@@ -1094,7 +1094,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1187,7 +1187,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1218,7 +1218,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1263,7 +1263,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "solid-line",
@@ -1308,7 +1308,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "line"],
+                    ["==", ["geometry-type"], "LineString"],
                     ["==", ["get", "kind"], "region"]
                 ],
                 "technique": "text",
@@ -1324,7 +1324,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "boundaries"],
-                    ["==", ["get", "$geometryType"], "point"]
+                    ["==", ["geometry-type"], "Point"]
                 ],
                 "technique": "text",
                 "attr": {
@@ -1341,7 +1341,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban"]
                 ],
                 "technique": "fill",
@@ -1356,7 +1356,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "urban_area"]
                 ],
                 "technique": "none",
@@ -1386,7 +1386,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1420,7 +1420,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "runway"]
                 ],
                 "technique": "fill",
@@ -1435,7 +1435,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "aerodrome"]
                 ],
                 "technique": "fill",
@@ -1449,7 +1449,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "national_park"]
                 ],
                 "technique": "fill",
@@ -1463,7 +1463,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "pitch"]
                 ],
                 "technique": "fill",
@@ -1477,7 +1477,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "hospital"]
                 ],
                 "technique": "fill",
@@ -1491,7 +1491,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "cemetery"]
                 ],
                 "technique": "fill",
@@ -1505,7 +1505,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "bridge"]
                 ],
                 "technique": "fill",
@@ -1519,7 +1519,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1537,7 +1537,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["==", ["get", "kind"], "religion"]
                 ],
                 "technique": "fill",
@@ -1551,7 +1551,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1569,7 +1569,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     [
                         "in",
                         ["get", "kind"],
@@ -1587,7 +1587,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "landuse"],
-                    ["==", ["get", "$geometryType"], "polygon"],
+                    ["==", ["geometry-type"], "Polygon"],
                     ["any", ["==", ["get", "kind"], "beach"], ["$=", ["get", "kind"], "_site"]]
                 ],
                 "technique": "fill",
@@ -2145,7 +2145,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "polygon"]
+                    ["==", ["geometry-type"], "Polygon"]
                 ],
                 "technique": "extruded-polygon",
                 "minZoomLevel": 16,
@@ -2173,7 +2173,7 @@
                 "when": [
                     "all",
                     ["==", ["get", "$layer"], "buildings"],
-                    ["==", ["get", "$geometryType"], "point"],
+                    ["==", ["geometry-type"], "Point"],
                     ["==", ["get", "kind"], "address"]
                 ],
                 "technique": "text",

--- a/test/rendering/GeoJsonDataRendering.ts
+++ b/test/rendering/GeoJsonDataRendering.ts
@@ -175,7 +175,7 @@ describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", functio
 
         const ourStyle: StyleSet = [
             {
-                when: ["==", ["get", "$geometryType"], "polygon"],
+                when: ["==", ["geometry-type"], "Polygon"],
                 technique: "extruded-polygon",
                 attr: {
                     vertexColors: false,
@@ -205,7 +205,7 @@ describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", functio
 
         const ourStyle: StyleSet = [
             {
-                when: ["==", ["get", "$geometryType"], "polygon"],
+                when: ["==", ["geometry-type"], "Polygon"],
                 technique: "extruded-polygon",
                 attr: {
                     vertexColors: true,


### PR DESCRIPTION
Also remove the deprecate usages of $geometryType in harp-map-theme.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
