### PR TITLE
MINOR: Refactor ClipPlanesEvaluator(s), remove MapView dependency.

### DIFF
--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -292,7 +292,7 @@ export namespace MapViewUtils {
      */
     export function getTargetAndDistance(
         projection: Projection,
-        camera: THREE.PerspectiveCamera,
+        camera: THREE.Camera,
         elevationProvider?: ElevationProvider
     ): { target: THREE.Vector3; distance: number } {
         const cameraPitch = extractAttitude({ projection }, camera).pitch;

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -468,8 +468,11 @@ export class VisibleTileSet {
         if (minElevation !== undefined) {
             this.options.clipPlanesEvaluator.minElevation = minElevation;
         }
+        const { camera, projection, elevationProvider } = this.m_frustumIntersection.mapView;
         this.m_viewRange = this.options.clipPlanesEvaluator.evaluateClipPlanes(
-            this.m_frustumIntersection.mapView
+            camera,
+            projection,
+            elevationProvider
         );
         return this.m_viewRange;
     }


### PR DESCRIPTION
This change is required in order to provide MapViewAtmosphere support
without MapView dependency (see PR: #1378)
Cleanups the code and changes interfaces to not use MapView reference.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
