### PR TITLE
HARP-9984 Fix: MapControls don't cache zoom after end of interaction.

### DIFF
--- a/@here/harp-map-controls/lib/MapControls.ts
+++ b/@here/harp-map-controls/lib/MapControls.ts
@@ -726,7 +726,11 @@ export class MapControls extends THREE.EventDispatcher {
                 if (this.m_needsRenderLastFrame) {
                     this.m_needsRenderLastFrame = false;
                     this.m_zoomAnimationTime = this.zoomInertiaDampingDuration;
+
+                    this.m_targetedZoom = undefined;
+                    this.m_currentZoom = undefined;
                     this.stopZoom();
+                    return;
                 }
             } else {
                 this.m_needsRenderLastFrame = true;


### PR DESCRIPTION
Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
