### PR TITLE
HARP-9155: Add support for geometry attachments.

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -158,6 +158,43 @@ export interface Geometry {
      * Optional array of objects. It can be used to pass user data from the geometry to the mesh.
      */
     objInfos?: AttributeMap[];
+
+    /**
+     * Optional [[Array]] of [[Attachment]]s.
+     */
+    attachments?: Attachment[];
+}
+
+/**
+ * Attachments together with [[Geometry]] define the meshes and the objects
+ * of a [[Scene]].
+ */
+export interface Attachment {
+    /**
+     * The unique uuid of this [[Attachment]].
+     */
+    uuid?: string;
+
+    /**
+     * The name of this [[Attachment]].
+     */
+    name?: string;
+
+    /**
+     * The index [[BufferAttribute]]. If not provided the index
+     * buffer of the [[Geometry]] will be used.
+     */
+    index?: BufferAttribute;
+
+    /**
+     * Optional additional buffer index used to create an edge object.
+     */
+    edgeIndex?: BufferAttribute;
+
+    /**
+     * The draw [[Group]]]s of this [[Attachment]].
+     */
+    groups: Group[];
 }
 
 /**

--- a/@here/harp-mapview-decoder/lib/TileDecoderService.ts
+++ b/@here/harp-mapview-decoder/lib/TileDecoderService.ts
@@ -119,6 +119,13 @@ export class TileDecoderService extends WorkerService {
                 const obj = geom.objInfos[0] as any;
                 transferBufferAttribute(obj.displacementMap);
             }
+
+            if (Array.isArray(geom.attachments)) {
+                geom.attachments.forEach(attachment => {
+                    transferBufferAttribute(attachment.index);
+                    transferBufferAttribute(attachment.edgeIndex);
+                });
+            }
         });
 
         decodedTile.techniques.forEach(technique => {


### PR DESCRIPTION
Geometry attachments can be used to create sets of
objects sharing buffer and feature data (e.g. objInfos).

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
