### PR TITLE
HARP-9898: Fix TextElement's (labels) TextBufferObject handling.

### DIFF
--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -589,7 +589,7 @@ function placePointLabelAtCurrentAnchor(
         env,
         screenCollisions,
         isRejected,
-        false,
+        !labelState.visible,
         outScreenPosition
     );
 
@@ -704,7 +704,7 @@ function placePointLabelAtAnchor(
 
     // Glyphs arrangement have been changed remove text buffer object which needs to be
     // re-created.
-    if (forceInvalidation) {
+    if (measureText) {
         label.textBufferObject = undefined;
     }
 

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -155,6 +155,7 @@ export class TextElementState {
             }
         }
         this.m_viewDistance = undefined;
+        this.element.textBufferObject = undefined;
     }
 
     /**
@@ -176,6 +177,7 @@ export class TextElementState {
             this.element.bounds = predecessor.element.bounds;
             this.element.glyphCaseArray = predecessor.element.glyphCaseArray;
         }
+        this.element.textBufferObject = undefined;
     }
 
     /**

--- a/@here/harp-text-canvas/lib/TextCanvas.ts
+++ b/@here/harp-text-canvas/lib/TextCanvas.ts
@@ -635,8 +635,8 @@ export class TextCanvas {
                 characterBounds = [];
             }
             if (params.storeStyles === true) {
-                renderStyle = this.m_currentTextRenderStyle;
-                layoutStyle = this.m_currentTextLayoutStyle;
+                renderStyle = this.m_currentTextRenderStyle.clone();
+                layoutStyle = this.m_currentTextLayoutStyle.clone();
             }
         }
 
@@ -692,7 +692,7 @@ export class TextCanvas {
                 }
                 targetLayer = tempLayer;
             }
-            position = params.position;
+            position = params.position?.clone();
             scale = params.scale;
             rotation = params.rotation;
             color = params.color;


### PR DESCRIPTION
This changes includes:
- Cleanup label's TextBufferObject whenever it's layout changes,
- Provide proper copies (not references) of TextRenderStyle and TextLayoutStyle for
TextBufferObject creation.
- Cleanup TextBufferObject whenever TextElementState is reset or replaced
(derived) from predecessor.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
