### PR TITLE
HARP-8515: Basic checks nulls/undefined/errors in style.

### DIFF
--- a/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedProperty.ts
@@ -98,10 +98,22 @@ export function isInterpolatedProperty(p: any): p is InterpolatedProperty {
 */
 export function getPropertyValue(property: Value | Expr | undefined, env: Env): any {
     if (Expr.isExpr(property)) {
-        return property.evaluate(env, ExprScope.Dynamic);
+        try {
+            return property.evaluate(env, ExprScope.Dynamic);
+        } catch (error) {
+            logger.error(
+                "failed to evaluate expression",
+                JSON.stringify(property),
+                "error",
+                String(error)
+            );
+            return null;
+        }
     }
 
-    if (typeof property !== "string") {
+    if (property === null || typeof property === "undefined") {
+        return null;
+    } else if (typeof property !== "string") {
         // Property in numeric or array, etc. format
         return property;
     } else {

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -423,16 +423,15 @@ export function getMaterialConstructor(technique: Technique): MaterialConstructo
 /**
  * Allows to easy parse/encode technique's base color property value as number coded color.
  *
- * Function takes care about property parsing, interpolation and encoding if neccessary. If
- * you wish to get default value without interpolation simply ignore @param zoom when calling.
+ * Function takes care about property parsing, interpolation and encoding if neccessary.
  *
  * @see ColorUtils
  * @param technique the technique where we search for base (transparency) color value
- * @param zoomLevel zoom level used for value interpolation.
- * @returns [[number]] encoded color value (in custom #TTRRGGBB) format or [[undefined]] if
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @returns [[number]] encoded color value (in custom #TTRRGGBB) format or `undefined` if
  * base color property is not defined in the technique passed.
  */
-export function evaluateBaseColorProperty(technique: Technique, env?: Env): number | undefined {
+export function evaluateBaseColorProperty(technique: Technique, env: Env): number | undefined {
     const baseColorProp = getBaseColorProp(technique);
     if (baseColorProp !== undefined) {
         return evaluateColorProperty(baseColorProp, env);
@@ -495,7 +494,7 @@ function applyShaderTechniqueToMaterial(technique: ShaderTechnique, material: TH
  *
  * @param technique technique from where params are copied
  * @param material target material
- * @param zoomLevel tile zoom level for zoom-level dependent props
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  * @param skipExtraProps optional, skipped props.
  */
 function applyTechniqueToMaterial(
@@ -561,7 +560,7 @@ function applyTechniqueToMaterial(
  * @param material target material
  * @param propertyName material and technique parameter name (or index) that is to be transferred
  * @param techniqueAttrValue technique property value which will be applied to material attribute
- * @param zoomLevel optional tile zoom level.
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  */
 function applyTechniquePropertyToMaterial(
     material: THREE.Material,
@@ -577,7 +576,10 @@ function applyTechniquePropertyToMaterial(
             env
         );
     } else {
-        m[propertyName] = evaluateProperty(techniqueAttrValue, env);
+        const value = evaluateProperty(techniqueAttrValue, env);
+        if (value !== null) {
+            m[propertyName] = value;
+        }
     }
 }
 
@@ -592,7 +594,7 @@ function applyTechniquePropertyToMaterial(
  * @param material the material to which color is applied
  * @param prop technique property (color) name
  * @param value color value
- * @param zoomLevel optional tile zoom level for zoom-level dependent properties are evaluated.
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  */
 export function applySecondaryColorToMaterial(
     materialColor: THREE.Color,
@@ -600,7 +602,9 @@ export function applySecondaryColorToMaterial(
     env?: Env
 ) {
     let value = evaluateColorProperty(techniqueColor, env);
-
+    if (value === undefined) {
+        return;
+    }
     if (ColorUtils.hasAlphaInHex(value)) {
         logger.warn("Used RGBA value for technique color without transparency support!");
         // Just for clarity remove transparency component, even if that would be ignored
@@ -626,7 +630,7 @@ export function applySecondaryColorToMaterial(
  * @param material the material to which color is applied
  * @param prop technique property (color) name
  * @param value color value in custom number format
- * @param zoomLevel optional, tile zoom level for zoom-level dependent properties are evaluated.
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  */
 export function applyBaseColorToMaterial(
     material: THREE.Material,
@@ -636,6 +640,9 @@ export function applyBaseColorToMaterial(
     env?: Env
 ) {
     const colorValue = evaluateColorProperty(techniqueColor, env);
+    if (colorValue === undefined) {
+        return;
+    }
 
     const { r, g, b, a } = ColorUtils.getRgbaFromHex(colorValue);
     // Override material opacity and blending by mixing technique defined opacity
@@ -661,12 +668,12 @@ export function applyBaseColorToMaterial(
 /**
  * Calculates the value of the technique defined property.
  *
- * Function takes care about property interpolation (when @param zoom is set) as also parsing
+ * Function takes care about property interpolation (when @param `env` is set) as also parsing
  * string encoded numbers.
  *
  * @note Use with care, because function does not recognize property type.
  * @param value the value of color property defined in technique
- * @param zoomLevel zoom level used for interpolation.
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  */
 function evaluateProperty(value: any, env?: Env): any {
     if (env !== undefined && (isInterpolatedProperty(value) || Expr.isExpr(value))) {
@@ -678,15 +685,19 @@ function evaluateProperty(value: any, env?: Env): any {
 /**
  * Calculates the numerical value of the technique defined color property.
  *
- * Function takes care about color interpolation (when @param zoom is set) as also parsing
+ * Function takes care about color interpolation (when @param `env is set) as also parsing
  * string encoded colors.
  *
  * @note Use with care, because function does not recognize property type.
  * @param value the value of color property defined in technique
- * @param zoomLevel zoom level used for interpolation.
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  */
-export function evaluateColorProperty(value: Value, env?: Env): number {
+export function evaluateColorProperty(value: Value, env?: Env): number | undefined {
     value = evaluateProperty(value, env);
+
+    if (value === undefined || value === null) {
+        return undefined;
+    }
 
     if (typeof value === "number") {
         return value;
@@ -699,7 +710,8 @@ export function evaluateColorProperty(value: Value, env?: Env): number {
         }
     }
 
-    throw new Error(`Unsupported color format: '${value}'`);
+    logger.error(`Unsupported color format: '${value}'`);
+    return undefined;
 }
 
 /**

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -6,7 +6,7 @@
 
 import * as THREE from "three";
 
-import { ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
+import { Env, ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
 import { ColorUtils } from "@here/harp-datasource-protocol/lib/ColorUtils";
 import { enforceBlending, MapMeshStandardMaterial } from "@here/harp-materials";
 import { evaluateBaseColorProperty } from "./DecodedTileHelpers";
@@ -29,8 +29,9 @@ const DEPTH_PRE_PASS_RENDER_ORDER_OFFSET = 1e-6;
  * disabled by `enableDepthPrePass` option.
  *
  * @param technique [[BaseStandardTechnique]] instance to be checked
+ * @param env [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
  */
-export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique) {
+export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique, env: Env) {
     // Depth pass explicitly disabled
     if (technique.enableDepthPrePass === false) {
         return false;
@@ -43,7 +44,7 @@ export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique)
     if (!transparent) {
         // We do not support switching depth pass during alpha interpolation, ignore zoom level
         // when calculating base color value.
-        const color = evaluateBaseColorProperty(technique);
+        const color = evaluateBaseColorProperty(technique, env);
         if (color !== undefined) {
             const alpha = ColorUtils.getAlphaFromHex(color);
             transparent = alpha > 0.0 && alpha < 1.0;

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -898,7 +898,7 @@ export class TileGeometryCreator {
                         technique.animateExtrusion,
                         discreteZoomEnv
                     );
-                    if (animateExtrusionValue !== undefined) {
+                    if (animateExtrusionValue !== null) {
                         animateExtrusionValue =
                             typeof animateExtrusionValue === "boolean"
                                 ? animateExtrusionValue
@@ -907,14 +907,15 @@ export class TileGeometryCreator {
                                 : false;
                     }
                     extrusionAnimationEnabled =
-                        animateExtrusionValue !== undefined &&
+                        animateExtrusionValue !== null &&
                         animatedExtrusionHandler.forceEnabled === false
                             ? animateExtrusionValue
                             : animatedExtrusionHandler.enabled;
                 }
 
                 const renderDepthPrePass =
-                    isExtrudedPolygonTechnique(technique) && isRenderDepthPrePassEnabled(technique);
+                    isExtrudedPolygonTechnique(technique) &&
+                    isRenderDepthPrePassEnabled(technique, discreteZoomEnv);
 
                 if (renderDepthPrePass) {
                     const depthPassMesh = createDepthPrePassMesh(object as THREE.Mesh);
@@ -1099,6 +1100,7 @@ export class TileGeometryCreator {
                         outlineTechnique.secondaryColor ?? 0x000000,
                         discreteZoomEnv
                     );
+
                     if (outlineTechnique.secondaryCaps !== undefined) {
                         outlineMaterial.caps = outlineTechnique.secondaryCaps;
                     }
@@ -1154,7 +1156,7 @@ export class TileGeometryCreator {
                                 // hide outline when it's equal or smaller then line to avoid subpixel contour
                                 const lineWidth =
                                     techniqueSecondaryWidth <= techniqueLineWidth &&
-                                    (techniqueOpacity === undefined || techniqueOpacity === 1)
+                                    (techniqueOpacity === null || techniqueOpacity === 1)
                                         ? 0
                                         : techniqueSecondaryWidth;
                                 lineMaterial.lineWidth = lineWidth * unitFactor * 0.5;

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -216,12 +216,14 @@ export class TextStyleCache {
         // Store color (RGB) in cache and multiply opacity value with the color alpha channel.
         if (technique.color !== undefined) {
             let hexColor = evaluateColorProperty(technique.color, discreteZoomEnv);
-            if (ColorUtils.hasAlphaInHex(hexColor)) {
-                const alpha = ColorUtils.getAlphaFromHex(hexColor);
-                opacity = opacity * alpha;
-                hexColor = ColorUtils.removeAlphaFromHex(hexColor);
+            if (hexColor !== undefined) {
+                if (ColorUtils.hasAlphaInHex(hexColor)) {
+                    const alpha = ColorUtils.getAlphaFromHex(hexColor);
+                    opacity = opacity * alpha;
+                    hexColor = ColorUtils.removeAlphaFromHex(hexColor);
+                }
+                color = ColorCache.instance.getColor(hexColor);
             }
-            color = ColorCache.instance.getColor(hexColor);
         }
 
         // Sets background size to 0.0 if default and technique attribute is undefined.
@@ -256,12 +258,14 @@ export class TextStyleCache {
         // Store background color (RGB) in cache and multiply backgroundOpacity by its alpha.
         if (technique.backgroundColor !== undefined) {
             let hexBgColor = evaluateColorProperty(technique.backgroundColor, discreteZoomEnv);
-            if (ColorUtils.hasAlphaInHex(hexBgColor)) {
-                const alpha = ColorUtils.getAlphaFromHex(hexBgColor);
-                backgroundOpacity = backgroundOpacity * alpha;
-                hexBgColor = ColorUtils.removeAlphaFromHex(hexBgColor);
+            if (hexBgColor !== undefined) {
+                if (ColorUtils.hasAlphaInHex(hexBgColor)) {
+                    const alpha = ColorUtils.getAlphaFromHex(hexBgColor);
+                    backgroundOpacity = backgroundOpacity * alpha;
+                    hexBgColor = ColorUtils.removeAlphaFromHex(hexBgColor);
+                }
+                backgroundColor = ColorCache.instance.getColor(hexBgColor);
             }
-            backgroundColor = ColorCache.instance.getColor(hexBgColor);
         }
 
         const renderParams = {

--- a/@here/harp-mapview/test/DecodedTileHelpersTest.ts
+++ b/@here/harp-mapview/test/DecodedTileHelpersTest.ts
@@ -7,14 +7,24 @@
 import { assert } from "chai";
 import * as THREE from "three";
 
-import { MapEnv, SolidLineTechnique } from "@here/harp-datasource-protocol";
+import { Expr, getPropertyValue, MapEnv, SolidLineTechnique } from "@here/harp-datasource-protocol";
 import { SolidLineMaterial } from "@here/harp-materials";
-import { applyBaseColorToMaterial, createMaterial } from "../lib/DecodedTileHelpers";
+import { assertLogsSync } from "@here/harp-test-utils";
+import { LoggerManager } from "@here/harp-utils";
+import {
+    applyBaseColorToMaterial,
+    createMaterial,
+    evaluateColorProperty
+} from "../lib/DecodedTileHelpers";
 
 // tslint:disable:only-arrow-functions
 
+function assertLogsError(testCode: () => void, errorMessagePattern: string | RegExp) {
+    return assertLogsSync(testCode, LoggerManager.instance.channel, "error", errorMessagePattern);
+}
+
 describe("DecodedTileHelpers", function() {
-    const env = new MapEnv({ $zoom: 10 });
+    const env = new MapEnv({ $zoom: 10, $pixelToMeters: 2 });
     describe("#createMaterial", function() {
         it("supports #rgba in base material colors", function() {
             const technique: SolidLineTechnique = {
@@ -47,6 +57,18 @@ describe("DecodedTileHelpers", function() {
             assert.equal(material.color.getHex(), 0xff00ff);
             assert.equal(material.transparent, false);
         });
+        it("ignores invalid colors", function() {
+            const technique: SolidLineTechnique = {
+                name: "solid-line",
+                lineWidth: 10,
+                renderOrder: 0,
+                color: "not-a-color"
+            };
+            assertLogsError(() => {
+                const material = createMaterial({ technique, env })! as SolidLineMaterial;
+                assert.exists(material);
+            }, /Unsupported color format/);
+        });
     });
     it("#applyBaseColorToMaterial toggles opacity with material", function() {
         const material = new THREE.MeshBasicMaterial();
@@ -71,5 +93,63 @@ describe("DecodedTileHelpers", function() {
         assert.equal(material.blending, THREE.NormalBlending);
         assert.equal(material.color.getHex(), 0xff00ff);
         assert.equal(material.transparent, false);
+    });
+    describe("#evaluateColorProperty", function() {
+        it("leaves numbers untouched", function() {
+            assert.strictEqual(evaluateColorProperty(0, env), 0);
+            assert.strictEqual(evaluateColorProperty(0xff00ff, env), 0xff00ff);
+            assert.strictEqual(evaluateColorProperty(0x7aff00ff, env), 0x7aff00ff);
+        });
+        it("converts invalid inputs to undefined", function() {
+            assertLogsError(() => {
+                assert.strictEqual(evaluateColorProperty("aa", env), undefined);
+            }, /Unsupported color format/);
+            assertLogsError(() => {
+                assert.strictEqual(evaluateColorProperty("#fffff", env), undefined);
+            }, /Unsupported color format/);
+            assertLogsError(() => {
+                assert.strictEqual(evaluateColorProperty(false, env), undefined);
+            }, /Unsupported color format/);
+
+            assertLogsError(() => {
+                assert.strictEqual(evaluateColorProperty(true, env), undefined);
+            }, /Unsupported color format/);
+        });
+        it("evaluates string encoded numerals", function() {
+            assert.strictEqual(evaluateColorProperty("#ff00ff", env), 0xff00ff);
+            assert.strictEqual(evaluateColorProperty("rgb(255, 0, 0)", env), 0xff0000);
+            assert.strictEqual(evaluateColorProperty("rgba(255, 0, 0, 0.5)", env), -2130771968);
+        });
+    });
+
+    describe("#getPropertyValue", function() {
+        it("returns literals untouched", function() {
+            assert.equal(getPropertyValue(0, env), 0);
+            assert.equal(getPropertyValue("a", env), "a");
+            assert.equal(getPropertyValue(true, env), true);
+            assert.equal(getPropertyValue(false, env), false);
+            assert.equal(getPropertyValue(null, env), null);
+            assert.deepEqual(getPropertyValue({ foo: "bar" }, env), { foo: "bar" });
+        });
+        it("flattens null & undefiled to null", function() {
+            assert.equal(getPropertyValue(undefined, env), null);
+        });
+        it("evaluates basic expressions", function() {
+            assert.equal(getPropertyValue(Expr.fromJSON(null), env), null);
+            assert.equal(getPropertyValue(Expr.fromJSON(["+", 2, 2]), env), 4);
+            assert.equal(getPropertyValue(Expr.fromJSON(["get", "$zoom"]), env), 10);
+        });
+        it("evaluates errorneous expressions to null", function() {
+            assertLogsError(() => {
+                assert.equal(getPropertyValue(Expr.fromJSON(["-", 2, "not-a-number"]), env), null);
+            }, /failed to evaluate expression/);
+        });
+        it("evaluates string encoded numerals", function() {
+            assert.equal(getPropertyValue("2m", env), 2);
+            assert.equal(getPropertyValue("2px", env), 4);
+            assert.strictEqual(getPropertyValue("#ff00ff", env), 0xff00ff);
+            assert.strictEqual(getPropertyValue("rgb(255, 0, 0)", env), 0xff0000);
+            assert.strictEqual(getPropertyValue("rgba(255, 0, 0, 0.5)", env), -2130771968);
+        });
     });
 });


### PR DESCRIPTION
As dynamic expression may return invalid value (bad type, null, error),
we have to guard places when style expressions/values are used.

This patch protects against style / Expr yielding:

 * null
 * invalid colors
 * errors thrown while evaluating expressions

Related-to: HARP-8515

Followup of #1241 and #1233 