### PR TITLE
UrlUtils: Support for data: URI scheme.

### DIFF
--- a/@here/harp-utils/lib/UrlUtils.ts
+++ b/@here/harp-utils/lib/UrlUtils.ts
@@ -14,6 +14,8 @@
  *
  * See [[baseUri]] for reference how base URL of `parentUri` is determined.
  *
+ * Supports `http:`, `https:`, `file:`, `data:` schemes.
+ *
  * Examples:
  *
  *     // normal case, child is sibling
@@ -47,7 +49,7 @@ export function resolveReferenceUri(parentUri: string | undefined, childUri: str
     }
 }
 
-const absoluteUrlWithOriginRe = new RegExp("^(?:[a-z]+:)?//", "i");
+const absoluteUrlWithOriginRe = new RegExp("^(((?:[a-z]+:)?//)|(file:/)|(data:))", "i");
 
 /**
  * Returns base URL of given resource URL.

--- a/@here/harp-utils/test/UrlUtilsTest.ts
+++ b/@here/harp-utils/test/UrlUtilsTest.ts
@@ -42,6 +42,12 @@ describe("UrlUtils", function() {
             assert.equal(resolveReferenceUri("file://foo/", "bar.js"), "file://foo/bar.js");
             assert.equal(resolveReferenceUri("file://foo/", "/bar.js"), "file:///bar.js");
         });
+        it("handles data: scheme", function() {
+            assert.equal(
+                resolveReferenceUri("https://bar.com/foo/", "data:whatever"),
+                "data:whatever"
+            );
+        });
         it("handles relative parent URL", function() {
             assert.equal(
                 resolveReferenceUri("resources/day.json", "font.json"),


### PR DESCRIPTION
In order to support `data:` scheme in `Theme`, we must recognize
`data:` as absolute uri (before this patch `data:` URIs were threated
as `relative path` and thus resolved vs `baseURL`.

Related-to: HARP-7206
