### PR TITLE
HARP-6487: Provide h/vPlacement attributes support for point labels.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -691,12 +691,32 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     wrappingMode?: DynamicProperty<"None" | "Character" | "Word">;
     /**
      * Text position regarding the baseline.
+     *
+     * @deprecated Use [[hPlacement]] attribute, which defines label text placement in exactly
+     * opposite way, text that were `Left` aligned are by deduction `Right` placed relative to
+     * the label icon.
      */
     hAlignment?: DynamicProperty<"Left" | "Center" | "Right">;
     /**
      * Text position inside a line.
+     *
+     * @deprecated Use [[vPlacement]] attribute instead.
      */
     vAlignment?: DynamicProperty<"Above" | "Center" | "Below">;
+    /**
+     * Text position regarding the baseline.
+     *
+     * @deprecated Use [[hPlacement]] attribute, which defines label text placement in exactly
+     * opposite way, text that were `Left` aligned are by deduction `Right` placed relative to
+     * the label icon.
+     */
+    hPlacement?: DynamicProperty<"Left" | "Center" | "Right">;
+    /**
+     * Text position inside a line.
+     *
+     * @deprecated Use [[vPlacement]] attribute instead.
+     */
+    vPlacement?: DynamicProperty<"Top" | "Center" | "Bottom">;
 }
 
 export interface LineTechniqueParams extends BaseTechniqueParams {

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -199,6 +199,8 @@ const lineMarkerTechniquePropTypes = mergeTechniqueDescriptor<LineMarkerTechniqu
             wrappingMode: AttrScope.TechniqueGeometry,
             hAlignment: AttrScope.TechniqueGeometry,
             vAlignment: AttrScope.TechniqueGeometry,
+            hPlacement: AttrScope.TechniqueGeometry,
+            vPlacement: AttrScope.TechniqueGeometry,
             backgroundColor: AttrScope.TechniqueRendering,
             backgroundSize: AttrScope.TechniqueRendering,
             backgroundOpacity: AttrScope.TechniqueRendering,

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -1001,6 +1001,8 @@ export interface TextStyleDefinition {
     wrappingMode?: "None" | "Character" | "Word";
     hAlignment?: "Left" | "Center" | "Right";
     vAlignment?: "Above" | "Center" | "Below";
+    hPlacement?: "Left" | "Center" | "Right";
+    vPlacement?: "Above" | "Center" | "Below";
 }
 
 /**

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -7,10 +7,10 @@
 import { Env } from "@here/harp-datasource-protocol";
 import { ProjectionType } from "@here/harp-geoutils";
 import {
-    HorizontalAlignment,
+    HorizontalPlacement,
     MeasurementParameters,
     TextCanvas,
-    VerticalAlignment
+    VerticalPlacement
 } from "@here/harp-text-canvas";
 import { assert, Math2D, MathUtils } from "@here/harp-utils";
 import * as THREE from "three";
@@ -186,7 +186,7 @@ export function checkReadyForPlacement(
 }
 
 /**
- * Computes the offset for a point text accordingly to text alignment (and icon, if any).
+ * Computes the offset for a point text accordingly to text placement (and icon, if any).
  * @param textElement The text element of which the offset will computed. It must be a point
  * label with [[layoutStyle]] and [[bounds]] already computed.
  * @param offset The offset result.
@@ -199,11 +199,15 @@ function computePointTextOffset(
     assert(textElement.layoutStyle !== undefined);
     assert(textElement.bounds !== undefined);
 
-    const hAlign = textElement.layoutStyle!.horizontalAlignment;
-    const vAlign = textElement.layoutStyle!.verticalAlignment;
+    // Consider getting placement attributes from different (specialized) container.
+    const hPlace = textElement.layoutStyle!.horizontalPlacement;
+    const vPlace = textElement.layoutStyle!.verticalPlacement;
 
-    switch (hAlign) {
-        case HorizontalAlignment.Right:
+    // Always make sure that output offset is reset before being computed.
+    offset.set(0, 0);
+
+    switch (hPlace) {
+        case HorizontalPlacement.Left:
             offset.x = -textElement.xOffset;
             break;
         default:
@@ -211,11 +215,11 @@ function computePointTextOffset(
             break;
     }
 
-    switch (vAlign) {
-        case VerticalAlignment.Below:
+    switch (vPlace) {
+        case VerticalPlacement.Below:
             offset.y = -textElement.yOffset;
             break;
-        case VerticalAlignment.Above:
+        case VerticalPlacement.Above:
             offset.y = textElement.yOffset - textElement.bounds!.min.y;
             break;
         default:
@@ -227,8 +231,8 @@ function computePointTextOffset(
         assert(textElement.poiInfo.computedWidth !== undefined);
         assert(textElement.poiInfo.computedHeight !== undefined);
 
-        offset.x += textElement.poiInfo.computedWidth! * (0.5 + hAlign);
-        offset.y += textElement.poiInfo.computedHeight! * (0.5 + vAlign);
+        offset.x += textElement.poiInfo.computedWidth! * (0.5 + hPlace);
+        offset.y += textElement.poiInfo.computedHeight! * (0.5 + vPlace);
     }
     return offset;
 }

--- a/@here/harp-text-canvas/lib/typesetting/LineTypesetter.ts
+++ b/@here/harp-text-canvas/lib/typesetting/LineTypesetter.ts
@@ -83,11 +83,12 @@ export class LineTypesetter implements Typesetter {
         );
         this.m_tempSmallCaps = this.m_currentParams!.smallCapsArray !== undefined;
 
+        // tslint:disable:deprecation
         this.m_currentParams.position.y +=
             this.m_currentParams.textLayoutStyle.verticalAlignment *
             this.m_currentParams.glyphs[0].font.metrics.capHeight *
             this.m_tempScale;
-
+        // tslint:enable:deprecation
         const isOnlyMeasured =
             this.m_currentParams.globalBounds !== undefined &&
             this.m_currentParams.vertexBuffer === undefined;
@@ -178,10 +179,12 @@ export class LineTypesetter implements Typesetter {
 
                 // Calculate the correct starting position for the line base on alignment, and place
                 // all glyphs in it.
+                // tslint:disable:deprecation
                 const lineAlignment =
                     this.m_tempLineDirection === UnicodeUtils.Direction.RTL && isBidirectionalLine
                         ? 1.0 + this.m_currentParams.textLayoutStyle.horizontalAlignment
                         : this.m_currentParams.textLayoutStyle.horizontalAlignment;
+                // tslint:enable:deprecation
                 this.m_currentParams.position.x =
                     this.m_currentParams.position.x + lineCurrX * lineAlignment;
                 if (
@@ -256,10 +259,12 @@ export class LineTypesetter implements Typesetter {
             lineCount <= this.m_currentParams.textLayoutStyle.maxLines - 1 &&
             lineStartIdx <= this.m_currentParams.glyphs.length - 1
         ) {
+            // tslint:disable:deprecation
             const offset =
                 this.m_tempLineDirection === UnicodeUtils.Direction.RTL && isBidirectionalLine
                     ? 1.0 + this.m_currentParams.textLayoutStyle.horizontalAlignment
                     : this.m_currentParams.textLayoutStyle.horizontalAlignment;
+            // tslint:enable:deprecation
             this.m_currentParams.position.setX(
                 this.m_currentParams.position.x + lineCurrX * offset
             );

--- a/@here/harp-text-canvas/lib/typesetting/PathTypesetter.ts
+++ b/@here/harp-text-canvas/lib/typesetting/PathTypesetter.ts
@@ -140,6 +140,7 @@ export class PathTypesetter implements Typesetter {
                       )
                     : 1.0);
         }
+        // tslint:disable:deprecation
         this.m_tempPathOffset = Math.min(
             Math.max(
                 -this.m_currentParams.textLayoutStyle.horizontalAlignment +
@@ -149,6 +150,7 @@ export class PathTypesetter implements Typesetter {
             ),
             1
         );
+        // tslint:enable:deprecation
 
         // Place the input text as a single path line.
         return this.placeLine(this.m_tempLineDirection, isBidirectional);
@@ -233,10 +235,12 @@ export class PathTypesetter implements Typesetter {
         const path = this.m_currentParams!.path;
 
         const defaultGlyphRotation = textRenderStyle.rotation;
+        // tslint:disable:deprecation
         const normalDisplacement =
             textLayoutStyle.verticalAlignment *
             glyphDataArray[0].font.metrics.capHeight *
             this.m_tempScale;
+        // tslint:enable:deprecation
 
         // Move through the glyph array following the run's direction (as the order of the glyphs in
         // memory might not match the order on glyphs on scree).


### PR DESCRIPTION
Introduce new Theme style attributes for 'labeled-icon':
- hPlacement : Left | Center | Right,
- vPlacement : Above | Center | Below.

The first one works in opposite way to hAlignment, while the second
has the same meaning. Both attributes takes precedence over the
h/vAlignment if set, otherwise alignment attributes may specify
text placement over the point anchor, although this attributes are
from now marked as deprecated.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
