### PR TITLE
HARP-7885: Support TypeScript project references.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ test-npm-packages-app/
 .DS_Store
 .nyc_output/
 rendering-test-results/
+*.tsbuildinfo
+*.ts.map
 
 credentials.js

--- a/@here/harp-atlas-tools/.npmignore
+++ b/@here/harp-atlas-tools/.npmignore
@@ -10,3 +10,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-atlas-tools/package.json
+++ b/@here/harp-atlas-tools/package.json
@@ -8,12 +8,12 @@
         "harp-sprites-generator": "lib/cli-sprites-generator.js"
     },
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "watch": "tsc -w",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "watch": "tsc --build -w",
         "generateAtlas": "ts-node src/cli-atlas-generator.ts",
         "generateSprites": "ts-node src/cli-sprites-generator.ts",
         "test": "yarn build && yarn generateAtlas",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-atlas-tools/tsconfig.json
+++ b/@here/harp-atlas-tools/tsconfig.json
@@ -1,17 +1,8 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "rootDir": "src",
-        "outDir": "lib",
-        "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
+        "outDir": "lib"
     },
     "exclude": ["node_modules"],
     "include": ["src/*.ts"]

--- a/@here/harp-datasource-protocol/.npmignore
+++ b/@here/harp-datasource-protocol/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -9,8 +9,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS",
         "generate-json-schema": "ts-json-schema-generator --no-type-check --path ./lib/Theme.ts --type Theme --validationKeywords defaultSnippets > theme.schema.json"
     },
     "repository": {

--- a/@here/harp-datasource-protocol/tsconfig.json
+++ b/@here/harp-datasource-protocol/tsconfig.json
@@ -1,14 +1,21 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-geometry"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-debug-datasource/.npmignore
+++ b/@here/harp-debug-datasource/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-debug-datasource/package.json
+++ b/@here/harp-debug-datasource/package.json
@@ -10,8 +10,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-debug-datasource/tsconfig.json
+++ b/@here/harp-debug-datasource/tsconfig.json
@@ -1,14 +1,24 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lrucache"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-text-canvas"
+        }
+    ]
 }

--- a/@here/harp-examples/.npmignore
+++ b/@here/harp-examples/.npmignore
@@ -4,3 +4,5 @@ tsconfig.json
 .gitreview
 example-definitions.js.in
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-examples/tsconfig.json
+++ b/@here/harp-examples/tsconfig.json
@@ -1,17 +1,9 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
         "declaration": false,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
         "resolveJsonModule": true,
-        "downlevelIteration": true,
-        "jsx": "react",
         "skipLibCheck": true,
         "baseUrl": "../../"
     }

--- a/@here/harp-examples/webpack.config.js
+++ b/@here/harp-examples/webpack.config.js
@@ -38,7 +38,7 @@ const commonConfig = {
             three: "THREE",
             fs: "undefined"
         },
-        function(context, request, callback) {
+        function (context, request, callback) {
             return /three\.module\.js$/.test(request) ? callback(null, "THREE") : callback();
         }
     ],
