### PR TITLE
MINOR: Remove 3D objects from root more efficiently.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2765,9 +2765,7 @@ export class MapView extends THREE.EventDispatcher {
         this.m_renderer.clear();
 
         // clear the scene
-        while (this.m_mapTilesRoot.children.length > 0) {
-            this.m_mapTilesRoot.remove(this.m_mapTilesRoot.children[0]);
-        }
+        this.m_mapTilesRoot.children.length = 0;
 
         if (gatherStatistics) {
             setupTime = PerformanceTimer.now();


### PR DESCRIPTION
At the beginning of a frame, the previous frame objects are
removed from the scene calling MapView's mapTilesRoot.remove()
for each one of them. Each remove() call searches for the object
in an array and then splices it.
It's much simpler to just set the root's children array to length 0.

The average speedup is small, but it gets rid of some peaks where the
whole removal was taking ~1ms.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
