### PR TITLE
Remove 'renderOrderOffset'.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -220,12 +220,6 @@ export interface Group {
     start: number;
     count: number;
     technique: number;
-
-    /**
-     * Offset added to [[Technique]]'s [[renderOrder]] when calculating final `renderOrder` of
-     * geometry object from given group.
-     */
-    renderOrderOffset?: number;
     featureId?: number;
 
     /**

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -188,11 +188,6 @@ export interface BaseTechniqueParams {
     category?: string;
 
     /**
-     *
-     */
-    renderOrderOffset?: number;
-
-    /**
      * Optional. If `true`, no IDs will be saved for the geometry this technique creates.
      */
     transient?: boolean;

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -78,7 +78,6 @@ export const baseTechniqueParamsDescriptor: TechniqueDescriptor<BaseTechniquePar
     attrTransparencyColor: "color",
     attrScopes: {
         renderOrder: AttrScope.TechniqueGeometry,
-        renderOrderOffset: AttrScope.TechniqueGeometry,
         enabled: AttrScope.FeatureGeometry,
         kind: AttrScope.TechniqueGeometry,
         transient: AttrScope.TechniqueGeometry,

--- a/@here/harp-examples/decoder/custom_decoder.ts
+++ b/@here/harp-examples/decoder/custom_decoder.ts
@@ -75,8 +75,7 @@ class CustomDecoder extends ThemedTileDecoder
                 {
                     start: 0,
                     count: indices.length,
-                    technique: techniqueIndex,
-                    renderOrderOffset: 0
+                    technique: techniqueIndex
                 }
             ],
             vertexAttributes: []

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -701,10 +701,6 @@ export class TileGeometryCreator {
 
                 object.renderOrder = technique.renderOrder!;
 
-                if (group.renderOrderOffset !== undefined) {
-                    object.renderOrder += group.renderOrderOffset;
-                }
-
                 if (srcGeometry.uuid !== undefined) {
                     object.userData.geometryId = srcGeometry.uuid;
                 }
@@ -1125,10 +1121,6 @@ export class TileGeometryCreator {
                         outlineTechnique.secondaryRenderOrder !== undefined
                             ? outlineTechnique.secondaryRenderOrder
                             : technique.renderOrder - 0.0000001;
-
-                    if (group.renderOrderOffset !== undefined) {
-                        outlineObj.renderOrder += group.renderOrderOffset;
-                    }
 
                     const fadingParams = this.getFadingParams(discreteZoomEnv, technique);
                     FadingFeature.addRenderHelper(

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -32,7 +32,6 @@ const logger = LoggerManager.instance.create("OmvDataSource");
 export interface LinesGeometry {
     type: GeometryType;
     lines: LineGroup;
-    renderOrderOffset?: number;
     technique: number;
 
     /**

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -1130,26 +1130,14 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
         uvs?: number[][],
         offsets?: number[][]
     ): void {
-        const renderOrderOffset = evaluateTechniqueAttr<number>(
-            context,
-            technique.renderOrderOffset,
-            0
-        );
-
         let lineGroup: LineGroup;
-        const lineGroupGeometries = linesGeometry.find(aLine => {
-            return (
-                aLine.technique === techniqueIndex && aLine.renderOrderOffset === renderOrderOffset
-            );
-        });
+        const lineGroupGeometries = linesGeometry.find(aLine => aLine.technique === techniqueIndex);
         const hasNormalsAndUvs = uvs !== undefined;
         if (lineGroupGeometries === undefined) {
             lineGroup = new LineGroup(hasNormalsAndUvs, undefined, lineType === LineType.Simple);
             const aLine: LinesGeometry = {
                 type: lineType === LineType.Complex ? GeometryType.SolidLine : GeometryType.Line,
                 technique: techniqueIndex,
-                renderOrderOffset:
-                    renderOrderOffset !== undefined ? Number(renderOrderOffset) : undefined,
                 lines: lineGroup
             };
 
@@ -1788,7 +1776,6 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
     private processLines(linesArray: LinesGeometry[]) {
         linesArray.forEach(linesGeometry => {
             const { vertices, indices } = linesGeometry.lines;
-            const renderOrderOffset = linesGeometry.renderOrderOffset;
             const technique = linesGeometry.technique;
             const buffer = new Float32Array(vertices).buffer as ArrayBuffer;
             const index = new Uint32Array(indices).buffer as ArrayBuffer;
@@ -1807,7 +1794,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                     name: "index"
                 },
                 interleavedVertexAttributes: [attr],
-                groups: [{ start: 0, count: indices.length, technique, renderOrderOffset }],
+                groups: [{ start: 0, count: indices.length, technique }],
                 vertexAttributes: [],
                 featureStarts: linesGeometry.featureStarts,
                 objInfos: linesGeometry.objInfos
@@ -1820,7 +1807,6 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
     private processSimpleLines(linesArray: LinesGeometry[]) {
         linesArray.forEach(linesGeometry => {
             const { vertices, indices } = linesGeometry.lines;
-            const renderOrderOffset = linesGeometry.renderOrderOffset;
             const technique = linesGeometry.technique;
             const buffer = new Float32Array(vertices).buffer as ArrayBuffer;
             const index = new Uint32Array(indices).buffer as ArrayBuffer;
@@ -1839,7 +1825,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                     name: "index"
                 },
                 vertexAttributes: [attr],
-                groups: [{ start: 0, count: indices.length, technique, renderOrderOffset }],
+                groups: [{ start: 0, count: indices.length, technique }],
                 featureStarts: linesGeometry.featureStarts,
                 objInfos: linesGeometry.objInfos
             };


### PR DESCRIPTION
The property `renderOrderOffset` was superseded by dynamic
render order expressions and layer categories.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
