### PR TITLE
Fix the evaluation of "label" attributes of text techniques.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TileInfo.ts
+++ b/@here/harp-datasource-protocol/lib/TileInfo.ts
@@ -491,7 +491,11 @@ export namespace ExtendedTileInfo {
             // tslint:disable-next-line: deprecation
             if (technique.label !== undefined) {
                 // tslint:disable-next-line: deprecation
-                const name = env.lookup(technique.label);
+                const attributeName = evaluateTechniqueAttr(context, technique.label);
+                if (typeof attributeName !== "string") {
+                    return undefined;
+                }
+                const name = env.lookup(attributeName);
                 return typeof name === "string" ? name : undefined;
             }
             // tslint:disable-next-line: deprecation


### PR DESCRIPTION
The current code was assuming that label attributes of text
techniques were always string literals. Of course, this
is not the case when using expressions.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
