### PR TITLE
HARP-9275: Implement VertexCache for mesh on the fly transformations.

### DIFF
--- a/@here/harp-mapview/lib/geometry/VertexCache.ts
+++ b/@here/harp-mapview/lib/geometry/VertexCache.ts
@@ -34,7 +34,7 @@ export class VertexCache {
      * Creates a new cache with the specified maximum size.
      * @param maxVertexCount The maximum number of vertices the cache will store.
      */
-    constructor(public maxVertexCount: number) {
+    constructor(readonly maxVertexCount: number) {
         this.m_cache.length = this.maxVertexCount * Field.Count;
         this.clear();
     }

--- a/@here/harp-mapview/lib/geometry/VertexCache.ts
+++ b/@here/harp-mapview/lib/geometry/VertexCache.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Vector3Like } from "@here/harp-geoutils";
+import { assert } from "@here/harp-utils";
+
+// Offsets for the fields stored in cache for each vertex.
+enum Field {
+    VertexId = 0,
+    OlderIdx, // Index in cache of the immediately older vertex.
+    NewerIdx, // Index in cache of the immediately newer vertex.
+    X,
+    Y,
+    Z,
+    Count
+}
+
+const Invalid: number = -1;
+
+/**
+ * Compact vertex LRU Cache for on the fly temporary mesh transformations.
+ * @internal
+ */
+export class VertexCache {
+    private m_cache: number[] = []; // Stores all fields for every cached vertex (see Field).
+    private m_vertexCount: number = 0;
+    private m_oldestIdx: number = 0;
+    private m_newestIdx: number = 0;
+
+    /**
+     * Creates a new cache with the specified maximum size.
+     * @param maxVertexCount The maximum number of vertices the cache will store.
+     */
+    constructor(public maxVertexCount: number) {
+        this.m_cache.length = this.maxVertexCount * Field.Count;
+        this.clear();
+    }
+
+    /**
+     * Clears the vertex cache.
+     */
+    clear() {
+        this.m_cache.fill(Invalid);
+        this.m_vertexCount = 0;
+    }
+
+    /**
+     * Gets a vertex from cache.
+     * @param vertexId The id of the vertex to get.
+     * @param vertex The vertex coordinates will be set here if found.
+     * @returns whether the vertex was found on cache.
+     */
+    get(vertexId: number, vertex: Vector3Like): boolean {
+        const vertexIdx = this.find(vertexId);
+        if (vertexIdx === undefined) {
+            return false;
+        }
+        this.promoteEntry(vertexIdx);
+        this.getVertex(vertexIdx, vertex);
+        return true;
+    }
+
+    /**
+     * Sets a vertex in cache. It's assumed there's no vertex with the same id already in cache.
+     * @param vertexId The vertex id.
+     * @param vertex The vertex coordinates.
+     */
+    set(vertexId: number, vertex: Vector3Like) {
+        let vertexIdx = Invalid;
+        if (this.m_vertexCount < this.maxVertexCount) {
+            vertexIdx = this.m_vertexCount * Field.Count;
+            this.m_vertexCount++;
+        } else {
+            vertexIdx = this.m_oldestIdx;
+        }
+        if (this.m_vertexCount === 1) {
+            this.m_oldestIdx = this.m_newestIdx = vertexIdx;
+        } else {
+            this.promoteEntry(vertexIdx);
+        }
+        this.setVertex(vertexIdx, vertexId, vertex);
+    }
+
+    private find(vertexId: number): number | undefined {
+        const size = this.m_cache.length;
+        for (let i = 0; i < size; i += Field.Count) {
+            if (this.m_cache[i] === vertexId) {
+                return i;
+            }
+        }
+        return undefined;
+    }
+    private promoteEntry(vertexIdx: number): void {
+        if (vertexIdx === this.m_newestIdx) {
+            return;
+        } // already newest, nothing to do
+        // re-link newer and older items
+        const newerIdx = this.getNewerIdx(vertexIdx);
+        const olderIdx = this.getOlderIdx(vertexIdx);
+        if (newerIdx !== Invalid) {
+            assert(this.getOlderIdx(newerIdx) === vertexIdx);
+            this.setOlderIdx(newerIdx, olderIdx);
+        }
+        if (olderIdx !== Invalid) {
+            assert(this.getNewerIdx(olderIdx) === vertexIdx);
+            this.setNewerIdx(olderIdx, newerIdx);
+        }
+        if (vertexIdx === this.m_oldestIdx) {
+            this.m_oldestIdx = newerIdx;
+        }
+        // re-link ourselves
+        this.setNewerIdx(vertexIdx, Invalid);
+        this.setOlderIdx(vertexIdx, this.m_newestIdx);
+        // finally, set ourselves as the newest entry
+        assert(this.m_newestIdx !== Invalid);
+        assert(this.getNewerIdx(this.m_newestIdx) === Invalid);
+        this.setNewerIdx(this.m_newestIdx, vertexIdx);
+        this.m_newestIdx = vertexIdx;
+    }
+    private getOlderIdx(vertexIdx: number): number {
+        return this.m_cache[vertexIdx + Field.OlderIdx];
+    }
+    private setOlderIdx(vertexIdx: number, olderIdx: number): void {
+        this.m_cache[vertexIdx + Field.OlderIdx] = olderIdx;
+    }
+    private getNewerIdx(vertexIdx: number): number {
+        return this.m_cache[vertexIdx + Field.NewerIdx];
+    }
+    private setNewerIdx(vertexIdx: number, newerIdx: number): void {
+        this.m_cache[vertexIdx + Field.NewerIdx] = newerIdx;
+    }
+    private getVertex(vertexIdx: number, vertex: Vector3Like): void {
+        vertex.x = this.m_cache[vertexIdx + Field.X];
+        vertex.y = this.m_cache[vertexIdx + Field.Y];
+        vertex.z = this.m_cache[vertexIdx + Field.Z];
+    }
+    private setVertex(vertexIdx: number, vertexId: number, vertex: Vector3Like): void {
+        this.m_cache[vertexIdx] = vertexId;
+        this.m_cache[vertexIdx + Field.X] = vertex.x;
+        this.m_cache[vertexIdx + Field.Y] = vertex.y;
+        this.m_cache[vertexIdx + Field.Z] = vertex.z;
+    }
+}

--- a/@here/harp-mapview/test/VertexCacheTest.ts
+++ b/@here/harp-mapview/test/VertexCacheTest.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { expect } from "chai";
+import { VertexCache } from "../lib/geometry/VertexCache";
+
+describe("VertexCache", function() {
+    it("get returns a previously set and non-evicted vertex", function() {
+        const cache = new VertexCache(3);
+        const expectedVertex = { x: 1, y: 4, z: -1 };
+        cache.set(5, expectedVertex);
+        cache.set(9, { x: 9, y: 3, z: 2 });
+        cache.set(1, { x: 1, y: 1, z: 3 });
+
+        const actualVertex = { x: 0, y: 0, z: 0 };
+        const found = cache.get(5, actualVertex);
+        expect(found).equals(true);
+        expect(actualVertex).deep.equals(expectedVertex);
+    });
+
+    it("clear removes all vertices from cache", function() {
+        const size = 5;
+        const cache = new VertexCache(size);
+
+        for (let i = 0; i < size; i++) {
+            cache.set(i, { x: 1, y: 2, z: 3 });
+        }
+        cache.clear();
+        for (let i = 0; i < size; i++) {
+            const found = cache.get(i, { x: 0, y: 0, z: 0 });
+            expect(found).equals(false);
+        }
+    });
+
+    it("set evicts vertices in insertion order if get is never called", function() {
+        const size = 5;
+        const cache = new VertexCache(size);
+
+        for (let i = 0; i < size; i++) {
+            cache.set(i, { x: i * 10, y: i * 100, z: i * 1000 });
+        }
+
+        for (let i = size; i < 2 * size; i++) {
+            cache.set(i, { x: i * 10, y: i * 100, z: i * 1000 });
+
+            const found = cache.get(i - size, { x: 0, y: 0, z: 0 });
+            expect(found).equals(false);
+        }
+    });
+
+    it("set evicts least recently used vertex", function() {
+        const size = 5;
+        const cache = new VertexCache(size);
+
+        for (let i = 0; i < size; i++) {
+            cache.set(i, { x: i * 10, y: i * 100, z: i * 1000 });
+        }
+
+        for (let i = size - 1; i >= 0; i--) {
+            const found = cache.get(i, { x: 0, y: 0, z: 0 });
+            expect(found).equals(true);
+        }
+
+        for (let i = size; i < 2 * size; i++) {
+            cache.set(i, { x: i * 10, y: i * 100, z: i * 1000 });
+
+            const found = cache.get(2 * size - i - 1, { x: 0, y: 0, z: 0 });
+            expect(found).equals(false);
+        }
+    });
+});


### PR DESCRIPTION
It'll be used for mesh displacements on picking. Terrain overlay is done
by displacing meshes in the vertex shader. To pick those meshes, they
are displaced in CPU. To avoid allocating the whole position buffer again,
intersection test is done on the fly for every triangle after it's displaced.

To avoid recomputations of the same vertex, a small LRU cache is used.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
