### PR TITLE
HARP-6501: MapView.lookAt for GeoBox and arbitrary point support

### DIFF
--- a/@here/harp-examples/src/getting-started_look-at.ts
+++ b/@here/harp-examples/src/getting-started_look-at.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GeoBox, GeoCoordinates, mercatorProjection, sphereProjection } from "@here/harp-geoutils";
+import { GUI } from "dat.gui";
+import { HelloWorldExample } from "./getting-started_hello-world_npm";
+
+/**
+ * This example builds on top of the [[HelloWorldExample]], so please consult that first for any
+ * questions regarding basic setup of the map.
+ *
+ * In this example we show use the of [[MapView.lookAt]] method to focus camera on certain
+ * world features (continents, countries, cities).
+ *
+ * Here a GUI is also set up so as to fiddle with the tilt and distance from the page.
+ */
+export namespace LookAtExample {
+    const mapView = HelloWorldExample.mapView;
+    mapView.projection = sphereProjection;
+    mapView.theme = { extends: "resources/berlin_tilezen_base_globe.json" };
+    mapView.tilt = 0;
+    mapView.heading = 0;
+
+    const exampleActions = {
+        CenterGlobe() {
+            mapView.lookAt({ target: { lat: 0, lng: 0 } });
+        },
+        ResetView() {
+            mapView.lookAt({ heading: 0, tilt: 0 });
+        },
+        LookEast() {
+            mapView.lookAt({ heading: 90 });
+        },
+        LookWest() {
+            mapView.lookAt({ heading: -90 });
+        },
+        LookSouth() {
+            mapView.lookAt({ heading: 180 });
+        },
+        Tilt45() {
+            mapView.lookAt({ tilt: 45 });
+        },
+        Tilt0() {
+            mapView.lookAt({ tilt: 0 });
+        },
+        GeoExtent10() {
+            mapView.lookAt({ bounds: { latitudeSpan: 10, longitudeSpan: 10 } });
+        },
+        GeoExtentGlobe() {
+            mapView.lookAt({ bounds: { latitudeSpan: 180, longitudeSpan: 360 } });
+        }
+    };
+
+    const exampleBounds = {
+        ["London"]: new GeoBox(
+            new GeoCoordinates(51.28043, -0.56316),
+            new GeoCoordinates(51.68629, 0.28206)
+        ),
+        ["Berlin"]: new GeoBox(
+            new GeoCoordinates(52.37615, 13.11938),
+            new GeoCoordinates(52.66058, 13.65801)
+        ),
+        ["France"]: new GeoBox(
+            new GeoCoordinates(41.33374, -5.1406),
+            new GeoCoordinates(51.08906, 9.55932)
+        ),
+        ["India"]: new GeoBox(
+            new GeoCoordinates(6.75649, 68.17939),
+            new GeoCoordinates(33.25441, 97.16157)
+        ),
+        ["USA"]: new GeoBox(
+            new GeoCoordinates(24.527135, -131.660156),
+            new GeoCoordinates(51.289406, -71.367188)
+        ),
+        ["World"]: new GeoBox(new GeoCoordinates(-55, -180), new GeoCoordinates(78, 180)),
+        ["Europe"]: new GeoBox(
+            new GeoCoordinates(34.307144, -25.839844),
+            new GeoCoordinates(66.548263, 44.121094)
+        ),
+
+        // These features are defined by random points surrouding them to show that [[lookAt]]
+        // can work with arbitrary point clouds too.
+        ["Africa"]: [
+            new GeoCoordinates(32.66827, 36.15456),
+            new GeoCoordinates(9.87776, 55.79889),
+            new GeoCoordinates(-21.14927, 55.41922),
+            new GeoCoordinates(-37.23619, 10.88411),
+            new GeoCoordinates(-34.66981, 39.03188),
+            new GeoCoordinates(12.9366, -25.47008),
+            new GeoCoordinates(37.64753, -10.81045)
+        ],
+        ["Australia"]: [
+            new GeoCoordinates(0.319314, 130.85031),
+            new GeoCoordinates(-4.03136, 153.57669),
+            new GeoCoordinates(-28.94059, 156.3926),
+            new GeoCoordinates(-45.25263, 147.50161),
+            new GeoCoordinates(-36.99093, 113.46194),
+            new GeoCoordinates(-21.93939, 112.09722)
+        ],
+        ["Asia"]: [
+            new GeoCoordinates(38.70557, 25.095676273814004),
+            new GeoCoordinates(40.46185, 25.83294696123821),
+            new GeoCoordinates(47.56539, 49.337120152451824),
+            new GeoCoordinates(73.83876, 68.08862941747252),
+            new GeoCoordinates(81.76084, 90.62772020101889),
+            new GeoCoordinates(67.63809, -168.68095103187997),
+            new GeoCoordinates(62.90522, -171.40633287870494),
+            new GeoCoordinates(48.53365, 157.00900173445882),
+            new GeoCoordinates(34.06298, 141.58701888473408),
+            new GeoCoordinates(-4.09993, 131.63498333285776),
+            new GeoCoordinates(-10.31057, 127.50500787226275),
+            new GeoCoordinates(-12.24436, 115.18798058166826),
+            new GeoCoordinates(12.1344, 43.53950783023524),
+            new GeoCoordinates(28.33851, 32.586304605269305)
+        ],
+        ["SouthAmerica"]: [
+            new GeoCoordinates(-0.037727, -85.18558),
+            new GeoCoordinates(12.08309, -79.51376),
+            new GeoCoordinates(14.99663, -62.62817),
+            new GeoCoordinates(-5.82442, -30.97989),
+            new GeoCoordinates(-58.76469, -63.97934),
+            new GeoCoordinates(-55.51751, -77.08135)
+        ],
+        ["NorthAmerica"]: [
+            new GeoCoordinates(51.95849, -169.69321),
+            new GeoCoordinates(82.20267, -5.83541),
+            new GeoCoordinates(68.46351, -20.30972),
+            new GeoCoordinates(46.1365, -51.80882),
+            new GeoCoordinates(17.92657, -65.01497),
+            new GeoCoordinates(4.20772, -79.38697),
+            new GeoCoordinates(20.15675, -112.33495)
+        ],
+
+        // These features cross antimeridian and/or include poles to showcase that we support
+        // these weird scenarios too.
+        ["Antarctica"]: [
+            new GeoCoordinates(-65.29705, 51.32607),
+            new GeoCoordinates(-67.30229, -5.99415),
+            new GeoCoordinates(-60.20446, -57.72913),
+            new GeoCoordinates(-69.89815, -123.99539),
+            new GeoCoordinates(-64.45382, 157.49746),
+            new GeoCoordinates(-58.62286, 98.65179),
+            new GeoCoordinates(-90, 180),
+            new GeoCoordinates(-90, -180)
+        ],
+        ["PacificOcean"]: [
+            new GeoCoordinates(27.0819, 116.99188331207404),
+            new GeoCoordinates(64.74506, -175.21090904770676),
+            new GeoCoordinates(7.32805, -78.13612731489623),
+            new GeoCoordinates(-55.58942, -70.25827916326132),
+            new GeoCoordinates(-75.2942, -123.99212082420046),
+            new GeoCoordinates(-16.05847, 146.5315368832761)
+        ],
+        ["ArcticOcean"]: [
+            new GeoCoordinates(68.45423, -67.72241699176338),
+            new GeoCoordinates(65.63336, -17.597189318841238),
+            new GeoCoordinates(63.30735, 38.63837863819523),
+            new GeoCoordinates(66.05542, 73.80738827811217),
+            new GeoCoordinates(70.19595, 131.7552825070622),
+            new GeoCoordinates(65.12073, -168.5813757864778),
+            new GeoCoordinates(50.9709, -81.03147632358663),
+            new GeoCoordinates(90, 180),
+            new GeoCoordinates(90, -180)
+        ],
+        ["BeringSea"]: [
+            new GeoCoordinates(50.95019, -179.1428493376325),
+            new GeoCoordinates(52.91106, 159.02544759162745),
+            new GeoCoordinates(69.90354, 179.15147738391926),
+            new GeoCoordinates(70.25714, -161.597647174786),
+            new GeoCoordinates(55.76049, -157.31410465785078)
+        ]
+    };
+
+    let lastLocationName: keyof typeof exampleBounds;
+    function useLocation(name: keyof typeof exampleBounds) {
+        mapView.lookAt({ bounds: exampleBounds[name] });
+        lastLocationName = name;
+    }
+
+    useLocation("Europe");
+
+    const gui = new GUI();
+
+    const options = { globe: true };
+    gui.add(options, "globe").onChange(() => {
+        mapView.projection = options.globe ? sphereProjection : mercatorProjection;
+        mapView.lookAt({ bounds: exampleBounds[lastLocationName] });
+    });
+
+    for (const exampleAction of Object.keys(exampleActions)) {
+        const name = exampleAction.replace(/example/i, "");
+        guiAddButton(gui, name, exampleActions[exampleAction as keyof typeof exampleActions]);
+    }
+
+    const boundsFolder = gui.addFolder("Bounds");
+    for (const areaName of Object.keys(exampleBounds)) {
+        guiAddButton(boundsFolder, areaName, () => {
+            useLocation(areaName as keyof typeof exampleBounds);
+        });
+    }
+}
+
+function guiAddButton(gui: GUI, name: string, callback: () => void) {
+    gui.add(
+        {
+            [name]: callback
+        },
+        name
+    );
+}

