### PR TITLE
HARP-9897: Add support for vector2/3/4 operators.

### DIFF
--- a/@here/harp-datasource-protocol/StyleExpressions.md
+++ b/@here/harp-datasource-protocol/StyleExpressions.md
@@ -165,6 +165,33 @@ returns the value of the first `fallback` that is a number.
 ["to-number", value, fallback...]
 ```
 
+## to-vector2
+
+Converts the value to "vector2", if the value cannot be converted to a vector2
+returns the value of the first `fallback` that is a vector2.
+
+```javascript
+["to-vector2", value, fallback...]
+```
+
+## to-vector3
+
+Converts the value to "vector3", if the value cannot be converted to a vector3
+returns the value of the first `fallback` that is a vector3.
+
+```javascript
+["to-vector3", value, fallback...]
+```
+
+## to-vector4
+
+Converts the value to "vector4", if the value cannot be converted to a vector4
+returns the value of the first `fallback` that is a vector4.
+
+```javascript
+["to-vector4", value, fallback...]
+```
+
 ## literal
 
 Returns the given object or array.
@@ -300,6 +327,33 @@ fallback that is a `string`.
 ["string", value, fallback...]
 ```
 
+## vector2
+
+Returns `value` if it is `vector2`; otherwise, returns the first
+fallback that is a `vector2`.
+
+```javascript
+["vector2", value, fallback...]
+```
+
+## vector3
+
+Returns `value` if it is `vector3`; otherwise, returns the first
+fallback that is a `vector3`.
+
+```javascript
+["vector3", value, fallback...]
+```
+
+## vector4
+
+Returns `value` if it is `vector4`; otherwise, returns the first
+fallback that is a `vector4`.
+
+```javascript
+["vector4", value, fallback...]
+```
+
 ## array
 
 Validates the type of the given array value. The `type`
@@ -343,6 +397,23 @@ for example:
 // create an array with the values of the feature properties
 // 'kind' and 'kind_details'
 ["make-array", ["get", "kind"], ["get", "kind_details"]]
