### PR TITLE
HARP-6487: Provide `placement` attribute support for point/line labels.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -432,6 +432,37 @@ export enum PoiStackMode {
 }
 
 /**
+ * Defines options of available placements.
+ *
+ * Possible values are defined as vertical placement letter, horizontal letter, where
+ * one of the letters may be ignored (meaning center), going clock-wise, we have:
+ * `TL` (top-left), `T` (top-center), `TR` (top-right), `R` (center-right), `BR` (bottom-right),
+ * `B` (bottom-center), `BL` (bottom-left), `L` (left), `C` (center-center).
+ * Additionally instead of `T`, `B`, `L`, `R` geographic directions may be used accordingly:
+ * `N` (north), `S` (south), `E` (east), `W` (west).
+ */
+export enum Placement {
+    TopLeft = "TL",
+    TopCenter = "T",
+    TopRight = "TR",
+    CenterRight = "R",
+    BottomRight = "BR",
+    BottomCenter = "B",
+    BottomLeft = "BL",
+    CenterLeft = "L",
+    CenterCenter = "C",
+    North = "N",
+    South = "S",
+    East = "E",
+    West = "W"
+}
+
+/**
+ * Array of available text placements.
+ */
+export type Placements = Placement[];
+
+/**
  * Technique that describes icons with labels. Used in [[PoiTechnique]] and [[LineMarkerTechnique]]
  * (for road shields).
  */
@@ -691,12 +722,28 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     wrappingMode?: DynamicProperty<"None" | "Character" | "Word">;
     /**
      * Text position regarding the baseline.
+     *
+     * @note The [[placement]] attribute may override the alignment settings.
      */
     hAlignment?: DynamicProperty<"Left" | "Center" | "Right">;
     /**
      * Text position inside a line.
+     *
+     * @note The [[placement]] attribute may supersede it.
      */
     vAlignment?: DynamicProperty<"Above" | "Center" | "Below">;
+    /**
+     * Text label position regarding to the point of placement (anchor point).
+     *
+     * This attribute defines an array of possible placements relating to the anchor.
+     * Keep in mind that horizontal placement works in opposite way to alignment, so the text
+     * located on the **right side** of the placement (anchor) point will be always `Left`
+     * aligned by deduction. In the same way the label  **left side** placed is `Right` aligned
+     * relative to the label icon or origin point.
+     *
+     * @note This attribute supersedes [[hAlignment]] and [[vAlignment]] if defined.
+     */
+    placement?: Placements;
 }
 
 export interface LineTechniqueParams extends BaseTechniqueParams {

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -199,6 +199,7 @@ const lineMarkerTechniquePropTypes = mergeTechniqueDescriptor<LineMarkerTechniqu
             wrappingMode: AttrScope.TechniqueGeometry,
             hAlignment: AttrScope.TechniqueGeometry,
             vAlignment: AttrScope.TechniqueGeometry,
+            placement: AttrScope.TechniqueGeometry,
             backgroundColor: AttrScope.TechniqueRendering,
             backgroundSize: AttrScope.TechniqueRendering,
             backgroundOpacity: AttrScope.TechniqueRendering,

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -14,6 +14,7 @@ import {
     ExtrudedPolygonTechniqueParams,
     FillTechniqueParams,
     MarkerTechniqueParams,
+    Placements,
     PointTechniqueParams,
     SegmentsTechniqueParams,
     ShaderTechniqueParams,
@@ -1001,6 +1002,7 @@ export interface TextStyleDefinition {
     wrappingMode?: "None" | "Character" | "Word";
     hAlignment?: "Left" | "Center" | "Right";
     vAlignment?: "Above" | "Center" | "Below";
+    placement?: Placements;
 }
 
 /**


### PR DESCRIPTION
Introduce new `placement` technique attribute for:
- 'labeled-icon' (PoiTechnique),
- 'line-marker' (LineMarkerTechnique),
techniques that are utilizing LineMarkerTechniqueParams set.

The attribute holds an array of possible (and optional) text
placements relative to label origin (screen anchor) point.
If placements are defined they override hAlignment and vAlignment
settings defined in style. Each placement option is defined in array
as 1 or 2 characters string defining the text position relative to
origin. i.e. "TR" (top-right), "BL", (bottom-left) or simply
"R" (center-right).

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
