### PR TITLE
HARP-8498: Refactor object construction in TileGeometryCreator.

### DIFF
--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -66,10 +66,11 @@ import { AnimatedExtrusionTileHandler } from "../AnimatedExtrusionHandler";
 import {
     applyBaseColorToMaterial,
     applySecondaryColorToMaterial,
+    buildObject,
     compileTechniques,
     createMaterial,
     getBufferAttribute,
-    getObjectConstructor
+    usesObject3D
 } from "../DecodedTileHelpers";
 import {
     createDepthPrePassMesh,
@@ -576,9 +577,7 @@ export class TileGeometryCreator {
                     groups[groupIndex].createdOffsets!.push(tile.offset);
                 }
 
-                const ObjectCtor = getObjectConstructor(technique, tile, elevationEnabled);
-
-                if (ObjectCtor === undefined) {
+                if (!usesObject3D(technique)) {
                     continue;
                 }
 
@@ -676,9 +675,12 @@ export class TileGeometryCreator {
                     srcGeometry.featureStarts &&
                     srcGeometry.featureStarts.length > 0;
 
-                const object = new ObjectCtor(
+                const object = buildObject(
+                    technique,
                     bufferGeometry,
-                    hasFeatureGroups ? [material] : material
+                    hasFeatureGroups ? [material] : material,
+                    tile,
+                    elevationEnabled
                 );
 
                 object.renderOrder = technique.renderOrder!;
@@ -1097,7 +1099,13 @@ export class TileGeometryCreator {
                     if (outlineTechnique.secondaryCaps !== undefined) {
                         outlineMaterial.caps = outlineTechnique.secondaryCaps;
                     }
-                    const outlineObj = new ObjectCtor(bufferGeometry, outlineMaterial);
+                    const outlineObj = buildObject(
+                        technique,
+                        bufferGeometry,
+                        outlineMaterial,
+                        tile,
+                        elevationEnabled
+                    );
 
                     outlineObj.renderOrder =
                         outlineTechnique.secondaryRenderOrder !== undefined


### PR DESCRIPTION
Substitude getObjectConstructor by buildObject. Return the created object
instead of the constructor. It's simpler and more flexible, since buildObject
can do more than just choosing a constructor.

Also refactor TileCreationTest to remove all copy-pasta.Frankly the test is useless
and I'd rather remove it completely.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
