### PR TITLE
HARP-9344: WebTileDataSource - don't use const enums.

### DIFF
--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -413,13 +413,13 @@ export class WebTileDataSource extends DataSource {
  * Definitions of variable values to be used with `WebTileDataSource`
  */
 export namespace WebTileDataSource {
-    export const enum ppiValue {
+    export enum ppiValue {
         ppi72 = 72,
         ppi250 = 250,
         ppi320 = 320,
         ppi500 = 500
     }
-    export const enum resolutionValue {
+    export enum resolutionValue {
         resolution256 = 256,
         resolution512 = 512
     }


### PR DESCRIPTION
`const enum`s are not emitted to Javascript by default, so javascript
users would see `WebTileDataSource.ppiValue` as `undefined`.

Note `const enum`s are there only for performance reasons and those
contants are not intended to be used in performance sensitive code so
there is no reason to hack it around with `preserveConstEnums` compiler
flag.