### PR TITLE
HARP-9275: DisplacedBufferGeometry/Attribute classes to displace mesh…

### DIFF
--- a/@here/harp-mapview/lib/geometry/DisplacedBufferAttribute.ts
+++ b/@here/harp-mapview/lib/geometry/DisplacedBufferAttribute.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Vector3Like } from "@here/harp-geoutils";
+import { sampleBilinear } from "@here/harp-utils";
+import * as THREE from "three";
+import { VertexCache } from "./VertexCache";
+
+/**
+ * @internal
+ * BufferAttribute decorator that displaces on the fly the coordinates in a given attribute using a
+ * specified displacement map.
+ */
+export class DisplacedBufferAttribute extends THREE.BufferAttribute {
+    private static MAX_CACHE_SIZE = 6;
+    private m_texture?: Float32Array;
+    private m_textureWidth: number = 0;
+    private m_textureHeight: number = 0;
+    private m_cache = new VertexCache(DisplacedBufferAttribute.MAX_CACHE_SIZE);
+    private m_lastBufferIndex?: number;
+    private m_lastPos = new THREE.Vector3();
+    private m_tmpNormal = new THREE.Vector3();
+
+    /**
+     * Creates an instance of displaced buffer attribute.
+     * @param originalAttribute The buffer attribute to be displaced (e.g. the position attribute).
+     * @param m_normals The normals along which the coordinates will be displaced.
+     * @param m_uvs The uv coordinates to be used to sample the displacement map.
+     * @param displacementMap A texture with the displacement values in 32bit floats.
+     */
+    constructor(
+        public originalAttribute: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+        private m_normals: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+        private m_uvs: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+        displacementMap: THREE.DataTexture
+    ) {
+        super(originalAttribute.array, originalAttribute.itemSize, originalAttribute.normalized);
+        this.resetTexture(displacementMap);
+    }
+
+    /**
+     * Resets the displaced buffer attribute to use new buffer attributes or displacement map.
+     * @param originalAttribute The buffer attribute to be displaced (e.g. the position attribute).
+     * @param normals The normals along which the coordinates will be displaced.
+     * @param uvs  The uv coordinates to be used to sample the displacement map.
+     * @param displacementMap A texture with the displacement values in 32bit floats.
+     */
+    reset(
+        originalAttribute: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+        normals: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+        uvs: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+        displacementMap: THREE.DataTexture
+    ) {
+        this.array = originalAttribute.array;
+        this.itemSize = originalAttribute.itemSize;
+        this.count = this.array.length / this.itemSize;
+        this.normalized = originalAttribute.normalized;
+        this.originalAttribute = originalAttribute;
+        this.m_normals = normals;
+        this.m_uvs = uvs;
+        this.m_cache.clear();
+        this.m_lastBufferIndex = undefined;
+        this.resetTexture(displacementMap);
+    }
+
+    // HARP-9585: These getters are overrides of the base class ones, however tslint doesn't
+    // recognize them as such.
+    getX(index: number): number {
+        return this.getDisplacedCoordinate(index).x;
+    }
+    getY(index: number): number {
+        return this.getDisplacedCoordinate(index).y;
+    }
+    getZ(index: number): number {
+        return this.getDisplacedCoordinate(index).z;
+    }
+
+    private resetTexture(displacementMap: THREE.DataTexture) {
+        this.m_texture = new Float32Array(displacementMap.image.data.buffer);
+        this.m_textureWidth = displacementMap.image.width;
+        this.m_textureHeight = displacementMap.image.height;
+    }
+    private getDisplacedCoordinate(bufferIndex: number): Vector3Like {
+        if (bufferIndex === this.m_lastBufferIndex) {
+            return this.m_lastPos;
+        }
+        this.m_lastBufferIndex = bufferIndex;
+        if (this.m_cache.get(bufferIndex, this.m_lastPos)) {
+            return this.m_lastPos;
+        }
+        this.displacePosition(bufferIndex);
+        this.m_cache.set(bufferIndex, this.m_lastPos);
+        return this.m_lastPos;
+    }
+    private displacePosition(bufferIndex: number) {
+        this.m_lastPos.set(
+            super.getX(bufferIndex),
+            super.getY(bufferIndex),
+            super.getZ(bufferIndex)
+        );
+        const normals = this.m_normals as THREE.BufferAttribute;
+        this.m_tmpNormal.fromBufferAttribute(normals, bufferIndex);
+        const uvs = this.m_uvs;
+        const u = THREE.MathUtils.clamp(uvs.getX(bufferIndex), 0, 1);
+        const v = THREE.MathUtils.clamp(uvs.getY(bufferIndex), 0, 1);
+        const displacement = sampleBilinear(
+            this.m_texture!,
+            this.m_textureWidth,
+            this.m_textureHeight,
+            u,
+            v
+        );
+        this.m_lastPos.add(this.m_tmpNormal.multiplyScalar(displacement));
+    }
+}

