### PR TITLE
Remove unused `featureId` from 'Group'.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -220,7 +220,6 @@ export interface Group {
     start: number;
     count: number;
     technique: number;
-    featureId?: number;
 
     /**
      * Contains tile offsets if its [[Geometry]] has been created.

--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -696,7 +696,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 });
 
                 const count = indices.length - start;
-                groups.push({ start, count, technique: techniqueIndex, featureId });
+                groups.push({ start, count, technique: techniqueIndex });
             } else {
                 logger.warn(
                     `OmvDecodedTileEmitter#processLineFeature: Invalid line technique
@@ -1594,8 +1594,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 groups.push({
                     start: startIndexCount,
                     count,
-                    technique: techniqueIndex,
-                    featureId
+                    technique: techniqueIndex
                 });
             }
         }


### PR DESCRIPTION
The `featureId` property is not used, the omv datasource was setting it
when decoding some of the features but its value was never read.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
