### PR TITLE
HARP-9251: Fix SolidLineMaterial.lineWidth semantics.

### DIFF
--- a/@here/harp-lines/test/rendering/RenderLines.ts
+++ b/@here/harp-lines/test/rendering/RenderLines.ts
@@ -282,7 +282,7 @@ describe("Rendering lines: ", function() {
     }
 
     it("renders solid lines - lineWidth: 1", async function(this: Mocha.Context) {
-        const lineStyle = { lineWidth: 1, color: "#FFF" };
+        const lineStyle = { lineWidth: 2, color: "#FFF" };
         await renderLines(linesConfig, this, "solid-lines-1px", lineStyle);
     });
 
@@ -292,7 +292,7 @@ describe("Rendering lines: ", function() {
         const camera = createPerspectiveCamera(width, height);
 
         const lineStyle = {
-            lineWidth: 1,
+            lineWidth: 2,
             color: "#FFF"
         };
         await renderLines(config, this, "undisplaced-solid-lines-persective", lineStyle, camera);
@@ -305,7 +305,7 @@ describe("Rendering lines: ", function() {
 
         const displacementMap: THREE.Texture = createFakeDisplacementMap(cellSize);
         const lineStyle = {
-            lineWidth: 1,
+            lineWidth: 2,
             color: "#FFF",
             displacementMap
         };
@@ -313,19 +313,19 @@ describe("Rendering lines: ", function() {
     });
 
     it("renders solid lines - lineWidth: 20", async function(this: Mocha.Context) {
-        const lineStyle = { lineWidth: 20, color: "#FFF" };
+        const lineStyle = { lineWidth: 40, color: "#FFF" };
         await renderLines(linesConfig, this, "solid-lines-20px", lineStyle);
     });
 
     it("renders solid lines with outline - outlineWidth: 5", async function(this: Mocha.Context) {
-        const lineStyle = { lineWidth: 10, color: "#F00", outlineWidth: 5, outlineColor: "#0F0" };
+        const lineStyle = { lineWidth: 20, color: "#F00", outlineWidth: 5, outlineColor: "#0F0" };
         await renderLines(linesConfig, this, "solid-lines-outline", lineStyle);
     });
 
     // tslint:disable-next-line: max-line-length
     it("renders dashed lines with outline - outlineWidth: 3, dashSize: 4", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 4,
+            lineWidth: 8,
             color: "#F00",
             gapSize: 4,
             dashSize: 4,
@@ -338,7 +338,7 @@ describe("Rendering lines: ", function() {
 
     it("renders dashed lines with outline - transparent", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 4,
+            lineWidth: 8,
             color: "#F00",
             gapSize: 4,
             dashSize: 4,
@@ -349,14 +349,14 @@ describe("Rendering lines: ", function() {
     });
 
     // tslint:disable-next-line: max-line-length
-    it("renders dashed lines - lineWidth: 1, gapSize: 2, dashSize: 2", async function(this: Mocha.Context) {
-        const lineStyle = { lineWidth: 1, color: "#FFF", gapSize: 2, dashSize: 2 };
+    it("renders dashed lines - lineWidth: 2, gapSize: 2, dashSize: 2", async function(this: Mocha.Context) {
+        const lineStyle = { lineWidth: 2, color: "#FFF", gapSize: 2, dashSize: 2 };
         await renderLines(linesConfig, this, "dashed-lines-1px", lineStyle);
     });
 
     it("renders dashed lines with dashColor: #F00", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 1,
+            lineWidth: 2,
             color: "#FFF",
             gapSize: 2,
             dashSize: 2,
@@ -367,18 +367,18 @@ describe("Rendering lines: ", function() {
 
     // tslint:disable-next-line: max-line-length
     it("renders dashed lines - lineWidth: 20,gapSize: 2, dashSize: 2", async function(this: Mocha.Context) {
-        const lineStyle = { lineWidth: 20, color: "#FFF", gapSize: 2, dashSize: 2 };
+        const lineStyle = { lineWidth: 40, color: "#FFF", gapSize: 2, dashSize: 2 };
         await renderLines(linesConfig, this, "dashed-lines-20px", lineStyle);
     });
 
     it("renders solid lines - overdraw check", async function(this: Mocha.Context) {
-        const lineStyle = { lineWidth: 20, color: "#FFF", opacity: 0.5, transparent: true };
+        const lineStyle = { lineWidth: 40, color: "#FFF", opacity: 0.5, transparent: true };
         await renderLines(checkOverDrawLines, this, "solid-lines-overdraw-20px", lineStyle);
     });
 
     it("renders dashed lines - overdraw check", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 20,
+            lineWidth: 40,
             color: "#FFF",
             opacity: 0.5,
             transparent: true,
@@ -392,7 +392,7 @@ describe("Rendering lines: ", function() {
     it("renders dashed lines with round dashes - no outline, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Round",
-            lineWidth: 8,
+            lineWidth: 16,
             color: "#F00",
             gapSize: 16,
             dashSize: 16,
@@ -410,7 +410,7 @@ describe("Rendering lines: ", function() {
     it("renders dashed lines with round dashes - outlineWidth: 3, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Round",
-            lineWidth: 8,
+            lineWidth: 16,
             color: "#F00",
             gapSize: 16,
             dashSize: 16,
@@ -430,7 +430,7 @@ describe("Rendering lines: ", function() {
     it("renders dashed lines with diamond dashes - no outline, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Diamond",
-            lineWidth: 8,
+            lineWidth: 16,
             color: "#F00",
             gapSize: 16,
             dashSize: 16,
@@ -448,7 +448,7 @@ describe("Rendering lines: ", function() {
     it("renders dashed lines w/ diamond dashes - outlineWidth: 3, dashSize: 16", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Diamond",
-            lineWidth: 8,
+            lineWidth: 16,
             color: "#F00",
             gapSize: 16,
             dashSize: 16,
@@ -467,7 +467,7 @@ describe("Rendering lines: ", function() {
     it("renders dashed lines with stretched diamond dashes", async function(this: Mocha.Context) {
         const lineStyle = {
             dashes: "Diamond",
-            lineWidth: 8,
+            lineWidth: 16,
             color: "#F00",
             gapSize: 0.01,
             dashSize: 32,
@@ -483,7 +483,7 @@ describe("Rendering lines: ", function() {
 
     it("renders solid lines - caps check round", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 20,
+            lineWidth: 40,
             color: "#FFF",
             opacity: 0.5,
             transparent: true,
@@ -499,7 +499,7 @@ describe("Rendering lines: ", function() {
 
     it("renders solid lines - caps check none", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 20,
+            lineWidth: 40,
             color: "#FFF",
             opacity: 0.5,
             transparent: true,
@@ -515,7 +515,7 @@ describe("Rendering lines: ", function() {
 
     it("renders solid lines - caps check square", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 20,
+            lineWidth: 40,
             color: "#FFF",
             opacity: 0.5,
             transparent: true,
@@ -531,7 +531,7 @@ describe("Rendering lines: ", function() {
 
     it("renders solid lines - caps check triangle out", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 20,
+            lineWidth: 40,
             color: "#FFF",
             opacity: 0.5,
             transparent: true,
@@ -547,7 +547,7 @@ describe("Rendering lines: ", function() {
 
     it("renders solid lines - caps check triangle in", async function(this: Mocha.Context) {
         const lineStyle = {
-            lineWidth: 20,
+            lineWidth: 40,
             color: "#FFF",
             opacity: 0.5,
             transparent: true,

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -768,9 +768,7 @@ export class TileGeometryCreator {
                             }
 
                             lineMaterial.lineWidth =
-                                getPropertyValue(technique.lineWidth, mapView.env) *
-                                unitFactor *
-                                0.5;
+                                getPropertyValue(technique.lineWidth, mapView.env) * unitFactor;
 
                             if (technique.outlineWidth !== undefined) {
                                 lineMaterial.outlineWidth =
@@ -1165,7 +1163,7 @@ export class TileGeometryCreator {
                                     (techniqueOpacity === null || techniqueOpacity === 1)
                                         ? 0
                                         : techniqueSecondaryWidth;
-                                lineMaterial.lineWidth = lineWidth * unitFactor * 0.5;
+                                lineMaterial.lineWidth = lineWidth * unitFactor;
                             }
                         }
                     );

--- a/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
@@ -20,7 +20,7 @@ export default {
 vec3 extrudeLine(
         in vec3 vertexPosition,
         in float linePosition,
-        in float lineWidth,
+        in float extrusionWidth,
         in vec4 bitangent,
         in vec3 tangent,
         inout vec2 uv
@@ -31,15 +31,15 @@ vec3 extrudeLine(
     float angle = bitangent.w;
     // Extrude according to the angle between segments to properly render narrow joints...
     if (angle != 0.0) {
-        result += uv.y * lineWidth * bitangent.xyz / cos(angle / 2.0);
-        uv.x = linePosition + uv.x * lineWidth * uv.y * tan(angle / 2.0);
+        result += uv.y * extrusionWidth * bitangent.xyz / cos(angle / 2.0);
+        uv.x = linePosition + uv.x * extrusionWidth * uv.y * tan(angle / 2.0);
     }
     // ... or extrude in a simple manner for segments that keep the same direction.
     else {
-        result += uv.y * lineWidth * bitangent.xyz + uv.x * lineWidth * tangent;
-        uv.x = linePosition + uv.x * lineWidth;
+        result += uv.y * extrusionWidth * bitangent.xyz + uv.x * extrusionWidth * tangent;
+        uv.x = linePosition + uv.x * extrusionWidth;
     }
-    uv.y *= lineWidth;
+    uv.y *= extrusionWidth;
     return result;
 }
 `,

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -78,7 +78,7 @@ attribute vec3 normal;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
-uniform float lineWidth;
+uniform float extrusionWidth;
 uniform float outlineWidth;
 uniform vec2 drawRange;
 
@@ -114,14 +114,14 @@ void main() {
 
     // Calculate the extruded vertex position (and scale the extrusion direction).
     vec3 pos = extrudeLine(
-        position, linePos, lineWidth + outlineWidth, bitangent, tangent, extrusionDir);
+        position, linePos, extrusionWidth + outlineWidth, bitangent, tangent, extrusionDir);
 
     // Store the normalized extrusion coordinates in vCoords (with their ranges in vRange).
-    vRange = vec3(extrusionCoord.z, lineWidth, extrusionFactor);
+    vRange = vec3(extrusionCoord.z, extrusionWidth, extrusionFactor);
     vCoords = vec4(extrusionDir / vRange.xy, segment / vRange.x);
 
     // Adjust the segment to fit the drawRange.
-    float capDist = (lineWidth + outlineWidth) / extrusionCoord.z;
+    float capDist = (extrusionWidth + outlineWidth) / extrusionCoord.z;
     if ((vCoords.w + capDist) < drawRange.x || (vCoords.z - capDist) > drawRange.y) {
         vCoords.zw += 1.0;
     }
@@ -161,7 +161,7 @@ precision highp int;
 uniform vec3 diffuse;
 uniform vec3 outlineColor;
 uniform float opacity;
-uniform float lineWidth;
+uniform float extrusionWidth;
 uniform float outlineWidth;
 uniform vec2 tileSize;
 uniform vec2 drawRange;
@@ -203,7 +203,7 @@ void main() {
     // Calculate distance to center (0.0: lineCenter, 1.0: lineEdge).
     float distToCenter = roundEdgesAndAddCaps(vCoords, vRange);
     // Calculate distance to edge (-1.0: lineCenter, 0.0: lineEdge).
-    float distToEdge = distToCenter - (lineWidth + outlineWidth) / lineWidth;
+    float distToEdge = distToCenter - (extrusionWidth + outlineWidth) / extrusionWidth;
 
     // Decrease the line opacity by the distToEdge, making the transition steeper when the slope
     // of distToChange increases (i.e. the line is further away).
@@ -434,7 +434,7 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
                     outlineColor: new THREE.Uniform(
                         new THREE.Color(SolidLineMaterial.DEFAULT_COLOR)
                     ),
-                    lineWidth: new THREE.Uniform(SolidLineMaterial.DEFAULT_WIDTH),
+                    extrusionWidth: new THREE.Uniform(SolidLineMaterial.DEFAULT_WIDTH),
                     outlineWidth: new THREE.Uniform(SolidLineMaterial.DEFAULT_OUTLINE_WIDTH),
                     opacity: new THREE.Uniform(SolidLineMaterial.DEFAULT_OPACITY),
                     tileSize: new THREE.Uniform(new THREE.Vector2()),
@@ -630,10 +630,10 @@ export class SolidLineMaterial extends THREE.RawShaderMaterial
      * Line width.
      */
     get lineWidth(): number {
-        return this.uniforms.lineWidth.value as number;
+        return (this.uniforms.extrusionWidth.value as number) * 2;
     }
     set lineWidth(value: number) {
-        this.uniforms.lineWidth.value = value;
+        this.uniforms.extrusionWidth.value = value / 2;
     }
 
     /**


### PR DESCRIPTION
Cleanup.

SolidLineMaterial.lineWidth was really "extrusion ratio" applied for each half, thus lineWidth=1 means "actual width" 2.

This cleans up and thus SolidLineTechnique.lineWidth doesn't need to be halved before applying to material. 