--- a/@here/harp-mapview/lib/geometry/DisplacedBufferGeometry.ts
+++ b/@here/harp-mapview/lib/geometry/DisplacedBufferGeometry.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as THREE from "three";
+import { DisplacedBufferAttribute } from "./DisplacedBufferAttribute";
+
+const tmpNormalMin = new THREE.Vector3();
+const tmpNormalMax = new THREE.Vector3();
+const tmpBBox = new THREE.Box3();
+
+/**
+ * @internal
+ * Range of displacement values found in a given displacement map.
+ */
+export interface DisplacementRange {
+    min: number;
+    max: number;
+}
+
+/**
+ * @internal
+ * BufferGeometry decorator that displaces on the fly the position attribute using a specified
+ * displacement map.
+ */
+export class DisplacedBufferGeometry extends THREE.BufferGeometry {
+    private m_displacedPositions: DisplacedBufferAttribute;
+    private m_originalBoundingBox = new THREE.Box3();
+
+    /**
+     * Creates an instance of displaced buffer geometry.
+     * @param originalGeometry The goeometry to be displaced.
+     * @param displacementMap A texture with the displacement values.
+     * @param m_displacementRange The displacement value range found in the displacement map.
+     * @param displacedPositions Buffer attribute that will be used for displaced positions if
+     * provided, otherwise a new buffer attribute will be created.
+     */
+    constructor(
+        public originalGeometry: THREE.BufferGeometry,
+        displacementMap: THREE.DataTexture,
+        private m_displacementRange: DisplacementRange,
+        displacedPositions?: DisplacedBufferAttribute
+    ) {
+        super();
+        if (!displacedPositions) {
+            this.m_displacedPositions = new DisplacedBufferAttribute(
+                originalGeometry.attributes.position,
+                originalGeometry.attributes.normal,
+                originalGeometry.attributes.uv,
+                displacementMap
+            );
+        } else {
+            this.m_displacedPositions = displacedPositions;
+        }
+        this.resetAttributes();
+    }
+
+    /**
+     * Resets the displaced buffer geometry to use new geometry or displacement map.
+     * @param geometry The goeometry to be displaced.
+     * @param displacementMap A texture with the displacement values.
+     * @param displacementRange The displacement value range found in the displacement map.
+     */
+    reset(
+        geometry: THREE.BufferGeometry,
+        displacementMap: THREE.DataTexture,
+        displacementRange: DisplacementRange
+    ) {
+        this.originalGeometry = geometry;
+        const positions = geometry.attributes.position;
+        const normals = geometry.attributes.normal;
+        const uvs = geometry.attributes.uv;
+        this.m_displacedPositions.reset(positions, normals, uvs, displacementMap);
+        const displacementRangeChanged =
+            this.m_displacementRange.min !== displacementRange.min ||
+            this.m_displacementRange.max !== displacementRange.max;
+        this.m_displacementRange = displacementRange;
+        this.resetAttributes();
+        this.resetBoundingVolumes(displacementRangeChanged);
+    }
+
+    // HARP-9585: Override of base class method, however tslint doesn't recognize it as such.
+    computeBoundingBox(): void {
+        // Calculate a coarse approximation of the displaced geometry bbox by displacing the
+        // original bbox and enlarging it to cover the whole displacement range.
+        // This approximation is used to avoid having to displace the whole geometry, which will
+        // be done only if the bbox test passes.
+        if (this.originalGeometry.boundingBox === null) {
+            this.originalGeometry.computeBoundingBox();
+        }
+        const origBBox = this.m_originalBoundingBox.copy(this.originalGeometry.boundingBox);
+        if (this.boundingBox === null) {
+            this.boundingBox = origBBox.clone();
+        } else {
+            this.boundingBox.copy(origBBox);
+        }
+        tmpBBox.copy(origBBox);
+        tmpNormalMin.fromBufferAttribute(this.attributes.normal as THREE.BufferAttribute, 0);
+        tmpNormalMax.copy(tmpNormalMin);
+        this.boundingBox
+            .translate(tmpNormalMin.multiplyScalar(this.m_displacementRange.min))
+            .union(tmpBBox.translate(tmpNormalMax.multiplyScalar(this.m_displacementRange.max)));
+    }
+
+    // HARP-9585: Override of base class method, however tslint doesn't recognize it as such.
+    computeBoundingSphere(): void {
+        // Use as coarse approximation the sphere bounding the bbox.
+        if (this.boundingBox === null) {
+            this.computeBoundingBox();
+        }
+        if (this.boundingSphere === null) {
+            this.boundingSphere = new THREE.Sphere();
+        }
+        this.boundingBox.getBoundingSphere(this.boundingSphere);
+    }
+
+    private needsBoundingBoxUpdate(displacementRangeChanged: boolean): boolean {
+        return (
+            displacementRangeChanged ||
+            (this.boundingBox &&
+                (!this.originalGeometry.boundingBox ||
+                    !this.m_originalBoundingBox.equals(this.originalGeometry.boundingBox)))
+        );
+    }
+
+    private resetBoundingVolumes(displacementRangeChanged: boolean) {
+        if (this.needsBoundingBoxUpdate(displacementRangeChanged)) {
+            this.computeBoundingBox();
+            if (this.boundingSphere) {
+                this.computeBoundingSphere();
+            }
+        }
+    }
+
+    private resetAttributes() {
+        this.index = this.originalGeometry.index;
+        this.groups = this.originalGeometry.groups;
+        this.drawRange = this.originalGeometry.drawRange;
+        this.attributes = { ...this.originalGeometry.attributes };
+        this.attributes.position = this.m_displacedPositions;
+    }
+}