--- a/@here/harp-geoutils/index.ts
+++ b/@here/harp-geoutils/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./lib/coordinates/GeoBox";
+export * from "./lib/coordinates/GeoBoxExtentLike";
 export * from "./lib/coordinates/GeoCoordinatesLike";
 export * from "./lib/coordinates/GeoCoordinates";
 export * from "./lib/coordinates/GeoPointLike";

--- a/@here/harp-geoutils/lib/coordinates/GeoBox.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoBox.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { GeoBoxExtentLike } from "./GeoBoxExtentLike";
 import { GeoCoordinates } from "./GeoCoordinates";
 
 import * as THREE from "three";
@@ -11,7 +12,7 @@ import * as THREE from "three";
 /**
  * `GeoBox` is used to represent a bounding box in geo coordinates.
  */
-export class GeoBox {
+export class GeoBox implements GeoBoxExtentLike {
     /**
      * Returns a `GeoBox` with the given geo coordinates.
      *
@@ -20,6 +21,25 @@ export class GeoBox {
      */
     static fromCoordinates(southWest: GeoCoordinates, northEast: GeoCoordinates): GeoBox {
         return new GeoBox(southWest, northEast);
+    }
+
+    /**
+     * Returns a `GeoBox` with the given center and dimensions.
+     *
+     * @param center The center position of geo box.
+     * @param extent Box latitude and logitude span
+     */
+    static fromCenterAndExtents(center: GeoCoordinates, extent: GeoBoxExtentLike): GeoBox {
+        return new GeoBox(
+            new GeoCoordinates(
+                center.latitude - extent.latitudeSpan / 2,
+                center.longitude - extent.longitudeSpan / 2
+            ),
+            new GeoCoordinates(
+                center.latitude + extent.latitudeSpan / 2,
+                center.longitude + extent.longitudeSpan / 2
+            )
+        );
     }
 
     /**

--- a/@here/harp-geoutils/lib/coordinates/GeoBoxExtentLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoBoxExtentLike.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Represents an object that carry [[GeoBox]] extents like interface.
+ */
+export interface GeoBoxExtentLike {
+    /**
+     * Latitude span in degrees.
+     */
+    readonly latitudeSpan: number;
+
+    /**
+     * Longitude span in degrees
+     */
+    readonly longitudeSpan: number;
+}
+
+/**
+ * Type guard to assert that `object` conforms to [[GeoBoxExtentLike]] interface.
+ */
+export function isGeoBoxExtentLike(obj: any): obj is GeoBoxExtentLike {
+    return (
+        obj &&
+        typeof obj === "object" &&
+        typeof obj.latitudeSpan === "number" &&
+        typeof obj.longitudeSpan === "number"
+    );
+}

--- a/@here/harp-geoutils/lib/math/MathUtils.ts
+++ b/@here/harp-geoutils/lib/math/MathUtils.ts
@@ -107,6 +107,20 @@ export namespace MathUtils {
     }
 
     /**
+     * Normalize latitude angle in degrees to range `[-180, 180]`.
+     *
+     * @param a Latitude angle in degrees.
+     * @returns Latitude angle in degrees in range `[-180, 180]`.
+     */
+    export function normalizeLongitudeDeg(a: number): number {
+        a = normalizeAngleDeg(a);
+        if (a > 180) {
+            a = a - 360;
+        }
+        return a;
+    }
+
+    /**
      * Return the minimal delta between angles `a` and `b` given in degrees.
      *
      * Equivalent to `a - b` in coordinate space with exception vector direction can be reversed

--- a/@here/harp-geoutils/test/GeoBoxTest.ts
+++ b/@here/harp-geoutils/test/GeoBoxTest.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { assert } from "chai";
+import { GeoBox } from "../lib/coordinates/GeoBox";
+import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
+import { MathUtils } from "../lib/math/MathUtils";
+
+const GEOCOORDS_EPSILON = 0.000001;
+
+describe("GeoBox", function() {
+    it("support antimeridian crossing geobox #1", function() {
+        const g = GeoBox.fromCoordinates(
+            new GeoCoordinates(-10, 170),
+            new GeoCoordinates(10, -160)
+        );
+
+        assert.equal(g.west, 170);
+        assert.equal(g.east, -160);
+        assert.equal(g.north, 10);
+        assert.equal(g.south, -10);
+
+        assert.approximately(g.center.longitude, 185, GEOCOORDS_EPSILON);
+        assert.approximately(g.center.latitude, 0, GEOCOORDS_EPSILON);
+
+        assert.approximately(g.longitudeSpan, 30, GEOCOORDS_EPSILON);
+        assert.approximately(g.latitudeSpan, 20, GEOCOORDS_EPSILON);
+    });
+
+    it("support antimeridian crossing geobox #2", function() {
+        const auckland = new GeoCoordinates(-36.8, 174.7);
+        const sanfrancisco = new GeoCoordinates(37.7, -122.6);
+
+        const g = GeoBox.fromCoordinates(auckland, sanfrancisco);
+
+        assert.equal(g.west, auckland.longitude);
+        assert.equal(g.east, sanfrancisco.longitude);
+        assert.equal(g.north, sanfrancisco.latitude);
+        assert.equal(g.south, auckland.latitude);
+
+        assert.approximately(
+            g.longitudeSpan,
+            Math.abs(MathUtils.angleDistanceDeg(auckland.longitude, sanfrancisco.longitude)),
+            GEOCOORDS_EPSILON
+        );
+        assert.approximately(
+            g.latitudeSpan,
+            Math.abs(MathUtils.angleDistanceDeg(auckland.latitude, sanfrancisco.latitude)),
+            GEOCOORDS_EPSILON
+        );
+        assert.approximately(
+            g.center.longitude,
+            MathUtils.interpolateAnglesDeg(auckland.longitude, sanfrancisco.longitude, 0.5),
+            GEOCOORDS_EPSILON
+        );
+        assert.approximately(
+            g.center.latitude,
+            MathUtils.interpolateAnglesDeg(auckland.latitude, sanfrancisco.latitude, 0.5),
+            GEOCOORDS_EPSILON
+        );
+    });
+});

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,8 +22,11 @@ import {
 import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import {
     EarthConstants,
+    GeoBox,
+    GeoBoxExtentLike,
     GeoCoordinates,
     GeoCoordLike,
+    isGeoBoxExtentLike,
     isGeoCoordinatesLike,
     mercatorProjection,
     Projection,
@@ -684,19 +687,44 @@ const MapViewDefaults = {
 };
 
 /**
- * Parameters for MapView.lookAt
+ * Parameters for [[MapView.lookAt]].
  */
 export interface LookAtParams {
     /**
      * Target/look at point of the MapView.
+     *
      * @note If the given point is not on the ground (altitude != 0) [[MapView]] will do a
      * raycasting internally to find a target on the ground.
+     *
      * As a consequence [[MapView.target]] and [[MapView.zoomLevel]] will not match the values
      * that were passed into the [[MapView.lookAt]] method.
      * @default `new GeoCoordinates(25, 0)` in [[MapView.constructor]] context.
      * @default [[MapView.target]] in [[MapView.lookAt]] context.
      */
     target: GeoCoordLike;
+
+    /**
+     * Fit MapView to these boundaries.
+     *
+     * If specified, `zoomLevel` and `distance` parameters are ignored and `lookAt` calculates best
+     * `zoomLevel` to fit given bounds.
+     *
+     * * if `bounds` is [[GeoBox]], then `lookAt` use [[LookAtParams.target]] or `bounds.target` and
+     *   ensure whole box is visible
+     *
+     * * if `bounds` is [[GeoBoxExtentLike]], then `lookAt` will use [[LookAtParams.target]] or
+     *   current [[MapView.target]] and ensure whole extents are visible
+     *
+     * * if `bounds` is [[GeoCoordLike]][], then `lookAt` will use [[LookAtParams.target]] or
+     *   calculated `target` as center of world box covering given points and ensure all points are
+     *   visible
+     *
+     * Note in sphere projection some points are not visible if you specify bounds that span more
+     * than 180 degreess in any direction.
+     *
+     * @see [[MapView.lookAt]] for defails how `bounds` interact with `target` parameter
+     */
+    bounds: GeoBox | GeoBoxExtentLike | GeoCoordLike[];
 
     /**
      * Camera distance to the target point in world units.
@@ -2059,6 +2087,55 @@ export class MapView extends THREE.EventDispatcher {
         this.m_textElementsRenderer.clearOverlayText();
     }
 
+    // tslint:disable: max-line-length
+    /**
+     * Adjusts the camera to look at a given geo coordinate with tilt and heading angles.
+     *
+     * #### Note on `target` and `bounds`
+     *
+     * If `bounds` are specified, `zoomLevel` and `distance` parameters are ignored and `lookAt`
+     * calculates best zoomLevel (and possibly target) to fit given bounds.
+     *
+     * Following table shows how relation between `bounds` and target.
+     *
+     * | `bounds`             | `target`    | actual `target`
+     * | ------               | ------      | --------
+     * | [[GeoBox]]           | _defined_   | `params.target` is used
+     * | [[GeoBox]]           | `undefined` | `bounds.center` is used as new `target`
+     * | [[GeoBoxExtentLike]] | `undefined` | current `MapView.target` is used
+     * | [[GeoBoxExtentLike]] | _defined_   | `params.target` is used
+     * | [[GeoCoordLike]][]   | `undefined` | new `target` is calculated as center of world box covering given points
+     * | [[GeoCoordLike]][]   | _defined_   | `params.target` is used and zoomLevel is adjusted to view all given geo points
+     *
+     * In each case, `lookAt` finds minimum `zoomLevel` that covers given extents or geo points.
+     *
+     * With flat projection, if `bounds` represents points on both sides of antimeridian, and
+     * [[MapViewOptions.tileWrappingEnabled]] is used, `lookAt` will use this knowledge and find
+     * minimal view that may cover "next" or "previous" world.
+     *
+     * With sphere projection if `bounds` represents points on both sides of globe, best effort
+     * method is used to find best `target``.
+     *
+     * #### Examples
+     *
+     * ```
+     * mapView.lookAt({heading: 90})
+     *     // look east retaining current `target`, `zoomLevel` and `tilt`
+     *
+     * mapView.lookAt({lat: 40.707, lng: -74.01})
+     *    // look at Manhattan, New York retaining other view params
+     *
+     * mapView.lookAt(bounds: { latitudeSpan: 10, longitudeSpan: 10})
+     *    // look at current `target`, but extending zoomLevel so we see 10 degrees of lat/long span
+     * ```
+     *
+     * @see More examples in [[LookAtExample]].
+     *
+     * @param params [[LookAtParams]]
+     */
+    lookAt(params: Partial<LookAtParams>): void;
+    // tslint:enable: max-line-length
+
     /**
      * The method that sets the camera to the desired angle (`tiltDeg`) and `distance` (in meters)
      * to the `target` location, from a certain heading (`headingAngle`).
@@ -2073,12 +2150,6 @@ export class MapView extends THREE.EventDispatcher {
      * @deprecated Use lookAt version with [[LookAtParams]] object parameter.
      */
     lookAt(target: GeoCoordLike, distance: number, tiltDeg?: number, headingDeg?: number): void;
-
-    /**
-     * Adjusts the camera to look at a given geo coordinate with tilt and heading angles.
-     * @param params LookAtParams
-     */
-    lookAt(params: Partial<LookAtParams>): void;
 
     lookAt(
         targetOrParams: GeoCoordLike | Partial<LookAtParams>,
@@ -2686,7 +2757,7 @@ export class MapView extends THREE.EventDispatcher {
         const tangentSpaceMatrix = cache.matrix4[1];
         // 1. Build the matrix of the tangent space of the camera.
         cameraPos.setFromMatrixPosition(camera.matrixWorld); // Ensure using world position.
-        projection.localTangentSpace(projection.unprojectPoint(cameraPos), transform);
+        projection.localTangentSpace(this.m_targetGeoPos, transform);
         tangentSpaceMatrix.makeBasis(transform.xAxis, transform.yAxis, transform.zAxis);
 
         // 2. Change the basis of matrixWorld to the tangent space to get the new base axes.
@@ -2730,8 +2801,63 @@ export class MapView extends THREE.EventDispatcher {
 
     private lookAtImpl(params: Partial<LookAtParams>): void {
         const tilt = Math.min(getOptionValue(params.tilt, this.tilt), MapViewUtils.MAX_TILT_DEG);
-        const target = GeoCoordinates.fromObject(getOptionValue(params.target, this.target));
         const heading = getOptionValue(params.heading, this.heading);
+
+        let target: GeoCoordinates | undefined;
+        if (params.bounds !== undefined) {
+            let geoPoints: GeoCoordLike[];
+
+            if (params.bounds instanceof GeoBox) {
+                target = params.target
+                    ? GeoCoordinates.fromObject(params.target)
+                    : params.bounds.center;
+                geoPoints = MapViewUtils.geoBoxToGeoPoints(params.bounds);
+            } else if (isGeoBoxExtentLike(params.bounds)) {
+                target = params.target ? GeoCoordinates.fromObject(params.target) : this.target;
+                const box = GeoBox.fromCenterAndExtents(target, params.bounds);
+                geoPoints = MapViewUtils.geoBoxToGeoPoints(box);
+            } else if (Array.isArray(params.bounds)) {
+                geoPoints = params.bounds;
+                if (params.target !== undefined) {
+                    target = GeoCoordinates.fromObject(params.target);
+                }
+            } else {
+                throw Error("#lookAt: Invalid 'bounds' value");
+            }
+            if (this.m_tileWrappingEnabled && this.projection.type === ProjectionType.Planar) {
+                // In flat projection, with wrap around enabled, we should detect clusters of
+                // points around  antimeridian and possible move some points to sibling worlds.
+                //
+                // Here, we fit points into minimal geo box taking world wrapping into account.
+                geoPoints = MapViewUtils.wrapGeoPointsToScreen(geoPoints, target!);
+            }
+            const worldPoints = geoPoints.map(point =>
+                this.projection.projectPoint(GeoCoordinates.fromObject(point), new THREE.Vector3())
+            );
+            const worldTarget = new THREE.Vector3();
+            if (target! === undefined) {
+                const box = new THREE.Box3().setFromPoints(worldPoints);
+                box.getCenter(worldTarget);
+                this.projection.scalePointToSurface(worldTarget);
+                target = this.projection.unprojectPoint(worldTarget);
+            } else {
+                this.projection.projectPoint(target, worldTarget);
+            }
+            return this.lookAtImpl(
+                MapViewUtils.getFitBoundsLookAtParams(target, worldTarget, worldPoints, {
+                    tilt,
+                    heading,
+                    minDistance: MapViewUtils.calculateDistanceFromZoomLevel(
+                        this,
+                        this.maxZoomLevel
+                    ),
+                    projection: this.projection,
+                    camera: this.camera
+                })
+            );
+        }
+        target =
+            params.target !== undefined ? GeoCoordinates.fromObject(params.target) : this.target;
 
         const distance =
             params.zoomLevel !== undefined
@@ -2858,11 +2984,6 @@ export class MapView extends THREE.EventDispatcher {
      * Derive the look at settings (i.e. target, zoom, ...) from the current camera.
      */
     private updateLookAtSettings() {
-        const { yaw, pitch, roll } = this.extractAttitude();
-        this.m_yaw = yaw;
-        this.m_pitch = pitch;
-        this.m_roll = roll;
-
         // tslint:disable-next-line: deprecation
         const { target, distance } = MapViewUtils.getTargetAndDistance(
             this.projection,
@@ -2874,6 +2995,11 @@ export class MapView extends THREE.EventDispatcher {
         this.m_targetGeoPos = this.projection.unprojectPoint(this.m_targetWorldPos);
         this.m_targetDistance = distance;
         this.m_zoomLevel = MapViewUtils.calculateZoomLevelFromDistance(this, this.m_targetDistance);
+
+        const { yaw, pitch, roll } = this.extractAttitude();
+        this.m_yaw = yaw;
+        this.m_pitch = pitch;
+        this.m_roll = roll;
     }
 
     /**


### PR DESCRIPTION
MapView.lookAt for GeoBox and arbitrary point support

* MapView.lookAt: supports 'bounds' align view to fit GeoBox or arbitrary
  set of geo points

* new "getting-started / look-at" example to showing various usages of
  `lookAt`

* MapView: fix re-calculation of tilt/heading in lookAt() on sphere
  projection
