### PR TITLE
HARP-10054: Select regions using dynamic properties.

### DIFF
--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -4,13 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Feature,
-    FillStyle,
-    StyleDeclaration,
-    StyleSelector,
-    StyleSet
-} from "@here/harp-datasource-protocol";
+import { Feature } from "@here/harp-datasource-protocol";
 import { GeoJsonDataProvider } from "@here/harp-geojson-datasource";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
@@ -49,7 +43,8 @@ import * as geojson from "../resources/italy.json";
  */
 
 export namespace GeoJsonStylingGame {
-    document.body.innerHTML += `
+    async function main() {
+        document.body.innerHTML += `
         <style>
             #mapCanvas {
               top: 0;
@@ -70,148 +65,159 @@ export namespace GeoJsonStylingGame {
         <p id="prompter">Find the following region: <strong id="asked-name"></strong></p>
     `;
 
-    const REGION_LIST = (geojson.features as Feature[])
-        .filter(feature => {
-            return feature.properties !== undefined && feature.properties.name !== undefined;
-        })
-        .map(feature => feature.properties.name as string);
-    let askedName: string = "";
+        const REGION_LIST = (geojson.features as Feature[])
+            .filter(feature => {
+                return feature.properties !== undefined && feature.properties.name !== undefined;
+            })
+            .map(feature => feature.properties.name as string);
 
-    // This will dismiss the picking and the style changes when the correct region is clicked, so
-    // that the user cannot miss it in case he clicked on another one immediately after.
-    let discardPick: boolean = false;
+        let askedName: string = "";
 
-    // snippet:harp_gl_initmapview.ts
-    const mapView = new MapView({
-        canvas: document.getElementById("mapCanvas") as HTMLCanvasElement,
-        theme: "resources/berlin_tilezen_night_reduced.json",
-        target: new GeoCoordinates(42.2, 12.5),
-        zoomLevel: 5.9
-    });
-    CopyrightElementHandler.install("copyrightNotice", mapView);
-    mapView.resize(window.innerWidth, window.innerHeight);
-    window.addEventListener("resize", () => {
+        // This will dismiss the picking and the style changes when the correct region is clicked,
+        // so that the user cannot miss it in case he clicked on another one immediately after.
+        let discardPick: boolean = false;
+
+        // snippet:harp_gl_initmapview.ts
+        const mapView = new MapView({
+            canvas: document.getElementById("mapCanvas") as HTMLCanvasElement,
+            theme: "resources/berlin_tilezen_night_reduced.json",
+            target: new GeoCoordinates(42.2, 12.5),
+            zoomLevel: 5.9
+        });
+        CopyrightElementHandler.install("copyrightNotice", mapView);
         mapView.resize(window.innerWidth, window.innerHeight);
-    });
-    mapView.canvas.addEventListener("contextmenu", e => e.preventDefault());
-    const baseMap = new OmvDataSource({
-        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-        apiFormat: APIFormat.XYZOMV,
-        styleSetName: "tilezen",
-        authenticationCode: apikey,
-        authenticationMethod: {
-            method: AuthenticationMethod.QueryString,
-            name: "apikey"
-        },
-        copyrightInfo
-    });
-    mapView.addDataSource(baseMap);
-    // end:harp_gl_initmapview.ts
+        window.addEventListener("resize", () => {
+            mapView.resize(window.innerWidth, window.innerHeight);
+        });
+        mapView.canvas.addEventListener("contextmenu", e => e.preventDefault());
+        const baseMap = new OmvDataSource({
+            baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+            apiFormat: APIFormat.XYZOMV,
+            styleSetName: "tilezen",
+            authenticationCode: apikey,
+            authenticationMethod: {
+                method: AuthenticationMethod.QueryString,
+                name: "apikey"
+            },
+            copyrightInfo
+        });
+        mapView.addDataSource(baseMap);
+        // end:harp_gl_initmapview.ts
 
-    // snippet:harp_gl_staticgeojson.ts
-    const geoJsonDataProvider = new GeoJsonDataProvider(
-        "italy",
-        new URL("resources/italy.json", window.location.href)
-    );
+        // snippet:harp_gl_staticgeojson.ts
+        const geoJsonDataProvider = new GeoJsonDataProvider(
+            "italy",
+            new URL("resources/italy.json", window.location.href)
+        );
 
-    const geoJsonDataSource = new OmvDataSource({
-        dataProvider: geoJsonDataProvider,
-        name: "geojson",
-        styleSetName: "geojson",
-        gatherFeatureAttributes: true
-    });
+        const geoJsonDataSource = new OmvDataSource({
+            dataProvider: geoJsonDataProvider,
+            name: "geojson",
+            styleSetName: "geojson",
+            gatherFeatureAttributes: true
+        });
 
-    mapView.addDataSource(geoJsonDataSource).then(() => {
+        await mapView.addDataSource(geoJsonDataSource);
+
         setStyleSet();
         askName();
         mapView.canvas.addEventListener("click", displayAnswer);
-    });
-    // end:harp_gl_staticgeojson.ts
+        // end:harp_gl_staticgeojson.ts
 
-    // snippet:harp_gl_gamelogic.ts
-    function displayAnswer(e: MouseEvent) {
-        if (discardPick) {
-            return;
+        // snippet:harp_gl_gamelogic.ts
+        function displayAnswer(e: MouseEvent) {
+            if (discardPick) {
+                return;
+            }
+
+            const intersectionResults = mapView.intersectMapObjects(e.pageX, e.pageY);
+
+            const usableResults = intersectionResults.filter(
+                result => result.userData?.$layer === "italy"
+            );
+
+            if (usableResults.length === 0) {
+                return;
+            }
+
+            const name = usableResults[0].userData.name;
+            const correct = name === askedName;
+
+            setStyleSet({ name, correct });
+
+            // Discard the picking when the StyleSet is changed so that the new tiles have the time
+            // to be generated before changing them all over again.
+            discardPick = true;
+            setTimeout(
+                () => {
+                    if (correct) {
+                        askName();
+                    }
+                    setStyleSet();
+                    discardPick = false;
+                },
+                // If the answer is correct, wait a longer time so that the user has time to see the
+                // correct result in case he was clicking fast and randomly.
+                correct ? 1000 : 300
+            );
+        }
+        // end:harp_gl_gamelogic.ts
+
+        interface IStatus {
+            name: string;
+            correct: boolean;
         }
 
-        const intersectionResults = mapView.intersectMapObjects(e.pageX, e.pageY);
-        const usableResults = intersectionResults.filter(result => result.userData !== undefined);
-
-        if (usableResults.length === 0) {
-            return;
-        }
-
-        const name = usableResults[0].userData.name;
-        const correct = name === askedName;
-
-        setStyleSet({ name, correct });
-
-        // Discard the picking when the StyleSet is changed so that the new tiles have the time
-        // to be generated before changing them all over again.
-        discardPick = true;
-        setTimeout(
-            () => {
-                if (correct) {
-                    askName();
+        geoJsonDataSource.setStyleSet([
+            {
+                description: "GeoJson polygon",
+                when: ["==", ["geometry-type"], "Polygon"],
+                renderOrder: 1000,
+                technique: "fill",
+                attr: {
+                    color: "#37afaa",
+                    lineColor: "#267874",
+                    lineWidth: 1
                 }
-                setStyleSet();
-                discardPick = false;
             },
-            // If the answer is correct, wait a longer time so that the user has time to see the
-            // correct result in case he was clicking fast and randomly.
-            correct ? 1000 : 300
-        );
-    }
-    // end:harp_gl_gamelogic.ts
+            {
+                description: "GeoJson polygons selection",
+                when: ["==", ["geometry-type"], "Polygon"],
+                renderOrder: 1010,
+                technique: "fill",
+                attr: {
+                    // enable geometries created by this technique only when
+                    // the feature's name is equal to the value stored
+                    // in the dynamic property named `selected`
+                    enabled: ["==", ["get", "name"], ["get", "selected", ["dynamic-properties"]]],
 
-    interface IStatus {
-        name: string;
-        correct: boolean;
-    }
+                    // select the color based on the the value of the dynamic property `correct`.
+                    color: [
+                        "case",
+                        ["get", "correct", ["dynamic-properties"]],
+                        "#009900",
+                        "#ff4422"
+                    ],
 
-    const outlineStyle: StyleDeclaration = {
-        when: "$geometryType == 'polygon'",
-        description: "GeoJson polygon outline",
-        renderOrder: 1001,
-        technique: "solid-line",
-        attr: {
-            color: "#267874",
-            lineWidth: 1,
-            metricUnit: "Pixel"
+                    // avoid picking
+                    transient: true
+                }
+            }
+        ]);
+
+        // snippet:harp_gl_gamestyleset.ts
+        function setStyleSet(status?: IStatus) {
+            mapView.setDynamicProperty("selected", status?.name ?? null);
+            mapView.setDynamicProperty("correct", status?.correct ?? false);
         }
-    };
-    const baseRegionsStyle: StyleDeclaration = {
-        description: "GeoJson polygon",
-        when: "$geometryType == 'polygon'",
-        renderOrder: 1000,
-        technique: "fill",
-        attr: {
-            color: "#37afaa"
-        }
-    };
-    const activeRegionStyle: FillStyle & StyleSelector = {
-        description: "GeoJson polygon",
-        when: "$geometryType == 'polygon'",
-        renderOrder: 1010,
-        technique: "fill",
-        attr: {}
-    };
+        // end:harp_gl_gamestyleset.ts
 
-    // snippet:harp_gl_gamestyleset.ts
-    function setStyleSet(status?: IStatus) {
-        const styleSet: StyleSet = [baseRegionsStyle, outlineStyle];
-        if (status !== undefined) {
-            activeRegionStyle.when = `$geometryType == "polygon" && name == "${status.name}"`;
-            activeRegionStyle.attr!.color = status.correct ? "#009900" : "#ff4422";
-            styleSet.push(activeRegionStyle);
+        function askName() {
+            const nameIndex = Math.floor(Math.random() * REGION_LIST.length);
+            askedName = REGION_LIST[nameIndex];
+            (document.getElementById("asked-name") as HTMLParagraphElement).innerHTML = askedName;
         }
-        geoJsonDataSource.setStyleSet(styleSet);
     }
-    // end:harp_gl_gamestyleset.ts
 
-    function askName() {
-        const nameIndex = Math.floor(Math.random() * REGION_LIST.length);
-        askedName = REGION_LIST[nameIndex];
-        (document.getElementById("asked-name") as HTMLParagraphElement).innerHTML = askedName;
-    }
+    main();
 }


### PR DESCRIPTION
This change rewrites the logic of the GeoJson styling game to
use the ["dynamic-properties"] to handle selections instead of
setting a new styleset and redecode the tiles.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
