### PR TITLE
Change default HERE Authentication and Services

### DIFF
--- a/@here/create-harp.gl-app/README.md
+++ b/@here/create-harp.gl-app/README.md
@@ -5,8 +5,7 @@ Application creator for [harp.gl](https://github.com/heremaps/harp.gl) based pro
 ## Pre-requirements
 
 * [node.js](https://nodejs.org/)
-* By default, generated app retrieves map data from free XYZ Vector Tiles service. You need an `access_token` that you can generate yourself after registration from the
-[Token Manager](https://xyz.api.here.com/token-ui/).
+* By default, generated app retrieves map data from HERE Vector Tiles Service. You need an `apikey` that you can generate yourself. Please see our [Getting Started Guide](../../docs/GettingStartedGuide.md).
 
 ## Usage
 

--- a/@here/generator-harp.gl/README.md
+++ b/@here/generator-harp.gl/README.md
@@ -7,8 +7,7 @@ Yeoman generator for [harp.gl](https://github.com/heremaps/harp.gl) based projec
 * [node.js](https://nodejs.org/)
 * [yeoman](https://yeoman.io/) - Install globally with `npm install -g yo` or use without
   installation with `npx` like this `npx yo`.
-* By default, generated app retrieves map data from free XYZ Vector Tiles service. You need an `access_token` that you can generate yourself after registration from the
-[Token Manager](https://xyz.api.here.com/token-ui/).
+* By default, generated app retrieves map data from HERE Vector Tiles Service. You need an `apikey` that you can generate yourself. Please see our [Getting Started Guide](../../docs/GettingStartedGuide.md).
 
 ## Usage
 
@@ -23,11 +22,14 @@ Set you access token in `View.ts`:
 
 ```typescript
 const omvDataSource = new OmvDataSource({
-    baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
-    apiFormat: APIFormat.XYZOMV,
-    styleSetName: "tilezen",
-    maxZoomLevel: 17,
-    authenticationCode: "YOUR_ACCESS_TOKEN"
+   baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+   apiFormat: harp.APIFormat.XYZOMV,
+   styleSetName: "tilezen",
+   authenticationCode: "YOUR-APIKEY",
+   authenticationMethod: {
+         method: harp.AuthenticationMethod.QueryString,
+         name: "apikey"
+   }
 });
 ```
 Then start it using `webpack-dev-server`:

--- a/@here/generator-harp.gl/generators/app/index.js
+++ b/@here/generator-harp.gl/generators/app/index.js
@@ -24,8 +24,8 @@ module.exports = class extends Generator {
             },
             {
                 type: "input",
-                name: "access_token",
-                message: "access token"
+                name: "apikey",
+                message: "APIKey"
             }
         ]);
 
@@ -38,7 +38,7 @@ module.exports = class extends Generator {
             generator_version: version
         });
         this.fs.copyTpl([this.templatePath(this.answers.language)], this.destinationPath(), {
-            access_token: this.answers.access_token
+            apikey: this.answers.apikey
         });
     }
 

--- a/@here/generator-harp.gl/generators/app/templates/javascript/View.js
+++ b/@here/generator-harp.gl/generators/app/templates/javascript/View.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { MapControls } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 
 const defaultTheme = "resources/berlin_tilezen_base.json";
 
@@ -34,11 +34,14 @@ export class View {
                 }
             ]);
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: "<%= access_token %>"
+            authenticationCode: "<%= apikey %>",
+            authenticationMethod: {
+                  method: AuthenticationMethod.QueryString,
+                  name: "apikey"
+            }
         });
         mapView.addDataSource(omvDataSource);
         MapControls.create(mapView);

--- a/@here/generator-harp.gl/generators/app/templates/typescript/View.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/View.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +7,7 @@
 import { Theme } from "@here/harp-datasource-protocol";
 import { MapControls } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 
 const defaultTheme = "resources/berlin_tilezen_base.json";
 
@@ -47,11 +47,14 @@ export class View {
             ]);
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: "<%= access_token %>"
+            authenticationCode: "<%= apikey %>",
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            }
         });
         mapView.addDataSource(omvDataSource);
 