+```
+
+## make-vector
+
+Creates a vector 2/3/4 from the given components.
+
+```javascript
+["make-vector", x, y];
+["make-vector", x, y, z];
+["make-vector", x, y, z, w];
+```
+
+for example:
+
+```javascript
+// create a vector2 containing 10 and the value of the feature "y".
+["make-vector", 10, ["get", "y"]]
 ```
 
 ## coalesce

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -15,6 +15,8 @@ import {
 } from "./InterpolatedPropertyDefs";
 import { Definitions, isBoxedDefinition, isLiteralDefinition } from "./Theme";
 
+import * as THREE from "three";
+
 export * from "./Env";
 
 const exprEvaluator = new ExprEvaluator();
@@ -628,6 +630,13 @@ class ExprSerializer implements ExprVisitor<JsonValue, void> {
     }
 
     visitObjectLiteralExpr(expr: ObjectLiteralExpr, context: void): JsonValue {
+        if (expr.value instanceof THREE.Vector2) {
+            return ["make-vector", expr.value.x, expr.value.y];
+        } else if (expr.value instanceof THREE.Vector3) {
+            return ["make-vector", expr.value.x, expr.value.y, expr.value.z];
+        } else if (expr.value instanceof THREE.Vector4) {
+            return ["make-vector", expr.value.x, expr.value.y, expr.value.z, expr.value.w];
+        }
         return ["literal", expr.value as JsonObject];
     }
 

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -36,6 +36,7 @@ import { MiscOperators } from "./operators/MiscOperators";
 import { ObjectOperators } from "./operators/ObjectOperators";
 import { StringOperators } from "./operators/StringOperators";
 import { TypeOperators } from "./operators/TypeOperators";
+import { VectorOperators } from "./operators/VectorOperators";
 
 export interface OperatorDescriptor {
     /**
@@ -234,3 +235,4 @@ ExprEvaluator.defineOperators(InterpolationOperators);
 ExprEvaluator.defineOperators(ObjectOperators);
 ExprEvaluator.defineOperators(FeatureOperators);
 ExprEvaluator.defineOperators(MapOperators);
+ExprEvaluator.defineOperators(VectorOperators);

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -17,6 +17,7 @@ import {
     HasAttributeExpr,
     isJsonExpr,
     JsonExpr,
+    LiteralExpr,
     MatchExpr,
     NullLiteralExpr,
     NumberLiteralExpr,
@@ -26,7 +27,6 @@ import {
     VarExpr
 } from "./Expr";
 import { ExprPool } from "./ExprPool";
-import {} from "./InterpolatedProperty";
 import {
     interpolatedPropertyDefinitionToJsonExpr,
     isInterpolatedPropertyDefinition
@@ -958,10 +958,20 @@ export function makeDecodedTechnique(technique: IndexedTechnique): IndexedTechni
         if (!technique.hasOwnProperty(attrName)) {
             continue;
         }
+
         let attrValue: any = (technique as any)[attrName];
+
+        if (
+            typeof attrValue === "object" &&
+            (attrValue.isVector2 || attrValue.isVector3 || attrValue.isVector4)
+        ) {
+            attrValue = LiteralExpr.fromValue(attrValue);
+        }
+
         if (Expr.isExpr(attrValue)) {
             attrValue = attrValue.toJSON();
         }
+
         (result as any)[attrName] = attrValue;
     }
     return (result as any) as IndexedTechnique;

--- a/@here/harp-datasource-protocol/lib/operators/VectorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/VectorOperators.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Value } from "../Env";
+import { CallExpr, NumberLiteralExpr } from "../Expr";
+import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
+
+import * as THREE from "three";
+
+type MakeVectorCallExpr = CallExpr & {
+    _value?: THREE.Vector2 | THREE.Vector3 | THREE.Vector4;
+};
+
+function isVector(
+    context: ExprEvaluatorContext,
+    call: CallExpr,
+    type: "vector2" | "vector3" | "vector4"
+): Value {
+    let ctor: new () => object;
+    switch (type) {
+        case "vector2":
+            ctor = THREE.Vector2;
+            break;
+        case "vector3":
+            ctor = THREE.Vector3;
+            break;
+        case "vector4":
+            ctor = THREE.Vector4;
+            break;
+    }
+    for (const childExpr of call.args) {
+        const value = context.evaluate(childExpr);
+        if (value instanceof ctor) {
+            return value;
+        }
+    }
+    throw new Error(`expected a "${type}"`);
+}
+
+function toVector(
+    context: ExprEvaluatorContext,
+    call: CallExpr,
+    type: "vector2" | "vector3" | "vector4"
+): Value {
+    let VectorCtor: any;
+    let components: number;
+
+    switch (type) {
+        case "vector2":
+            VectorCtor = THREE.Vector2;
+            components = 2;
+            break;
+        case "vector3":
+            VectorCtor = THREE.Vector3;
+            components = 3;
+            break;
+        case "vector4":
+            VectorCtor = THREE.Vector4;
+            components = 4;
+            break;
+    }
+
+    for (const childExpr of call.args) {
+        const value = context.evaluate(childExpr);
+        if (value instanceof VectorCtor) {
+            return value;
+        } else if (
+            Array.isArray(value) &&
+            value.length === components &&
+            value.every(v => typeof v === "number")
+        ) {
+            return new VectorCtor().fromArray(value);
+        }
+    }
+    throw new Error(`expected a "${type}"`);
+}
+
+const operators = {
+    "make-vector": {
+        call: (context: ExprEvaluatorContext, call: MakeVectorCallExpr) => {
+            if (call._value !== undefined) {
+                return call._value;
+            }
+
+            if (call.args.length < 2) {
+                throw new Error("not enough arguments");
+            } else if (call.args.length > 4) {
+                throw new Error("too many arguments");
+            }
+
+            const components = call.args.map(arg => context.evaluate(arg)) as number[];
+
+            components.forEach((element, index) => {
+                if (typeof element !== "number") {
+                    throw new Error(
+                        `expected vector component at index ${index} to have type "number"`
+                    );
+                }
+            });
+
+            let result: THREE.Vector2 | THREE.Vector3 | THREE.Vector4 | undefined;
+
+            switch (components.length) {
+                case 2:
+                    result = new THREE.Vector2().fromArray(components);
+                    break;
+                case 3:
+                    result = new THREE.Vector3().fromArray(components);
+                    break;
+                case 4:
+                    result = new THREE.Vector4().fromArray(components);
+                    break;
+                default:
+                    throw new Error("too many arguments");
+            }
+
+            if (call.args.every(arg => arg instanceof NumberLiteralExpr)) {
+                call._value = result;
+            }
+
+            return result;
+        }
+    },
+    vector2: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => isVector(context, call, "vector2")
+    },
+    vector3: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => isVector(context, call, "vector3")
+    },
+    vector4: {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => isVector(context, call, "vector4")
+    },
+    "to-vector2": {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => toVector(context, call, "vector2")
+    },
+    "to-vector3": {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => toVector(context, call, "vector3")
+    },
+    "to-vector4": {
+        call: (context: ExprEvaluatorContext, call: CallExpr) => toVector(context, call, "vector4")
+    }
+};
+
+export const VectorOperators: OperatorDescriptorMap = operators;
+export type VectorOperatorNames = keyof typeof operators;

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -512,6 +512,163 @@ describe("ExprEvaluator", function() {
         });
     });
 
+    describe("Operator 'make-vector'", function() {
+        it("create", function() {
+            assert.isTrue(
+                new THREE.Vector2(1, 2).equals(evaluate(["make-vector", 1, 2]) as THREE.Vector2)
+            );
+
+            assert.isTrue(
+                new THREE.Vector3(1, 2, 3).equals(
+                    evaluate(["make-vector", 1, 2, 3]) as THREE.Vector3
+                )
+            );
+
+            assert.isTrue(
+                new THREE.Vector4(1, 2, 3, 4).equals(
+                    evaluate(["make-vector", 1, 2, 3, 4]) as THREE.Vector4
+                )
+            );
+        });
+
+        it("syntax", function() {
+            assert.throws(() => evaluate(["make-vector"]), "not enough arguments");
+            assert.throws(() => evaluate(["make-vector", 1]), "not enough arguments");
+            assert.throws(() => evaluate(["make-vector", 1, 2, 3, 4, 5]), "too many arguments");
+            assert.throws(
+                () => evaluate(["make-vector", 1, "x"]),
+                'expected vector component at index 1 to have type "number"'
+            );
+            assert.throws(
+                () => evaluate(["make-vector", 1, false]),
+                'expected vector component at index 1 to have type "number"'
+            );
+        });
+    });
+
+    describe("Operator 'vector2/3/4'", function() {
+        it("evaluate", function() {
+            const v2 = new THREE.Vector2(10, 20);
+            const v3 = new THREE.Vector3(10, 20, 30);
+            const v4 = new THREE.Vector4(10, 20, 30, 40);
+            const env = { v2, v3, v4 };
+
+            assert.strictEqual(evaluate(["vector2", ["get", "v2"]], env), v2);
+
+            assert.strictEqual(evaluate(["vector2", ["get", "v3"], ["get", "v2"]], env), v2);
+
+            assert.strictEqual(
+                evaluate(["vector2", ["get", "v4"], ["get", "v3"], ["get", "v2"]], env),
+                v2
+            );
+
+            assert.strictEqual(evaluate(["vector3", ["get", "v3"]], env), v3);
+
+            assert.strictEqual(evaluate(["vector3", ["get", "v3"], ["get", "v2"]], env), v3);
+
+            assert.strictEqual(
+                evaluate(["vector3", ["get", "v4"], ["get", "v3"], ["get", "v2"]], env),
+                v3
+            );
+
+            assert.strictEqual(evaluate(["vector4", ["get", "v4"]], env), v4);
+
+            assert.strictEqual(
+                evaluate(["vector4", ["get", "v4"], ["get", "v3"], ["get", "v2"]], env),
+                v4
+            );
+
+            assert.throws(
+                () => evaluate(["vector2", ["get", "v3"], ["get", "v4"]], env),
+                'expected a "vector2"'
+            );
+
+            assert.throws(
+                () => evaluate(["vector3", ["get", "v2"], ["get", "v4"]], env),
+                'expected a "vector3"'
+            );
+
+            assert.throws(
+                () => evaluate(["vector4", ["get", "v2"], ["get", "v3"]], env),
+                'expected a "vector4"'
+            );
+        });
+    });
+
+    describe("Operator 'to-vector2/3/4'", function() {
+        it("evaluate", function() {
+            const v2 = new THREE.Vector2(10, 20);
+            const v3 = new THREE.Vector3(10, 20, 30);
+            const v4 = new THREE.Vector4(10, 20, 30, 40);
+            const env = { v2, v3, v4 };
+
+            assert.strictEqual(evaluate(["to-vector2", ["get", "v2"]], env), v2);
+
+            assert.strictEqual(evaluate(["to-vector2", ["get", "v3"], ["get", "v2"]], env), v2);
+
+            assert.strictEqual(
+                evaluate(["to-vector2", ["get", "v4"], ["get", "v3"], ["get", "v2"]], env),
+                v2
+            );
+
+            assert.strictEqual(evaluate(["to-vector3", ["get", "v3"]], env), v3);
+
+            assert.strictEqual(evaluate(["to-vector3", ["get", "v3"], ["get", "v2"]], env), v3);
+
+            assert.strictEqual(
+                evaluate(["to-vector3", ["get", "v4"], ["get", "v3"], ["get", "v2"]], env),
+                v3
+            );
+
+            assert.strictEqual(evaluate(["to-vector4", ["get", "v4"]], env), v4);
+
+            assert.strictEqual(
+                evaluate(["to-vector4", ["get", "v4"], ["get", "v3"], ["get", "v2"]], env),
+                v4
+            );
+
+            assert.throws(
+                () => evaluate(["to-vector2", ["get", "v3"], ["get", "v4"]], env),
+                'expected a "vector2"'
+            );
+
+            assert.throws(
+                () => evaluate(["to-vector3", ["get", "v2"], ["get", "v4"]], env),
+                'expected a "vector3"'
+            );
+
+            assert.throws(
+                () => evaluate(["to-vector4", ["get", "v2"], ["get", "v3"]], env),
+                'expected a "vector4"'
+            );
+        });
+
+        it("convert from array", function() {
+            const v2 = [10, 20];
+            const v3 = [10, 20, 30];
+            const v4 = [10, 20, 30, 40];
+            const env = { v2, v3, v4 };
+
+            assert.isTrue(
+                new THREE.Vector2()
+                    .fromArray(v2)
+                    .equals(evaluate(["to-vector2", ["get", "v2"]], env) as THREE.Vector2)
+            );
+
+            assert.isTrue(
+                new THREE.Vector3()
+                    .fromArray(v3)
+                    .equals(evaluate(["to-vector3", ["get", "v3"]], env) as THREE.Vector3)
+            );
+
+            assert.isTrue(
+                new THREE.Vector4()
+                    .fromArray(v4)
+                    .equals(evaluate(["to-vector4", ["get", "v4"]], env) as THREE.Vector4)
+            );
+        });
+    });
+
     describe("Operator 'typeof'", function() {
         it("evaluate", function() {
             assert.strictEqual(evaluate(["typeof", "x"]), "string");


### PR DESCRIPTION
This change introduces new operator and type conversions to
support vector2/3/4.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
