### PR TITLE
HARP-6487: Provide h/vPlacement theme attributes for point/line labels.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -691,12 +691,26 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     wrappingMode?: DynamicProperty<"None" | "Character" | "Word">;
     /**
      * Text position regarding the baseline.
+     *
+     * @note Alternative to [[hPlacement]] attribute, which defines label text placement in exactly
+     * opposite way, text that were `Left` aligned are by deduction `Right` placed relative to
+     * the label anchor.
      */
     hAlignment?: DynamicProperty<"Left" | "Center" | "Right">;
     /**
      * Text position inside a line.
+     *
+     * @note Same as [[vPlacement]] attribute although the [[vPlacement]] takes precedence.
      */
     vAlignment?: DynamicProperty<"Above" | "Center" | "Below">;
+    /**
+     * Text horizontal position relating to the label's anchor point (icon, image).
+     */
+    hPlacement?: DynamicProperty<"Left" | "Center" | "Right">;
+    /**
+     * Text vertical position relating to the label anchor.
+     */
+    vPlacement?: DynamicProperty<"Top" | "Center" | "Bottom">;
 }
 
 export interface LineTechniqueParams extends BaseTechniqueParams {

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -199,6 +199,8 @@ const lineMarkerTechniquePropTypes = mergeTechniqueDescriptor<LineMarkerTechniqu
             wrappingMode: AttrScope.TechniqueGeometry,
             hAlignment: AttrScope.TechniqueGeometry,
             vAlignment: AttrScope.TechniqueGeometry,
+            hPlacement: AttrScope.TechniqueGeometry,
+            vPlacement: AttrScope.TechniqueGeometry,
             backgroundColor: AttrScope.TechniqueRendering,
             backgroundSize: AttrScope.TechniqueRendering,
             backgroundOpacity: AttrScope.TechniqueRendering,

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -1001,6 +1001,8 @@ export interface TextStyleDefinition {
     wrappingMode?: "None" | "Character" | "Word";
     hAlignment?: "Left" | "Center" | "Right";
     vAlignment?: "Above" | "Center" | "Below";
+    hPlacement?: "Left" | "Center" | "Right";
+    vPlacement?: "Top" | "Center" | "Bottom";
 }
 
 /**

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -201,7 +201,8 @@ function computePointTextOffset(
 
     const hAlign = textElement.layoutStyle!.horizontalAlignment;
     const vAlign = textElement.layoutStyle!.verticalAlignment;
-
+    // Make sure output vector (offset) is reset before being computed.
+    offset.set(0, 0);
     switch (hAlign) {
         case HorizontalAlignment.Right:
             offset.x = -textElement.xOffset;

--- a/@here/harp-text-canvas/lib/rendering/TextStyle.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextStyle.ts
@@ -55,11 +55,33 @@ export enum VerticalAlignment {
 
 /**
  * Horizontal alignment to be used when placing text.
+ *
+ * @note Horizontal alignment value is exactly opposite to [[HorizontalPlacement]] value,
+ * cause when you place text on the right side of point (or icon) you normally want to have it
+ * left-aligned.
  */
 export enum HorizontalAlignment {
     Left = 0.0,
     Center = -0.5,
     Right = -1.0
+}
+
+/**
+ * Vertical position of text area relative to the placement context (point, line).
+ */
+export enum VerticalPlacement {
+    Above = 0.0,
+    Center = -0.5,
+    Below = -1.0
+}
+
+/**
+ * Horizontal position of text element relative to the placement context (point, line).
+ */
+export enum HorizontalPlacement {
+    Left = -1.0,
+    Center = -0.5,
+    Right = 0.0
 }
 
 /**
@@ -445,6 +467,28 @@ export class TextLayoutStyle {
     }
     set horizontalAlignment(value: HorizontalAlignment) {
         this.m_params.horizontalAlignment = value;
+    }
+
+    /**
+     * Text element horizontal position relating to the placement point.
+     */
+    get verticalPlacement(): VerticalPlacement {
+        return (this.m_params.verticalAlignment! as unknown) as VerticalPlacement;
+    }
+    set verticalPlacement(value: VerticalPlacement) {
+        // Update vertical alignment, both values works interchangeably.
+        this.m_params.verticalAlignment = (value as unknown) as VerticalAlignment;
+    }
+
+    /**
+     * Text element vertical position relating to the point of placement.
+     */
+    get horizontalPlacement(): HorizontalPlacement {
+        return (this.m_params.horizontalAlignment! as unknown) as HorizontalPlacement;
+    }
+    set horizontalPlacement(value: HorizontalPlacement) {
+        // Update horizontal alignment, which is exactly opposite to placement.
+        this.m_params.horizontalAlignment = (value as unknown) as HorizontalAlignment;
     }
 
     /**


### PR DESCRIPTION
Introduce new Theme style attributes for 'labeled-icon' technique:
- hPlacement : Left | Center | Right,
- vPlacement : Above | Center | Below.
The first one works in opposite way to hAlignment, while the second
has the same meaning. Both attributes takes precedence over the
h/vAlignment if set, otherwise alignment attributes may specify
text placement over the point anchor, although this attributes are
from now marked as deprecated.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