--- a/@here/harp-mapview/test/DisplacedBufferAttributeTest.ts
+++ b/@here/harp-mapview/test/DisplacedBufferAttributeTest.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { expect } from "chai";
+import * as THREE from "three";
+import { DisplacedBufferAttribute } from "../lib/geometry/DisplacedBufferAttribute";
+
+function createBuffer(array: number[], itemSize: number) {
+    return new THREE.BufferAttribute(new Uint32Array(array), itemSize);
+}
+
+function createTexture(array: number[]) {
+    const side = Math.sqrt(array.length);
+    expect(side).to.satisfy(Number.isInteger);
+    return new THREE.DataTexture(new Float32Array(array), side, side);
+}
+
+function getPos(attribute: DisplacedBufferAttribute, index: number): number[] {
+    return [attribute.getX(index), attribute.getY(index), attribute.getZ(index)];
+}
+describe("DisplacedBufferAttribute", function() {
+    it("after reset new attributes and displacement map are used", function() {
+        const oldPositions = createBuffer([1, 1, 1], 3);
+        const oldNormals = createBuffer([0, 0, 1], 3);
+        const oldUvs = createBuffer([0, 0], 2);
+        const oldMap = createTexture([10, 11, 12, 13]);
+        const displacedAttribute = new DisplacedBufferAttribute(
+            oldPositions,
+            oldNormals,
+            oldUvs,
+            oldMap
+        );
+
+        const newPositions = createBuffer([5, 5, 5], 3);
+        const newNormals = createBuffer([1, 1, 1], 3);
+        const newUvs = createBuffer([1, 1], 2);
+        const newMap = createTexture([1, 2, 3, 4]);
+        displacedAttribute.reset(newPositions, newNormals, newUvs, newMap);
+
+        expect(getPos(displacedAttribute, 0)).deep.equals([9, 9, 9]);
+    });
+
+    it("after reset old displaced geometry is dicarded", function() {
+        const oldPositions = createBuffer([1, 1, 1], 3);
+        const oldNormals = createBuffer([0, 0, 1], 3);
+        const oldUvs = createBuffer([0, 0], 2);
+        const oldMap = createTexture([1, 1, 1, 1]);
+        const displacedAttribute = new DisplacedBufferAttribute(
+            oldPositions,
+            oldNormals,
+            oldUvs,
+            oldMap
+        );
+        expect(getPos(displacedAttribute, 0)).deep.equals([1, 1, 2]);
+
+        oldPositions.setX(0, 2);
+        displacedAttribute.reset(oldPositions, oldNormals, oldUvs, oldMap);
+
+        expect(getPos(displacedAttribute, 0)).deep.equals([2, 1, 2]);
+    });
+
+    it("consecutive calls to getX/Y/Z with the same index reuse computed position", function() {
+        const oldPositions = createBuffer([1, 1, 1], 3);
+        const oldNormals = createBuffer([0, 0, 1], 3);
+        const oldUvs = createBuffer([0, 0], 2);
+        const oldMap = createTexture([1, 1, 1, 1]);
+        const displacedAttribute = new DisplacedBufferAttribute(
+            oldPositions,
+            oldNormals,
+            oldUvs,
+            oldMap
+        );
+        expect(getPos(displacedAttribute, 0)).deep.equals([1, 1, 2]);
+
+        oldPositions.setX(0, 2);
+
+        expect(getPos(displacedAttribute, 0)).deep.equals([1, 1, 2]);
+    });
+});

