### PR TITLE
HARP-9275: Test intersection with tiles on picking.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -30,7 +30,6 @@ export interface DecodedTile {
     textGeometries?: TextGeometry[]; // ### deprecate
     poiGeometries?: PoiGeometry[];
     tileInfo?: TileInfo;
-    maxGeometryHeight?: number;
     decodeTime?: number; // time used to decode (in ms)
 
     /**
@@ -39,6 +38,12 @@ export interface DecodedTile {
      * more accurate bounding box once the data is decoded.
      */
     boundingBox?: OrientedBox3;
+
+    /**
+     * Data sources not defining a bounding box may define alternatively a maximum geometry height
+     * in meters. The bounding box of the resulting tile will be extended to encompass this height.
+     */
+    maxGeometryHeight?: number;
 
     /**
      * Tile data Copyright holder identifiers.

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -242,8 +242,6 @@ export class PickHandler {
             return a.distance - b.distance;
         });
 
-        this.mapView.update();
-
         return pickResults;
     }
 

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -374,7 +374,7 @@ export class Tile implements CachedResource {
     private m_textElementsChanged: boolean | undefined;
 
     // Center of the tile's unelevated bounding box world coordinates.
-    private readonly m_center = new THREE.Vector3();
+    private readonly m_worldCenter = new THREE.Vector3();
     private m_visibleArea: number = 0;
     // Minimum and maximum tile elevation.
     private m_minElevation: number = 0;
@@ -407,7 +407,7 @@ export class Tile implements CachedResource {
         localTangentSpace?: boolean
     ) {
         this.geoBox = this.dataSource.getTilingScheme().getGeoBox(this.tileKey);
-        this.setBoundingBox();
+        this.updateBoundingBox();
         this.m_localTangentSpace = localTangentSpace !== undefined ? localTangentSpace : false;
         this.m_textStyleCache = new TileTextStyleCache(this);
     }
@@ -465,7 +465,7 @@ export class Tile implements CachedResource {
      * The center of this `Tile` in world coordinates.
      */
     get center(): THREE.Vector3 {
-        return this.m_center;
+        return this.m_worldCenter;
     }
 
     /**
@@ -731,7 +731,7 @@ export class Tile implements CachedResource {
             // If the decoder provides a more accurate bounding box than the one we computed from
             // the flat geo box we take it instead.
             this.m_maxGeometryHeight = undefined;
-            this.setBoundingBox(decodedTile.boundingBox);
+            this.updateBoundingBox(decodedTile.boundingBox);
         } else {
             // Otherwise, if an elevation range was set, elevate bounding box to match
             // the elevated geometry.
@@ -1068,7 +1068,12 @@ export class Tile implements CachedResource {
         return this.m_boundingBox;
     }
 
-    private setBoundingBox(newBoundingBox?: OrientedBox3) {
+    /**
+     * Updates the tile's world bounding box.
+     * @param [newBoundingBox] The new bounding box to set. If undefined, the bounding box will be
+     * computed by projecting the tile's geoBox.
+     */
+    private updateBoundingBox(newBoundingBox?: OrientedBox3) {
         if (newBoundingBox) {
             this.m_boundingBox.copy(newBoundingBox);
 
@@ -1080,7 +1085,7 @@ export class Tile implements CachedResource {
         } else {
             this.projection.projectBox(this.geoBox, this.boundingBox);
         }
-        this.m_center.copy(this.boundingBox.position);
+        this.m_worldCenter.copy(this.boundingBox.position);
     }
 
     private elevateBoundingBox() {

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -552,8 +552,7 @@ export class VisibleTileSet {
                 // Update the visible area of the tile. This is used for those tiles that are
                 // currently loaded and are waiting to be decoded to sort the jobs by area.
                 tile.visibleArea = tileEntry.area;
-                tile.minElevation = tileEntry.minElevation;
-                tile.maxElevation = tileEntry.maxElevation;
+                tile.setElevation(tileEntry.minElevation, tileEntry.maxElevation);
 
                 actuallyVisibleTiles.push(tile);
             }

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -597,11 +597,8 @@ export class VisibleTileSet {
             const tiles = renderListEntry.renderedTiles;
             tiles.forEach(tile => {
                 tile.update(renderListEntry.zoomLevel);
-                minElevation = MathUtils.min2(minElevation, tile.minElevation);
-                maxElevation = MathUtils.max2(
-                    maxElevation,
-                    tile.maxElevation + tile.maxGeometryHeight
-                );
+                minElevation = MathUtils.min2(minElevation, tile.geoBox.minAltitude);
+                maxElevation = MathUtils.max2(maxElevation, tile.geoBox.maxAltitude);
             });
         });
 

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -198,9 +198,6 @@ export class TileGeometryCreator {
             return technique.enabled !== false;
         };
 
-        if (decodedTile.maxGeometryHeight !== undefined) {
-            tile.maxGeometryHeight = decodedTile.maxGeometryHeight;
-        }
         this.createObjects(tile, decodedTile, filter);
 
         this.preparePois(tile, decodedTile);

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -42,7 +42,12 @@ class FakeMapView {
     get scene() {
         return this.m_scene;
     }
+
+    get projection() {
+        return mercatorProjection;
+    }
 }
+
 class MockDataSource extends DataSource {
     /** @override */
     getTilingScheme(): TilingScheme {


### PR DESCRIPTION
Only objects in intersected tiles are tested for intersection.

Tile bounding boxes are updated to go from minElevation to
maxElevation + maxGeometryHeight.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
