### PR TITLE
Add an alternative decoder for omv payloads.

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -34,7 +34,6 @@ import * as THREE from "three";
 // tslint:disable-next-line:max-line-length
 import { AttrEvaluationContext } from "@here/harp-datasource-protocol/lib/TechniqueAttr";
 import { IGeometryProcessor, ILineGeometry, IPolygonGeometry } from "./IGeometryProcessor";
-import { OmvProtobufDataAdapter } from "./OmvData";
 import {
     ComposedDataFilter,
     OmvFeatureFilter,
@@ -53,6 +52,7 @@ import { OmvTileInfoEmitter } from "./OmvTileInfoEmitter";
 import { OmvTomTomFeatureModifier } from "./OmvTomTomFeatureModifier";
 import { WorldTileProjectionCookie } from "./OmvUtils";
 import { StyleSetDataFilter } from "./StyleSetDataFilter";
+import { VTDataAdapter } from "./VTDataAdapter";
 import { VTJsonDataAdapter } from "./VTJsonDataAdapter";
 
 const logger = LoggerManager.instance.create("OmvDecoder", { enabled: false });
@@ -174,7 +174,7 @@ export class OmvDecoder implements IGeometryProcessor {
             ? new ComposedDataFilter([styleSetDataFilter, m_dataFilter])
             : styleSetDataFilter;
         // Register the default adapters.
-        this.m_dataAdapters.push(new OmvProtobufDataAdapter(this, dataPreFilter, logger));
+        this.m_dataAdapters.push(new VTDataAdapter(this, dataPreFilter, logger));
         this.m_dataAdapters.push(new VTJsonDataAdapter(this, dataPreFilter, logger));
     }
 

--- a/@here/harp-omv-datasource/lib/VTDataAdapter.ts
+++ b/@here/harp-omv-datasource/lib/VTDataAdapter.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MapEnv } from "@here/harp-datasource-protocol/lib/Env";
+import { GeoBox, TileKey } from "@here/harp-geoutils";
+import { ILogger } from "@here/harp-utils";
+import { IGeometryProcessor, ILineGeometry, IPolygonGeometry } from "./IGeometryProcessor";
+import { OmvFeatureFilter } from "./OmvDataFilter";
+import { OmvDataAdapter } from "./OmvDecoder";
+import { OmvGeometryType } from "./OmvDecoderDefs";
+
+import * as THREE from "three";
+
+import Pbf = require("pbf");
+
+declare function require(name: string): any;
+
+// tslint:disable:no-var-requires
+const { VectorTile, VectorTileFeature } = require("@mapbox/vector-tile");
+
+export class VTDataAdapter implements OmvDataAdapter {
+    readonly id = "VtDataAdapter";
+
+    constructor(
+        readonly processor: IGeometryProcessor,
+        readonly dataFilter?: OmvFeatureFilter,
+        readonly m_logger?: ILogger
+    ) {}
+
+    canProcess(data: ArrayBufferLike | {}) {
+        return data instanceof ArrayBuffer;
+    }
+
+    process(data: ArrayBufferLike, tileKey: TileKey, geoBox: GeoBox): void {
+        const pbf = new Pbf(new Uint8Array(data));
+        const vt = new VectorTile(pbf);
+
+        const $zoom = Math.max(0, tileKey.level - (this.processor.storageLevelOffset || 0));
+        const $level = tileKey.level;
+
+        // tslint:disable-next-line: forin
+        for (const layerName in vt.layers) {
+            if (!vt.layers.hasOwnProperty(layerName)) {
+                continue;
+            }
+
+            if (this.dataFilter?.wantsLayer(layerName, $level) === false) {
+                continue;
+            }
+
+            const layer = vt.layers[layerName];
+            for (let i = 0; i < layer.length; ++i) {
+                const feature = layer.feature(i);
+                const type = VectorTileFeature.types[feature.type];
+
+                switch (type) {
+                    case "Point": {
+                        if (
+                            this.dataFilter?.wantsPointFeature(
+                                layerName,
+                                OmvGeometryType.POINT,
+                                $level
+                            ) === false
+                        ) {
+                            break;
+                        }
+
+                        const coords: THREE.Vec2[][] = feature.loadGeometry();
+                        const geometry: THREE.Vector2[] = [];
+                        coords.forEach(points => {
+                            points.forEach(p => {
+                                geometry.push(new THREE.Vector2(p.x, p.y));
+                            });
+                        });
+                        const env = new MapEnv({
+                            ...feature.properties,
+                            $geometryType: "point",
+                            $layer: layerName,
+                            $zoom,
+                            $level
+                        });
+
+                        this.processor.processPointFeature(
+                            layerName,
+                            vt.extent ?? 4096,
+                            geometry,
+                            env,
+                            tileKey.level
+                        );
+
+                        break;
+                    }
+
+                    case "Polygon": {
+                        if (
+                            this.dataFilter?.wantsPolygonFeature(
+                                layerName,
+                                OmvGeometryType.POLYGON,
+                                $level
+                            ) === false
+                        ) {
+                            break;
+                        }
+
+                        const coords: THREE.Vec2[][] = feature.loadGeometry();
+
+                        const rings: THREE.Vector2[][] = coords.map(points =>
+                            points.map(p => new THREE.Vector2(p.x, p.y))
+                        );
+
+                        const geometry: IPolygonGeometry = { rings };
+
+                        const env = new MapEnv({
+                            ...feature.properties,
+                            $geometryType: "polygon",
+                            $layer: layerName,
+                            $zoom,
+                            $level
+                        });
+
+                        this.processor.processPolygonFeature(
+                            layerName,
+                            vt.extent ?? 4096,
+                            [geometry],
+                            env,
+                            tileKey.level
+                        );
+
+                        break;
+                    }
+
+                    case "LineString": {
+                        if (
+                            this.dataFilter?.wantsLineFeature(
+                                layerName,
+                                OmvGeometryType.LINESTRING,
+                                $level
+                            ) === false
+                        ) {
+                            break;
+                        }
+
+                        const coords: THREE.Vec2[][] = feature.loadGeometry();
+
+                        const geometry: ILineGeometry[] = coords.map(points => {
+                            const positions = points.map(c => new THREE.Vector2(c.x, c.y));
+                            return { positions };
+                        });
+
+                        const env = new MapEnv({
+                            ...feature.properties,
+                            $geometryType: "line",
+                            $layer: layerName,
+                            $zoom,
+                            $level
+                        });
+
+                        this.processor.processLineFeature(
+                            layerName,
+                            vt.extent ?? 4096,
+                            geometry,
+                            env,
+                            tileKey.level
+                        );
+                        break;
+                    }
+
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/@here/harp-omv-datasource/package.json
+++ b/@here/harp-omv-datasource/package.json
@@ -39,8 +39,10 @@
         "@here/harp-text-canvas": "^0.14.0",
         "@here/harp-transfer-manager": "^0.14.0",
         "@here/harp-utils": "^0.14.0",
+        "@mapbox/vector-tile": "^1.3.1",
         "earcut": "^2.1.3",
         "long": "^4.0.0",
+        "pbf": "^3.2.1",
         "protobufjs": "^6.8.4"
     },
     "devDependencies": {
@@ -52,6 +54,7 @@
         "@types/long": "^4.0.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.0.8",
+        "@types/pbf": "^3.0.2",
         "@types/sinon": "^7.0.13",
         "chai": "^4.0.2",
         "copyfiles": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,18 @@
     commander "^4.0.1"
     puppeteer "^2.0.0"
 
+"@mapbox/point-geometry@~0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+  integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
+
+"@mapbox/vector-tile@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
+  integrity sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==
+  dependencies:
+    "@mapbox/point-geometry" "~0.1.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -471,6 +483,11 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/pbf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/pbf/-/pbf-3.0.2.tgz#8d291ad68b4b8c533e96c174a2e3e6399a59ed61"
+  integrity sha512-EDrLIPaPXOZqDjrkzxxbX7UlJSeQVgah3i0aA4pOSzmK9zq3BIh7/MZIQxED7slJByvKM4Gc6Hypyu2lJzh3SQ==
 
 "@types/range-parser@*":
   version "1.2.3"
@@ -3776,7 +3793,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.4:
+ieee754@^1.1.12, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -5863,6 +5880,14 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
+pbf@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.2.1.tgz#b4c1b9e72af966cd82c6531691115cc0409ffe2a"
+  integrity sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==
+  dependencies:
+    ieee754 "^1.1.12"
+    resolve-protobuf-schema "^2.1.0"
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -6135,6 +6160,11 @@ protobufjs@^6.8.4:
     "@types/long" "^4.0.0"
     "@types/node" "^10.1.0"
     long "^4.0.0"
+
+protocol-buffers-schema@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz#2f0ea31ca96627d680bf2fefae7ebfa2b6453eae"
+  integrity sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA==
 
 proxy-addr@~2.0.5:
   version "2.0.6"
@@ -6603,6 +6633,13 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-protobuf-schema@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz#9ca9a9e69cf192bbdaf1006ec1973948aa4a3758"
+  integrity sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==
+  dependencies:
+    protocol-buffers-schema "^3.3.1"
 
 resolve-url@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This change introduces an alternative decoder for protobuf omv
payloads.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