--- a/@here/harp-examples/config.ts
+++ b/@here/harp-examples/config.ts
@@ -1,17 +1,11 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @hidden */
-export const appId = "devportal-demo-20180625";
-
-/** @hidden */
-export const appCode = "9v2BkviRwi9Ot26kp2IysQ";
-
-/** @hidden */
-export const accessToken = "AGln99HORnqL1kfIQtsQl70";
+export const apikey = "J0IJdYzKDYS3nHVDDEWETIqK3nAcxqW42vz7xeSq61M";
 
 /** @hidden */
 export const copyrightInfo = [

--- a/@here/harp-examples/lib/PerformanceUtils.ts
+++ b/@here/harp-examples/lib/PerformanceUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,6 @@ import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls } from "@here/harp-map-controls";
 import {
     computeArrayStats,
-    CopyrightInfo,
     DataSource,
     MapView,
     MapViewEventNames,
@@ -19,11 +18,10 @@ import {
     SimpleFrameStatistics
 } from "@here/harp-mapview";
 import { debugContext } from "@here/harp-mapview/lib/DebugContext";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { assert, LoggerManager, PerformanceTimer } from "@here/harp-utils";
 import * as THREE from "three";
-
-import { accessToken } from "../config";
+import { apikey, copyrightInfo } from "../config";
 import { PerformanceTestData } from "./PerformanceConfig";
 
 const logger = LoggerManager.instance.create("PerformanceUtils");
@@ -182,25 +180,20 @@ export namespace PerformanceUtils {
         dataSourceTypes: string[],
         storageLevelOffsetModifier: number
     ): Promise<DataSource[]> {
-        const hereCopyrightInfo: CopyrightInfo = {
-            id: "here.com",
-            year: new Date().getFullYear(),
-            label: "HERE",
-            link: "https://legal.here.com/terms"
-        };
-        const copyrights: CopyrightInfo[] = [hereCopyrightInfo];
-
         const createDataSource = (dataSourceType: string): OmvDataSource => {
             let dataSource: OmvDataSource | undefined;
             switch (dataSourceType) {
                 case "OMV":
                     dataSource = new OmvDataSource({
-                        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+                        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                         apiFormat: APIFormat.XYZOMV,
                         styleSetName: "tilezen",
-                        maxZoomLevel: 17,
-                        authenticationCode: accessToken,
-                        copyrightInfo: copyrights
+                        authenticationCode: apikey,
+                        authenticationMethod: {
+                            method: AuthenticationMethod.QueryString,
+                            name: "apikey"
+                        },
+                        copyrightInfo
                     });
                     break;
                 default:

--- a/@here/harp-examples/src/datasource_features_lines-and-points.ts
+++ b/@here/harp-examples/src/datasource_features_lines-and-points.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,8 +14,8 @@ import {
 import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 import { faults, hotspots } from "../resources/geology";
 
 /**
@@ -225,11 +225,14 @@ export namespace LinesPointsFeaturesExample {
 
         const baseMap = new OmvDataSource({
             name: "basemap",
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
         mapView.addDataSource(baseMap);

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,9 +13,9 @@ import {
 import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 import { COUNTRIES } from "../resources/countries";
 
 /**
@@ -334,11 +334,14 @@ export namespace PolygonsFeaturesExample {
 
         const baseMap = new OmvDataSource({
             name: "basemap",
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
         mapView.addDataSource(baseMap);

--- a/@here/harp-examples/src/datasource_geojson_choropleth.ts
+++ b/@here/harp-examples/src/datasource_geojson_choropleth.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,9 +9,9 @@ import { GeoJsonDataProvider } from "@here/harp-geojson-datasource";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * This example demonstrates how to generate a heatmap-like [[StyleSet]] for a GeoJson. To do so,
@@ -83,11 +83,14 @@ export namespace GeoJsonHeatmapExample {
         });
 
         const baseMapDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
 

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,8 +14,8 @@ import {
 import { GeoJsonDataProvider } from "@here/harp-geojson-datasource";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 import * as geojson from "../resources/italy.json";
 
 /**
@@ -95,11 +95,14 @@ export namespace GeoJsonStylingGame {
     });
     mapView.canvas.addEventListener("contextmenu", e => e.preventDefault());
     const baseMap = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
         copyrightInfo
     });
     mapView.addDataSource(baseMap);

--- a/@here/harp-examples/src/datasource_here_vector_tile.ts
+++ b/@here/harp-examples/src/datasource_here_vector_tile.ts
@@ -1,13 +1,13 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
-import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken } from "../config";
+import { MapView } from "@here/harp-mapview";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * MapView initialization sequence enables setting all the necessary elements on a map  and returns
@@ -21,73 +21,63 @@ import { accessToken } from "../config";
  * map canvas within.
  *
  * ```typescript
- * [[include:harp_gl_datasource_xyzmvt_example_0.ts]]
+ * [[include:harp_gl_datasource_here_vector_tile_example_0.ts]]
  * ```
  *
- * During the initialization, canvas element with a given `id` is searched for first. Than a
+ * During the initialization, canvas element with a given `id` is searched for first. Then a
  * [[MapView]] object is created and set to initial values of camera settings and map's geo center.
  *
  * ```typescript
- * [[include:harp_gl_datasource_xyzmvt_example_1.ts]]
+ * [[include:harp_gl_datasource_here_vector_tile_example_1.ts]]
  * ```
  * As a map needs controls to allow any interaction with the user (e.g. panning), a [[MapControls]]
  * object is created.
  *
  * ```typescript
- * [[include:harp_gl_datasource_xyzmvt_example_2.ts]]
+ * [[include:harp_gl_datasource_here_vector_tile_example_2.ts]]
  * ```
  * Finally the map is being resized to fill the whole screen and a listener for a "resize" event is
  * added, which enables adjusting the map's size to the browser's window size changes.
  *
  * ```typescript
- * [[include:harp_gl_datasource_xyzmvt_example_3.ts]]
+ * [[include:harp_gl_datasource_here_vector_tile_example_3.ts]]
  * ```
- * At the end of the initialization a [[MapView]] object is returned. To show map tiles an exemplary
- * datasource is used, [[OmvDataSource]]:
+ * At the end of the initialization a [[MapView]] object is returned. To show vector tiles the HERE
+ * Vector Tile datasource is used, [[OmvDataSource]]:
  *
  * ```typescript
- * [[include:harp_gl_datasource_xyzmvt_example_4.ts]]
+ * [[include:harp_gl_datasource_here_vector_tile_example_4.ts]]
  * ```
  *
  * After creating a specific datasource it needs to be added to the map in order to be seen.
  *
  * ```typescript
- * [[include:harp_gl_datasource_xyzmvt_example_5.ts]]
+ * [[include:harp_gl_datasource_here_vector_tile_example_5.ts]]
  * ```
  *
  */
-export namespace DatasourceXYZMVTExample {
+export namespace DatasourceHEREVectorTileExample {
     // creates a new MapView for the HTMLCanvasElement of the given id
     function initializeMapView(id: string): MapView {
-        // snippet:harp_gl_datasource_xyzmvt_example_0.ts
+        // snippet:harp_gl_datasource_here_vector_tile_example_0.ts
         const canvas = document.getElementById(id) as HTMLCanvasElement;
-        // end:harp_gl_datasource_xyzmvt_example_0.ts
+        // end:harp_gl_datasource_here_vector_tile_example_0.ts
 
-        // snippet:harp_gl_datasource_xyzmvt_example_1.ts
+        // snippet:harp_gl_datasource_here_vector_tile_example_1.ts
         const map = new MapView({
             canvas,
             theme: "resources/berlin_tilezen_base.json"
         });
-        // end:harp_gl_datasource_xyzmvt_example_1.ts
+        // end:harp_gl_datasource_here_vector_tile_example_1.ts
 
-        CopyrightElementHandler.install("copyrightNotice")
-            .attach(map)
-            .setDefaults([
-                {
-                    id: "openstreetmap.org",
-                    label: "OpenStreetMap contributors",
-                    link: "https://www.openstreetmap.org/copyright"
-                }
-            ]);
-
-        // snippet:harp_gl_datasource_xyzmvt_example_2.ts
+        // snippet:harp_gl_datasource_here_vector_tile_example_2.ts
         const mapControls = new MapControls(map);
         mapControls.maxTiltAngle = 50;
         const ui = new MapControlsUI(mapControls, { zoomLevel: "input", projectionSwitch: true });
         canvas.parentElement!.appendChild(ui.domElement);
-        // end:harp_gl_datasource_xyzmvt_example_2.ts
+        // end:harp_gl_datasource_here_vector_tile_example_2.ts
 
-        // snippet:harp_gl_datasource_xyzmvt_example_3.ts
+        // snippet:harp_gl_datasource_here_vector_tile_example_3.ts
         // resize the mapView to maximum
         map.resize(window.innerWidth, window.innerHeight);
 
@@ -95,24 +85,28 @@ export namespace DatasourceXYZMVTExample {
         window.addEventListener("resize", () => {
             map.resize(window.innerWidth, window.innerHeight);
         });
-        // end:harp_gl_datasource_xyzmvt_example_3.ts
+        // end:harp_gl_datasource_here_vector_tile_example_3.ts
 
         return map;
     }
 
     const mapView = initializeMapView("mapCanvas");
 
-    // snippet:harp_gl_datasource_xyzmvt_example_4.ts
+    // snippet:harp_gl_datasource_here_vector_tile_example_4.ts
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-        apiFormat: APIFormat.XYZMVT,
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+        apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
+        copyrightInfo
     });
-    // end:harp_gl_datasource_xyzmvt_example_4.ts
+    // end:harp_gl_datasource_here_vector_tile_example_4.ts
 
-    // snippet:harp_gl_datasource_xyzmvt_example_5.ts
+    // snippet:harp_gl_datasource_here_vector_tile_example_5.ts
     mapView.addDataSource(omvDataSource);
-    // end:harp_gl_datasource_xyzmvt_example_5.ts
+    // end:harp_gl_datasource_here_vector_tile_example_5.ts
 }

--- a/@here/harp-examples/src/datasource_satellite-tile.ts
+++ b/@here/harp-examples/src/datasource_satellite-tile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,16 +7,16 @@
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { WebTileDataSource } from "@here/harp-webtile-datasource";
-import { appCode, appId } from "../config";
+import { apikey } from "../config";
 
 // tslint:disable:max-line-length
 /**
  * A simple example using the webtile data source. Tiles are retrieved from
  * ```
- * https://1.aerial.maps.api.here.com/maptile/2.1/maptile/newest/satellite.day/${level}/${column}/${row}/512/png8?app_id=${appId}&app_code=${appCode}
+ * https://1.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/satellite.day/${level}/${column}/${row}/512/png8?apikey=${apikey}
  * ```
  *
- * A [[WebTileDataSource]] is created with specified applications' appId and appCode passed
+ * A [[WebTileDataSource]] is created with specified applications' apikey passed
  * as [[WebTileDataSourceOptions]]
  * ```typescript
  * [[include:harp_gl_datasource_satellitetile_1.ts]]
@@ -60,8 +60,7 @@ export namespace SatelliteDataSourceExample {
 
     // snippet:harp_gl_datasource_satellitetile_1.ts
     const webTileDataSource = new WebTileDataSource({
-        appId,
-        appCode,
+        apikey,
         tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE
     });
     // end:harp_gl_datasource_satellitetile_1.ts

--- a/@here/harp-examples/src/datasource_webtile.ts
+++ b/@here/harp-examples/src/datasource_webtile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,16 +7,16 @@
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { WebTileDataSource } from "@here/harp-webtile-datasource";
-import { appCode, appId } from "../config";
+import { apikey } from "../config";
 
 // tslint:disable:max-line-length
 /**
  * A simple example using the webtile data source. Tiles are retrieved from
  * ```
- * https://1.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/${level}/${column}/${row}/512/png8?app_id=${appId}&app_code=${appCode}
+ * https://1.base.maps.ls.hereapi.com/maptile/2.1/maptile/newest/normal.day/${level}/${column}/${row}/512/png8?apikey=${apikey}
  * ```
  *
- * A [[WebTileDataSource]] is created with specified applications' appId and appCode passed
+ * A [[WebTileDataSource]] is created with specified applications' apikey passed
  * as [[WebTileDataSourceOptions]]
  * ```typescript
  * [[include:harp_gl_datasource_webtile_1.ts]]
@@ -60,8 +60,7 @@ export namespace WebTileDataSourceExample {
 
     // snippet:harp_gl_datasource_webtile_1.ts
     const webTileDataSource = new WebTileDataSource({
-        appId,
-        appCode,
+        apikey,
         ppi: WebTileDataSource.ppiValue.ppi320
     });
     // end:harp_gl_datasource_webtile_1.ts

--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +8,8 @@ import { StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { FeaturesDataSource } from "@here/harp-features-datasource";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * In this example we avail ourselves of the [[FeaturesDataSource]] and its `setFromGeoJson` method
@@ -170,11 +170,14 @@ export namespace GeoJsonExample {
         });
 
         const baseMap = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
         mapView.addDataSource(baseMap);

--- a/@here/harp-examples/src/getting-started_free-camera.ts
+++ b/@here/harp-examples/src/getting-started_free-camera.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,9 +14,9 @@ import {
     MapViewOptions,
     MapViewUtils
 } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 // Import the gesture handlers from the three.js additional libraries.
 // The controls are not in common.js they explicitly require a
@@ -101,11 +101,14 @@ export namespace FreeCameraAppDebuggingToolExample {
          */
         start() {
             const omvDataSource = new OmvDataSource({
-                baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+                baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                 apiFormat: APIFormat.XYZOMV,
                 styleSetName: "tilezen",
-                maxZoomLevel: 17,
-                authenticationCode: accessToken,
+                authenticationCode: apikey,
+                authenticationMethod: {
+                    method: AuthenticationMethod.QueryString,
+                    name: "apikey"
+                },
                 copyrightInfo
             });
 

--- a/@here/harp-examples/src/getting-started_globe-projection.ts
+++ b/@here/harp-examples/src/getting-started_globe-projection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,8 @@
 import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 export namespace GlobeExample {
     // Create a new MapView for the HTMLCanvasElement of the given id.
@@ -36,11 +36,14 @@ export namespace GlobeExample {
         const map = initializeMapView("mapCanvas");
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
 

--- a/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
+++ b/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
@@ -99,11 +99,14 @@
             const copyrights = [hereCopyrightInfo];
 
             const omvDataSource = new harp.OmvDataSource({
-                baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+                baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                 apiFormat: harp.APIFormat.XYZOMV,
                 styleSetName: "tilezen",
-                maxZoomLevel: 17,
-                authenticationCode: token,
+                authenticationCode: apikey,
+                authenticationMethod: {
+                    method: harp.AuthenticationMethod.QueryString,
+                    name: "apikey"
+                },
                 copyrightInfo: copyrights
             });
 

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,8 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * MapView initialization sequence enables setting all the necessary elements on a map  and returns
@@ -113,11 +113,13 @@ export namespace HelloWorldExample {
     function addOmvDataSource(map: MapView) {
         // snippet:harp_gl_hello_world_example_4.ts
         const omvDataSource = new OmvDataSource({
-            url: "https://xyz.api.here.com/tiles/herebase.02/{z}/{x}/{y}/omv",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+            apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            urlParams: {
-                access_token: accessToken
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
             },
             copyrightInfo
         });

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,9 +7,9 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, ThemeLoader } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * This example copies the base example and adds a GUI allowing to switch between all the open-
@@ -47,11 +47,14 @@ export namespace ThemesExample {
     const mapView = initializeMapView();
 
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
         copyrightInfo
     });
 

--- a/@here/harp-examples/src/getting-started_orbiting-view.ts
+++ b/@here/harp-examples/src/getting-started_orbiting-view.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,9 +11,9 @@ import {
     MapViewEventNames,
     MapViewUtils
 } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * In this example we simply use the `lookAt` method to make the camera orbit around a geolocation.
@@ -77,11 +77,14 @@ export namespace CameraOrbitExample {
         });
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
         mapView.addDataSource(omvDataSource);

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -1,13 +1,13 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, PickResult } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * This example showcases how picking works.
@@ -135,11 +135,14 @@ export namespace PickingExample {
         // end:datasource_object_picking_1.ts
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             gatherFeatureAttributes: true,
             createTileInfo: true,
             copyrightInfo

--- a/@here/harp-examples/src/rendering_post-effects_all.ts
+++ b/@here/harp-examples/src/rendering_post-effects_all.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,9 +7,9 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * Harp's effects playground example with GUI to tweak values in one's own map. The effects are
@@ -58,11 +58,14 @@ export namespace EffectsAllExample {
     const map = initializeMapView("mapCanvas");
 
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
         copyrightInfo
     });
     map.addDataSource(omvDataSource);

--- a/@here/harp-examples/src/rendering_post-effects_themes.ts
+++ b/@here/harp-examples/src/rendering_post-effects_themes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,9 +7,9 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * Example showing how to use separate post effects JSON files to configure the rendering through
@@ -47,11 +47,14 @@ export namespace EffectsExample {
     const map = initializeMapView("mapCanvas");
 
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
         copyrightInfo
     });
     map.addDataSource(omvDataSource);

--- a/@here/harp-examples/src/rendering_synchronous.ts
+++ b/@here/harp-examples/src/rendering_synchronous.ts
@@ -1,13 +1,13 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import THREE = require("three");
-import { accessToken } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * The example shows how to render map synchronously within your own render loop.
@@ -64,11 +64,15 @@ export namespace SynchronousRendering {
         });
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
+            copyrightInfo
         });
         map.addDataSource(omvDataSource);
 

--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,8 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 export namespace DataDrivenThemeExample {
     document.body.innerHTML +=
@@ -96,12 +96,14 @@ export namespace DataDrivenThemeExample {
         const map = initializeMapView("mapCanvas");
 
         const omvDataSource = new OmvDataSource({
-            url: "https://xyz.api.here.com/tiles/osmbase/512/all/{z}/{x}/{y}.mvt",
-            urlParams: {
-                access_token: accessToken
-            },
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+            apiFormat: APIFormat.XYZOMV,
             styleSetName: "population",
-            maxZoomLevel: 17,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
 

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,8 +7,8 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * This example shows how to customize builtin `Berlin` theme using [Theme] `definition` mechanism.
@@ -129,11 +129,14 @@ export namespace HelloCustomThemeExample {
 
     function addOmvDataSource(map: MapView) {
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
 

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,8 +9,8 @@ import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * This example showcases interpolated [[MapView]] techniques.
@@ -455,11 +455,14 @@ export namespace TiledGeoJsonTechniquesExample {
         });
 
         const baseMapDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 16,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
 

--- a/@here/harp-examples/src/styling_textured-areas.ts
+++ b/@here/harp-examples/src/styling_textured-areas.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,8 +9,8 @@ import { isJsonExpr } from "@here/harp-datasource-protocol/lib/Expr";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, ThemeLoader } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken, copyrightInfo } from "../config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 export namespace HelloWorldTexturedExample {
     function main() {
@@ -19,11 +19,14 @@ export namespace HelloWorldTexturedExample {
         const mapView = initializeMapView("mapCanvas");
 
         const omvDataSource = new OmvDataSource({
-            baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
-            maxZoomLevel: 17,
-            authenticationCode: accessToken,
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
             copyrightInfo
         });
 

--- a/@here/harp-examples/src/synchronized-views.ts
+++ b/@here/harp-examples/src/synchronized-views.ts
@@ -1,14 +1,14 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
-import { CopyrightElementHandler, CopyrightInfo, MapView, MapViewUtils } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken } from "../config";
+import { CopyrightElementHandler, MapView, MapViewUtils } from "@here/harp-mapview";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * An example showing triple map view build with 3 [[MapView]]s each with a different theme and/or
@@ -132,21 +132,16 @@ export namespace TripleViewExample {
     // end:harp_gl_multiview_tripleView_1.ts
 
     // snippet:harp_gl_multiview_tripleView_2.ts
-    const hereCopyrightInfo: CopyrightInfo = {
-        id: "here.com",
-        year: new Date().getFullYear(),
-        label: "HERE",
-        link: "https://legal.here.com/terms"
-    };
-    const copyrights: CopyrightInfo[] = [hereCopyrightInfo];
-
     const xyzDataSourceParams = {
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken,
-        copyrightInfo: copyrights
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
+        copyrightInfo
     };
     const dataSources = {
         omvDataSource1: new OmvDataSource(xyzDataSourceParams),

--- a/@here/harp-examples/src/threejs_raycast.ts
+++ b/@here/harp-examples/src/threejs_raycast.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,9 +7,9 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { LongPressHandler, MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { accessToken, copyrightInfo } from "../config";
+import { apikey, copyrightInfo } from "../config";
 
 /**
  * This example shows how we can pick the scene and add a [three.js](https://threejs.org/) object.
@@ -140,11 +140,14 @@ export namespace ThreejsRaycast {
     const mapView = initializeMapView("mapCanvas");
 
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        maxZoomLevel: 17,
-        authenticationCode: accessToken,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
         copyrightInfo
     });
 

--- a/@here/harp-omv-datasource/README.md
+++ b/@here/harp-omv-datasource/README.md
@@ -15,7 +15,9 @@ Each tile is encoded using [Protobuf](https://github.com/google/protobuf).
 
 ### HERE Vector Tiles
 
-REST service implemented with `APIFormat.HereV1` in `OmvRestClient.ts`.
+REST service implemented with `APIFormat.HereV1` in `OmvRestClient.ts` if you want to use `AuthenticationTypeBearer` by default, if you want to use `APIKey` you can use `APIFormat.XYZOMV`.
+
+You can find more about the different access methods [here](https://developer.here.com/documentation/authentication/dev_guide/index.html).
 
 The HERE Vector Tile Service allows you to request tiles containing vector data
 using content from the [HERE Open Location Platform](https://openlocation.here.com/).

--- a/@here/harp-omv-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-omv-datasource/lib/OmvRestClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,6 +16,9 @@ const logger = LoggerManager.instance.create("OmvRestClient");
 export enum APIFormat {
     /**
      * Use the REST API format of HERE Vector Tiles Server component version 1.
+     *
+     * Documentation:
+     *  https://developer.here.com/documentation/vector-tiles-api/dev_guide/index.html
      *
      * Usage:
      *

--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -32,14 +32,9 @@ export interface WebTileRenderingOptions {
  */
 export interface WebTileDataSourceParameters {
     /**
-     * The `appId` for the access of the Web Tile Data.
+     * The `apikey` for the access of the Web Tile Data.
      */
-    appId: string;
-
-    /**
-     * The `appCode` for the access of the Web Tile Data.
-     */
-    appCode: string;
+    apikey: string;
 
     // tslint:disable:max-line-length
     /**
@@ -58,13 +53,12 @@ export interface WebTileDataSourceParameters {
      * (https://developer.here.com/documentation/map-tile/topics/examples-base.html):
      *
      *     https://
-     *       2.base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day/11/525/761/256/png8
-     *       ?app_id={YOUR_APP_ID}
-     *       &app_code={YOUR_APP_CODE}
+     *       2.base.maps.ls.hereapi.com/maptile/2.1/maptile/newest/normal.day/11/525/761/256/png8
+     *       ?apikey={YOUR_API_KEY}
      *
      * `tileBaseAddress` should be:
      *
-     *      base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day
+     *      base.maps.ls.hereapi.com/maptile/2.1/maptile/newest/normal.day
      *
      * Rest of parameters are added by [[WebTileDataSource]].
      *
@@ -196,8 +190,7 @@ interface MapTileParams {
  *
  * ```typescript
  * const webTileDataSource = new WebTileDataSource({
- *     appId: <appId>,
- *     appCode: <appCode>
+ *     apikey: <apikey>
  * });
  * ```
  * @see [[DataSource]], [[OmvDataSource]].
@@ -208,27 +201,27 @@ export class WebTileDataSource extends DataSource {
      * @see https://developer.here.com/documentation/map-tile/topics/example-normal-day-view.html
      */
     static readonly TILE_BASE_NORMAL =
-        "base.maps.api.here.com/maptile/2.1/maptile/newest/normal.day";
+        "base.maps.ls.hereapi.com/maptile/2.1/maptile/newest/normal.day";
     /**
      * Base address for Aerial Map rendered using `hybrid.day` scheme.
      * @see https://developer.here.com/documentation/map-tile/topics/example-hybrid-map.html
      */
     static readonly TILE_AERIAL_HYBRID =
-        "aerial.maps.api.here.com/maptile/2.1/maptile/newest/hybrid.day";
+        "aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/hybrid.day";
 
     /**
      * Base address for Aerial Map rendered using `satellite.day` scheme.
      * @see https://developer.here.com/documentation/map-tile/topics/example-satellite-map.html
      */
     static readonly TILE_AERIAL_SATELLITE =
-        "aerial.maps.api.here.com/maptile/2.1/maptile/newest/satellite.day";
+        "aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/satellite.day";
 
     /**
      * Base address for Traffic Map rendered using `normal.day` scheme.
      * @see https://developer.here.com/documentation/map-tile/topics/example-traffic.html
      */
     static readonly TILE_TRAFFIC_NORMAL =
-        "traffic.maps.api.here.com/maptile/2.1/traffictile/newest/normal.day";
+        "traffic.maps.ls.hereapi.com/maptile/2.1/traffictile/newest/normal.day";
 
     private m_resolution: WebTileDataSource.resolutionValue;
     private m_ppi: WebTileDataSource.ppiValue;
@@ -276,10 +269,10 @@ export class WebTileDataSource extends DataSource {
         const mapId = getOptionValue(mapTileParams.mapVersion, "newest");
         const scheme = mapTileParams.scheme || "normal.day";
         const baseScheme = scheme.split(".")[0] || "normal";
-        const { appId, appCode } = this.m_options;
+        const { apikey } = this.m_options;
         const url =
             `https://1.${baseHostName}/maptile/2.1/copyright/${mapId}` +
-            `?output=json&app_id=${appId}&app_code=${appCode}`;
+            `?output=json&apikey=${apikey}`;
         this.m_copyrightProvider = new UrlCopyrightProvider(url, baseScheme);
     }
 
@@ -308,13 +301,13 @@ export class WebTileDataSource extends DataSource {
         const column = tileKey.column;
         const row = tileKey.row;
         const level = tileKey.level;
-        const { appId, appCode } = this.m_options;
+        const { apikey } = this.m_options;
         const quadKey = tileKey.toQuadKey();
         const server = parseInt(quadKey[quadKey.length - 1], 10) + 1;
         let url =
             `https://${server}.${this.m_tileBaseAddress}/` +
             `${level}/${column}/${row}/${this.m_resolution}/png8` +
-            `?app_id=${appId}&app_code=${appCode}` +
+            `?apikey=${apikey}` +
             getOptionValue(this.m_options.additionalRequestParameters, "");
 
         if (this.m_ppi !== WebTileDataSource.ppiValue.ppi72) {

--- a/@here/harp-webtile-datasource/test/WebTileTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,54 +16,44 @@ describe("WebTileDataSource", function() {
     });
 
     it("#createWebTileDataSource has default values", async function() {
-        const appId = "123";
-        const appCode = "456";
+        const apikey = "123";
         const webTileDataSource = new WebTileDataSource({
-            appId,
-            appCode
+            apikey
         });
         assert(webTileDataSource.maxZoomLevel === 19);
     });
     it("#createWebTileDataSource with 256px and ppi320", async function() {
-        const appId = "123";
-        const appCode = "456";
+        const apikey = "123";
         const webTileDataSource = new WebTileDataSource({
-            appId,
-            appCode,
+            apikey,
             resolution: WebTileDataSource.resolutionValue.resolution256,
             ppi: WebTileDataSource.ppiValue.ppi320
         });
         assert(webTileDataSource.maxZoomLevel === 20);
     });
     it("#createWebTileDataSource with satellite.day", async function() {
-        const appId = "123";
-        const appCode = "456";
+        const apikey = "123";
         const webTileDataSource = new WebTileDataSource({
-            appId,
-            appCode,
+            apikey,
             tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE
         });
         assert(webTileDataSource.maxZoomLevel === 19);
     });
     it("#createWebTileDataSource with satellite.day and 256px", async function() {
-        const appId = "123";
-        const appCode = "456";
+        const apikey = "123";
         const webTileDataSource = new WebTileDataSource({
-            appId,
-            appCode,
+            apikey,
             tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE,
             resolution: WebTileDataSource.resolutionValue.resolution256
         });
         assert(webTileDataSource.maxZoomLevel === 20);
     });
     it("#createWebTileDataSource with satellite.day and ppi320", async function() {
-        const appId = "123";
-        const appCode = "456";
+        const apikey = "123";
         assert.throw(
             () =>
                 new WebTileDataSource({
-                    appId,
-                    appCode,
+                    apikey,
                     tileBaseAddress: WebTileDataSource.TILE_AERIAL_SATELLITE,
                     ppi: WebTileDataSource.ppiValue.ppi320
                 })

--- a/README.md
+++ b/README.md
@@ -59,13 +59,20 @@ const map = new harp.MapView({
 });
 const controls = new harp.MapControls(map);
 const omvDataSource = new harp.OmvDataSource({
-   baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+   baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
    apiFormat: harp.APIFormat.XYZOMV,
    styleSetName: "tilezen",
-   authenticationCode: "YOUR-XYZ-TOKEN",
+   authenticationCode: "YOUR-APIKEY",
+   authenticationMethod: {
+         method: harp.AuthenticationMethod.QueryString,
+         name: "apikey"
+   }
 });
 map.addDataSource(omvDataSource);
 ```
+
+> How to get access to the data? How to get your apikey?
+> Please see the [Acquiring credentials section](docs/GettingStartedGuide.md#credentials)
 
 ### Node modules
 

--- a/docs/GettingStartedGuide.md
+++ b/docs/GettingStartedGuide.md
@@ -40,16 +40,19 @@ const controls = new harp.MapControls(map);
 window.onresize = () => map.resize(window.innerWidth, window.innerHeight);
 
 const omvDataSource = new harp.OmvDataSource({
-   baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+   baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
    apiFormat: harp.APIFormat.XYZOMV,
    styleSetName: "tilezen",
-   authenticationCode: "YOUR-XYZ-TOKEN",
+   authenticationCode: "YOUR-APIKEY",
+   authenticationMethod: {
+         method: harp.AuthenticationMethod.QueryString,
+         name: "apikey"
+   }
 });
 map.addDataSource(omvDataSource);
 ```
 
-You need to [obtain authentication code](#credentials) to replace 'YOUR-XYZ-TOKEN'.
-
+You need to [obtain an apikey](#credentials) to replace `YOUR-APIKEY` and use the service to download vector tiles.
 
 For more information on the simple bundle, please visit the [@here/harp.gl module](../@here/harp.gl) directory.
 
@@ -189,19 +192,19 @@ to our `MapView` instance:
 import { APIFormat, AuthenticationTypeMapboxV4, OmvDataSource } from "@here/harp-omv-datasource";
 
 const dataSource = new OmvDataSource({
-    baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
-    apiFormat: APIFormat.XYZOMV,
-    styleSetName: "tilezen",
-    maxZoomLevel: 17,
-    authenticationCode: "your access token for xyz service",
-    authenticationMethod: AuthenticationTypeMapboxV4
+   baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+   apiFormat: harp.APIFormat.XYZOMV,
+   styleSetName: "tilezen",
+   authenticationCode: "YOUR-APIKEY",
+   authenticationMethod: {
+         method: harp.AuthenticationMethod.QueryString,
+         name: "apikey"
+   }
 });
 mapView.addDataSource(dataSource);
 ```
 
-Note, that this example uses vector tiles downloaded from HERE XYZ service and access to these
-files is protected by access token. You should replace `your access token for xyz service` with real
-one, see [HERE Credentials](#credentials) section below.
+You need to [obtain an apikey](#credentials) to replace `YOUR-APIKEY` and use the service to download vector tiles.
 
 ### Enable user interaction with map
 
@@ -223,19 +226,16 @@ the [examples package](../@here/harp-examples/README.md)
 
 ## <a name="credentials"></a> HERE Credentials
 
-In order to use some of the HERE Services, such as XYZ or Map Tile API, you would need to register
+In order to use some of the HERE Services, you would need to register
 and generate credentials.
 
-First, you need to become a [HERE Developer](https://www.here.xyz/getting-started/).
+First, you need to become a [HERE Developer](https://developer.here.com/).
 
-Afterwards, depending on which service do you want, you might need different credentials.
+Afterwards, please read the [Authentication and Authorization Guide](https://developer.here.com/documentation/authentication/dev_guide/index.html).
 
-For Map Tile API, which is needed for the webtile examples, you need to generate a pair of `app_id`
-and `app_code`, that you can do directly from your Developer Dashboard, see a step-by-step guide
-[here](https://www.here.xyz/getting-started/).
+For [Map Tile API](https://developer.here.com/documentation/map-tile/dev_guide/topics/quick-start-map-tile.html), which is needed for the webtile examples, you need to generate an `apikey`.
 
-For XYZ Vector Tiles, you need an `access_token` that you can generate yourself from the
-[Token Manager](https://xyz.api.here.com/token-ui/). You can see a step-by-step guide [here](https://www.here.xyz/api/getting-token/).
+For [Vector Tiles](https://developer.here.com/documentation/vector-tiles-api/dev_guide/index.html), you need to generate an `apikey`.
 
 These credentials need to be passed to the Service in order to retrieve tiles, please see the
 examples to check how it is done.

--- a/scripts/credentials.ts
+++ b/scripts/credentials.ts
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import * as fs from "fs";
-import { accessToken } from "../@here/harp-examples/config";
+import { apikey } from "../@here/harp-examples/config";
 
 // tslint:disable : no-console
 
@@ -20,6 +20,6 @@ if (targetDir === undefined) {
     process.exit(1);
 }
 
-const credentialsResult = `const token = '${accessToken}'`;
+const credentialsResult = `const apikey = '${apikey}'`;
 fs.mkdirSync(targetDir, { recursive: true });
 fs.writeFileSync(`${targetDir}/credentials.js`, credentialsResult, { encoding: "utf8" });

--- a/test/performance/OmvDecoderPerformanceTest.ts
+++ b/test/performance/OmvDecoderPerformanceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,10 +10,15 @@ import { assert } from "chai";
 
 import { Theme } from "@here/harp-datasource-protocol";
 import { MapEnv, StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
-import { accessToken } from "@here/harp-examples/config";
+import { apikey } from "@here/harp-examples/config";
 import { sphereProjection, TileKey, webMercatorProjection } from "@here/harp-geoutils";
 import { ThemeLoader } from "@here/harp-mapview";
-import { APIFormat, OmvRestClient, OmvRestClientParameters } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    OmvRestClient,
+    OmvRestClientParameters
+} from "@here/harp-omv-datasource";
 import {
     IGeometryProcessor,
     ILineGeometry,
@@ -183,9 +188,13 @@ createOMVDecoderPerformanceTest("theme=berlin tiles=4 region=berlin data=herebas
     theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
     tiles: BERLIN_CENTER_TILES,
     omvRestClientOptions: {
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
-        authenticationCode: accessToken
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        }
     }
 });
 
@@ -193,9 +202,13 @@ createOMVDecoderPerformanceTest("theme=berlin tiles=4 region=berlin data=osmbase
     theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
     tiles: BERLIN_CENTER_TILES,
     omvRestClientOptions: {
-        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-        apiFormat: APIFormat.XYZMVT,
-        authenticationCode: accessToken
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+        apiFormat: APIFormat.XYZOMV,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        }
     }
 });
 
@@ -217,9 +230,13 @@ createOMVDecoderPerformanceTest("theme=berlin tiles=10 region=ny data=herebase",
     theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
     tiles: NEW_YORK_TILES,
     omvRestClientOptions: {
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
-        authenticationCode: accessToken
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        }
     }
 });
 
@@ -227,8 +244,12 @@ createOMVDecoderPerformanceTest("theme=berlin tiles=10 region=ny data=osmbase", 
     theme: getTestResourceUrl("@here/harp-map-theme", "resources/berlin_tilezen_base.json"),
     tiles: NEW_YORK_TILES,
     omvRestClientOptions: {
-        baseUrl: "https://xyz.api.here.com/tiles/osmbase/256/all",
-        apiFormat: APIFormat.XYZMVT,
-        authenticationCode: accessToken
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+        apiFormat: APIFormat.XYZOMV,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        }
     }
 });

--- a/www/src/index.ts
+++ b/www/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +8,8 @@
 import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, OmvDataSource } from "@here/harp-omv-datasource";
-import { accessToken } from "../../@here/harp-examples/config";
+import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey, copyrightInfo } from "../../@here/harp-examples/config";
 
 // tslint:disable-next-line:no-var-requires
 const theme = require("../resources/theme.json");
@@ -88,10 +88,15 @@ function main() {
     map.animatedExtrusionHandler.enabled = false;
 
     const omvDataSource = new OmvDataSource({
-        baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",
-        authenticationCode: accessToken
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
+        copyrightInfo
     });
     map.addDataSource(omvDataSource);
 


### PR DESCRIPTION
This change includes the following updates:
* change default vector tile service to use the official HERE Vector Tile
* change default web tile service to use the official HERE Map Tile API
* unify authentication mechanisms to use `apikey`
* introduce common `apikey` in `config.ts`
* update documentation and Getting Started Guide to point to latest references on Authentifixation

Signed-off-by: Ignacio Julve <41909512+musculman@users.noreply.github.com>
