### PR TITLE
HARP-9159: Cleanup kind-based filtering.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -20,23 +20,9 @@ export type LineCaps = "Square" | "Round" | "None" | "TriangleOut" | "TriangleIn
 export type LineDashes = "Square" | "Round" | "Diamond";
 
 /**
- * The kind of geometry is used to group objects together,
- * allowing the group to be hidden or displayed.
- *
- * Any string can be used to specify the kind of the technique in a style in the theme file. Is is
- * suggested to specify multiple kinds for specific types of data. For a highway, the following list
- * of kinds is suggested:
- *
- *    ["line", "road", "road:highway"]
- *
- * If it is a tunnel for a highway:
- *
- *    ["line", "road", "road:highway", "tunnel", "road:tunnel", "road:highway:tunnel"]
- *
- * If specified in this way, specific types of data (here: highway roads) can be enabled and/or
- * disabled.
+ * Standard kinds of geometry.
  */
-export enum GeometryKind {
+export enum StandardGeometryKind {
     /**
      * Used in the enabledKinds/disabledKinds filter to match any kind.
      */
@@ -92,6 +78,28 @@ export enum GeometryKind {
      */
     Detail = "detail"
 }
+
+/**
+ * Geometry kind used for use by [[BaseTechniqueParams.kind]].
+ *
+ * The kind of geometry is used to group objects together,
+ * allowing the group to be hidden or displayed.
+ *
+ * Any string can be used to specify the kind of the technique in a style in the theme file. Is is
+ * suggested to specify multiple kinds for specific types of data. For a highway, the following list
+ * of kinds is suggested:
+ *
+ *    ["line", "road", "road:highway"]
+ *
+ * If it is a tunnel for a highway:
+ *
+ *    ["line", "road", "road:highway", "tunnel", "road:tunnel", "road:highway:tunnel"]
+ *
+ * If specified in this way, specific types of data (here: highway roads) can be enabled and/or
+ * disabled.
+ */
+export type GeometryKind = string | StandardGeometryKind;
+export const GeometryKind = StandardGeometryKind;
 
 /**
  * Decorate property type with possible dynamic variants.
@@ -212,14 +220,19 @@ export interface BaseTechniqueParams {
     /**
      * Specified kind of geometry. One kind is set as default in the technique, and can be
      * overridden in the style.
+     *
+     * @deprecated Use [[enabled]] with expressions based on `['dynamic-properties']` operator.
      */
     kind?: GeometryKind | GeometryKindSet;
 
     /**
-     * Set to `true` if this `Technique`s kind is in the set of enabled [[GeometryKind]]s, set to
-     * `false` if is in the disabled [[GeometryKind]]s. Disabling overrules enabling.
+     * Runtime filtering of techniques.
+     *
+     * Use with `['dynamic-properties']` operator for dynamic feature highlight, highlighig etc.
+     *
+     * @see Picking example - [[PickingExample]]
      */
-    enabled?: boolean;
+    enabled?: DynamicProperty<boolean>;
 }
 
 export enum TextureCoordinateType {

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -553,6 +553,11 @@ export interface IndexedTechniqueParams {
      * @hidden
      */
     _usesFeatureState?: boolean;
+
+    /**
+     * Last computed state derived from [[Technique.kind]].
+     */
+    _kindState?: boolean;
 }
 
 /**

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -17,6 +17,7 @@ import {
     getArrayConstructor,
     getFeatureId,
     getPropertyValue,
+    IndexedTechnique,
     isCirclesTechnique,
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
@@ -58,7 +59,7 @@ import {
     SolidLineMaterial
 } from "@here/harp-materials";
 import { ContextualArabicConverter } from "@here/harp-text-canvas";
-import { assert, LoggerManager } from "@here/harp-utils";
+import { assert } from "@here/harp-utils";
 import * as THREE from "three";
 
 import { AnimatedExtrusionTileHandler } from "../AnimatedExtrusionHandler";
@@ -83,9 +84,7 @@ import { TextElement } from "../text/TextElement";
 import { DEFAULT_TEXT_DISTANCE_SCALE } from "../text/TextElementsRenderer";
 import { Tile, TileFeatureData } from "../Tile";
 import { LodMesh } from "./LodMesh";
-import { TileGeometryLoader } from "./TileGeometryLoader";
 
-const logger = LoggerManager.instance.create("TileGeometryCreator");
 const tmpVector3 = new THREE.Vector3();
 const tmpVector2 = new THREE.Vector2();
 
@@ -145,37 +144,22 @@ export class TileGeometryCreator {
         disabledKinds?: GeometryKindSet | undefined
     ) {
         for (const technique of decodedTile.techniques) {
-            // Already processed
-            if (technique.enabled !== undefined) {
-                continue;
-            }
-
-            // Turn technique.kind from the style, which may be a string or an array of strings,
-            // into a GeometryKindSet.
-            if (technique.kind !== undefined) {
-                if (Array.isArray(technique.kind)) {
-                    technique.kind = new GeometryKindSet(technique.kind);
-                } else if (typeof technique.kind !== "string") {
-                    logger.warn("Technique has unknown type of kind:", technique);
-                    technique.kind = undefined;
-                }
-            }
+            // tslint:disable-next-line: deprecation
+            const kind = technique.kind;
 
             // No info about kind, no way to filter it.
-            if (
-                technique.kind === undefined ||
-                (technique.kind instanceof Set && (technique.kind as GeometryKindSet).size === 0)
-            ) {
-                technique.enabled = true;
+            if (kind === undefined || (kind instanceof Set && kind.size === 0)) {
+                technique._kindState = true;
                 continue;
             }
 
             // Technique is enabled only if enabledKinds is defined and technique belongs to that set or
             // if that's not the case, disabledKinds must be undefined or technique does not belong to it.
-            technique.enabled =
-                !(disabledKinds !== undefined && disabledKinds.hasOrIntersects(technique.kind)) ||
-                (enabledKinds !== undefined && enabledKinds.hasOrIntersects(technique.kind));
+            technique._kindState =
+                !(disabledKinds !== undefined && disabledKinds.hasOrIntersects(kind)) ||
+                (enabledKinds !== undefined && enabledKinds.hasOrIntersects(kind));
         }
+
         for (const srcGeometry of decodedTile.geometries) {
             for (const group of srcGeometry.groups) {
                 group.createdOffsets = [];
@@ -196,8 +180,8 @@ export class TileGeometryCreator {
      * @param decodedTile The decodedTile containing the actual tile map data.
      */
     createAllGeometries(tile: Tile, decodedTile: DecodedTile) {
-        const filter = (technique: Technique): boolean => {
-            return technique.enabled !== false;
+        const filter = (technique: IndexedTechnique): boolean => {
+            return technique._kindState !== false;
         };
 
         this.createObjects(tile, decodedTile, filter);
@@ -206,7 +190,7 @@ export class TileGeometryCreator {
 
         // TextElements do not get their geometry created by Tile, but are managed on a
         // higher level.
-        const textFilter = (technique: Technique): boolean => {
+        const textFilter = (technique: IndexedTechnique): boolean => {
             if (
                 !isPoiTechnique(technique) &&
                 !isLineMarkerTechnique(technique) &&
@@ -264,14 +248,6 @@ export class TileGeometryCreator {
 
         this.processPriorities(tile);
 
-        for (const technique of decodedTile.techniques) {
-            // Make sure that all technique have their geometryKind set, either from the Theme or
-            // their default value.
-            if (technique.kind === undefined) {
-                TileGeometryLoader.setDefaultGeometryKind(technique);
-            }
-        }
-
         // Speedup and simplify following code: Test all techniques if they intersect with
         // enabledKinds and disabledKinds, in which case they are flagged. The disabledKinds can be
         // ignored hereafter.
@@ -321,7 +297,7 @@ export class TileGeometryCreator {
     prepareTextPaths(
         textPathGeometries: TextPathGeometry[],
         decodedTile: DecodedTile,
-        textFilter?: (technique: Technique) => boolean
+        textFilter?: (technique: IndexedTechnique) => boolean
     ): TextPathGeometry[] {
         const processedPaths = new Array<TextPathGeometry>();
         const newPaths = textPathGeometries.slice();
@@ -358,7 +334,7 @@ export class TileGeometryCreator {
     createTextElements(
         tile: Tile,
         decodedTile: DecodedTile,
-        textFilter?: (technique: Technique) => boolean
+        textFilter?: (technique: IndexedTechnique) => boolean
     ) {
         const mapView = tile.mapView;
         const textStyleCache = tile.textStyleCache;
@@ -378,7 +354,7 @@ export class TileGeometryCreator {
                 const technique = decodedTile.techniques[textPath.technique];
 
                 if (
-                    technique.enabled === false ||
+                    technique._kindState === false ||
                     !isTextTechnique(technique) ||
                     (textFilter !== undefined && !textFilter(technique))
                 ) {
@@ -440,6 +416,7 @@ export class TileGeometryCreator {
                         : DEFAULT_TEXT_DISTANCE_SCALE;
                 textElement.mayOverlap = technique.mayOverlap === true;
                 textElement.reserveSpace = technique.reserveSpace !== false;
+                // tslint:disable-next-line: deprecation
                 textElement.kind = technique.kind;
                 // Get the userData for text element picking.
                 textElement.userData = textPath.objInfos;
@@ -457,7 +434,7 @@ export class TileGeometryCreator {
                 const technique = decodedTile.techniques[text.technique];
 
                 if (
-                    technique.enabled === false ||
+                    technique._kindState === false ||
                     !isTextTechnique(technique) ||
                     (textFilter !== undefined && !textFilter(technique))
                 ) {
@@ -525,6 +502,7 @@ export class TileGeometryCreator {
                             : mapView.maxZoomLevel;
                     textElement.mayOverlap = technique.mayOverlap === true;
                     textElement.reserveSpace = technique.reserveSpace !== false;
+                    // tslint:disable-next-line: deprecation
                     textElement.kind = technique.kind;
 
                     textElement.fadeNear = fadeNear;
@@ -550,7 +528,7 @@ export class TileGeometryCreator {
     createObjects(
         tile: Tile,
         decodedTile: DecodedTile,
-        techniqueFilter?: (technique: Technique) => boolean
+        techniqueFilter?: (technique: IndexedTechnique) => boolean
     ) {
         const materials: THREE.Material[] = [];
         const mapView = tile.mapView;
@@ -572,7 +550,7 @@ export class TileGeometryCreator {
 
                 if (
                     group.createdOffsets!.indexOf(tile.offset) !== -1 ||
-                    technique.enabled === false ||
+                    technique._kindState === false ||
                     (techniqueFilter !== undefined && !techniqueFilter(technique))
                 ) {
                     continue;
@@ -625,6 +603,9 @@ export class TileGeometryCreator {
                     }
                     materials[techniqueIndex] = material;
                 }
+
+                // tslint:disable-next-line: deprecation
+                const techniqueKind = technique.kind;
 
                 // Modify the standard textured shader to support height-based coloring.
                 if (isTerrainTechnique(technique)) {
@@ -933,7 +914,7 @@ export class TileGeometryCreator {
                     const depthPassMesh = createDepthPrePassMesh(object as THREE.Mesh);
                     // Set geometry kind for depth pass mesh so that it gets the displacement map
                     // for elevation overlay.
-                    this.registerTileObject(tile, depthPassMesh, technique.kind);
+                    this.registerTileObject(tile, depthPassMesh, techniqueKind);
                     objects.push(depthPassMesh);
 
                     if (extrusionAnimationEnabled) {
@@ -946,7 +927,7 @@ export class TileGeometryCreator {
                     setDepthPrePassStencil(depthPassMesh, object as THREE.Mesh);
                 }
 
-                this.registerTileObject(tile, object, technique.kind);
+                this.registerTileObject(tile, object, techniqueKind);
                 objects.push(object);
 
                 // Add the extruded building edges as a separate geometry.
@@ -1026,7 +1007,7 @@ export class TileGeometryCreator {
                         });
                     }
 
-                    this.registerTileObject(tile, edgeObj, technique.kind);
+                    this.registerTileObject(tile, edgeObj, techniqueKind);
                     objects.push(edgeObj);
                 }
 
@@ -1100,7 +1081,7 @@ export class TileGeometryCreator {
                             : undefined
                     );
 
-                    this.registerTileObject(tile, outlineObj, technique.kind);
+                    this.registerTileObject(tile, outlineObj, techniqueKind);
                     objects.push(outlineObj);
                 }
 
@@ -1180,7 +1161,7 @@ export class TileGeometryCreator {
                         }
                     );
 
-                    this.registerTileObject(tile, outlineObj, technique.kind);
+                    this.registerTileObject(tile, outlineObj, techniqueKind);
                     objects.push(outlineObj);
                 }
             }

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -37,20 +37,11 @@ export class TileGeometryLoader {
      * @param {DecodedTile} decodedTile
      * @returns {GeometryKindSet} The set of kinds used in the decodeTile.
      */
-    static prepareDecodedTile(decodedTile: DecodedTile): GeometryKindSet {
+    static prepareAvailableGeometryKinds(decodedTile: DecodedTile): GeometryKindSet {
         const foundSet: GeometryKindSet = new GeometryKindSet();
 
         for (const technique of decodedTile.techniques) {
-            let geometryKind = technique.kind;
-
-            // Set default kind based on technique.
-            if (geometryKind === undefined) {
-                geometryKind = TileGeometryLoader.setDefaultGeometryKind(technique);
-            }
-
-            if (Array.isArray(geometryKind)) {
-                geometryKind = new GeometryKindSet(geometryKind);
-            }
+            const geometryKind = TileGeometryLoader.compileGeometryKind(technique);
 
             if (geometryKind instanceof Set) {
                 for (const kind of geometryKind) {
@@ -69,7 +60,8 @@ export class TileGeometryLoader {
      *
      * @param {Technique} technique
      */
-    static setDefaultGeometryKind(technique: Technique): GeometryKind | GeometryKindSet {
+    static compileGeometryKind(technique: Technique): GeometryKind | GeometryKindSet {
+        // tslint:disable-next-line: deprecation
         let geometryKind = technique.kind;
 
         // Set default kind based on technique.
@@ -95,7 +87,11 @@ export class TileGeometryLoader {
                 geometryKind = GeometryKind.All;
             }
 
+            // tslint:disable-next-line: deprecation
             technique.kind = geometryKind;
+        } else if (Array.isArray(geometryKind)) {
+            // tslint:disable-next-line: deprecation
+            geometryKind = technique.kind = new GeometryKindSet(geometryKind);
         }
 
         return geometryKind;
@@ -160,7 +156,7 @@ export class TileGeometryLoader {
         this.m_decodedTile = decodedTile;
 
         if (this.m_decodedTile !== undefined) {
-            this.m_availableGeometryKinds = TileGeometryLoader.prepareDecodedTile(
+            this.m_availableGeometryKinds = TileGeometryLoader.prepareAvailableGeometryKinds(
                 this.m_decodedTile
             );
         }

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -122,7 +122,7 @@ export class PoiManager {
             const technique = decodedTile.techniques[techniqueIndex] as IndexedTechnique;
 
             if (
-                technique.enabled === false ||
+                technique._kindState === false ||
                 (!isLineMarkerTechnique(technique) && !isPoiTechnique(technique))
             ) {
                 continue;
@@ -588,6 +588,8 @@ export class PoiManager {
                 ? technique.distanceScale
                 : DEFAULT_TEXT_DISTANCE_SCALE;
 
+        // tslint:disable-next-line: deprecation
+        textElement.kind = technique.kind;
         return textElement;
     }
 }

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -481,9 +481,10 @@ export class OmvDecoder implements IGeometryProcessor {
     ): IndexedTechnique[] {
         if (this.m_dataFilter !== undefined && this.m_dataFilter.hasKindFilter) {
             techniques = techniques.filter(technique => {
-                return technique.kind === undefined
-                    ? this.m_dataFilter!.wantsKind(defaultKind)
-                    : this.m_dataFilter!.wantsKind(technique.kind as GeometryKind);
+                const kind =
+                    // tslint:disable-next-line: deprecation
+                    technique.kind === undefined ? defaultKind : (technique.kind as GeometryKind);
+                return this.m_dataFilter!.wantsKind(kind);
             });
         }
         return techniques;


### PR DESCRIPTION
* `GeometryKind` is now free string, whereas builtin values moved to
  `StandardGeometryKind`
* fix: Pois and LineMarkers can be hidden now
* fix: disabling/enabling fixed (previously it retained state from
  initial geometry creation)
* `TileGeometryManager` and friends now use internal technique member
   to track actual state derived from `kind` instead of clobbering
   `Technique.enabled`
* `Technique.enabled` documented as free for use for filtering