### PR TITLE
HARP-8744 Opaque buildings

### DIFF
--- a/@here/harp-examples/src/threejs_shadows.ts
+++ b/@here/harp-examples/src/threejs_shadows.ts
@@ -231,7 +231,11 @@ export namespace ThreejsShadows {
                 },
                 castShadow: true
             }
-        ]
+        ],
+        definitions: {
+            // Opaque buildings
+            defaultBuildingColor: "#EDE7E1FF"
+        }
     };
     initializeMapView("mapCanvas", theme);
 }


### PR DESCRIPTION
Buildings are transparent because otherwise the shadow shows through, this can be fixed with some
bias as shown in the PR: #1461, however this introduces z fighting, and the values would need to be
customized for a specific screen resolution etc.

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>