@@ -58,6 +58,7 @@ const commonConfig = {
                     configFile: path.join(process.cwd(), "tsconfig.json"),
                     onlyCompileBundledFiles: true,
                     transpileOnly: prepareOnly,
+                    projectReferences: true,
                     compilerOptions: {
                         sourceMap: !prepareOnly,
                         declaration: false
@@ -167,7 +168,7 @@ const allEntries = Object.assign({}, webpackEntries, htmlEntries);
  *     [examplePage: string]: string // maps example page to example source
  * }
  */
-const exampleDefs = Object.keys(allEntries).reduce(function(r, entry) {
+const exampleDefs = Object.keys(allEntries).reduce(function (r, entry) {
     r[entry + ".html"] = path.relative(__dirname, allEntries[entry]);
     return r;
 }, {});

--- a/@here/harp-features-datasource/.npmignore
+++ b/@here/harp-features-datasource/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-features-datasource/package.json
+++ b/@here/harp-features-datasource/package.json
@@ -5,9 +5,9 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-features-datasource/tsconfig.json
+++ b/@here/harp-features-datasource/tsconfig.json
@@ -1,14 +1,30 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-geojson-datasource"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-omv-datasource"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-fetch/.npmignore
+++ b/@here/harp-fetch/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-fetch/package.json
+++ b/@here/harp-fetch/package.json
@@ -10,8 +10,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-fetch/tsconfig.json
+++ b/@here/harp-fetch/tsconfig.json
@@ -1,14 +1,10 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"]
 }

--- a/@here/harp-geojson-datasource/.npmignore
+++ b/@here/harp-geojson-datasource/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-geojson-datasource/package.json
+++ b/@here/harp-geojson-datasource/package.json
@@ -9,9 +9,9 @@
         "main": "index-worker.js"
     },
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-geojson-datasource/tsconfig.json
+++ b/@here/harp-geojson-datasource/tsconfig.json
@@ -1,14 +1,42 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-fetch"
+        },
+        {
+            "path": "../harp-geometry"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lines"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-mapview-decoder"
+        },
+        {
+            "path": "../harp-text-canvas"
+        },
+        {
+            "path": "../harp-transfer-manager"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-geometry/.npmignore
+++ b/@here/harp-geometry/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-geometry/package.json
+++ b/@here/harp-geometry/package.json
@@ -9,8 +9,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-geometry/tsconfig.json
+++ b/@here/harp-geometry/tsconfig.json
@@ -1,14 +1,18 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-geoutils/.npmignore
+++ b/@here/harp-geoutils/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-geoutils/package.json
+++ b/@here/harp-geoutils/package.json
@@ -5,9 +5,9 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-geoutils/tsconfig.json
+++ b/@here/harp-geoutils/tsconfig.json
@@ -1,14 +1,10 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"]
 }

--- a/@here/harp-lines/.npmignore
+++ b/@here/harp-lines/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-lines/package.json
+++ b/@here/harp-lines/package.json
@@ -10,8 +10,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-lines/tsconfig.json
+++ b/@here/harp-lines/tsconfig.json
@@ -1,14 +1,15 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-materials"
+        }
+    ]
 }

--- a/@here/harp-lrucache/.npmignore
+++ b/@here/harp-lrucache/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-lrucache/package.json
+++ b/@here/harp-lrucache/package.json
@@ -9,8 +9,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-lrucache/tsconfig.json
+++ b/@here/harp-lrucache/tsconfig.json
@@ -1,14 +1,15 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-map-controls/.npmignore
+++ b/@here/harp-map-controls/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-map-controls/package.json
+++ b/@here/harp-map-controls/package.json
@@ -9,8 +9,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-map-controls/tsconfig.json
+++ b/@here/harp-map-controls/tsconfig.json
@@ -1,14 +1,21 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-map-theme/.npmignore
+++ b/@here/harp-map-theme/.npmignore
@@ -7,3 +7,5 @@ tsconfig.json
 resources-dev/
 scripts/
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-map-theme/package.json
+++ b/@here/harp-map-theme/package.json
@@ -9,7 +9,7 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "prepare-icons": "ts-node ./scripts/prepareIcons.ts",
         "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS && ts-node ./scripts/prepack.ts"
     },

--- a/@here/harp-map-theme/tsconfig.json
+++ b/@here/harp-map-theme/tsconfig.json
@@ -1,14 +1,10 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"]
 }

