### PR TITLE
MINOR: Simplify rayCastWorldCoordinates using rayCaster.setFromCamera.

### DIFF
--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -455,20 +455,8 @@ export namespace MapViewUtils {
             pointOnScreenYinNDC,
             0
         );
-        const cameraPos = cache.vector3[1].copy(mapView.camera.position);
+        rayCaster.setFromCamera(pointInNDCPosition, mapView.camera);
 
-        cache.matrix4[0].extractRotation(mapView.camera.matrixWorld);
-
-        // Prepare the unprojection matrix which projects from NDC space to camera space
-        // and takes the current rotation of the camera into account.
-        cache.matrix4[1].multiplyMatrices(
-            cache.matrix4[0],
-            cache.matrix4[1].getInverse(mapView.camera.projectionMatrix)
-        );
-        // Unproject the point via the unprojection matrix.
-        const pointInCameraSpace = pointInNDCPosition.applyMatrix4(cache.matrix4[1]);
-        // Use the point in camera space as the vector towards this point.
-        rayCaster.set(cameraPos, pointInCameraSpace.normalize());
         if (elevation !== undefined) {
             groundPlane.constant -= elevation;
             groundSphere.radius += elevation;


### PR DESCRIPTION
It does the same as the code previously used in rayCastWorldCoordinates, but supporting
also orthographic cameras and using the camera cached inverse projection
matrix instead of recomputing it.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
