### PR TITLE
HARP-8744 Fix lighting for shadows

### DIFF
--- a/@here/harp-examples/src/threejs_shadows.ts
+++ b/@here/harp-examples/src/threejs_shadows.ts
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    isLiteralDefinition,
-    Style,
-    StyleDeclaration,
-    Theme
-} from "@here/harp-datasource-protocol";
-import { isJsonExpr } from "@here/harp-datasource-protocol/lib/Expr";
+import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import {
@@ -189,22 +183,11 @@ const addOmvDataSource = (): Promise<void> => {
     return map.addDataSource(omvDataSource);
 };
 
-const patchFillStyle = (styleDeclaration: StyleDeclaration) => {
-    if (!isJsonExpr(styleDeclaration)) {
-        const style = styleDeclaration as Style;
-        if (style.technique === "fill") {
-            (style as any).technique = "standard";
-        }
-    }
-};
-
 /**
- * Replace all occurences of "fill" technique in the theme with "standard" technique.
- * "standard" technique is using three.js MeshStandardMaterial and is needed to receive
- * shadows.
+ * Replaces the lights in the style to cast shadows.
  * @param theme The theme to patch
  */
-const patchTheme = (theme: Theme) => {
+const fixLights = (theme: Theme) => {
     theme.lights = [
         {
             type: "ambient",
@@ -214,36 +197,18 @@ const patchTheme = (theme: Theme) => {
         },
         {
             type: "directional",
-            color: "#ffcccc",
+            color: "#ffffff",
             name: "light1",
             intensity: 1,
+            // Will be overriden immediately, see `updateLight`
             direction: {
                 x: 0,
                 y: 0.01,
-                z: 1
+                z: -1
             },
             castShadow: true
         }
     ];
-    if (theme.styles === undefined || theme.styles.tilezen === undefined) {
-        throw Error("Theme has no tilezen styles");
-    }
-
-    if (theme.definitions !== undefined) {
-        for (const definitionName in theme.definitions) {
-            if (!theme.definitions.hasOwnProperty(definitionName)) {
-                continue;
-            }
-            const definition = theme.definitions[definitionName];
-            if (!isLiteralDefinition(definition)) {
-                const styleDeclaration = definition as StyleDeclaration;
-                patchFillStyle(styleDeclaration);
-            }
-        }
-    }
-    theme.styles.tilezen.forEach((styleDeclaration: StyleDeclaration) => {
-        patchFillStyle(styleDeclaration);
-    });
 };
 
 const addGuiElements = () => {
@@ -278,7 +243,7 @@ const addGuiElements = () => {
 
 export namespace ThreejsShadows {
     ThemeLoader.load("resources/berlin_tilezen_base.json").then((theme: Theme) => {
-        patchTheme(theme);
+        fixLights(theme);
         initializeMapView("mapCanvas", theme);
     });
 }

--- a/@here/harp-examples/src/threejs_shadows.ts
+++ b/@here/harp-examples/src/threejs_shadows.ts
@@ -7,12 +7,7 @@
 import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
-import {
-    CopyrightElementHandler,
-    MapView,
-    MapViewEventNames,
-    ThemeLoader
-} from "@here/harp-mapview";
+import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
 import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { assert } from "@here/harp-utils";
 import { GUI } from "dat.gui";
@@ -183,34 +178,6 @@ const addOmvDataSource = (): Promise<void> => {
     return map.addDataSource(omvDataSource);
 };
 
-/**
- * Replaces the lights in the style to cast shadows.
- * @param theme The theme to patch
- */
-const fixLights = (theme: Theme) => {
-    theme.lights = [
-        {
-            type: "ambient",
-            color: "#ffffff",
-            name: "ambientLight",
-            intensity: 0.9
-        },
-        {
-            type: "directional",
-            color: "#ffffff",
-            name: "light1",
-            intensity: 1,
-            // Will be overriden immediately, see `updateLight`
-            direction: {
-                x: 0,
-                y: 0.01,
-                z: -1
-            },
-            castShadow: true
-        }
-    ];
-};
-
 const addGuiElements = () => {
     // Instructions
     const message = document.createElement("div");
@@ -242,8 +209,29 @@ const addGuiElements = () => {
 };
 
 export namespace ThreejsShadows {
-    ThemeLoader.load("resources/berlin_tilezen_base.json").then((theme: Theme) => {
-        fixLights(theme);
-        initializeMapView("mapCanvas", theme);
-    });
+    const theme: Theme = {
+        extends: "resources/berlin_tilezen_base.json",
+        lights: [
+            {
+                type: "ambient",
+                color: "#ffffff",
+                name: "ambientLight",
+                intensity: 0.9
+            },
+            {
+                type: "directional",
+                color: "#ffffff",
+                name: "light1",
+                intensity: 1,
+                // Will be overriden immediately, see `updateLight`
+                direction: {
+                    x: 0,
+                    y: 0.01,
+                    z: -1
+                },
+                castShadow: true
+            }
+        ]
+    };
+    initializeMapView("mapCanvas", theme);
 }

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -121,7 +121,7 @@ export function createMaterial(
     ) {
         settings.fog = options.fog;
     }
-    settings.removeDiffuseLight = technique.name === "fill";
+    settings.removeDiffuseLight = options.shadowsEnabled === true && technique.name === "fill";
 
     const material = new Constructor(settings);
 

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -19,6 +19,7 @@ import {
     Theme,
     Value
 } from "@here/harp-datasource-protocol";
+import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import {
     EarthConstants,
     GeoCoordinates,
@@ -39,8 +40,6 @@ import {
     UriResolver
 } from "@here/harp-utils";
 import * as THREE from "three";
-
-import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import { AnimatedExtrusionHandler } from "./AnimatedExtrusionHandler";
 import { BackgroundDataSource } from "./BackgroundDataSource";
 import { CameraMovementDetector } from "./CameraMovementDetector";
@@ -1053,6 +1052,13 @@ export class MapView extends THREE.EventDispatcher {
         this.m_textElementsRenderer = this.createTextRenderer();
 
         this.drawFrame();
+    }
+
+    /**
+     * Returns the lights configured by the theme.
+     */
+    get lights(): THREE.Light[] {
+        return this.m_createdLights ?? [];
     }
 
     /**

--- a/@here/harp-mapview/lib/ThemeHelpers.ts
+++ b/@here/harp-mapview/lib/ThemeHelpers.ts
@@ -108,7 +108,7 @@ export function toTextureFilter(filter: MagFilter | MinFilter): THREE.TextureFil
 }
 
 /**
- * Create a specific light for lightening the map.
+ * Create a specific light for lighting the map.
  */
 export function createLight(lightDescription: Light): THREE.Light {
     switch (lightDescription.type) {

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -14,6 +14,7 @@ import { DisplacementFeature, DisplacementFeatureParameters } from "./Displaceme
 import { ExtrusionFeatureDefs } from "./MapMeshMaterialsDefs";
 import extrusionShaderChunk from "./ShaderChunks/ExtrusionChunks";
 import fadingShaderChunk from "./ShaderChunks/FadingChunks";
+import { simpleLightingShadowChunk } from "./ShaderChunks/ShadowChunks";
 
 const emptyTexture = new THREE.Texture();
 
@@ -40,6 +41,18 @@ export interface FadingFeatureParameters {
      * Distance to the camera (range: `[0.0, 1.0]`) from which the objects are transparent.
      */
     fadeFar?: number;
+}
+
+/**
+ * Parameter used to control patching the standard material shader to ensure that the materials
+ * color isn't affected by the light direction, only valid for techniques that are "fill"
+ */
+export interface ShadowFeatureParameters {
+    /**
+     * Whether the diffuse light component is removed (i.e. the materials color is therefore just
+     * the ambient + shadow).
+     */
+    removeDiffuseLight?: boolean;
 }
 
 /**
@@ -715,6 +728,27 @@ export class FadingFeatureMixin implements FadingFeature {
     }
 }
 
+/**
+ * Class to apply the code necessary to customize the standard shader to remove the diffuse light
+ * component.
+ */
+export class ShadowFeatureMixin {
+    onBeforeCompile?: CompileCallback;
+    private m_removeDiffuseLight?: boolean;
+
+    protected applyShadowParameters(params?: ShadowFeatureParameters) {
+        this.m_removeDiffuseLight = params?.removeDiffuseLight;
+        if (this.m_removeDiffuseLight === true) {
+            this.onBeforeCompile = chainCallbacks(this.onBeforeCompile, shader => {
+                shader.fragmentShader = THREE.ShaderChunk.meshphysical_frag.replace(
+                    "#include <lights_physical_pars_fragment>",
+                    simpleLightingShadowChunk
+                );
+            });
+        }
+    }
+}
+
 export namespace ExtrusionFeature {
     /**
      * Checks if feature is enabled based on [[ExtrusionFeature]] properties.
@@ -1121,7 +1155,8 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
     constructor(
         params?: THREE.MeshStandardMaterialParameters &
             FadingFeatureParameters &
-            ExtrusionFeatureParameters
+            ExtrusionFeatureParameters &
+            ShadowFeatureParameters
     ) {
         super(params);
 
@@ -1134,6 +1169,8 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
 
         this.addExtrusionProperties();
         this.applyExtrusionParameters({ ...params, zFightingWorkaround: true });
+
+        this.applyShadowParameters(params);
     }
 
     clone(): this {
@@ -1199,6 +1236,20 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
     set extrusionRatio(value: number) {
         // to be overridden
     }
+    /**
+     * This is needed to simplify the lighting calculation, currently there is no support for
+     * switching this at runtime. It is required here to be a parameter because the parameters
+     * are applied to this material, and if this isn't here, three.js will complain that the get/set
+     * properties are missing.
+     * @internal
+     */
+    get removeDiffuseLight(): boolean {
+        return false;
+    }
+    /** @internal */
+    set removeDiffuseLight(val: boolean) {
+        // Stays empty.
+    }
 
     protected addFadingProperties(): void {
         // to be overridden
@@ -1227,6 +1278,14 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
     protected copyExtrusionParameters(source: FadingFeature) {
         // to be overridden
     }
+
+    protected applyShadowParameters(params?: ShadowFeatureParameters) {
+        // to be overriden
+    }
+
+    protected addShadowProperty() {
+        // to be overriden
+    }
     // Mixin declarations end -----------------------------------------------------------
 }
 
@@ -1240,3 +1299,4 @@ applyMixinsWithoutProperties(MapMeshBasicMaterial, [ExtrusionFeatureMixin]);
 applyMixinsWithoutProperties(MapMeshStandardMaterial, [ExtrusionFeatureMixin]);
 applyMixinsWithoutProperties(MapMeshDepthMaterial, [ExtrusionFeatureMixin]);
 applyMixinsWithoutProperties(MapMeshBasicMaterial, [DisplacementFeatureMixin]);
+applyMixinsWithoutProperties(MapMeshStandardMaterial, [ShadowFeatureMixin]);

--- a/@here/harp-materials/lib/ShaderChunks/ShadowChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ShadowChunks.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This shader chunk replaces the default lighting in the standard material, the problem with this
+ * is that the final pixel color is the addition of the material color and the light, this means
+ * that the final map's rendered color is vastly different from that configured by the designers.
+ * This chunk removes the extra highlight by providing just two colors, the material color when not
+ * in shadow and a reduced color value when in shadow (currently 50% of the material's color).
+ */
+export const simpleLightingShadowChunk = `
+    struct PhysicalMaterial {
+        vec3	diffuseColor;
+        float	specularRoughness;
+        vec3	specularColor;
+    };
+
+    #define DEFAULT_SPECULAR_COEFFICIENT 0.04
+
+    void RE_Direct_Physical( const in IncidentLight directLight,
+        const in GeometricContext geometry,
+        const in PhysicalMaterial material,
+        inout ReflectedLight reflectedLight ) {
+        // directLight.color is the light color * shadow, internally three.js uses a step function, so
+        // this value is either the light color or black. in order to lighten up the shadows, we
+        // take add 50% of the color to grey (to give us either pure white or grey) and multiply this to
+        // the material's diffuse color.
+        #if defined(USE_SHADOWMAP)
+            reflectedLight.directDiffuse = (0.5 * directLight.color +
+                vec3(0.5,0.5,0.5)) * material.diffuseColor;
+        #else
+            reflectedLight.directDiffuse = material.diffuseColor;
+        #endif
+    }
+
+    void RE_IndirectDiffuse_Physical( const in vec3 irradiance,
+        const in GeometricContext geometry,
+        const in PhysicalMaterial material,
+        inout ReflectedLight reflectedLight ) {
+            // Disable influence of indirect light (it is handled in the RE_Direct_Physical function)
+    }
+
+    void RE_IndirectSpecular_Physical( const in vec3 radiance,
+        const in vec3 irradiance,
+        const in vec3 clearcoatRadiance,
+        const in GeometricContext geometry,
+        const in PhysicalMaterial material,
+        inout ReflectedLight reflectedLight) {
+            // Disable specular reflection of light.
+    }
+
+    #define RE_Direct               RE_Direct_Physical
+    #define RE_IndirectDiffuse      RE_IndirectDiffuse_Physical
+    #define RE_IndirectSpecular     RE_IndirectSpecular_Physical
+`;


### PR DESCRIPTION
This improves the lighting of flat objects, such that the final rendered pixel color isn't impacted by a diffuse component. Previously the color would be based on the direction (using a diffuse shading model), however this dramatically changes the color of the scene and would require a lot of rework from the designers / different theme files for shadow / non shadowed themes.

- "fill" techniques can now handle shadows, when shadows are enabled, they now
  use a tweaked version of the standard material.

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>
