### PR TITLE
Remove InterpolatedProperty from Technique.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -9,8 +9,10 @@ import { ExprEvaluator, ExprEvaluatorContext, OperatorDescriptor } from "./ExprE
 import { ExprInstantiator, InstantiationContext } from "./ExprInstantiator";
 import { ExprParser } from "./ExprParser";
 import { ExprPool } from "./ExprPool";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
-import { interpolatedPropertyDefinitionToJsonExpr } from "./InterpolatedPropertyDefs";
+import {
+    interpolatedPropertyDefinitionToJsonExpr,
+    isInterpolatedPropertyDefinition
+} from "./InterpolatedPropertyDefs";
 import { Definitions, isBoxedDefinition, isLiteralDefinition } from "./Theme";
 
 export * from "./Env";

--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -11,11 +11,7 @@ import { ColorUtils } from "./ColorUtils";
 import { Env } from "./Env";
 import { ExponentialInterpolant } from "./ExponentialInterpolant";
 import { Expr, ExprScope, Value } from "./Expr";
-import {
-    InterpolatedProperty,
-    InterpolatedPropertyDefinition,
-    InterpolationMode
-} from "./InterpolatedPropertyDefs";
+import { InterpolatedPropertyDefinition, InterpolationMode } from "./InterpolatedPropertyDefs";
 import {
     parseStringEncodedNumeral,
     StringEncodedColorFormats,
@@ -38,26 +34,41 @@ const interpolants = [
 const tmpBuffer = new Array<number>(StringEncodedNumeralFormatMaxSize);
 
 /**
- * Checks if a property is interpolated.
- * @param p property to be checked
+ * Property which value is interpolated across different zoom levels.
  */
-export function isInterpolatedPropertyDefinition<T>(
-    p: any
-): p is InterpolatedPropertyDefinition<T> {
-    if (
-        p &&
-        p.interpolationMode === undefined &&
-        Array.isArray(p.values) &&
-        p.values.length > 0 &&
-        p.values[0] !== undefined &&
-        Array.isArray(p.zoomLevels) &&
-        p.zoomLevels.length > 0 &&
-        p.zoomLevels[0] !== undefined &&
-        p.values.length === p.zoomLevels.length
-    ) {
-        return true;
-    }
-    return false;
+export interface InterpolatedProperty {
+    /**
+     * Interpolation mode that should be used for this property.
+     */
+    interpolationMode: InterpolationMode;
+
+    /**
+     * Zoom level keys array.
+     */
+    zoomLevels: Float32Array;
+
+    /**
+     * Property values array.
+     */
+    values: ArrayLike<any>;
+
+    /**
+     * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
+     */
+    exponent?: number;
+
+    /**
+     * @hidden
+     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
+     */
+    _stringEncodedNumeralType?: StringEncodedNumeralType;
+
+    /**
+     * @hidden
+     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
+     * [[StringEncodedNumeral]]s.
+     */
+    _stringEncodedNumeralDynamicMask?: Float32Array;
 }
 
 /**
@@ -85,16 +96,9 @@ export function isInterpolatedProperty(p: any): p is InterpolatedProperty {
 * @param property Property of a technique.
 * @param env The [[Env]] used to evaluate the property
 */
-export function getPropertyValue(
-    property: Value | Expr | InterpolatedProperty | undefined,
-    env: Env
-): any {
+export function getPropertyValue(property: Value | Expr | undefined, env: Env): any {
     if (Expr.isExpr(property)) {
         return property.evaluate(env, ExprScope.Dynamic);
-    }
-
-    if (isInterpolatedProperty(property)) {
-        return evaluateInterpolatedProperty(property, env);
     }
 
     if (typeof property !== "string") {

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -5,7 +5,6 @@
  */
 
 import { JsonExpr } from "./Expr";
-import { StringEncodedNumeralType } from "./StringEncodedNumeral";
 
 /**
  * Interpolation mode used when computing a [[InterpolatedProperty]] value for a given zoom level.
@@ -36,41 +35,26 @@ export interface InterpolatedPropertyDefinition<T> {
 }
 
 /**
- * Property which value is interpolated across different zoom levels.
+ * Checks if a property is interpolated.
+ * @param p property to be checked
  */
-export interface InterpolatedProperty {
-    /**
-     * Interpolation mode that should be used for this property.
-     */
-    interpolationMode: InterpolationMode;
-
-    /**
-     * Zoom level keys array.
-     */
-    zoomLevels: Float32Array;
-
-    /**
-     * Property values array.
-     */
-    values: ArrayLike<any>;
-
-    /**
-     * Exponent used in interpolation. Only valid with `Exponential` [[InterpolationMode]].
-     */
-    exponent?: number;
-
-    /**
-     * @hidden
-     * [[StringEncodedNumeral]] type needed to interpret interpolated values back to numbers.
-     */
-    _stringEncodedNumeralType?: StringEncodedNumeralType;
-
-    /**
-     * @hidden
-     * Array of `0` and `1`mask values used to modify the interpolation behaviour of some
-     * [[StringEncodedNumeral]]s.
-     */
-    _stringEncodedNumeralDynamicMask?: Float32Array;
+export function isInterpolatedPropertyDefinition<T>(
+    p: any
+): p is InterpolatedPropertyDefinition<T> {
+    if (
+        p &&
+        p.interpolationMode === undefined &&
+        Array.isArray(p.values) &&
+        p.values.length > 0 &&
+        p.values[0] !== undefined &&
+        Array.isArray(p.zoomLevels) &&
+        p.zoomLevels.length > 0 &&
+        p.zoomLevels[0] !== undefined &&
+        p.values.length === p.zoomLevels.length
+    ) {
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -27,8 +27,11 @@ import {
     VarExpr
 } from "./Expr";
 import { ExprPool } from "./ExprPool";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
-import { interpolatedPropertyDefinitionToJsonExpr } from "./InterpolatedPropertyDefs";
+import {} from "./InterpolatedProperty";
+import {
+    interpolatedPropertyDefinitionToJsonExpr,
+    isInterpolatedPropertyDefinition
+} from "./InterpolatedPropertyDefs";
 import { AttrScope, mergeTechniqueDescriptor } from "./TechniqueDescriptor";
 import { IndexedTechnique, Technique, techniqueDescriptors } from "./Techniques";
 import {

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -6,8 +6,6 @@
 
 import { LoggerManager } from "@here/harp-utils";
 import { Env, Expr, ExprScope, MapEnv, Value } from "./Expr";
-import { getPropertyValue, isInterpolatedProperty } from "./InterpolatedProperty";
-import { InterpolatedProperty } from "./InterpolatedPropertyDefs";
 
 const logger = LoggerManager.instance.create("TechniqueAttr");
 
@@ -46,7 +44,7 @@ export interface AttrEvaluationContext {
  */
 export function evaluateTechniqueAttr<T = Value>(
     context: Env | AttrEvaluationContext,
-    attrValue: T | Expr | InterpolatedProperty | undefined
+    attrValue: T | Expr | undefined
 ): T | undefined;
 
 /**
@@ -56,13 +54,13 @@ export function evaluateTechniqueAttr<T = Value>(
  */
 export function evaluateTechniqueAttr<T = Value>(
     context: Env | AttrEvaluationContext,
-    attrValue: T | Expr | InterpolatedProperty | undefined,
+    attrValue: T | Expr | undefined,
     defaultValue: T
 ): T;
 
 export function evaluateTechniqueAttr<T = Value>(
     context: Env | AttrEvaluationContext,
-    attrValue: T | Expr | InterpolatedProperty | undefined,
+    attrValue: T | Expr | undefined,
     defaultValue?: T
 ): T | undefined {
     const env = context instanceof Env ? context : context.env;
@@ -79,8 +77,6 @@ export function evaluateTechniqueAttr<T = Value>(
             logger.error(`failed to evaluate expression '${JSON.stringify(attrValue)}': ${error}`);
             evaluated = undefined;
         }
-    } else if (isInterpolatedProperty(attrValue)) {
-        evaluated = getPropertyValue(attrValue, context instanceof Env ? context : context.env);
     } else {
         evaluated = (attrValue as unknown) as Value;
     }

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -25,7 +25,7 @@ import {
 } from "./TechniqueParams";
 
 import { Expr, JsonExpr } from "./Expr";
-import { InterpolatedProperty, InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
+import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 import {
     AttrScope,
     mergeTechniqueDescriptor,
@@ -66,7 +66,7 @@ export type RemoveJsonExpr<T> = T | JsonExpr extends T ? Exclude<T, JsonExpr> : 
  */
 export type MakeTechniqueAttrs<T> = {
     [P in keyof T]: T[P] | JsonExpr extends T[P]
-        ? RemoveInterpolatedPropDef<RemoveJsonExpr<T[P]>> | Expr | InterpolatedProperty
+        ? RemoveInterpolatedPropDef<RemoveJsonExpr<T[P]>> | Expr
         : T[P];
 };
 

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -6,7 +6,7 @@
 
 import { Vector3Like } from "@here/harp-geoutils/lib/math/Vector3Like";
 import { isJsonExpr, JsonExpr } from "./Expr";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedProperty";
+import { isInterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 import {
     BaseTechniqueParams,
     BasicExtrudedLineTechniqueParams,

--- a/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/InterpolationOperators.ts
@@ -6,8 +6,12 @@
 
 import { CallExpr, ExprScope, LiteralExpr, NumberLiteralExpr, Value } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
-import { createInterpolatedProperty, evaluateInterpolatedProperty } from "../InterpolatedProperty";
-import { InterpolatedProperty, InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
+import {
+    createInterpolatedProperty,
+    evaluateInterpolatedProperty,
+    InterpolatedProperty
+} from "../InterpolatedProperty";
+import { InterpolatedPropertyDefinition } from "../InterpolatedPropertyDefs";
 
 type InterpolateCallExpr = CallExpr & {
     _mode?: InterpolatedPropertyDefinition<any>["interpolation"];

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -9,8 +9,8 @@
 
 import { assert } from "chai";
 import { MapEnv } from "../lib/Env";
-import { evaluateInterpolatedProperty } from "../lib/InterpolatedProperty";
-import { InterpolatedProperty, InterpolationMode } from "../lib/InterpolatedPropertyDefs";
+import { evaluateInterpolatedProperty, InterpolatedProperty } from "../lib/InterpolatedProperty";
+import { InterpolationMode } from "../lib/InterpolatedPropertyDefs";
 import { StringEncodedNumeralType } from "../lib/StringEncodedNumeral";
 
 const levels = new Float32Array([0, 5, 10]);


### PR DESCRIPTION
InterpolatedProperty is only used in scope of interpolation
operators so can be removed from typings and "general" codebase.
