### PR TITLE
HARP-6488: Solve multiple label placements when checking collisions.

### DIFF
--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -429,6 +429,11 @@ function placePointLabelChoosingAnchor(
     // Store label state - persistent or new label.
     const persistent = labelState.visible;
 
+    // Text elements with multi-anchor placement require their own layout style.
+    // Provide private copy of label layout and attach it to current label and text canvas.
+    label.layoutStyle = label.layoutStyle!.clone();
+    textCanvas.textLayoutStyle = label.layoutStyle!;
+
     // The current implementation does not provide placements options via theme style yet,
     // so function tries the anchor placements from pre-defined placements arrays.
     // TODO: HARP-6487 Placements options should be loaded from the theme.

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -324,6 +324,8 @@ export function placeIcon(
  * @param textCanvas The text canvas where the label will be placed.
  * @param screenCollisions Used to check collisions with other labels.
  * @param outScreenPosition The final label screen position after applying any offsets.
+ * @param multiAnchor The parameter decides if multi-anchor placement algorithm should be
+ * used, be default [[false]] meaning try to place label using current alignment settings only.
  * @returns `PlacementResult.Ok` if point __label can be placed__ at the base or any optional
  * anchor point. `PlacementResult.Rejected` if there's a collision for all placements or it's
  * __persistent label with icon rejected and text visible__. Finally `PlacementResult.Invisible`
@@ -337,7 +339,8 @@ export function placePointLabel(
     textCanvas: TextCanvas,
     screenCollisions: ScreenCollisions,
     isRejected: boolean,
-    outScreenPosition: THREE.Vector3
+    outScreenPosition: THREE.Vector3,
+    multiAnchor: boolean = false
 ): PlacementResult {
     const layoutStyle = labelState.element.layoutStyle!;
 
@@ -350,6 +353,7 @@ export function placePointLabel(
     // For centered point labels and labels with icon rejected, do only current anchor testing.
     // TODO: Should be removed after placements are provided via style - see HARP-6487.
     if (
+        !multiAnchor ||
         isRejected ||
         (layoutStyle.verticalAlignment === VerticalAlignment.Center &&
             layoutStyle.horizontalAlignment === HorizontalAlignment.Center)

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -46,7 +46,7 @@ import {
     placeIcon,
     PlacementResult,
     placePathLabel,
-    placePointLabel,
+    placePointLabelChoosingAnchor,
     PrePlacementResult
 } from "./Placement";
 import { PlacementStats } from "./PlacementStats";
@@ -1606,7 +1606,7 @@ export class TextElementsRenderer {
         // Render the label's text...
         // textRenderState is always defined at this point.
         if (renderText) {
-            const placeResult = placePointLabel(
+            const placeResult = placePointLabelChoosingAnchor(
                 labelState,
                 tempScreenPosition,
                 distanceScaleFactor,

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1606,6 +1606,8 @@ export class TextElementsRenderer {
         // Render the label's text...
         // textRenderState is always defined at this point.
         if (renderText) {
+            // Multi point (icons) features (line markers) will use single placement anchor, but
+            // single point labels (POIs, etc.) may use multi-placement algorithm.
             const placeResult = placePointLabel(
                 labelState,
                 tempScreenPosition,
@@ -1613,7 +1615,8 @@ export class TextElementsRenderer {
                 textCanvas,
                 this.m_screenCollisions,
                 iconRejected,
-                tempPosition
+                tempPosition,
+                iconIndex === undefined
             );
             if (placeResult === PlacementResult.Invisible) {
                 if (placementStats) {

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -46,7 +46,7 @@ import {
     placeIcon,
     PlacementResult,
     placePathLabel,
-    placePointLabelChoosingAnchor,
+    placePointLabel,
     PrePlacementResult
 } from "./Placement";
 import { PlacementStats } from "./PlacementStats";
@@ -1606,7 +1606,7 @@ export class TextElementsRenderer {
         // Render the label's text...
         // textRenderState is always defined at this point.
         if (renderText) {
-            const placeResult = placePointLabelChoosingAnchor(
+            const placeResult = placePointLabel(
                 labelState,
                 tempScreenPosition,
                 distanceScaleFactor,

--- a/@here/harp-mapview/test/PlacementTest.ts
+++ b/@here/harp-mapview/test/PlacementTest.ts
@@ -40,6 +40,12 @@ import { LoadingState, TextElement } from "../lib/text/TextElement";
 import { TextElementState } from "../lib/text/TextElementState";
 
 const inNodeContext = typeof window === "undefined";
+const screenWidth: number = 1024;
+const screenHeight: number = 1024;
+const screenTopLeft = new THREE.Vector2(-screenWidth / 2, -screenHeight / 2);
+const screenTopRight = new THREE.Vector2(screenWidth / 2, -screenHeight / 2);
+const screenBottomLeft = new THREE.Vector2(-screenWidth / 2, screenHeight / 2);
+const screenBottomRight = new THREE.Vector2(screenWidth / 2, screenHeight / 2);
 
 async function createTextElement(
     textCanvas: TextCanvas,
@@ -73,6 +79,18 @@ async function createTextElement(
     return textElement;
 }
 
+async function createPointTextElements(
+    textCanvas: TextCanvas,
+    texts: string[],
+    renderParams: TextRenderParameters | TextRenderStyle = {},
+    layoutParams: TextLayoutParameters | TextLayoutStyle = {}
+): Promise<TextElement[]> {
+    const promises = texts.map(text => {
+        return createTextElement(textCanvas, text, new THREE.Vector3(), renderParams, layoutParams);
+    });
+    return Promise.all(promises);
+}
+
 async function createTextCanvas(): Promise<TextCanvas> {
     let fontDir = getTestResourceUrl("@here/harp-fontcatalog", "");
     if (inNodeContext) {
@@ -91,11 +109,15 @@ async function createTextCanvas(): Promise<TextCanvas> {
     } as any);
 }
 
+function createTextElementsStates(textElements: TextElement[]): TextElementState[] {
+    return textElements.map(element => new TextElementState(element));
+}
+
 describe("Placement", function() {
     const sandbox = sinon.createSandbox();
     let textCanvas: TextCanvas;
     const screenCollisions: ScreenCollisions = new ScreenCollisions();
-    screenCollisions.update(1024, 1024);
+    screenCollisions.update(screenWidth, screenHeight);
     const appBaseUrl = getAppBaseUrl();
 
     before(async function() {
@@ -108,8 +130,8 @@ describe("Placement", function() {
             (global as any).document = {};
         }
         const image = {
-            width: 1024,
-            height: 1024
+            width: screenWidth,
+            height: screenHeight
         };
         const texture = new THREE.Texture(image as any);
         sandbox.stub(FontCatalog, "loadTexture").returns(Promise.resolve(texture));
@@ -501,6 +523,488 @@ describe("Placement", function() {
             expect(result).to.equal(PlacementResult.Ok);
             expect(position.x).to.equal(4);
             expect(position.y).to.equal(21.200000000000003);
+        });
+
+        context("single text with alternative placement", function() {
+            it("places text in top-left screen corner", async function() {
+                const textElement = await createTextElement(
+                    textCanvas,
+                    "Test Diagonal Alternative",
+                    new THREE.Vector3(),
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Right,
+                        verticalAlignment: VerticalAlignment.Below,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                const state = new TextElementState(textElement);
+
+                const outPosition = new THREE.Vector3();
+                const inPosition = new THREE.Vector2(-10, -10).add(screenTopLeft);
+
+                // Set the current style for the canvas.
+                textCanvas.textRenderStyle = textElement.renderStyle!;
+                textCanvas.textLayoutStyle = textElement.layoutStyle!;
+                // Run placement without multi-placement support
+                let result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    false
+                );
+
+                // Label out of screen and layout unchanged.
+                let layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Invisible);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Right);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Below);
+
+                // Place again with multi-placement support
+                result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    true
+                );
+                // Label placed and layout changed diagonally.
+                layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Ok);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Left);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Above);
+            });
+
+            it("places text in top-right screen corner", async function() {
+                const textElement = await createTextElement(
+                    textCanvas,
+                    "Test Diagonal Alternative",
+                    new THREE.Vector3(),
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Left,
+                        verticalAlignment: VerticalAlignment.Below,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                const state = new TextElementState(textElement);
+
+                const outPosition = new THREE.Vector3();
+                const inPosition = new THREE.Vector2(10, -10).add(screenTopRight);
+
+                // Set the current style for the canvas.
+                textCanvas.textRenderStyle = textElement.renderStyle!;
+                textCanvas.textLayoutStyle = textElement.layoutStyle!;
+                // Run placement without multi-placement support
+                let result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    false
+                );
+
+                // Label out of screen and layout unchanged.
+                let layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Invisible);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Left);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Below);
+
+                // Place again with multi-placement support
+                result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    true
+                );
+                // Label placed and layout changed diagonally.
+                layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Ok);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Right);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Above);
+            });
+
+            it("places text in bottom-right screen corner", async function() {
+                const textElement = await createTextElement(
+                    textCanvas,
+                    "Test Diagonal Alternative",
+                    new THREE.Vector3(),
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Left,
+                        verticalAlignment: VerticalAlignment.Above,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                const state = new TextElementState(textElement);
+
+                const outPosition = new THREE.Vector3();
+                const inPosition = new THREE.Vector2(10, 10).add(screenBottomRight);
+
+                // Set the current style for the canvas.
+                textCanvas.textRenderStyle = textElement.renderStyle!;
+                textCanvas.textLayoutStyle = textElement.layoutStyle!;
+                // Run placement without multi-placement support
+                let result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    false
+                );
+
+                // Label out of screen and layout unchanged.
+                let layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Invisible);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Left);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Above);
+
+                // Place again with multi-placement support
+                result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    true
+                );
+                // Label placed and layout changed diagonally.
+                layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Ok);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Right);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Below);
+            });
+
+            it("places text in bottom-left screen corner", async function() {
+                const textElement = await createTextElement(
+                    textCanvas,
+                    "Test Diagonal Alternative",
+                    new THREE.Vector3(),
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Right,
+                        verticalAlignment: VerticalAlignment.Above,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                const state = new TextElementState(textElement);
+
+                const outPosition = new THREE.Vector3();
+                const inPosition = new THREE.Vector2(-10, 10).add(screenBottomLeft);
+
+                // Set the current style for the canvas.
+                textCanvas.textRenderStyle = textElement.renderStyle!;
+                textCanvas.textLayoutStyle = textElement.layoutStyle!;
+                // Run placement without multi-placement support
+                let result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    false
+                );
+
+                // Label out of screen and layout unchanged.
+                let layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Invisible);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Right);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Above);
+
+                // Place again with multi-placement support
+                result = placePointLabel(
+                    state,
+                    inPosition,
+                    1.0,
+                    textCanvas,
+                    screenCollisions,
+                    false,
+                    outPosition,
+                    true
+                );
+                // Label placed and layout changed diagonally.
+                layout = textElement.layoutStyle!;
+                expect(result).to.equal(PlacementResult.Ok);
+                expect(layout.horizontalAlignment).to.be.equal(HorizontalAlignment.Left);
+                expect(layout.verticalAlignment).to.be.equal(VerticalAlignment.Below);
+            });
+        });
+
+        context("texts colliding with alternative placements", function() {
+            it("place two text at almost the same position", async function() {
+                const elements = await createPointTextElements(
+                    textCanvas,
+                    ["Test 1", "Test 2"],
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Right,
+                        verticalAlignment: VerticalAlignment.Below,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                expect(elements.length).to.equal(2);
+                const states = createTextElementsStates(elements);
+                const offset = 5; // Need to keep some offset because of internal margin
+                const inPositions = [new THREE.Vector2(-offset, 0), new THREE.Vector2(offset, 0)];
+                const outPositions = [new THREE.Vector3(), new THREE.Vector3()];
+
+                // Place each text element sequentially without multi-placement support
+                const results: PlacementResult[] = [0, 0];
+                for (let i = 0; i < states.length; ++i) {
+                    textCanvas.textRenderStyle = elements[i].renderStyle!;
+                    textCanvas.textLayoutStyle = elements[i].layoutStyle!;
+                    results[i] = placePointLabel(
+                        states[i],
+                        inPositions[i],
+                        1.0,
+                        textCanvas,
+                        screenCollisions,
+                        false,
+                        outPositions[i]
+                    );
+                    expect(outPositions[i].x).to.equal(inPositions[i].x);
+                    expect(outPositions[i].y).to.equal(inPositions[i].y);
+                }
+                // First element allocated, second collides, because it's a new label
+                // it retrieves PlacementResult.Invisible status.
+                expect(results[0]).to.equal(PlacementResult.Ok);
+                expect(results[1]).to.equal(PlacementResult.Invisible);
+
+                // Cleanup screen for next frame
+                screenCollisions.reset();
+
+                // Try again with multi-placement support.
+                for (let i = 0; i < states.length; ++i) {
+                    textCanvas.textRenderStyle = elements[i].renderStyle!;
+                    textCanvas.textLayoutStyle = elements[i].layoutStyle!;
+                    results[i] = placePointLabel(
+                        states[i],
+                        inPositions[i],
+                        1.0,
+                        textCanvas,
+                        screenCollisions,
+                        false,
+                        outPositions[i],
+                        true
+                    );
+                }
+                // First element has placement unchanged.
+                expect(outPositions[0].x).to.equal(inPositions[0].x);
+                expect(outPositions[0].y).to.equal(inPositions[0].y);
+                // Second occupies alternative placement.
+                expect(
+                    outPositions[1].x !== inPositions[1].x || outPositions[1].y !== inPositions[1].y
+                ).to.be.true;
+                // As also with different anchor.
+                const layout0 = elements[0].layoutStyle!;
+                const layout1 = elements[1].layoutStyle!;
+                expect(
+                    layout0.horizontalAlignment !== layout1.horizontalAlignment ||
+                        layout0.horizontalAlignment !== layout1.horizontalAlignment
+                ).to.be.true;
+                // Both elements allocated.
+                expect(results[0]).to.equal(PlacementResult.Ok);
+                expect(results[1]).to.equal(PlacementResult.Ok);
+            });
+
+            it("fail to place two centered texts at almost the same position", async function() {
+                const elements = await createPointTextElements(
+                    textCanvas,
+                    ["Test 1", "Test 2"],
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Center,
+                        verticalAlignment: VerticalAlignment.Center,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                expect(elements.length).to.equal(2);
+                const states = createTextElementsStates(elements);
+                const offset = 5; // Need to keep some offset because of internal margin
+                const inPositions = [new THREE.Vector2(-offset, 0), new THREE.Vector2(offset, 0)];
+                const outPositions = [new THREE.Vector3(), new THREE.Vector3()];
+
+                // Place each text element sequentially without multi-placement support
+                const results: PlacementResult[] = [0, 0];
+                for (let i = 0; i < states.length; ++i) {
+                    textCanvas.textRenderStyle = elements[i].renderStyle!;
+                    textCanvas.textLayoutStyle = elements[i].layoutStyle!;
+                    results[i] = placePointLabel(
+                        states[i],
+                        inPositions[i],
+                        1.0,
+                        textCanvas,
+                        screenCollisions,
+                        false,
+                        outPositions[i],
+                        true
+                    );
+                    // Even with multi-placement turned on, the labels are not using
+                    // alternative placement algorithm - they are excluded.
+                    // TODO: HARP-6487 This may be due to change when placements will be
+                    // parsed from theme.
+                    expect(elements[i].layoutStyle!.horizontalAlignment).to.equal(
+                        HorizontalAlignment.Center
+                    );
+                    expect(elements[i].layoutStyle!.verticalAlignment).to.equal(
+                        VerticalAlignment.Center
+                    );
+                }
+                // First element allocated, second collides, without alternative placement,
+                // centered labels are not handled with multi-anchor placement.
+                // Because it's a new label it retrieves PlacementResult.Invisible status.
+                expect(results[0]).to.equal(PlacementResult.Ok);
+                expect(results[1]).to.equal(PlacementResult.Invisible);
+            });
+
+            it("place two approaching texts", async function() {
+                const elements = await createPointTextElements(
+                    textCanvas,
+                    ["Test 1", "Test 2"],
+                    {},
+                    {
+                        horizontalAlignment: HorizontalAlignment.Right,
+                        verticalAlignment: VerticalAlignment.Below,
+                        wrappingMode: WrappingMode.None
+                    }
+                );
+                const states = createTextElementsStates(elements);
+                // Offset big enough to place without collisions
+                let offset = 50;
+                const inPositions = [new THREE.Vector2(-offset, 0), new THREE.Vector2(offset, 0)];
+                const outPositions = [new THREE.Vector3(), new THREE.Vector3()];
+
+                // Place each text element sequentially.
+                const results: PlacementResult[] = [0, 0];
+                for (let i = 0; i < states.length; ++i) {
+                    textCanvas.textRenderStyle = elements[i].renderStyle!;
+                    textCanvas.textLayoutStyle = elements[i].layoutStyle!;
+                    results[i] = placePointLabel(
+                        states[i],
+                        inPositions[i],
+                        1.0,
+                        textCanvas,
+                        screenCollisions,
+                        false,
+                        outPositions[i],
+                        false
+                    );
+                    expect(outPositions[i].x).to.equal(inPositions[i].x);
+                    expect(outPositions[i].y).to.equal(inPositions[i].y);
+                }
+                // First element allocated, second collides, because it's a new label
+                // it retrieves PlacementResult.Invisible status.
+                expect(results[0]).to.equal(PlacementResult.Ok);
+                expect(results[1]).to.equal(PlacementResult.Ok);
+                // Update their states
+                states[0].update(1);
+                states[1].update(1);
+                expect(states[0].textRenderState).to.be.not.undefined;
+                expect(states[1].textRenderState).to.be.not.undefined;
+                states[0].textRenderState?.startFadeIn(1);
+                states[1].textRenderState?.startFadeIn(1);
+                // Labels gets persistent state.
+                expect(states[0].visible).to.be.true;
+                expect(states[1].visible).to.be.true;
+
+                // Cleanup for the next - approaching frame.
+                screenCollisions.reset();
+                // Change the offset - labels approaching.
+                offset = 5;
+                inPositions[0].set(-offset, 0);
+                inPositions[1].set(offset, 0);
+                // Try again with multi-placement support and possible collisions.
+                for (let i = 0; i < states.length; ++i) {
+                    textCanvas.textRenderStyle = elements[i].renderStyle!;
+                    textCanvas.textLayoutStyle = elements[i].layoutStyle!;
+                    results[i] = placePointLabel(
+                        states[i],
+                        inPositions[i],
+                        1.0,
+                        textCanvas,
+                        screenCollisions,
+                        false,
+                        outPositions[i],
+                        true
+                    );
+                }
+                // First element has placement unchanged.
+                expect(outPositions[0].x).to.equal(inPositions[0].x);
+                expect(outPositions[0].y).to.equal(inPositions[0].y);
+                // Second occupies alternative placement.
+                expect(
+                    outPositions[1].x === inPositions[1].x && outPositions[1].y === inPositions[1].y
+                ).to.be.false;
+                // As also with different anchor.
+                const layout0 = elements[0].layoutStyle!;
+                const layout1 = elements[1].layoutStyle!;
+                expect(
+                    layout0.horizontalAlignment === layout1.horizontalAlignment ||
+                        layout0.horizontalAlignment === layout1.horizontalAlignment
+                ).to.be.false;
+                // Both elements allocated.
+                expect(results[0]).to.equal(PlacementResult.Ok);
+                expect(results[1]).to.equal(PlacementResult.Ok);
+                // Update states.
+                states[0].textRenderState?.updateFading(2, false);
+                states[1].textRenderState?.updateFading(2, false);
+                expect(states[0].visible).to.be.true;
+                expect(states[1].visible).to.be.true;
+
+                // Cleanup for the next - approaching frame.
+                screenCollisions.reset();
+                // Change the offset - labels are at very same position - impossible for placement.
+                offset = 0;
+                inPositions[0].set(-offset, 0);
+                inPositions[1].set(offset, 0);
+                // Try again with multi-placement support and possible collisions.
+                for (let i = 0; i < states.length; ++i) {
+                    textCanvas.textRenderStyle = elements[i].renderStyle!;
+                    textCanvas.textLayoutStyle = elements[i].layoutStyle!;
+                    results[i] = placePointLabel(
+                        states[i],
+                        inPositions[i],
+                        1.0,
+                        textCanvas,
+                        screenCollisions,
+                        false,
+                        outPositions[i],
+                        true
+                    );
+                }
+                // First element has placement unchanged.
+                expect(outPositions[0].x).to.equal(inPositions[0].x);
+                expect(outPositions[0].y).to.equal(inPositions[0].y);
+                // Second element has to stay at the same placement - for fading.
+                expect(outPositions[0].x).to.equal(inPositions[0].x);
+                expect(outPositions[0].y).to.equal(inPositions[0].y);
+                // First element space allocated - placed.
+                expect(results[0]).to.equal(PlacementResult.Ok);
+                // Second is rejected, but not invisible, because of its persistence
+                // state, it may start fading out now.
+                expect(results[1]).to.equal(PlacementResult.Rejected);
+            });
         });
     });
 


### PR DESCRIPTION
POC code which checks different anchor point (placements) that comes
internally from hard-coded table. Final solution should read
possible placement points from the technique (theme) definition and
store them in TextElement.m_layoutStyle.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
