### PR TITLE
Remove the usages of Technique._keys take #2

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -850,7 +850,6 @@ export class StyleSetEvaluator {
 
         technique._index = this.m_techniques.length;
         technique._styleSetIndex = style._styleSetIndex!;
-        technique._key = key;
         if (style.styleSet !== undefined) {
             technique._styleSet = style.styleSet;
         }

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -522,13 +522,6 @@ export interface IndexedTechniqueParams {
     _index: number;
 
     /**
-     * Unique technique key derived from all dynamic expressions that were input to this particular
-     * technique instance.
-     * @hidden
-     */
-    _key: string;
-
-    /**
      * Optimization: Unique [[Technique]] index of [[Style]] from which technique was derived.
      * @hidden
      */

--- a/@here/harp-datasource-protocol/test/TileInfoTest.ts
+++ b/@here/harp-datasource-protocol/test/TileInfoTest.ts
@@ -221,8 +221,7 @@ describe("ExtendedTileInfo", function() {
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const storedTechnique: IndexedTechnique = {
             name: "squares",
@@ -230,8 +229,7 @@ describe("ExtendedTileInfo", function() {
             size: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const env = new MapEnv({
             $layer: "point_layer-" + index,
@@ -260,8 +258,7 @@ describe("ExtendedTileInfo", function() {
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const storedTechnique: IndexedTechnique = {
             name: "line",
@@ -269,8 +266,7 @@ describe("ExtendedTileInfo", function() {
             lineWidth: index,
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const env = new MapEnv({
             $layer: "line_layer-" + index,
@@ -298,16 +294,14 @@ describe("ExtendedTileInfo", function() {
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const storedTechnique: IndexedTechnique = {
             name: "fill",
             color: "#00f",
             renderOrder: 0,
             _index: index,
-            _styleSetIndex: index,
-            _key: `${index}`
+            _styleSetIndex: index
         };
         const env = new MapEnv({
             $layer: "fill_layer-" + index,

--- a/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTile.ts
@@ -8,6 +8,8 @@ import {
     DecodedTile,
     Env,
     getPropertyValue,
+    IndexedTechnique,
+    IndexedTechniqueParams,
     isPoiTechnique,
     isTextTechnique,
     PoiGeometry,
@@ -134,7 +136,7 @@ export class GeoJsonTile extends Tile {
         if (decodedTile.poiGeometries !== undefined) {
             for (const geometry of decodedTile.poiGeometries) {
                 const techniqueIndex = geometry.technique!;
-                const technique = decodedTile.techniques[techniqueIndex];
+                const technique = decodedTile.techniques[techniqueIndex] as IndexedTechnique;
                 if (isPoiTechnique(technique)) {
                     this.addPois(geometry, technique, env, worldOffsetX);
                 }
@@ -143,7 +145,7 @@ export class GeoJsonTile extends Tile {
         if (decodedTile.textGeometries !== undefined) {
             for (const geometry of decodedTile.textGeometries) {
                 const techniqueIndex = geometry.technique!;
-                const technique = decodedTile.techniques[techniqueIndex];
+                const technique = decodedTile.techniques[techniqueIndex] as IndexedTechnique;
                 if (isTextTechnique(technique)) {
                     this.addTexts(geometry, technique, worldOffsetX);
                 }
@@ -157,7 +159,7 @@ export class GeoJsonTile extends Tile {
             );
             for (const textPath of this.preparedTextPaths) {
                 const techniqueIndex = textPath.technique!;
-                const technique = decodedTile.techniques[techniqueIndex];
+                const technique = decodedTile.techniques[techniqueIndex] as IndexedTechnique;
                 if (isTextTechnique(technique)) {
                     this.addTextPaths(textPath, technique, worldOffsetX);
                 }
@@ -180,7 +182,7 @@ export class GeoJsonTile extends Tile {
      */
     private addTextPaths(
         geometry: TextPathGeometry,
-        technique: TextTechnique,
+        technique: TextTechnique & IndexedTechniqueParams,
         worldOffsetX: number
     ) {
         const path: THREE.Vector3[] = [];
@@ -209,7 +211,7 @@ export class GeoJsonTile extends Tile {
     private addTextPath(
         path: THREE.Vector3[],
         text: string,
-        technique: TextTechnique,
+        technique: TextTechnique & IndexedTechniqueParams,
         geojsonProperties?: {}
     ) {
         const priority =
@@ -221,13 +223,11 @@ export class GeoJsonTile extends Tile {
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
-        const styleCache = this.mapView.textElementsRenderer.styleCache;
-
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             path,
-            styleCache.getRenderStyle(this, technique),
-            styleCache.getLayoutStyle(this, technique),
+            this.textStyleCache.getRenderStyle(technique),
+            this.textStyleCache.getLayoutStyle(technique),
             getPropertyValue(priority, this.mapView.env),
             xOffset,
             yOffset,
@@ -263,7 +263,11 @@ export class GeoJsonTile extends Tile {
      * @param geometry The Text geometry.
      * @param technique Text technique.
      */
-    private addTexts(geometry: TextGeometry, technique: TextTechnique, worldOffsetX: number) {
+    private addTexts(
+        geometry: TextGeometry,
+        technique: TextTechnique & IndexedTechniqueParams,
+        worldOffsetX: number
+    ) {
         const attribute = getBufferAttribute(geometry.positions);
 
         for (let index = 0; index < attribute.count; index++) {
@@ -291,7 +295,7 @@ export class GeoJsonTile extends Tile {
     private addText(
         position: THREE.Vector3,
         text: string,
-        technique: TextTechnique,
+        technique: TextTechnique & IndexedTechniqueParams,
         geojsonProperties?: {}
     ) {
         const priority =
@@ -303,12 +307,11 @@ export class GeoJsonTile extends Tile {
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
-        const styleCache = this.mapView.textElementsRenderer.styleCache;
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             position,
-            styleCache.getRenderStyle(this, technique),
-            styleCache.getLayoutStyle(this, technique),
+            this.textStyleCache.getRenderStyle(technique),
+            this.textStyleCache.getLayoutStyle(technique),
             getPropertyValue(priority, this.mapView.env),
             xOffset,
             yOffset,
@@ -342,7 +345,7 @@ export class GeoJsonTile extends Tile {
      */
     private addPois(
         geometry: PoiGeometry,
-        technique: PoiTechnique,
+        technique: PoiTechnique & IndexedTechniqueParams,
         env: Env,
         worldOffsetX: number
     ) {
@@ -371,7 +374,7 @@ export class GeoJsonTile extends Tile {
      */
     private addPoi(
         position: THREE.Vector3,
-        technique: PoiTechnique,
+        technique: PoiTechnique & IndexedTechniqueParams,
         env: Env,
         geojsonProperties?: {}
     ) {
@@ -383,12 +386,11 @@ export class GeoJsonTile extends Tile {
 
         const featureId = DEFAULT_LABELED_ICON.featureId;
 
-        const styleCache = this.mapView.textElementsRenderer.styleCache;
         const textElement = new TextElement(
             ContextualArabicConverter.instance.convert(label),
             position,
-            styleCache.getRenderStyle(this, technique),
-            styleCache.getLayoutStyle(this, technique),
+            this.textStyleCache.getRenderStyle(technique),
+            this.textStyleCache.getLayoutStyle(technique),
             getPropertyValue(priority, env),
             xOffset === undefined ? DEFAULT_LABELED_ICON.xOffset : xOffset,
             yOffset === undefined ? DEFAULT_LABELED_ICON.yOffset : yOffset,

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -23,6 +23,7 @@ import { PerformanceStatistics } from "./Statistics";
 import { TextElement } from "./text/TextElement";
 import { TextElementGroup } from "./text/TextElementGroup";
 import { TextElementGroupPriorityList } from "./text/TextElementGroupPriorityList";
+import { TileTextStyleCache } from "./text/TileTextStyleCache";
 import { MapViewUtils } from "./Utils";
 
 const logger = LoggerManager.instance.create("Tile");
@@ -388,6 +389,7 @@ export class Tile implements CachedResource {
 
     private m_animatedExtrusionTileHandler: AnimatedExtrusionTileHandler | undefined;
 
+    private m_textStyleCache: TileTextStyleCache;
     /**
      * Creates a new [[Tile]].
      *
@@ -407,6 +409,7 @@ export class Tile implements CachedResource {
         this.geoBox = this.dataSource.getTilingScheme().getGeoBox(this.tileKey);
         this.projection.projectBox(this.geoBox, this.boundingBox);
         this.m_localTangentSpace = localTangentSpace !== undefined ? localTangentSpace : false;
+        this.m_textStyleCache = new TileTextStyleCache(this);
     }
 
     /**
@@ -923,6 +926,14 @@ export class Tile implements CachedResource {
     }
 
     /**
+     * Text style cache for this tile.
+     * @hidden
+     */
+    get textStyleCache(): TileTextStyleCache {
+        return this.m_textStyleCache;
+    }
+
+    /**
      * Frees the rendering resources allocated by this `Tile`.
      *
      * The default implementation of this method frees the geometries and the materials for all the
@@ -987,6 +998,7 @@ export class Tile implements CachedResource {
             this.m_animatedExtrusionTileHandler.dispose();
         }
 
+        this.m_textStyleCache.clear();
         this.clearTextElements();
         this.invalidateResourceInfo();
     }

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -363,7 +363,7 @@ export class TileGeometryCreator {
         textFilter?: (technique: Technique) => boolean
     ) {
         const mapView = tile.mapView;
-        const textElementsRenderer = mapView.textElementsRenderer;
+        const textStyleCache = tile.textStyleCache;
         const worldOffsetX = tile.computeWorldOffsetX();
 
         const discreteZoomLevel = Math.floor(mapView.zoomLevel);
@@ -377,7 +377,7 @@ export class TileGeometryCreator {
             );
 
             for (const textPath of textPathGeometries) {
-                const technique = decodedTile.techniques[textPath.technique];
+                const technique = decodedTile.techniques[textPath.technique] as IndexedTechnique;
 
                 if (
                     technique.enabled === false ||
@@ -416,8 +416,8 @@ export class TileGeometryCreator {
                 const textElement = new TextElement(
                     ContextualArabicConverter.instance.convert(textPath.text),
                     path,
-                    textElementsRenderer.styleCache.getRenderStyle(tile, technique),
-                    textElementsRenderer.styleCache.getLayoutStyle(tile, technique),
+                    textStyleCache.getRenderStyle(technique),
+                    textStyleCache.getLayoutStyle(technique),
                     priority,
                     technique.xOffset !== undefined ? technique.xOffset : 0.0,
                     technique.yOffset !== undefined ? technique.yOffset : 0.0,
@@ -456,7 +456,7 @@ export class TileGeometryCreator {
                     continue;
                 }
 
-                const technique = decodedTile.techniques[text.technique];
+                const technique = decodedTile.techniques[text.technique] as IndexedTechnique;
 
                 if (
                     technique.enabled === false ||
@@ -505,8 +505,8 @@ export class TileGeometryCreator {
                     const textElement = new TextElement(
                         ContextualArabicConverter.instance.convert(label!),
                         new THREE.Vector3(x, y, z),
-                        textElementsRenderer.styleCache.getRenderStyle(tile, technique),
-                        textElementsRenderer.styleCache.getLayoutStyle(tile, technique),
+                        textStyleCache.getRenderStyle(technique),
+                        textStyleCache.getLayoutStyle(technique),
                         priority,
                         technique.xOffset || 0.0,
                         technique.yOffset || 0.0,

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -11,6 +11,8 @@ import {
     getFeatureId,
     getPropertyValue,
     ImageTexture,
+    IndexedTechnique,
+    IndexedTechniqueParams,
     isLineMarkerTechnique,
     isPoiTechnique,
     LineMarkerTechnique,
@@ -117,7 +119,7 @@ export class PoiManager {
         for (const poiGeometry of poiGeometries) {
             assert(poiGeometry.technique !== undefined);
             const techniqueIndex = assertExists(poiGeometry.technique);
-            const technique = decodedTile.techniques[techniqueIndex];
+            const technique = decodedTile.techniques[techniqueIndex] as IndexedTechnique;
 
             if (
                 technique.enabled === false ||
@@ -334,7 +336,7 @@ export class PoiManager {
     private addLineMarker(
         tile: Tile,
         poiGeometry: PoiGeometry,
-        technique: LineMarkerTechnique,
+        technique: LineMarkerTechnique & IndexedTechniqueParams,
         positions: THREE.BufferAttribute,
         worldOffsetX: number
     ) {
@@ -408,7 +410,7 @@ export class PoiManager {
     private addPoi(
         tile: Tile,
         poiGeometry: PoiGeometry,
-        technique: PoiTechnique,
+        technique: PoiTechnique & IndexedTechniqueParams,
         positions: THREE.BufferAttribute,
         worldOffsetX: number
     ) {
@@ -479,7 +481,7 @@ export class PoiManager {
     private checkCreateTextElement(
         tile: Tile,
         text: string,
-        technique: PoiTechnique | LineMarkerTechnique,
+        technique: (PoiTechnique | LineMarkerTechnique) & IndexedTechniqueParams,
         imageTextureName: string | undefined,
         poiTableName: string | undefined,
         poiName: string | undefined,
@@ -490,7 +492,6 @@ export class PoiManager {
         z: number | undefined,
         userData?: {}
     ): TextElement {
-        const textElementsRenderer = this.mapView.textElementsRenderer;
         const priority = technique.priority !== undefined ? technique.priority : 0;
         const positions = Array.isArray(x) ? (x as THREE.Vector3[]) : new THREE.Vector3(x, y, z);
 
@@ -512,8 +513,8 @@ export class PoiManager {
         const textElement: TextElement = new TextElement(
             ContextualArabicConverter.instance.convert(text),
             positions,
-            textElementsRenderer.styleCache.getRenderStyle(tile, technique),
-            textElementsRenderer.styleCache.getLayoutStyle(tile, technique),
+            tile.textStyleCache.getRenderStyle(technique),
+            tile.textStyleCache.getLayoutStyle(technique),
             getPropertyValue(priority, env),
             xOffset !== undefined ? xOffset : 0.0,
             yOffset !== undefined ? yOffset : 0.0,

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -7,11 +7,9 @@
 import {
     ColorUtils,
     getPropertyValue,
-    IndexedTechniqueParams,
     LineMarkerTechnique,
     MapEnv,
     PoiTechnique,
-    Technique,
     TextStyleDefinition,
     TextTechnique,
     Theme
@@ -39,121 +37,22 @@ import { TextCanvasRenderer } from "./TextCanvasRenderer";
 
 const logger = LoggerManager.instance.create("TextStyleCache");
 
-/**
- * [[TextStyle]] id for the default value inside a [[TextRenderStyleCache]] or a
- * [[TextLayoutStyleCache]].
- */
-export const DEFAULT_TEXT_STYLE_CACHE_ID = "Default";
+const defaultTextRenderStyle = new TextRenderStyle({
+    fontSize: {
+        unit: FontUnit.Pixel,
+        size: 32,
+        backgroundSize: 8
+    },
+    color: ColorCache.instance.getColor("#6d7477"),
+    opacity: 1.0,
+    backgroundColor: ColorCache.instance.getColor("#f7fbfd"),
+    backgroundOpacity: 0.5
+});
 
-/**
- * Calculates the [[TextStyle]] id that identifies either a [[TextRenderStyle]] or a
- * [[TextLayoutStyle]] inside a [[TextRenderStyleCache]] or a [[TextLayoutStyleCache]],
- * respectively.
- *
- * @param technique Technique defining the [[TextStyle]].
- * @param zoomLevel Zoom level for which to interpret the technique.
- *
- * @returns [[TextStyle]] id.
- */
-export function computeStyleCacheId(
-    datasourceName: string,
-    technique: Technique & Partial<IndexedTechniqueParams>,
-    zoomLevel: number
-): string {
-    return `${datasourceName}_${technique._key}_${zoomLevel}`;
-}
-
-/**
- * Cache storing [[MapView]]'s [[TextRenderStyle]]s.
- */
-export class TextRenderStyleCache {
-    private m_map: Map<string, TextRenderStyle> = new Map();
-    constructor() {
-        this.m_map.set(
-            DEFAULT_TEXT_STYLE_CACHE_ID,
-            new TextRenderStyle({
-                fontSize: {
-                    unit: FontUnit.Pixel,
-                    size: 32,
-                    backgroundSize: 8
-                },
-                color: ColorCache.instance.getColor("#6d7477"),
-                opacity: 1.0,
-                backgroundColor: ColorCache.instance.getColor("#f7fbfd"),
-                backgroundOpacity: 0.5
-            })
-        );
-    }
-
-    get size(): number {
-        return this.m_map.size;
-    }
-
-    get(id: string): TextRenderStyle | undefined {
-        return this.m_map.get(id);
-    }
-
-    set(id: string, value: TextRenderStyle): void {
-        this.m_map.set(id, value);
-    }
-
-    clear(): void {
-        this.m_map.clear();
-        this.m_map.set(
-            DEFAULT_TEXT_STYLE_CACHE_ID,
-            new TextRenderStyle({
-                fontSize: {
-                    unit: FontUnit.Pixel,
-                    size: 32,
-                    backgroundSize: 8
-                },
-                color: ColorCache.instance.getColor("#6d7477"),
-                opacity: 1.0,
-                backgroundColor: ColorCache.instance.getColor("#f7fbfd"),
-                backgroundOpacity: 0.5
-            })
-        );
-    }
-}
-
-/**
- * Cache storing [[MapView]]'s [[TextLayoutStyle]]s.
- */
-export class TextLayoutStyleCache {
-    private m_map: Map<string, TextLayoutStyle> = new Map();
-    constructor() {
-        this.m_map.set(
-            DEFAULT_TEXT_STYLE_CACHE_ID,
-            new TextLayoutStyle({
-                verticalAlignment: VerticalAlignment.Center,
-                horizontalAlignment: HorizontalAlignment.Center
-            })
-        );
-    }
-
-    get size(): number {
-        return this.m_map.size;
-    }
-
-    get(id: string): TextLayoutStyle | undefined {
-        return this.m_map.get(id);
-    }
-
-    set(id: string, value: TextLayoutStyle): void {
-        this.m_map.set(id, value);
-    }
-
-    clear(): void {
-        this.m_map.clear();
-        this.m_map.set(
-            DEFAULT_TEXT_STYLE_CACHE_ID,
-            new TextLayoutStyle({
-                verticalAlignment: VerticalAlignment.Center,
-                horizontalAlignment: HorizontalAlignment.Center
-            })
-        );
-    }
-}
+const defaultTextLayoutStyle = new TextLayoutStyle({
+    verticalAlignment: VerticalAlignment.Center,
+    horizontalAlignment: HorizontalAlignment.Center
+});
 
 const DEFAULT_STYLE_NAME = "default";
 
@@ -170,14 +69,12 @@ export interface TextElementStyle {
 }
 
 export class TextStyleCache {
-    private m_textRenderStyleCache = new TextRenderStyleCache();
-    private m_textLayoutStyleCache = new TextLayoutStyleCache();
     private m_textStyles: Map<string, TextElementStyle> = new Map();
     private m_defaultStyle: TextElementStyle = {
         name: DEFAULT_STYLE_NAME,
         fontCatalog: "",
-        renderParams: this.m_textRenderStyleCache.get(DEFAULT_TEXT_STYLE_CACHE_ID)!.params,
-        layoutParams: this.m_textLayoutStyleCache.get(DEFAULT_TEXT_STYLE_CACHE_ID)!.params
+        renderParams: defaultTextRenderStyle.params,
+        layoutParams: defaultTextLayoutStyle.params
     };
 
     constructor(private m_theme: Theme) {}
@@ -293,216 +190,197 @@ export class TextStyleCache {
     /**
      * Gets the appropriate [[TextRenderStyle]] to use for a label. Depends heavily on the label's
      * [[Technique]] and the current zoomLevel.
-     *
-     * @param technique Label's technique.
-     * @param techniqueIdx Label's technique index.
      */
-    getRenderStyle(
+    createRenderStyle(
         tile: Tile,
         technique: TextTechnique | PoiTechnique | LineMarkerTechnique
     ): TextRenderStyle {
         const mapView = tile.mapView;
-        const dataSource = tile.dataSource;
         const zoomLevel = mapView.zoomLevel;
         const discreteZoomLevel = Math.floor(zoomLevel);
 
-        const cacheId = computeStyleCacheId(dataSource.name, technique, discreteZoomLevel);
-        let renderStyle = this.m_textRenderStyleCache.get(cacheId);
-        if (renderStyle === undefined) {
-            // Environment with $zoom forced to integer to achieve stable interpolated values.
-            const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.env);
+        // Environment with $zoom forced to integer to achieve stable interpolated values.
+        const discreteZoomEnv = new MapEnv({ $zoom: discreteZoomLevel }, mapView.env);
 
-            const defaultRenderParams = this.m_defaultStyle.renderParams;
+        const defaultRenderParams = this.m_defaultStyle.renderParams;
 
-            // Sets opacity to 1.0 if default and technique attribute are undefined.
-            const defaultOpacity = getOptionValue(defaultRenderParams.opacity, 1.0);
-            // Interpolate opacity but only on discreet zoom levels (step interpolation).
-            let opacity = getPropertyValue(
-                getOptionValue(technique.opacity, defaultOpacity),
-                discreteZoomEnv
-            );
+        // Sets opacity to 1.0 if default and technique attribute are undefined.
+        const defaultOpacity = getOptionValue(defaultRenderParams.opacity, 1.0);
+        // Interpolate opacity but only on discreet zoom levels (step interpolation).
+        let opacity = getPropertyValue(
+            getOptionValue(technique.opacity, defaultOpacity),
+            discreteZoomEnv
+        );
 
-            let color: THREE.Color | undefined;
-            // Store color (RGB) in cache and multiply opacity value with the color alpha channel.
-            if (technique.color !== undefined) {
-                let hexColor = evaluateColorProperty(technique.color, discreteZoomEnv);
-                if (ColorUtils.hasAlphaInHex(hexColor)) {
-                    const alpha = ColorUtils.getAlphaFromHex(hexColor);
-                    opacity = opacity * alpha;
-                    hexColor = ColorUtils.removeAlphaFromHex(hexColor);
-                }
-                color = ColorCache.instance.getColor(hexColor);
+        let color: THREE.Color | undefined;
+        // Store color (RGB) in cache and multiply opacity value with the color alpha channel.
+        if (technique.color !== undefined) {
+            let hexColor = evaluateColorProperty(technique.color, discreteZoomEnv);
+            if (ColorUtils.hasAlphaInHex(hexColor)) {
+                const alpha = ColorUtils.getAlphaFromHex(hexColor);
+                opacity = opacity * alpha;
+                hexColor = ColorUtils.removeAlphaFromHex(hexColor);
             }
-
-            // Sets background size to 0.0 if default and technique attribute is undefined.
-            const defaultBackgroundSize = getOptionValue(
-                defaultRenderParams.fontSize!.backgroundSize,
-                0
-            );
-            const backgroundSize = getPropertyValue(
-                getOptionValue(technique.backgroundSize, defaultBackgroundSize),
-                discreteZoomEnv
-            );
-
-            const hasBackgroundDefined =
-                technique.backgroundColor !== undefined &&
-                technique.backgroundSize !== undefined &&
-                backgroundSize > 0;
-
-            // Sets background opacity to 1.0 if default and technique value is undefined while
-            // background size and color is specified, otherwise set value in default render
-            // params or 0.0 if neither set. Makes label opaque when backgroundColor and
-            // backgroundSize are set.
-            const defaultBackgroundOpacity = getOptionValue(
-                defaultRenderParams.backgroundOpacity,
-                0.0
-            );
-            let backgroundOpacity = getPropertyValue(
-                getOptionValue(
-                    technique.backgroundOpacity,
-                    hasBackgroundDefined ? 1.0 : defaultBackgroundOpacity
-                ),
-                discreteZoomEnv
-            );
-
-            let backgroundColor: THREE.Color | undefined;
-            // Store background color (RGB) in cache and multiply backgroundOpacity by its alpha.
-            if (technique.backgroundColor !== undefined) {
-                let hexBgColor = evaluateColorProperty(technique.backgroundColor, discreteZoomEnv);
-                if (ColorUtils.hasAlphaInHex(hexBgColor)) {
-                    const alpha = ColorUtils.getAlphaFromHex(hexBgColor);
-                    backgroundOpacity = backgroundOpacity * alpha;
-                    hexBgColor = ColorUtils.removeAlphaFromHex(hexBgColor);
-                }
-                backgroundColor = ColorCache.instance.getColor(hexBgColor);
-            }
-
-            const renderParams = {
-                fontName: getOptionValue(technique.fontName, defaultRenderParams.fontName),
-                fontSize: {
-                    unit: FontUnit.Pixel,
-                    size: getPropertyValue(
-                        getOptionValue(technique.size, defaultRenderParams.fontSize!.size),
-                        discreteZoomEnv
-                    ),
-                    backgroundSize
-                },
-                fontStyle:
-                    technique.fontStyle === "Regular" ||
-                    technique.fontStyle === "Bold" ||
-                    technique.fontStyle === "Italic" ||
-                    technique.fontStyle === "BoldItalic"
-                        ? FontStyle[technique.fontStyle]
-                        : defaultRenderParams.fontStyle,
-                fontVariant:
-                    technique.fontVariant === "Regular" ||
-                    technique.fontVariant === "AllCaps" ||
-                    technique.fontVariant === "SmallCaps"
-                        ? FontVariant[technique.fontVariant]
-                        : defaultRenderParams.fontVariant,
-                rotation: getOptionValue(technique.rotation, defaultRenderParams.rotation),
-                color: getOptionValue(
-                    color,
-                    getOptionValue(defaultRenderParams.color, DefaultTextStyle.DEFAULT_COLOR)
-                ),
-                backgroundColor: getOptionValue(
-                    backgroundColor,
-                    getOptionValue(
-                        defaultRenderParams.backgroundColor,
-                        DefaultTextStyle.DEFAULT_BACKGROUND_COLOR
-                    )
-                ),
-                opacity,
-                backgroundOpacity
-            };
-
-            const themeRenderParams = this.getTextElementStyle(technique.style).renderParams;
-            renderStyle = new TextRenderStyle({
-                ...themeRenderParams,
-                ...renderParams
-            });
-            this.m_textRenderStyleCache.set(cacheId, renderStyle);
+            color = ColorCache.instance.getColor(hexColor);
         }
+
+        // Sets background size to 0.0 if default and technique attribute is undefined.
+        const defaultBackgroundSize = getOptionValue(
+            defaultRenderParams.fontSize!.backgroundSize,
+            0
+        );
+        const backgroundSize = getPropertyValue(
+            getOptionValue(technique.backgroundSize, defaultBackgroundSize),
+            discreteZoomEnv
+        );
+
+        const hasBackgroundDefined =
+            technique.backgroundColor !== undefined &&
+            technique.backgroundSize !== undefined &&
+            backgroundSize > 0;
+
+        // Sets background opacity to 1.0 if default and technique value is undefined while
+        // background size and color is specified, otherwise set value in default render
+        // params or 0.0 if neither set. Makes label opaque when backgroundColor and
+        // backgroundSize are set.
+        const defaultBackgroundOpacity = getOptionValue(defaultRenderParams.backgroundOpacity, 0.0);
+        let backgroundOpacity = getPropertyValue(
+            getOptionValue(
+                technique.backgroundOpacity,
+                hasBackgroundDefined ? 1.0 : defaultBackgroundOpacity
+            ),
+            discreteZoomEnv
+        );
+
+        let backgroundColor: THREE.Color | undefined;
+        // Store background color (RGB) in cache and multiply backgroundOpacity by its alpha.
+        if (technique.backgroundColor !== undefined) {
+            let hexBgColor = evaluateColorProperty(technique.backgroundColor, discreteZoomEnv);
+            if (ColorUtils.hasAlphaInHex(hexBgColor)) {
+                const alpha = ColorUtils.getAlphaFromHex(hexBgColor);
+                backgroundOpacity = backgroundOpacity * alpha;
+                hexBgColor = ColorUtils.removeAlphaFromHex(hexBgColor);
+            }
+            backgroundColor = ColorCache.instance.getColor(hexBgColor);
+        }
+
+        const renderParams = {
+            fontName: getOptionValue(technique.fontName, defaultRenderParams.fontName),
+            fontSize: {
+                unit: FontUnit.Pixel,
+                size: getPropertyValue(
+                    getOptionValue(technique.size, defaultRenderParams.fontSize!.size),
+                    discreteZoomEnv
+                ),
+                backgroundSize
+            },
+            fontStyle:
+                technique.fontStyle === "Regular" ||
+                technique.fontStyle === "Bold" ||
+                technique.fontStyle === "Italic" ||
+                technique.fontStyle === "BoldItalic"
+                    ? FontStyle[technique.fontStyle]
+                    : defaultRenderParams.fontStyle,
+            fontVariant:
+                technique.fontVariant === "Regular" ||
+                technique.fontVariant === "AllCaps" ||
+                technique.fontVariant === "SmallCaps"
+                    ? FontVariant[technique.fontVariant]
+                    : defaultRenderParams.fontVariant,
+            rotation: getOptionValue(technique.rotation, defaultRenderParams.rotation),
+            color: getOptionValue(
+                color,
+                getOptionValue(defaultRenderParams.color, DefaultTextStyle.DEFAULT_COLOR)
+            ),
+            backgroundColor: getOptionValue(
+                backgroundColor,
+                getOptionValue(
+                    defaultRenderParams.backgroundColor,
+                    DefaultTextStyle.DEFAULT_BACKGROUND_COLOR
+                )
+            ),
+            opacity,
+            backgroundOpacity
+        };
+
+        const themeRenderParams = this.getTextElementStyle(technique.style).renderParams;
+        const renderStyle = new TextRenderStyle({
+            ...themeRenderParams,
+            ...renderParams
+        });
 
         return renderStyle;
     }
 
     /**
-     * Gets the appropriate [[TextRenderStyle]] to use for a label. Depends heavily on the label's
+     * Create the appropriate [[TextRenderStyle]] to use for a label. Depends heavily on the label's
      * [[Technique]] and the current zoomLevel.
      *
      * @param tile The [[Tile]] to process.
      * @param technique Label's technique.
      */
-    getLayoutStyle(
+    createLayoutStyle(
         tile: Tile,
         technique: TextTechnique | PoiTechnique | LineMarkerTechnique
     ): TextLayoutStyle {
         const mapView = tile.mapView;
         const floorZoomLevel = Math.floor(tile.mapView.zoomLevel);
-        const cacheId = computeStyleCacheId(tile.dataSource.name, technique, floorZoomLevel);
-        let layoutStyle = this.m_textLayoutStyleCache.get(cacheId);
 
-        if (layoutStyle === undefined) {
-            // Environment with $zoom forced to integer to achieve stable interpolated values.
-            const discreteZoomEnv = new MapEnv({ $zoom: floorZoomLevel }, mapView.env);
+        const discreteZoomEnv = new MapEnv({ $zoom: floorZoomLevel }, mapView.env);
 
-            const defaultLayoutParams = this.m_defaultStyle.layoutParams;
+        const defaultLayoutParams = this.m_defaultStyle.layoutParams;
 
-            const hAlignment = getPropertyValue(technique.hAlignment, discreteZoomEnv) as
-                | string
-                | undefined;
-            const vAlignment = getPropertyValue(technique.vAlignment, discreteZoomEnv) as
-                | string
-                | undefined;
-            const wrapping = getPropertyValue(technique.wrappingMode, discreteZoomEnv) as
-                | string
-                | undefined;
+        const hAlignment = getPropertyValue(technique.hAlignment, discreteZoomEnv) as
+            | string
+            | undefined;
+        const vAlignment = getPropertyValue(technique.vAlignment, discreteZoomEnv) as
+            | string
+            | undefined;
+        const wrapping = getPropertyValue(technique.wrappingMode, discreteZoomEnv) as
+            | string
+            | undefined;
 
-            const horizontalAlignment: HorizontalAlignment | undefined =
-                hAlignment === "Left" || hAlignment === "Center" || hAlignment === "Right"
-                    ? HorizontalAlignment[hAlignment]
-                    : defaultLayoutParams.horizontalAlignment;
+        const horizontalAlignment: HorizontalAlignment | undefined =
+            hAlignment === "Left" || hAlignment === "Center" || hAlignment === "Right"
+                ? HorizontalAlignment[hAlignment]
+                : defaultLayoutParams.horizontalAlignment;
 
-            const verticalAlignment: VerticalAlignment | undefined =
-                vAlignment === "Above" || vAlignment === "Center" || vAlignment === "Below"
-                    ? VerticalAlignment[vAlignment]
-                    : defaultLayoutParams.verticalAlignment;
+        const verticalAlignment: VerticalAlignment | undefined =
+            vAlignment === "Above" || vAlignment === "Center" || vAlignment === "Below"
+                ? VerticalAlignment[vAlignment]
+                : defaultLayoutParams.verticalAlignment;
 
-            const layoutParams = {
-                tracking:
-                    getPropertyValue(technique.tracking, discreteZoomEnv) ??
-                    defaultLayoutParams.tracking,
-                leading:
-                    getPropertyValue(technique.leading, discreteZoomEnv) ??
-                    defaultLayoutParams.leading,
-                maxLines:
-                    getPropertyValue(technique.maxLines, discreteZoomEnv) ??
-                    defaultLayoutParams.maxLines,
-                lineWidth:
-                    getPropertyValue(technique.lineWidth, discreteZoomEnv) ??
-                    defaultLayoutParams.lineWidth,
-                canvasRotation:
-                    getPropertyValue(technique.canvasRotation, discreteZoomEnv) ??
-                    defaultLayoutParams.canvasRotation,
-                lineRotation:
-                    getPropertyValue(technique.lineRotation, discreteZoomEnv) ??
-                    defaultLayoutParams.lineRotation,
-                wrappingMode:
-                    wrapping === "None" || wrapping === "Character" || wrapping === "Word"
-                        ? WrappingMode[wrapping]
-                        : defaultLayoutParams.wrappingMode,
-                horizontalAlignment,
-                verticalAlignment
-            };
+        const layoutParams = {
+            tracking:
+                getPropertyValue(technique.tracking, discreteZoomEnv) ??
+                defaultLayoutParams.tracking,
+            leading:
+                getPropertyValue(technique.leading, discreteZoomEnv) ?? defaultLayoutParams.leading,
+            maxLines:
+                getPropertyValue(technique.maxLines, discreteZoomEnv) ??
+                defaultLayoutParams.maxLines,
+            lineWidth:
+                getPropertyValue(technique.lineWidth, discreteZoomEnv) ??
+                defaultLayoutParams.lineWidth,
+            canvasRotation:
+                getPropertyValue(technique.canvasRotation, discreteZoomEnv) ??
+                defaultLayoutParams.canvasRotation,
+            lineRotation:
+                getPropertyValue(technique.lineRotation, discreteZoomEnv) ??
+                defaultLayoutParams.lineRotation,
+            wrappingMode:
+                wrapping === "None" || wrapping === "Character" || wrapping === "Word"
+                    ? WrappingMode[wrapping]
+                    : defaultLayoutParams.wrappingMode,
+            horizontalAlignment,
+            verticalAlignment
+        };
 
-            const themeLayoutParams = this.getTextElementStyle(technique.style);
-            layoutStyle = new TextLayoutStyle({
-                ...themeLayoutParams,
-                ...layoutParams
-            });
-            this.m_textLayoutStyleCache.set(cacheId, layoutStyle);
-        }
+        const themeLayoutParams = this.getTextElementStyle(technique.style);
+        const layoutStyle = new TextLayoutStyle({
+            ...themeLayoutParams,
+            ...layoutParams
+        });
 
         return layoutStyle;
     }

--- a/@here/harp-mapview/lib/text/TileTextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TileTextStyleCache.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    IndexedTechniqueParams,
+    LineMarkerTechnique,
+    PoiTechnique,
+    TextTechnique
+} from "@here/harp-datasource-protocol";
+import { TextLayoutStyle, TextRenderStyle } from "@here/harp-text-canvas";
+import { Tile } from "../Tile";
+
+export class TileTextStyleCache {
+    private textRenderStyles: TextRenderStyle[] = [];
+    private textLayoutStyles: TextLayoutStyle[] = [];
+    private tile: Tile;
+
+    constructor(tile: Tile) {
+        this.tile = tile;
+    }
+
+    clear() {
+        this.textRenderStyles.length = 0;
+        this.textLayoutStyles.length = 0;
+    }
+
+    getRenderStyle(
+        technique: (TextTechnique | PoiTechnique | LineMarkerTechnique) & IndexedTechniqueParams
+    ): TextRenderStyle {
+        let style = this.textRenderStyles[technique._index];
+        if (style === undefined) {
+            style = this.textRenderStyles[
+                technique._index
+            ] = this.tile.mapView.textElementsRenderer.styleCache.createRenderStyle(
+                this.tile,
+                technique
+            );
+        }
+        return style;
+    }
+
+    getLayoutStyle(
+        technique: (TextTechnique | PoiTechnique | LineMarkerTechnique) & IndexedTechniqueParams
+    ): TextLayoutStyle {
+        let style = this.textLayoutStyles[technique._index];
+        if (style === undefined) {
+            style = this.textLayoutStyles[
+                technique._index
+            ] = this.tile.mapView.textElementsRenderer.styleCache.createLayoutStyle(
+                this.tile,
+                technique
+            );
+        }
+        return style;
+    }
+}

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -143,7 +143,6 @@ describe("TileGeometryCreator", () => {
                     _category: "hi-priority",
                     _index: 0,
                     _styleSetIndex: 0,
-                    _key: "key-0",
                     renderOrder: -1,
                     name: "line",
                     color: "rgb(255,0,0)",
@@ -155,7 +154,6 @@ describe("TileGeometryCreator", () => {
                     _index: 1,
                     _styleSetIndex: 0,
                     renderOrder: -1,
-                    _key: "key-0",
                     name: "circles"
                 }
             ]


### PR DESCRIPTION
This patch removed IndexedTechnique._key from usage in render phase and
changes scope of caching of text style from "datasource" to "tile", as this
allows to identify text styles by `IndexedTechnique._index` only.

Followup of #1299