--- a/@here/harp-mapview-decoder/.npmignore
+++ b/@here/harp-mapview-decoder/.npmignore
@@ -6,3 +6,5 @@ tsconfig.json
 .gitreview
 webpack-test.config.js
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-mapview-decoder/package.json
+++ b/@here/harp-mapview-decoder/package.json
@@ -13,8 +13,8 @@
     },
     "scripts": {
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-mapview-decoder/tsconfig.json
+++ b/@here/harp-mapview-decoder/tsconfig.json
@@ -1,14 +1,30 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-fetch"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lrucache"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-mapview/.npmignore
+++ b/@here/harp-mapview/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-mapview/package.json
+++ b/@here/harp-mapview/package.json
@@ -17,9 +17,9 @@
         "test": "test"
     },
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-mapview/tsconfig.json
+++ b/@here/harp-mapview/tsconfig.json
@@ -1,14 +1,42 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-fetch"
+        },
+        {
+            "path": "../harp-geometry"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lines"
+        },
+        {
+            "path": "../harp-lrucache"
+        },
+        {
+            "path": "../harp-materials"
+        },
+        {
+            "path": "../harp-text-canvas"
+        },
+        {
+            "path": "../harp-transfer-manager"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-materials/.npmignore
+++ b/@here/harp-materials/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-materials/package.json
+++ b/@here/harp-materials/package.json
@@ -5,9 +5,9 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-materials/tsconfig.json
+++ b/@here/harp-materials/tsconfig.json
@@ -1,14 +1,18 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-olp-utils/.npmignore
+++ b/@here/harp-olp-utils/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-olp-utils/package.json
+++ b/@here/harp-olp-utils/package.json
@@ -4,9 +4,9 @@
     "description": "HERE OLP utilities",
     "main": "index.js",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-olp-utils/tsconfig.json
+++ b/@here/harp-olp-utils/tsconfig.json
@@ -1,14 +1,24 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-mapview-decoder"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-omv-datasource/.npmignore
+++ b/@here/harp-omv-datasource/.npmignore
@@ -6,3 +6,5 @@ tsconfig.json
 .gitreview
 *.proto
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-omv-datasource/package.json
+++ b/@here/harp-omv-datasource/package.json
@@ -12,10 +12,10 @@
         "test": "test"
     },
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/OmvTest.js",
         "gen-decoder": "pbjs -t static-module -w commonjs --no-encode --no-verify --no-create lib/proto/vector_tile.proto -o lib/proto/vector_tile.js && pbts lib/proto/vector_tile.js -o lib/proto/vector_tile.d.ts",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-omv-datasource/tsconfig.json
+++ b/@here/harp-omv-datasource/tsconfig.json
@@ -1,14 +1,45 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-geometry"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lines"
+        },
+        {
+            "path": "../harp-lrucache"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-mapview-decoder"
+        },
+        {
+            "path": "../harp-materials"
+        },
+        {
+            "path": "../harp-text-canvas"
+        },
+        {
+            "path": "../harp-transfer-manager"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp-test-utils/.npmignore
+++ b/@here/harp-test-utils/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-test-utils/package.json
+++ b/@here/harp-test-utils/package.json
@@ -6,9 +6,9 @@
     "browser": "index.web.js",
     "typings": "index.web",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-test-utils/tsconfig.json
+++ b/@here/harp-test-utils/tsconfig.json
@@ -1,14 +1,10 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"]
 }

--- a/@here/harp-text-canvas/.npmignore
+++ b/@here/harp-text-canvas/.npmignore
@@ -4,3 +4,6 @@ test/
 tsconfig.json
 .gitignore
 .gitreview
+*.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-text-canvas/package.json
+++ b/@here/harp-text-canvas/package.json
@@ -5,9 +5,9 @@
     "main": "index.js",
     "typings": "index",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-text-canvas/tsconfig.json
+++ b/@here/harp-text-canvas/tsconfig.json
@@ -1,14 +1,15 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-lrucache"
+        }
+    ]
 }

--- a/@here/harp-theme-tools/.npmignore
+++ b/@here/harp-theme-tools/.npmignore
@@ -10,3 +10,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-theme-tools/package.json
+++ b/@here/harp-theme-tools/package.json
@@ -6,10 +6,10 @@
         "harp-theme-optimizer": "lib/cli-build-theme.js"
     },
     "scripts": {
-        "build": "tsc",
-        "watch": "tsc -w",
+        "build": "tsc --build",
+        "watch": "tsc --build -w",
         "buildTheme": "ts-node src/cli-build-theme.ts",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-theme-tools/tsconfig.json
+++ b/@here/harp-theme-tools/tsconfig.json
@@ -1,18 +1,15 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
-        "rootDir": "src",
-        "outDir": "lib",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
     },
-    "exclude": ["node_modules"],
-    "include": ["src/*.ts"]
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-mapview"
+        }
+    ]
 }

--- a/@here/harp-transfer-manager/.npmignore
+++ b/@here/harp-transfer-manager/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-transfer-manager/package.json
+++ b/@here/harp-transfer-manager/package.json
@@ -10,8 +10,8 @@
     },
     "scripts": {
         "test": "cross-env mocha  --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-transfer-manager/tsconfig.json
+++ b/@here/harp-transfer-manager/tsconfig.json
@@ -1,14 +1,15 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-fetch"
+        }
+    ]
 }

