### PR TITLE
Add support for the feature-state operator.

### DIFF
--- a/@here/harp-datasource-protocol/StyleExpressions.md
+++ b/@here/harp-datasource-protocol/StyleExpressions.md
@@ -35,6 +35,14 @@ Returns the id of the current feature.
 ["id"]
 ```
 
+## feature-state
+
+Returns the value of the given property from the current feature's state.
+
+```javascript
+["feature-state", property]
+```
+
 ## geometry-type
 
 Returns a `string` representing the geometry type of the current feature.

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -42,6 +42,11 @@ export class ExprDependencies {
      * The properties needed to evaluate the [[Expr]].
      */
     readonly properties = new Set<string>();
+
+    /**
+     * `true` if the expression depends on the feature state.
+     */
+    featureState?: boolean;
 }
 
 class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
@@ -92,6 +97,10 @@ class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
         expr.args.forEach(childExpr => childExpr.accept(this, context));
 
         switch (expr.op) {
+            case "feature-state":
+                context.featureState = true;
+                context.properties.add("$state");
+                break;
             case "id":
                 context.properties.add("$id");
                 break;

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -102,6 +102,12 @@ interface StyleInternalParams {
      * @hidden
      */
     _geometryType?: string;
+
+    /**
+     * `true` if any of the properties of this technique
+     * requires access to the feature's state.
+     */
+    _usesFeatureState?: boolean;
 }
 
 type InternalStyle = Style & StyleSelector & StyleInternalParams;
@@ -721,6 +727,10 @@ export class StyleSetEvaluator {
             if (Expr.isExpr(attrValue)) {
                 const deps = attrValue.dependencies();
 
+                if (deps.featureState) {
+                    style._usesFeatureState = true;
+                }
+
                 if (deps.properties.size === 0 && !attrValue.isDynamic()) {
                     // no data-dependencies detected.
                     attrValue = attrValue.evaluate(this.m_emptyEnv);
@@ -853,6 +863,9 @@ export class StyleSetEvaluator {
         technique._styleSetIndex = style._styleSetIndex!;
         if (style.styleSet !== undefined) {
             technique._styleSet = style.styleSet;
+        }
+        if (style._usesFeatureState !== undefined) {
+            technique._usesFeatureState = style._usesFeatureState;
         }
         this.m_techniques.push(technique as IndexedTechnique);
         return technique as IndexedTechnique;

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -545,6 +545,14 @@ export interface IndexedTechniqueParams {
      * @hidden
      */
     _secondaryCategory?: string;
+
+    /**
+     * `true` if any of the properties of this technique needs to access
+     * the feature's state.
+     *
+     * @hidden
+     */
+    _usesFeatureState?: boolean;
 }
 
 /**

--- a/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CallExpr } from "../Expr";
+import { Env } from "../Env";
+import { CallExpr, ExprScope } from "../Expr";
 
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
@@ -22,6 +23,25 @@ const operators = {
                 default:
                     return null;
             }
+        }
+    },
+    "feature-state": {
+        isDynamicOperator: () => true,
+        call: (context: ExprEvaluatorContext, call: CallExpr) => {
+            if (context.scope !== ExprScope.Dynamic) {
+                throw new Error("feature-state cannot be used in this context");
+            }
+            const property = context.evaluate(call.args[0]);
+            if (typeof property !== "string") {
+                throw new Error(`expected the name of the property of the feature state`);
+            }
+            const state = context.env.lookup("$state");
+            if (Env.isEnv(state)) {
+                return state.lookup(property) ?? null;
+            } else if (state instanceof Map) {
+                return state.get(property) ?? null;
+            }
+            return null;
         }
     },
     id: {


### PR DESCRIPTION
This change adds the operator `["feature-state", property]` that
can be used to get property values that are not part of the feature
data.