--- a/@here/harp-mapview/test/DisplacedBufferGeometryTest.ts
+++ b/@here/harp-mapview/test/DisplacedBufferGeometryTest.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as THREE from "three";
+import {
+    DisplacedBufferGeometry,
+    DisplacementRange
+} from "../lib/geometry/DisplacedBufferGeometry";
+
+function createBuffer(array: number[], itemSize: number) {
+    return new THREE.BufferAttribute(new Uint32Array(array), itemSize);
+}
+
+function createTexture(array: number[]) {
+    const side = Math.sqrt(array.length);
+    expect(side).to.satisfy(Number.isInteger);
+    return new THREE.DataTexture(new Float32Array(array), side, side);
+}
+
+function createGeometry(): THREE.BufferGeometry {
+    const geometry = new THREE.BufferGeometry();
+    geometry.attributes.position = createBuffer([1, 1, 1, 2, 2, 2], 3);
+    geometry.attributes.normal = createBuffer([0, 0, 1, 0, 0, 1], 3);
+    geometry.attributes.uv = createBuffer([0, 0, 0, 0], 2);
+    geometry.index = createBuffer([0, 1], 1);
+    geometry.groups = [{ start: 0, count: 2 }];
+    geometry.drawRange = { start: 0, count: 2 };
+    return geometry;
+}
+describe("DisplacedBufferGeometry", function() {
+    it("constructor sets all properties except position attributes with same values as in original \
+    geometry", function() {
+        const originalGeometry = createGeometry();
+        const displacementMap = createTexture([1]);
+        const displacementRange: DisplacementRange = { min: 1, max: 1 };
+        const displacedGeometry = new DisplacedBufferGeometry(
+            originalGeometry,
+            displacementMap,
+            displacementRange
+        );
+        expect(displacedGeometry.index).deep.equals(originalGeometry.index);
+        expect(displacedGeometry.groups).deep.equals(originalGeometry.groups);
+        expect(displacedGeometry.drawRange).deep.equals(originalGeometry.drawRange);
+        expect(displacedGeometry.index).deep.equals(originalGeometry.index);
+
+        expect(displacedGeometry.attributes.position).not.equals(
+            originalGeometry.attributes.position
+        );
+        displacedGeometry.attributes.position = originalGeometry.attributes.position;
+        expect(displacedGeometry.attributes).deep.equals(originalGeometry.attributes);
+    });
+
+    it("after reset new geometry and displacement map are used", function() {
+        const originalGeometry = createGeometry();
+        const displacementMap = createTexture([1]);
+        const displacementRange: DisplacementRange = { min: 1, max: 1 };
+        const displacedGeometry = new DisplacedBufferGeometry(
+            originalGeometry,
+            displacementMap,
+            displacementRange
+        );
+        const newGeometry = createGeometry();
+        newGeometry.attributes.position.setXYZ(0, 5, 5, 5);
+        newGeometry.attributes.normal.setXYZ(0, 1, 1, 1);
+        newGeometry.attributes.uv.setXY(0, 1, 0);
+        newGeometry.index!.setX(1, 0);
+        newGeometry.groups = [
+            { start: 0, count: 1 },
+            { start: 1, count: 1 }
+        ];
+        newGeometry.drawRange = { start: 0, count: 1 };
+        const newMap = createTexture([100]);
+        const newRange: DisplacementRange = { min: 100, max: 100 };
+        displacedGeometry.reset(newGeometry, newMap, newRange);
+
+        expect(displacedGeometry.attributes.position.getX(0)).equals(105);
+        expect(displacedGeometry.index).deep.equals(newGeometry.index);
+        expect(displacedGeometry.groups).deep.equals(newGeometry.groups);
+        expect(displacedGeometry.drawRange).deep.equals(newGeometry.drawRange);
+        expect(displacedGeometry.index).deep.equals(newGeometry.index);
+        displacedGeometry.attributes.position = newGeometry.attributes.position;
+        expect(displacedGeometry.attributes).deep.equals(newGeometry.attributes);
+    });
+
+    it("reset keeps valid bounding volumes", function() {
+        const originalGeometry = createGeometry();
+        const displacementMap = createTexture([1]);
+        const displacementRange: DisplacementRange = { min: 1, max: 1 };
+        const displacedGeometry = new DisplacedBufferGeometry(
+            originalGeometry,
+            displacementMap,
+            displacementRange
+        );
+        displacedGeometry.computeBoundingBox();
+        displacedGeometry.computeBoundingSphere();
+
+        const computeBBoxSpy = sinon.spy(displacedGeometry, "computeBoundingBox");
+        const computeBSphereSpy = sinon.spy(displacedGeometry, "computeBoundingSphere");
+        displacedGeometry.reset(originalGeometry, displacementMap, displacementRange);
+
+        expect(computeBBoxSpy.called).equals(false);
+        expect(computeBSphereSpy.called).equals(false);
+    });
+
+    it("reset with new geometry updates old bounding volumes", function() {
+        const originalGeometry = createGeometry();
+        const displacementMap = createTexture([1]);
+        const displacementRange: DisplacementRange = { min: 1, max: 1 };
+        const displacedGeometry = new DisplacedBufferGeometry(
+            originalGeometry,
+            displacementMap,
+            displacementRange
+        );
+        displacedGeometry.computeBoundingBox();
+        displacedGeometry.computeBoundingSphere();
+
+        // Bounding volumes are updated on reset to new geometry without bounding box.
+        const newGeometry = createGeometry();
+
+        const computeBBoxSpy = sinon.spy(displacedGeometry, "computeBoundingBox");
+        const computeBSphereSpy = sinon.spy(displacedGeometry, "computeBoundingSphere");
+        displacedGeometry.reset(newGeometry, displacementMap, displacementRange);
+
+        expect(computeBBoxSpy.called).equals(true);
+        expect(computeBSphereSpy.called).equals(true);
+
+        // They are also updated on reset to new geometry with a different bounding box.
+        computeBBoxSpy.resetHistory();
+        computeBSphereSpy.resetHistory();
+        newGeometry.attributes.position.setXYZ(0, 5, 5, 5);
+        newGeometry.computeBoundingBox();
+        displacedGeometry.reset(newGeometry, displacementMap, displacementRange);
+
+        expect(computeBBoxSpy.called).equals(true);
+        expect(computeBSphereSpy.called).equals(true);
+    });
+
+    it("reset with new displacement min/max updates old bounding volumes", function() {
+        const originalGeometry = createGeometry();
+        const displacementMap = createTexture([1]);
+        const displacementRange: DisplacementRange = { min: 1, max: 1 };
+        const displacedGeometry = new DisplacedBufferGeometry(
+            originalGeometry,
+            displacementMap,
+            displacementRange
+        );
+        displacedGeometry.computeBoundingBox();
+        displacedGeometry.computeBoundingSphere();
+
+        const computeBBoxSpy = sinon.spy(displacedGeometry, "computeBoundingBox");
+        const computeBSphereSpy = sinon.spy(displacedGeometry, "computeBoundingSphere");
+        displacedGeometry.reset(displacedGeometry, displacementMap, { min: 2, max: 2 });
+
+        expect(computeBBoxSpy.called).equals(true);
+        expect(computeBSphereSpy.called).equals(true);
+    });
+
+    it("computeBoundingBox creates bbox containing all possible displaced positions", function() {
+        const originalGeometry = createGeometry();
+        const displacementMap = createTexture([1]);
+        originalGeometry.attributes.position = createBuffer([1, 1, 1, 2, 2, 2], 3);
+        originalGeometry.attributes.normal = createBuffer([0, 0, 1, 0, 0, 1], 3);
+        const displacementRange: DisplacementRange = { min: 5, max: 25 };
+        const displacedGeometry = new DisplacedBufferGeometry(
+            originalGeometry,
+            displacementMap,
+            displacementRange
+        );
+
+        displacedGeometry.computeBoundingBox();
+        const bbox: THREE.Box3 = displacedGeometry.boundingBox;
+
+        const positions = originalGeometry.attributes.position;
+        const normals = originalGeometry.attributes.normal;
+
+        for (let i = 0; i < positions.count; ++i) {
+            const position = new THREE.Vector3().fromBufferAttribute(positions, i);
+            const normal = new THREE.Vector3().fromBufferAttribute(normals, i);
+            bbox.containsPoint(
+                position.clone().add(normal.clone().multiplyScalar(displacementRange.min))
+            );
+            bbox.containsPoint(
+                position.clone().add(normal.clone().multiplyScalar(displacementRange.max))
+            );
+        }
+    });
+});


### PR DESCRIPTION
…es on the fly.

Mesh displacement for terrain overlay is done in the vertex shader. For picking,
mesh displacement is done on demand in the CPU.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
