### PR TITLE
Add support for filtering features based on their state

### DIFF
--- a/@here/harp-datasource-protocol/StyleExpressions.md
+++ b/@here/harp-datasource-protocol/StyleExpressions.md
@@ -87,7 +87,7 @@ Returns a `boolean` indicating if the current `feature` or the given
 
 Gets the properties that are evaluated at rendering time.
 
-``javascript
+```javascript
 // returns an object containing the dynamic properties.
 ["dynamic-properties"]
 

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -728,7 +728,11 @@ export class StyleSetEvaluator {
                 const deps = attrValue.dependencies();
 
                 if (deps.featureState) {
-                    style._usesFeatureState = true;
+                    if (attrName !== "enabled") {
+                        logger.log("feature-state is not supported in this context");
+                    } else {
+                        style._usesFeatureState = true;
+                    }
                 }
 
                 if (deps.properties.size === 0 && !attrValue.isDynamic()) {

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -79,7 +79,7 @@ export const baseTechniqueParamsDescriptor: TechniqueDescriptor<BaseTechniquePar
     attrScopes: {
         renderOrder: AttrScope.TechniqueGeometry,
         renderOrderOffset: AttrScope.TechniqueGeometry,
-        enabled: AttrScope.TechniqueGeometry,
+        enabled: AttrScope.FeatureGeometry,
         kind: AttrScope.TechniqueGeometry,
         transient: AttrScope.TechniqueGeometry,
         fadeFar: AttrScope.TechniqueRendering,

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Theme } from "@here/harp-datasource-protocol";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, PickResult } from "@here/harp-mapview";
 import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
@@ -74,7 +75,7 @@ export namespace PickingExample {
 
     // snippet:datasource_object_picking_2.ts
     const element = document.getElementById("mouse-picked-result") as HTMLPreElement;
-    let currentUserData: PickResult | undefined;
+    let current: PickResult | undefined;
 
     function handlePick(mapViewUsed: MapView, x: number, y: number) {
         // get an array of intersection results from MapView
@@ -83,9 +84,7 @@ export namespace PickingExample {
             .intersectMapObjects(x, y)
             .filter(item => item.userData !== undefined);
         if (usableIntersections.length > 1) {
-            usableIntersections = usableIntersections.filter(
-                item => item.userData !== currentUserData
-            );
+            usableIntersections = usableIntersections.filter(item => item !== current);
         }
 
         if (usableIntersections.length === 0) {
@@ -95,13 +94,17 @@ export namespace PickingExample {
         }
 
         // Get userData from the first result;
-        currentUserData = usableIntersections[0].userData;
+        current = usableIntersections[0];
+
+        if (current.userData?.name !== undefined) {
+            mapViewUsed.setDynamicProperty("selection", [current.userData.name]);
+        }
 
         // Show helper box
         element.style.visibility = "visible";
 
         // Display userData inside of helper box
-        element.innerText = JSON.stringify(currentUserData, undefined, 2);
+        element.innerText = JSON.stringify(current.userData, undefined, 2);
     }
     // end:datasource_object_picking_2.ts
 
@@ -110,10 +113,50 @@ export namespace PickingExample {
      */
     async function initializeMapView(id: string) {
         const canvas = document.getElementById(id) as HTMLCanvasElement;
+
+        const selectionTheme: Theme = {
+            styles: {
+                tilezen: [
+                    {
+                        layer: "roads",
+                        when: ["==", ["geometry-type"], "LineString"],
+                        technique: "solid-line",
+                        renderOrder: Number.MAX_SAFE_INTEGER,
+                        attr: {
+                            enabled: [
+                                "in",
+                                ["get", "name"],
+                                ["get", "selection", ["dynamic-properties"]]
+                            ],
+                            lineWidth: "2px"
+                        }
+                    },
+                    {
+                        layer: "landuse",
+                        when: ["==", ["geometry-type"], "Polygon"],
+                        technique: "solid-line",
+                        renderOrder: Number.MAX_SAFE_INTEGER,
+                        attr: {
+                            enabled: [
+                                "in",
+                                ["get", "name"],
+                                ["get", "selection", ["dynamic-properties"]]
+                            ],
+                            lineWidth: "2px"
+                        }
+                    }
+                ]
+            }
+        };
+
         const mapView = new MapView({
             canvas,
-            theme: "resources/berlin_tilezen_base.json",
-            enableRoadPicking: true
+            theme: {
+                extends: [selectionTheme, "resources/berlin_tilezen_base.json"]
+            },
+            enableRoadPicking: true,
+            target: [-74.01, 40.707],
+            zoomLevel: 18
         });
 
         CopyrightElementHandler.install("copyrightNotice", mapView);
@@ -147,6 +190,8 @@ export namespace PickingExample {
             createTileInfo: true,
             copyrightInfo
         });
+
+        mapView.setDynamicProperty("selection", []);
 
         await mapView.addDataSource(omvDataSource);
 

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -165,7 +165,6 @@ export class AnimatedExtrusionHandler {
  */
 export class AnimatedExtrusionTileHandler {
     private m_extrudedObjects: THREE.Object3D[] = [];
-    private m_animatedExtrusionRatio: number = ExtrusionFeatureDefs.DEFAULT_RATIO_MAX;
     private m_animatedExtrusionState: AnimatedExtrusionState = AnimatedExtrusionState.None;
     private m_animatedExtrusionStartTime: number | undefined = undefined;
     private m_mapView: MapView;
@@ -192,12 +191,16 @@ export class AnimatedExtrusionTileHandler {
      * for extrusion animation effect.
      */
     set extrusionRatio(value: number) {
-        this.m_animatedExtrusionRatio = value;
-
         this.m_extrudedObjects.forEach(object => {
-            const material = (object as THREE.Mesh | THREE.LineSegments)
-                .material as ExtrusionFeature;
-            material.extrusionRatio = this.m_animatedExtrusionRatio;
+            if (object instanceof THREE.Mesh || object instanceof THREE.LineSegments) {
+                if (Array.isArray(object.material)) {
+                    object.material.forEach((material: ExtrusionFeature) => {
+                        material.extrusionRatio = value;
+                    });
+                } else if (object.material) {
+                    (object.material as ExtrusionFeature).extrusionRatio = value;
+                }
+            }
         });
     }
 

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -3,7 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Definitions, StyleSet, Theme } from "@here/harp-datasource-protocol";
+import { Definitions, StyleSet, Theme, ValueMap } from "@here/harp-datasource-protocol";
 import { Projection, TileKey, TilingScheme } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
@@ -80,6 +80,8 @@ export abstract class DataSource extends THREE.EventDispatcher {
      */
     private m_storageLevelOffset: number = 0;
 
+    private readonly m_featureStateMap = new Map<number, ValueMap>();
+
     /**
      * Constructs a new `DataSource`.
      *
@@ -114,6 +116,45 @@ export abstract class DataSource extends THREE.EventDispatcher {
         if (storageLevelOffset !== undefined) {
             this.m_storageLevelOffset = storageLevelOffset;
         }
+    }
+
+    /**
+     * Gets the state of the given feature id.
+     *
+     * @param featureId The id of the feature.
+     */
+    getFeatureState(featureId: number): ValueMap | undefined {
+        return this.m_featureStateMap.get(featureId);
+    }
+
+    /**
+     * Clears the state of all the features of this [[DataSource]].
+     */
+    clearFeatureState() {
+        this.m_featureStateMap.clear();
+    }
+
+    /**
+     * Sets the state of the given feature id.
+     *
+     * ```typescript
+     * dataSource.setFeatureState(featureId, { enabled: true });
+     * ```
+     *
+     * @param featureId The id of the feature.
+     * @param state The new state of the feature.
+     */
+    setFeatureState(featureId: number, state: ValueMap) {
+        this.m_featureStateMap.set(featureId, state);
+    }
+
+    /**
+     * Removes the state associated to the given feature.
+     *
+     * @param featureId The id of the feature.
+     */
+    removeFeatureState(featureId: number) {
+        this.m_featureStateMap.delete(featureId);
     }
 
     /**

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -688,7 +688,18 @@ export class TileGeometryCreator {
                 const hasSolidLinesOutlines: boolean =
                     isSolidLineTechnique(technique) && technique.secondaryWidth !== undefined;
 
-                const object = new ObjectCtor(bufferGeometry, material);
+                // When the source geometry is split in groups, we
+                // should create objects with an array of materials.
+                const hasFeatureGroups =
+                    Expr.isExpr(technique.enabled) &&
+                    srcGeometry.featureStarts &&
+                    srcGeometry.featureStarts.length > 0;
+
+                const object = new ObjectCtor(
+                    bufferGeometry,
+                    hasFeatureGroups ? [material] : material
+                );
+
                 object.renderOrder = technique.renderOrder!;
 
                 if (group.renderOrderOffset !== undefined) {

--- a/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
+++ b/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
@@ -26,9 +26,15 @@ function overlayObject(object: TileObject, displacementMap: THREE.DataTexture): 
         return;
     }
 
-    const material = (object as any).material;
+    const material = (object as any).material as THREE.Mesh["material"];
 
-    if (hasDisplacementFeature(material)) {
+    if (Array.isArray(material)) {
+        material.forEach(mat => {
+            if (hasDisplacementFeature(mat)) {
+                mat.displacementMap = displacementMap;
+            }
+        });
+    } else if (material && hasDisplacementFeature(material)) {
         material.displacementMap = displacementMap;
     }
 }


### PR DESCRIPTION
Add support for filtering features based on their state.

This change adds APIs to manipulate the state of a feature.
Note, that currently the feature state can only be used to
enable/disable features. That is, harp.gl themes can use
`["feature-state", property]` in expressions assigned to
the `enabled` attribute, for example:

    {
        when: ["==", ["geometry-type"], "LineString"],
        layer: "roads",
        technique: "solid-line",
        renderOrder: 10000,
        attr: {
            enabled: ["feature-state", "enabled"],
            lineWidth: "1px",
            color: "#c00"
        }
    }

Application code can programmatically update the state of a feature
using the DataSource API, for example:

    dataSource.setFeatureState(featureId, {
        enabled: true
    });
    mapView.update()

