### PR TITLE
HARP-9861: Disable TextElementsRenderer overload mode.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1069,7 +1069,8 @@ export class TextElementsRenderer {
         this.m_textElementStateCache.clearTextCache();
         this.m_cacheInvalidated = false;
 
-        this.checkIfOverloaded(dataSourceTileList);
+        // TODO: HARP-9874. Remove overload mode and implement a label placement time limit.
+        //this.checkIfOverloaded(dataSourceTileList);
 
         // Used with tile offset to compute the x coordinate offset for tiles.
         const updateStartTime =


### PR DESCRIPTION
It's skipping label placements when rendered tiles have more than 20K labels
(even if they're not rendered in the current zoom level).

Label placement frame time limit will be reimplemented as part of HARP-9874.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