--- a/@here/harp-utils/.npmignore
+++ b/@here/harp-utils/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-utils/package.json
+++ b/@here/harp-utils/package.json
@@ -5,9 +5,9 @@
     "main": "index.js",
     "browser": "index.web.js",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/*.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-utils/tsconfig.json
+++ b/@here/harp-utils/tsconfig.json
@@ -1,14 +1,10 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"]
 }

--- a/@here/harp-webpack-utils/.npmignore
+++ b/@here/harp-webpack-utils/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-webpack-utils/package.json
+++ b/@here/harp-webpack-utils/package.json
@@ -3,8 +3,8 @@
     "version": "0.13.0",
     "description": "harp.gl webpack utilities",
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "build": "tsc --build $EXTRA_TSC_ARGS",
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-webpack-utils/tsconfig.json
+++ b/@here/harp-webpack-utils/tsconfig.json
@@ -1,14 +1,10 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"]
 }

--- a/@here/harp-webtile-datasource/.npmignore
+++ b/@here/harp-webtile-datasource/.npmignore
@@ -5,3 +5,5 @@ tsconfig.json
 .gitignore
 .gitreview
 *.tgz
+*.map
+*.tsbuildinfo

--- a/@here/harp-webtile-datasource/package.json
+++ b/@here/harp-webtile-datasource/package.json
@@ -8,9 +8,9 @@
         "test": "test"
     },
     "scripts": {
-        "build": "tsc $EXTRA_TSC_ARGS",
+        "build": "tsc --build $EXTRA_TSC_ARGS",
         "test": "cross-env mocha --require source-map-support/register $EXTRA_MOCHA_ARGS ./test/WebTileTest.js",
-        "prepare": "cross-env tsc --sourceMap false $EXTRA_TSC_ARGS"
+        "prepare": "cross-env tsc --build $EXTRA_TSC_ARGS"
     },
     "repository": {
         "type": "git",

--- a/@here/harp-webtile-datasource/tsconfig.json
+++ b/@here/harp-webtile-datasource/tsconfig.json
@@ -1,14 +1,30 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": true,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "composite": true,
+        "incremental": true,
+        "declarationMap": true
+    },
+    "exclude": ["dist/**", "test/**", "node_modules"],
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-geometry"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lrucache"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-utils"
+        }
+    ]
 }

--- a/@here/harp.gl/tsconfig.json
+++ b/@here/harp.gl/tsconfig.json
@@ -1,14 +1,60 @@
 {
+    "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
         "sourceMap": true,
-        "declaration": false,
-        "strictNullChecks": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": false,
-        "downlevelIteration": true
-    }
+        "declaration": false
+    },
+    "references": [
+        {
+            "path": "../harp-datasource-protocol"
+        },
+        {
+            "path": "../harp-debug-datasource"
+        },
+        {
+            "path": "../harp-features-datasource"
+        },
+        {
+            "path": "../harp-geojson-datasource"
+        },
+        {
+            "path": "../harp-geoutils"
+        },
+        {
+            "path": "../harp-lines"
+        },
+        {
+            "path": "../harp-lrucache"
+        },
+        {
+            "path": "../harp-map-controls"
+        },
+        {
+            "path": "../harp-mapview"
+        },
+        {
+            "path": "../harp-mapview-decoder"
+        },
+        {
+            "path": "../harp-materials"
+        },
+        {
+            "path": "../harp-olp-utils"
+        },
+        {
+            "path": "../harp-omv-datasource"
+        },
+        {
+            "path": "../harp-test-utils"
+        },
+        {
+            "path": "../harp-text-canvas"
+        },
+        {
+            "path": "../harp-utils"
+        },
+        {
+            "path": "../harp-webtile-datasource"
+        }
+    ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "CommonJS",
+        "target": "ES2017",
+        "strict": true
+    },
+    "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,13 @@
 {
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2017",
         "sourceMap": true,
         "baseUrl": ".",
         "rootDir": ".",
         "outDir": "./dist/node_modules/",
-        "jsx": "react",
-        "jsxFactory": "React.createElement",
-        "strict": true,
         "resolveJsonModule": true,
         "downlevelIteration": true,
-        "newLine": "LF",
-        "noImplicitReturns": true
+        "newLine": "LF"
     },
     "exclude": ["node_modules", "@here/*/node_modules", "dist"]
 }


### PR DESCRIPTION
This change adds explicit project references and the required
configuration options to build harp.gl modules using `tsc --build`.

Also, this change introduces a global tsconfig.base.json with
the common settings used by the harp.gl modules.