### PR TITLE
HARP-9576 Fix styling data-driven example

### DIFF
--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -32,7 +32,7 @@ export namespace DataDrivenThemeExample {
         }
     </style>
     <p id=info>This example shows how to utilize the data from the styles.<br/>` +
-        `Here the population of a country is displayed below its name.</p>`;
+        `Here the population of a city is displayed below its name.</p>`;
     function initializeMapView(id: string): MapView {
         const canvas = document.getElementById(id) as HTMLCanvasElement;
 
@@ -41,7 +41,7 @@ export namespace DataDrivenThemeExample {
             theme: {
                 extends: "resources/berlin_tilezen_base.json",
                 definitions: {
-                    countryPopulationLevel: {
+                    cityPopulationLevel: {
                         type: "number",
                         value: ["-", ["log10", ["number", ["get", "population"], 1000]], 3]
                     }
@@ -54,12 +54,12 @@ export namespace DataDrivenThemeExample {
                             when: [
                                 "all",
                                 ["==", ["get", "$layer"], "places"],
-                                ["==", ["get", "kind"], "country"]
+                                ["==", ["get", "kind"], "locality"]
                             ],
                             technique: "text",
                             attr: {
-                                priority: ["+", 100, ["^", 2, ["ref", "countryPopulationLevel"]]],
-                                size: ["+", 8, ["^", 1.7, ["ref", "countryPopulationLevel"]]],
+                                priority: ["+", 100, ["^", 2, ["ref", "cityPopulationLevel"]]],
+                                size: ["+", 8, ["^", 2, ["ref", "cityPopulationLevel"]]],
                                 text: [
                                     "concat",
                                     ["coalesce", ["get", "name:en"], ["get", "name"]],
@@ -70,13 +70,13 @@ export namespace DataDrivenThemeExample {
                                 backgroundColor: "#FFFFFF",
                                 backgroundOpacity: 0.7,
                                 fontVariant: "SmallCaps",
-                                opacity: 0.9
+                                opacity: 0.9,
+                                textFadeTime: 0
                             }
                         }
                     ]
                 }
             },
-            disableFading: true,
             target: new GeoCoordinates(50.443041, 11.4229649),
             zoomLevel: 5
         });

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -474,6 +474,7 @@ export class TileGeometryCreator {
                 textElement.kind = technique.kind;
                 // Get the userData for text element picking.
                 textElement.userData = textPath.objInfos;
+                textElement.textFadeTime = technique.textFadeTime;
 
                 tile.addTextElement(textElement);
             }
@@ -561,10 +562,10 @@ export class TileGeometryCreator {
 
                     textElement.fadeNear = fadeNear;
                     textElement.fadeFar = fadeFar;
+                    textElement.textFadeTime = technique.textFadeTime;
 
                     // Get the userData for text element picking.
                     textElement.userData = userData;
-
                     tile.addTextElement(textElement);
                 }
             }

--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -30,16 +30,29 @@ export const DEFAULT_FADE_TIME = 800;
  * @hidden
  */
 export class RenderState {
+    /**
+     * Current fading value [0..1]
+     */
+    value: number = 0.0;
+
+    /**
+     * Timestamp the fading started.
+     */
+    startTime: number = 0;
+
+    /**
+     * Computed opacity depending on value.
+     */
+    opacity: number = 1.0;
+
     private m_state = FadingState.Undefined;
 
     /**
      * Create a `RenderState`.
      *
-     * @param value Current fading value [0..1].
-     * @param startTime Time stamp the fading started.
-     * @param opacity Computed opacity depending on value.
+     * @param fadeTime The duration of the fading in milliseconds.
      */
-    constructor(public value = 0.0, public startTime = 0, public opacity = 1.0) {}
+    constructor(public fadeTime = DEFAULT_FADE_TIME) {}
 
     /**
      * Reset existing `RenderState` to appear like a fresh state.
@@ -122,7 +135,7 @@ export class RenderState {
             // The fadeout is not complete: compute the virtual fadingStartTime in the past, to get
             // a correct end time:
             this.value = 1.0 - this.value;
-            this.startTime = time - this.value * DEFAULT_FADE_TIME;
+            this.startTime = time - this.value * this.fadeTime;
         } else {
             this.startTime = time;
             this.value = 0.0;
@@ -147,7 +160,7 @@ export class RenderState {
         if (this.m_state === FadingState.FadingIn) {
             // The fade-in is not complete: compute the virtual fadingStartTime in the past, to get
             // a correct end time:
-            this.startTime = time - this.value * DEFAULT_FADE_TIME;
+            this.startTime = time - this.value * this.fadeTime;
             this.value = 1.0 - this.value;
         } else {
             this.startTime = time;
@@ -179,7 +192,7 @@ export class RenderState {
         const startValue = this.m_state === FadingState.FadingIn ? 0 : 1;
         const endValue = this.m_state === FadingState.FadingIn ? 1 : 0;
 
-        if (disableFading || fadingTime >= DEFAULT_FADE_TIME) {
+        if (disableFading || fadingTime >= this.fadeTime) {
             this.value = 1.0;
             this.opacity = endValue;
             this.m_state =
@@ -187,7 +200,7 @@ export class RenderState {
         } else {
             // TODO: HARP-7648. Do this once for all labels (calculate the last frame value
             // increment).
-            this.value = fadingTime / DEFAULT_FADE_TIME;
+            this.value = fadingTime / this.fadeTime;
 
             this.opacity = THREE.MathUtils.clamp(
                 MathUtils.smootherStep(startValue, endValue, this.value),

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -327,6 +327,12 @@ export class TextElement {
 
     pathLengthSqr?: number;
 
+    /**
+     * Time to fade in text in milliseconds.
+     * @default [[DEFAULT_FADE_TIME]] 800
+     */
+    textFadeTime?: number;
+
     type: TextElementType;
 
     private m_poiInfo?: PoiInfo;

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -117,11 +117,11 @@ export class TextElementState {
      * be out of view.
      */
     update(viewDistance: number | undefined) {
-        if (this.initialized) {
-            this.setViewDistance(viewDistance);
-        } else if (viewDistance !== undefined) {
-            this.initialize(viewDistance);
+        if (!this.initialized && viewDistance !== undefined) {
+            this.initializeRenderStates();
         }
+
+        this.setViewDistance(viewDistance);
     }
 
     /**
@@ -130,9 +130,6 @@ export class TextElementState {
      * be out of view.
      */
     setViewDistance(viewDistance: number | undefined) {
-        if (viewDistance === this.m_viewDistance) {
-            return;
-        }
         this.m_viewDistance = viewDistance;
     }
 
@@ -206,28 +203,28 @@ export class TextElementState {
     }
 
     /**
-     * @param viewDistance Current distance of the element to the view center.
+     * Initialize text and icon render states
      */
-    private initialize(viewDistance: number) {
+    private initializeRenderStates() {
         assert(this.m_textRenderState === undefined);
         assert(this.m_iconRenderStates === undefined);
 
-        this.setViewDistance(viewDistance);
-
+        const { textFadeTime } = this.element;
+        const iconFadeTime = this.element.poiInfo?.technique.iconFadeTime;
         if (this.element.type === TextElementType.LineMarker) {
             this.m_iconRenderStates = new Array<RenderState>();
             for (const _point of this.element.points as THREE.Vector3[]) {
                 const iconRenderStates = this.m_iconRenderStates as RenderState[];
-                const renderState = new RenderState();
+                const renderState = new RenderState(iconFadeTime);
                 iconRenderStates.push(renderState);
             }
             return;
         }
 
-        this.m_textRenderState = new RenderState();
+        this.m_textRenderState = new RenderState(textFadeTime);
 
         if (this.element.type === TextElementType.PoiLabel) {
-            this.m_iconRenderStates = new RenderState();
+            this.m_iconRenderStates = new RenderState(iconFadeTime);
         }
     }
 }

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1355,7 +1355,7 @@ export class TextElementsRenderer {
             placementStats.log();
         }
 
-        if (!this.m_options.disableFading && renderParams.fadeAnimationRunning) {
+        if (renderParams.fadeAnimationRunning) {
             this.m_viewUpdateCallback();
         }
     }

--- a/@here/harp-mapview/test/RenderStateTest.ts
+++ b/@here/harp-mapview/test/RenderStateTest.ts
@@ -1,0 +1,403 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable: no-unused-expression
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { expect } from "chai";
+
+import { DEFAULT_FADE_TIME, FadingState, RenderState } from "../lib/text/RenderState";
+
+describe("RenderState", function() {
+    describe("constructor", function() {
+        it("sets default fade time", function() {
+            const renderState = new RenderState();
+            expect(renderState.fadeTime).to.equal(DEFAULT_FADE_TIME);
+        });
+
+        it("sets default fade time when undefined is given as fade time", function() {
+            const renderState = new RenderState(undefined);
+            expect(renderState.fadeTime).to.equal(DEFAULT_FADE_TIME);
+        });
+
+        it("sets given fade time", function() {
+            const renderState = new RenderState(123);
+            expect(renderState.fadeTime).to.equal(123);
+        });
+    });
+
+    describe("reset", function() {
+        it("resets a new render state", function() {
+            const renderState = new RenderState();
+            renderState.reset();
+            expect(renderState.isUndefined()).to.be.true;
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.startTime).to.equal(0.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("resets a fading in render state", function() {
+            const renderState = new RenderState();
+            renderState.value = 1.0;
+            renderState.startTime = 2.0;
+            renderState.opacity = 0.5;
+            (renderState as any).m_state = FadingState.FadingIn;
+            renderState.reset();
+            expect(renderState.isUndefined()).to.be.true;
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.startTime).to.equal(0.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+    });
+
+    describe("isUndefined", function() {
+        it("returns true for undefined render states", function() {
+            const renderState = new RenderState();
+            expect(renderState.isUndefined()).to.be.true;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isUndefined()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isUndefined()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isUndefined()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isUndefined()).to.be.false;
+        });
+    });
+
+    describe("isFading", function() {
+        it("returns true for fading in and fading out render states", function() {
+            const renderState = new RenderState();
+            expect(renderState.isFading()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isFading()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isFading()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isFading()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isFading()).to.be.false;
+        });
+    });
+
+    describe("isFadingIn", function() {
+        it("returns true for fading in out render states", function() {
+            const renderState = new RenderState();
+            expect(renderState.isFadingIn()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isFadingIn()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isFadingIn()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isFadingIn()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isFadingIn()).to.be.false;
+        });
+    });
+
+    describe("isFadingOut", function() {
+        it("returns true for fading out render states", function() {
+            const renderState = new RenderState();
+            expect(renderState.isFadingOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isFadingOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isFadingOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isFadingOut()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isFadingOut()).to.be.false;
+        });
+    });
+
+    describe("isFadedIn", function() {
+        it("returns true for faded in render states", function() {
+            const renderState = new RenderState();
+            expect(renderState.isFadedIn()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isFadedIn()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isFadedIn()).to.be.true;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isFadedIn()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isFadedIn()).to.be.false;
+        });
+    });
+
+    describe("isFadedOut", function() {
+        it("returns true for faded out render states", function() {
+            const renderState = new RenderState();
+            expect(renderState.isFadedOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isFadedOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isFadedOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isFadedOut()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isFadedOut()).to.be.true;
+        });
+    });
+
+    describe("isVisible", function() {
+        it("returns true if render states are not undefined or faded out", function() {
+            const renderState = new RenderState();
+            expect(renderState.isVisible()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isVisible()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isVisible()).to.be.true;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isVisible()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isVisible()).to.be.false;
+        });
+    });
+
+    describe("startFadeIn", function() {
+        it("transitions an undefined state to fade in", function() {
+            const renderState = new RenderState();
+            renderState.startFadeIn(100);
+
+            expect(renderState.isFadingIn()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+
+        it("does not change an already fading in state", function() {
+            const renderState = new RenderState();
+            renderState.startFadeIn(100);
+            renderState.startFadeIn(200);
+
+            expect(renderState.isFadingIn()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+
+        it("does not change an already faded in state", function() {
+            const renderState = new RenderState();
+            renderState.value = 1.0;
+            renderState.startTime = 100;
+            renderState.opacity = 1.0;
+            (renderState as any).m_state = FadingState.FadedIn;
+            renderState.startFadeIn(200);
+
+            expect(renderState.isFadedIn()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("sets a fading out state to fading in", function() {
+            const renderState = new RenderState();
+            renderState.value = 0.6;
+            renderState.startTime = 100;
+            renderState.opacity = 0.6;
+            (renderState as any).m_state = FadingState.FadingOut;
+            renderState.startFadeIn(200);
+
+            expect(renderState.isFadingIn()).to.be.true;
+            expect(renderState.startTime).to.equal(-120);
+            expect(renderState.value).to.equal(0.4);
+            expect(renderState.opacity).to.equal(0.6);
+        });
+
+        it("fades in a faded out state", function() {
+            const renderState = new RenderState();
+            renderState.value = 0.0;
+            renderState.startTime = 100;
+            renderState.opacity = 0.0;
+
+            (renderState as any).m_state = FadingState.FadedOut;
+            renderState.startFadeIn(200);
+
+            expect(renderState.isFadingIn()).to.be.true;
+            expect(renderState.startTime).to.equal(200);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+    });
+
+    describe("startFadeOut", function() {
+        it("transitions an undefined state to fading out", function() {
+            const renderState = new RenderState();
+            renderState.startFadeOut(100);
+
+            expect(renderState.isFadingOut()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("does not change an already fading out state", function() {
+            const renderState = new RenderState();
+            renderState.startFadeOut(100);
+            renderState.startFadeOut(200);
+
+            expect(renderState.isFadingOut()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("does not change an already faded out state", function() {
+            const renderState = new RenderState();
+            renderState.value = 1.0;
+            renderState.startTime = 100;
+            renderState.opacity = 0.0;
+            (renderState as any).m_state = FadingState.FadedOut;
+
+            renderState.startFadeOut(200);
+
+            expect(renderState.isFadedOut()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+
+        it("sets a fading in state to fading out", function() {
+            const renderState = new RenderState();
+            renderState.value = 0.6;
+            renderState.startTime = 100;
+            renderState.opacity = 0.6;
+            (renderState as any).m_state = FadingState.FadingIn;
+
+            renderState.startFadeOut(200);
+
+            expect(renderState.isFadingOut()).to.be.true;
+            expect(renderState.startTime).to.equal(-280);
+            expect(renderState.value).to.equal(0.4);
+            expect(renderState.opacity).to.equal(0.6);
+        });
+
+        it("fades out a faded in state", function() {
+            const renderState = new RenderState();
+            renderState.value = 1.0;
+            renderState.startTime = 100;
+            renderState.opacity = 1.0;
+            (renderState as any).m_state = FadingState.FadedIn;
+
+            renderState.startFadeOut(200);
+
+            expect(renderState.isFadingOut()).to.be.true;
+            expect(renderState.startTime).to.equal(200);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+    });
+
+    describe("updateFading", function() {
+        it("does not update undefined states", function() {
+            const renderState = new RenderState();
+            renderState.updateFading(100, false);
+
+            expect(renderState.isUndefined()).to.be.true;
+            expect(renderState.startTime).to.equal(0);
+            expect(renderState.value).to.equal(0.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("does not update faded in states", function() {
+            const renderState = new RenderState();
+            renderState.value = 1.0;
+            renderState.startTime = 0;
+            renderState.opacity = 1.0;
+            (renderState as any).m_state = FadingState.FadedIn;
+
+            renderState.updateFading(100, false);
+
+            expect(renderState.isFadedIn()).to.be.true;
+            expect(renderState.startTime).to.equal(0);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("does not update faded out states", function() {
+            const renderState = new RenderState();
+            renderState.value = 1.0;
+            renderState.startTime = 0;
+            renderState.opacity = 0.0;
+            (renderState as any).m_state = FadingState.FadedOut;
+
+            renderState.updateFading(100, false);
+
+            expect(renderState.isFadedOut()).to.be.true;
+            expect(renderState.startTime).to.equal(0);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+
+        it("updates fading in states", function() {
+            const renderState = new RenderState();
+            renderState.startFadeIn(100);
+            renderState.updateFading(200, false);
+
+            expect(renderState.isFadingIn()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(0.125);
+            expect(renderState.opacity).to.equal(0.01605224609375);
+        });
+
+        it("switches to faded in after fading time passed", function() {
+            const renderState = new RenderState();
+            renderState.startFadeIn(100);
+            renderState.updateFading(100 + DEFAULT_FADE_TIME, false);
+
+            expect(renderState.isFadedIn()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("skips fading in when fading is disabled", function() {
+            const renderState = new RenderState();
+            renderState.startFadeIn(100);
+            renderState.updateFading(200, true);
+
+            expect(renderState.isFadedIn()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(1.0);
+        });
+
+        it("updates fading out states", function() {
+            const renderState = new RenderState();
+            renderState.startFadeOut(100);
+            renderState.updateFading(200, false);
+
+            expect(renderState.isFadingOut()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(0.125);
+            expect(renderState.opacity).to.equal(0.98394775390625);
+        });
+
+        it("switches to faded out after fading time passed", function() {
+            const renderState = new RenderState();
+            renderState.startFadeOut(100);
+            renderState.updateFading(100 + DEFAULT_FADE_TIME, false);
+
+            expect(renderState.isFadedOut()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+
+        it("skips fading out when fading is disabled", function() {
+            const renderState = new RenderState();
+            renderState.startFadeOut(100);
+            renderState.updateFading(200, true);
+
+            expect(renderState.isFadedOut()).to.be.true;
+            expect(renderState.startTime).to.equal(100);
+            expect(renderState.value).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
+        });
+    });
+});

--- a/@here/harp-mapview/test/TextElementStateTest.ts
+++ b/@here/harp-mapview/test/TextElementStateTest.ts
@@ -1,0 +1,416 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable: no-unused-expression
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { expect } from "chai";
+
+import { TextElementState } from "../lib/text/TextElementState";
+import { TextElementType } from "../lib/text/TextElementType";
+
+describe("TextElementState", function() {
+    describe("initialized", function() {
+        it("returns false for uninitialized state", function() {
+            const textElementState = new TextElementState({} as any);
+            expect(textElementState.initialized).to.be.false;
+        });
+
+        it("returns true for initialized state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel
+            } as any);
+            textElementState.update(0);
+            expect(textElementState.initialized).to.be.true;
+        });
+    });
+
+    describe("visible", function() {
+        it("returns false for uninitialized state", function() {
+            const textElementState = new TextElementState({} as any);
+            expect(textElementState.visible).to.be.false;
+        });
+
+        it("returns false when text is initialized but invisible", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel
+            } as any);
+            textElementState.update(0);
+            expect(textElementState.visible).to.be.false;
+        });
+
+        it("returns false when text and icon are initialized but invisible", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(0);
+            expect(textElementState.visible).to.be.false;
+        });
+
+        it("returns true when text is initialized and visible", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel
+            } as any);
+            textElementState.update(0);
+            textElementState.textRenderState!.startFadeIn(0);
+            expect(textElementState.visible).to.be.true;
+        });
+
+        it("returns true when icon is initialized and visible", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(0);
+            textElementState.iconRenderState!.startFadeIn(0);
+            expect(textElementState.visible).to.be.true;
+        });
+
+        it("returns true when icons are initialized and visible", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.LineMarker,
+                poiInfo: {
+                    technique: {}
+                },
+                points: [
+                    [0, 0],
+                    [0, 1]
+                ]
+            } as any);
+            textElementState.update(0);
+            textElementState.iconRenderStates![0].startFadeIn(0);
+            expect(textElementState.visible).to.be.true;
+        });
+    });
+
+    describe("reset", function() {
+        it("resets uninitialized state", function() {
+            const textElementState = new TextElementState({} as any);
+            expect(() => textElementState.reset()).to.not.throw();
+            expect(textElementState.viewDistance).to.be.undefined;
+        });
+
+        it("resets text state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel
+            } as any);
+            textElementState.update(0);
+            expect(() => textElementState.reset()).to.not.throw();
+
+            expect(textElementState.textRenderState!.isUndefined()).to.be.true;
+            expect(textElementState.viewDistance).to.be.undefined;
+        });
+
+        it("resets text and icon state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(0);
+            expect(() => textElementState.reset()).to.not.throw();
+
+            expect(textElementState.textRenderState!.isUndefined()).to.be.true;
+            expect(textElementState.iconRenderState!.isUndefined()).to.be.true;
+            expect(textElementState.viewDistance).to.be.undefined;
+        });
+
+        it("resets text and icons state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.LineMarker,
+                poiInfo: {
+                    technique: {}
+                },
+                points: [
+                    [0, 0],
+                    [0, 1]
+                ]
+            } as any);
+            textElementState.update(0);
+            expect(() => textElementState.reset()).to.not.throw();
+
+            expect(textElementState.iconRenderStates![0].isUndefined()).to.be.true;
+            expect(textElementState.iconRenderStates![1].isUndefined()).to.be.true;
+            expect(textElementState.viewDistance).to.be.undefined;
+        });
+    });
+
+    describe("replace", function() {
+        it("replaces an existing text element", function() {
+            const predecessorState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            predecessorState.update(0);
+            const predecessorText = predecessorState.textRenderState!;
+            const predecessorIcon = predecessorState.iconRenderState!;
+
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            predecessorState.update(0);
+
+            textElementState.replace(predecessorState);
+            expect(predecessorState.textRenderState).to.be.undefined;
+            expect(predecessorState.iconRenderState).to.be.undefined;
+            expect(predecessorState.iconRenderState).to.be.undefined;
+
+            expect(textElementState.textRenderState).to.equal(predecessorText);
+            expect(textElementState.iconRenderState).to.equal(predecessorIcon);
+        });
+
+        it("reuses text element glyphs and bounds", function() {
+            const predecessorState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                },
+                glyphs: {},
+                bounds: {},
+                glyphCaseArray: []
+            } as any);
+            predecessorState.update(0);
+            const predecessorGlyphs = predecessorState.element.glyphs;
+            const predecessorBounds = predecessorState.element.bounds;
+            const predecessorGlyphCaseArray = predecessorState.element.glyphCaseArray;
+
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            predecessorState.update(0);
+
+            textElementState.replace(predecessorState);
+            expect(textElementState.element.glyphs).to.equal(predecessorGlyphs);
+            expect(textElementState.element.bounds).to.equal(predecessorBounds);
+            expect(textElementState.element.glyphCaseArray).to.equal(predecessorGlyphCaseArray);
+        });
+    });
+
+    describe("update", function() {
+        it("does not initialize a text element state if view distance is undefined", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(undefined);
+
+            expect(textElementState.textRenderState).to.be.undefined;
+            expect(textElementState.iconRenderState).to.be.undefined;
+            expect(textElementState.viewDistance).to.be.undefined;
+        });
+
+        it("initializes a text element state and sets view distance", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(100);
+
+            expect(textElementState.textRenderState).to.not.be.undefined;
+            expect(textElementState.iconRenderState).to.not.be.undefined;
+            expect(textElementState.viewDistance).to.equal(100);
+        });
+
+        it("uses fading time from technique", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {
+                        textFadeTime: 100,
+                        iconFadeTime: 100
+                    }
+                },
+                textFadeTime: 100
+            } as any);
+            textElementState.update(100);
+
+            expect(textElementState.textRenderState).to.not.be.undefined;
+            expect(textElementState.textRenderState!.fadeTime).to.equal(100);
+            expect(textElementState.iconRenderState).to.not.be.undefined;
+            expect(textElementState.iconRenderState!.fadeTime).to.equal(100);
+            expect(textElementState.viewDistance).to.equal(100);
+        });
+
+        it("uses fading time from technique for line marker", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.LineMarker,
+                poiInfo: {
+                    technique: {
+                        textFadeTime: 100,
+                        iconFadeTime: 100
+                    }
+                },
+                textFadeTime: 100,
+                points: [
+                    [0, 1],
+                    [0, 2]
+                ]
+            } as any);
+            textElementState.update(100);
+
+            expect(textElementState.textRenderState).to.be.undefined;
+            expect(textElementState.iconRenderStates).to.not.be.undefined;
+            expect(textElementState.iconRenderStates![0].fadeTime).to.equal(100);
+            expect(textElementState.iconRenderStates![1].fadeTime).to.equal(100);
+            expect(textElementState.viewDistance).to.equal(100);
+        });
+
+        it("updates a initialized text element state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(100);
+
+            expect(textElementState.textRenderState).to.not.be.undefined;
+            expect(textElementState.iconRenderState).to.not.be.undefined;
+            expect(textElementState.viewDistance).to.equal(100);
+
+            textElementState.update(200);
+            expect(textElementState.viewDistance).to.equal(200);
+        });
+    });
+
+    describe("renderDistance", function() {
+        it("returns 0 if element is always on top", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                },
+                alwaysOnTop: true
+            } as any);
+            textElementState.update(100);
+
+            expect(textElementState.renderDistance).to.equal(0);
+        });
+
+        it("returns inversed view distance", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(100);
+
+            expect(textElementState.renderDistance).to.equal(-100);
+        });
+
+        it("returns 0 if view distance ", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(undefined);
+
+            expect(textElementState.renderDistance).to.equal(0);
+        });
+    });
+
+    describe("updateFading", function() {
+        it("ignores uninitialized states", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+
+            textElementState.updateFading(100, false);
+            expect(textElementState.textRenderState).to.be.undefined;
+            expect(textElementState.iconRenderState).to.be.undefined;
+            expect(textElementState.iconRenderStates).to.be.undefined;
+        });
+
+        it("updates text render state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel
+            } as any);
+            textElementState.update(100);
+            textElementState.textRenderState!.startFadeIn(50);
+            textElementState.updateFading(100, false);
+
+            expect(textElementState.textRenderState).to.not.be.undefined;
+            expect(textElementState.textRenderState!.isFadingIn()).to.be.true;
+            expect(textElementState.textRenderState!.value).to.equal(0.0625);
+            expect(textElementState.textRenderState!.opacity).to.equal(0.0022182464599609375);
+        });
+
+        it("updates icon render state", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                }
+            } as any);
+            textElementState.update(100);
+            textElementState.textRenderState!.startFadeIn(50);
+            textElementState.iconRenderState!.startFadeIn(50);
+            textElementState.updateFading(100, false);
+
+            expect(textElementState.textRenderState).to.not.be.undefined;
+            expect(textElementState.textRenderState!.isFadingIn()).to.be.true;
+            expect(textElementState.textRenderState!.value).to.equal(0.0625);
+            expect(textElementState.textRenderState!.opacity).to.equal(0.0022182464599609375);
+
+            expect(textElementState.iconRenderState).to.not.be.undefined;
+            expect(textElementState.iconRenderState!.isFadingIn()).to.be.true;
+            expect(textElementState.iconRenderState!.value).to.equal(0.0625);
+            expect(textElementState.iconRenderState!.opacity).to.equal(0.0022182464599609375);
+        });
+
+        it("updates icon render states", function() {
+            const textElementState = new TextElementState({
+                type: TextElementType.LineMarker,
+                poiInfo: {
+                    technique: {}
+                },
+                points: [
+                    [0, 1],
+                    [0, 2]
+                ]
+            } as any);
+            textElementState.update(100);
+            textElementState.iconRenderStates![0].startFadeIn(50);
+            textElementState.iconRenderStates![1].startFadeIn(50);
+            textElementState.updateFading(100, false);
+
+            expect(textElementState.iconRenderStates![0]).to.not.be.undefined;
+            expect(textElementState.iconRenderStates![0].isFadingIn()).to.be.true;
+            expect(textElementState.iconRenderStates![0].value).to.equal(0.0625);
+            expect(textElementState.iconRenderStates![0].opacity).to.equal(0.0022182464599609375);
+
+            expect(textElementState.iconRenderStates![1]).to.not.be.undefined;
+            expect(textElementState.iconRenderStates![1].isFadingIn()).to.be.true;
+            expect(textElementState.iconRenderStates![1].value).to.equal(0.0625);
+            expect(textElementState.iconRenderStates![1].opacity).to.equal(0.0022182464599609375);
+        });
+    });
+});


### PR DESCRIPTION
* Change to display of city population (countries do not contain population in new data source).
* Fix MapView.disableFadeIn option.
* Implement textFadeTime and iconFadeTime.

Signed-off-by: Marcel Pursche <marcel.pursche@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
