### PR TITLE
HARP-6487: Provide `placement` attribute support for point labels.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -440,6 +440,32 @@ export enum PoiStackMode {
 }
 
 /**
+ * Defines options (tokens) supported for text placements defined via [[placements]] attribute.
+ *
+ * Possible values are defined as vertical placement letter and horizontal letter, where
+ * one of the axis may be ignored and then assumed centered. Moving clock-wise, we have:
+ * `TL` (top-left), `T` (top-center), `TR` (top-right), `R` (center-right), `BR` (bottom-right),
+ * `B` (bottom-center), `BL` (bottom-left), `L` (left), `C` (center-center).
+ * Additionally instead of `T`, `B`, `L`, `R` geographic directions may be used accordingly:
+ * `N` (north), `S` (south), `E` (east), `W` (west).
+ */
+export enum PlacementToken {
+    TopLeft = "TL",
+    TopCenter = "T",
+    TopRight = "TR",
+    CenterRight = "R",
+    BottomRight = "BR",
+    BottomCenter = "B",
+    BottomLeft = "BL",
+    CenterLeft = "L",
+    CenterCenter = "C",
+    North = "N",
+    South = "S",
+    East = "E",
+    West = "W"
+}
+
+/**
  * Technique that describes icons with labels. Used in [[PoiTechnique]] and [[LineMarkerTechnique]]
  * (for road shields).
  */
@@ -448,7 +474,7 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
      * Text to be displayed for feature.
      *
      * Defaults to first defined:
-     *  - feature property `label` if present in technique (depreacted)
+     *  - feature property `label` if present in technique (deprecated)
      *  - `["get", "name:short"]` is `useAbbreviation` is true
      *  - `["get", "iso_code"]` is `useIsoCode` is true
      *  - `["get", "name:$LANGUAGE"]` for each specified language
@@ -617,7 +643,7 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     poiTable?: string;
     /**
      * Fixed name to identify POI options in the POI table. If `poiName` has a value, this value
-     * supercedes any value read from the field referenced in `poiNameField`.
+     * supersedes any value read from the field referenced in `poiNameField`.
      */
     poiName?: string;
     /**
@@ -719,12 +745,31 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     wrappingMode?: DynamicProperty<"None" | "Character" | "Word">;
     /**
      * Text position regarding the baseline.
+     *
+     * @note The [[placements]] attribute may override the alignment settings when using
+     * alternative placements algorithm.
      */
     hAlignment?: DynamicProperty<"Left" | "Center" | "Right">;
     /**
      * Text position inside a line.
+     *
+     * @note The [[placements]] attribute may supersede it, when using alternative placement
+     * algorithm.
      */
     vAlignment?: DynamicProperty<"Above" | "Center" | "Below">;
+    /**
+     * Text label positions relative to the label central position (anchor point).
+     *
+     * This attribute defines an comma separated tokens of possible text placements
+     * relative to label central position (anchor), for example: "TL, TR, C".
+     * Keep in mind that horizontal placement define text position in opposite way to
+     * the alignment, so the text `R` placed (located on the **right side** of label position)
+     * will be the same as `Left` aligned by deduction. On other side vertical placement is quite
+     * similar to vertical alignment so `T` placement corresponds with `Above` alignment.
+     *
+     * @note This attribute may supersede [[hAlignment]] and [[vAlignment]] if defined.
+     */
+    placements?: string;
 }
 
 export interface LineTechniqueParams extends BaseTechniqueParams {

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -446,22 +446,27 @@ export enum PoiStackMode {
  * one of the axis may be ignored and then assumed centered. Moving clock-wise, we have:
  * `TL` (top-left), `T` (top-center), `TR` (top-right), `R` (center-right), `BR` (bottom-right),
  * `B` (bottom-center), `BL` (bottom-left), `L` (left), `C` (center-center).
- * Additionally instead of `T`, `B`, `L`, `R` geographic directions may be used accordingly:
- * `N` (north), `S` (south), `E` (east), `W` (west).
+ * Alternatively instead of `T`, `B`, `L`, `R` geographic directions may be used accordingly:
+ * `NW` (north-west), `N` (north), `NE` (north-east), `E` (east), `SE` (south-east), `S` (south),
+ * `SW` (south-west), `W` (west).
  */
 export enum PlacementToken {
     TopLeft = "TL",
-    TopCenter = "T",
+    Top = "T",
     TopRight = "TR",
-    CenterRight = "R",
+    Right = "R",
     BottomRight = "BR",
-    BottomCenter = "B",
+    Bottom = "B",
     BottomLeft = "BL",
-    CenterLeft = "L",
-    CenterCenter = "C",
+    Left = "L",
+    Center = "C",
+    NorthWest = "NW",
     North = "N",
-    South = "S",
+    NorthEast = "NE",
     East = "E",
+    SouthEast = "SE",
+    South = "S",
+    SouthWest = "SW",
     West = "W"
 }
 
@@ -746,28 +751,26 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Text position regarding the baseline.
      *
-     * @note The [[placements]] attribute may override the alignment settings when using
-     * alternative placements algorithm.
+     * @note The [[placements]] attribute may override the alignment settings.
      */
     hAlignment?: DynamicProperty<"Left" | "Center" | "Right">;
     /**
      * Text position inside a line.
      *
-     * @note The [[placements]] attribute may supersede it, when using alternative placement
-     * algorithm.
+     * @note The [[placements]] attribute may supersede it.
      */
     vAlignment?: DynamicProperty<"Above" | "Center" | "Below">;
     /**
      * Text label positions relative to the label central position (anchor point).
      *
-     * This attribute defines an comma separated tokens of possible text placements
+     * This attribute defines a comma separated tokens of possible text placements
      * relative to label central position (anchor), for example: "TL, TR, C".
-     * Keep in mind that horizontal placement define text position in opposite way to
+     * Keep in mind that horizontal placement defines text position in opposite way to
      * the alignment, so the text `R` placed (located on the **right side** of label position)
      * will be the same as `Left` aligned by deduction. On other side vertical placement is quite
      * similar to vertical alignment so `T` placement corresponds with `Above` alignment.
      *
-     * @note This attribute may supersede [[hAlignment]] and [[vAlignment]] if defined.
+     * @note This attribute may override [[hAlignment]] and [[vAlignment]] if defined.
      */
     placements?: string;
 }

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -200,6 +200,7 @@ const lineMarkerTechniquePropTypes = mergeTechniqueDescriptor<LineMarkerTechniqu
             wrappingMode: AttrScope.TechniqueGeometry,
             hAlignment: AttrScope.TechniqueGeometry,
             vAlignment: AttrScope.TechniqueGeometry,
+            placements: AttrScope.TechniqueGeometry,
             backgroundColor: AttrScope.TechniqueRendering,
             backgroundSize: AttrScope.TechniqueRendering,
             backgroundOpacity: AttrScope.TechniqueRendering,

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -1007,6 +1007,11 @@ export interface TextStyleDefinition {
     wrappingMode?: "None" | "Character" | "Word";
     hAlignment?: "Left" | "Center" | "Right";
     vAlignment?: "Above" | "Center" | "Below";
+    /**
+     * @format comma separated list of placement tokens, i.e. "TR, TL, C"
+     * @see [[PlacementToken]]
+     */
+    placements?: string;
 }
 
 /**

--- a/@here/harp-mapview/lib/text/LayoutState.ts
+++ b/@here/harp-mapview/lib/text/LayoutState.ts
@@ -6,18 +6,15 @@
 
 import {
     DefaultTextStyle,
+    hAlignFromPlacement,
     HorizontalAlignment,
+    hPlacementFromAlignment,
     TextLayoutStyle,
-    VerticalAlignment
+    TextPlacement,
+    vAlignFromPlacement,
+    VerticalAlignment,
+    vPlacementFromAlignment
 } from "@here/harp-text-canvas";
-
-/**
- * Defines possible text placement relative to anchor.
- */
-export interface AnchorPlacement {
-    h: HorizontalAlignment;
-    v: VerticalAlignment;
-}
 
 /**
  * Layout state of the text part of the `TextElement`.
@@ -29,7 +26,7 @@ export class LayoutState {
     private m_hAlign = DefaultTextStyle.DEFAULT_HORIZONTAL_ALIGNMENT;
     private m_vAlign = DefaultTextStyle.DEFAULT_VERTICAL_ALIGNMENT;
 
-    constructor(placement: AnchorPlacement) {
+    constructor(placement: TextPlacement) {
         this.textPlacement = placement;
     }
     /**
@@ -37,9 +34,9 @@ export class LayoutState {
      *
      * @param placement The optional new anchor placement.
      */
-    set textPlacement(placement: AnchorPlacement) {
-        this.m_hAlign = placement.h;
-        this.m_vAlign = placement.v;
+    set textPlacement(placement: TextPlacement) {
+        this.m_hAlign = hAlignFromPlacement(placement.h);
+        this.m_vAlign = vAlignFromPlacement(placement.v);
     }
 
     /**
@@ -49,8 +46,11 @@ export class LayoutState {
      *
      * @returns The current anchor placement.
      */
-    get textPlacement(): AnchorPlacement {
-        return { h: this.m_hAlign, v: this.m_vAlign };
+    get textPlacement(): TextPlacement {
+        return {
+            h: hPlacementFromAlignment(this.m_hAlign),
+            v: vPlacementFromAlignment(this.m_vAlign)
+        };
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -4,8 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {
+    hAlignFromPlacement,
+    hPlacementFromAlignment,
+    TextPlacement,
+    vAlignFromPlacement,
+    vPlacementFromAlignment
+} from "@here/harp-text-canvas";
 import { assert } from "@here/harp-utils";
-import { AnchorPlacement, LayoutState } from "./LayoutState";
+import { LayoutState } from "./LayoutState";
 import { RenderState } from "./RenderState";
 import { TextElement } from "./TextElement";
 import { TextElementType } from "./TextElementType";
@@ -78,9 +85,9 @@ export class TextElementState {
      * If the text wasn't yet rendered or have no alternative placements it will fallback to
      * style/theme based placement.
      *
-     * @returns [[AnchorPlacement]] object containing vertical/horizontal align.
+     * @returns [[TextPlacement]] object containing vertical/horizontal align.
      */
-    get textPlacement(): AnchorPlacement {
+    get textPlacement(): TextPlacement {
         const themeLayout = this.element.layoutStyle!;
         const stateLayout = this.m_textLayoutState;
         // Would be good to test for persistence when getting state layout, but with this
@@ -88,7 +95,10 @@ export class TextElementState {
         const lastPlacement =
             stateLayout !== undefined
                 ? stateLayout.textPlacement
-                : { h: themeLayout.horizontalAlignment, v: themeLayout.verticalAlignment };
+                : {
+                      h: hPlacementFromAlignment(themeLayout.horizontalAlignment),
+                      v: vPlacementFromAlignment(themeLayout.verticalAlignment)
+                  };
         return lastPlacement;
     }
 
@@ -97,9 +107,9 @@ export class TextElementState {
      *
      * This may be base text anchor placement as defined by style or alternative placement.
      *
-     * @param placement The text placement to be used.
+     * @param placement The new [[TextPlacement]] to be used.
      */
-    set textPlacement(placement: AnchorPlacement) {
+    set textPlacement(placement: TextPlacement) {
         if (this.m_textLayoutState === undefined && this.isBaseTextPlacement(placement) === true) {
             // Do nothing, layout state is not required cause we leave the base placement.
             return;
@@ -116,17 +126,17 @@ export class TextElementState {
     /**
      * Returns information if the text placement provided is the base one defined in style (theme).
      *
-     * @param placement The text placement to check.
+     * @param placement The [[TextPlacement]] to check.
      * @returns [[true]] if the placement provided is exactly the same as in theme base layout,
      * [[false]] if it differs from the basic layout provided in style or
      * [[undefined]] if the layout style is not yet defined so it is hard to say.
      */
-    isBaseTextPlacement(placement: AnchorPlacement): boolean | undefined {
+    isBaseTextPlacement(placement: TextPlacement): boolean | undefined {
         const themeLayout = this.element.layoutStyle;
         if (themeLayout !== undefined) {
             return (
-                placement.h === themeLayout.horizontalAlignment &&
-                placement.v === themeLayout.verticalAlignment
+                hAlignFromPlacement(placement.h) === themeLayout.horizontalAlignment &&
+                vAlignFromPlacement(placement.v) === themeLayout.verticalAlignment
             );
         }
         return undefined;

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -542,12 +542,12 @@ function parseTechniquePlacementValue(p: string): TextPlacement | undefined {
     let found: boolean = true;
     switch (modifier) {
         // Top / north
-        case PlacementToken.TopCenter:
+        case PlacementToken.Top:
         case PlacementToken.North:
             textPlacement.v = VerticalPlacement.Top;
             break;
         // Bottom / south
-        case PlacementToken.BottomCenter:
+        case PlacementToken.Bottom:
         case PlacementToken.South:
             textPlacement.v = VerticalPlacement.Bottom;
             break;
@@ -564,12 +564,12 @@ function parseTechniquePlacementValue(p: string): TextPlacement | undefined {
     modifier = p.length === 1 ? p.charAt(0) : p.charAt(1);
     switch (modifier) {
         // Right / east
-        case PlacementToken.CenterRight:
+        case PlacementToken.Right:
         case PlacementToken.East:
             textPlacement.h = HorizontalPlacement.Right;
             break;
         // Left / west
-        case PlacementToken.CenterLeft:
+        case PlacementToken.Left:
         case PlacementToken.West:
             textPlacement.h = HorizontalPlacement.Left;
             break;

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -21,9 +21,9 @@ import {
     FontStyle,
     FontUnit,
     FontVariant,
-    hAlignFromPlacement,
     HorizontalAlignment,
     HorizontalPlacement,
+    resolvePlacementAndAlignment,
     TextCanvas,
     TextLayoutParameters,
     TextLayoutStyle,
@@ -31,7 +31,6 @@ import {
     TextPlacements,
     TextRenderParameters,
     TextRenderStyle,
-    vAlignFromPlacement,
     VerticalAlignment,
     VerticalPlacement,
     WrappingMode
@@ -59,8 +58,6 @@ const defaultTextRenderStyle = new TextRenderStyle({
 
 // By default text layout provides no options for placement, but single alignment.
 const defaultTextLayoutStyle = new TextLayoutStyle({
-    // TODO: Verify why default TextStyleCache layout style has different
-    // alignment settings then defaults in TextStyle.
     verticalAlignment: VerticalAlignment.Center,
     horizontalAlignment: HorizontalAlignment.Center,
     placements: []
@@ -477,24 +474,15 @@ function parseAlignmentAndPlacements(
     placements: TextPlacements;
 } {
     // Currently supported only for PoiTechnique.
-    const placements: TextPlacements = placementsTokens
+    const placements: TextPlacements | undefined = placementsTokens
         ? parseTechniquePlacements(placementsTokens)
-        : [];
+        : undefined;
 
-    // Ignore alignment attributes when placements attributes are defined or provide default
-    // values if none of them are defined.
-    // NOTE: Alignment ignore may be removed if we decide to support both attributes separately.
-    const horizontalAlignment =
-        placements.length > 0
-            ? hAlignFromPlacement(placements[0].h)
-            : parseTechniqueHAlignValue(hAlignment);
-
-    const verticalAlignment =
-        placements.length > 0
-            ? vAlignFromPlacement(placements[0].v)
-            : parseTechniqueVAlignValue(vAlignment);
-
-    return { horizontalAlignment, verticalAlignment, placements };
+    return resolvePlacementAndAlignment(
+        parseTechniqueHAlignValue(hAlignment),
+        parseTechniqueVAlignValue(vAlignment),
+        placements
+    );
 }
 
 function parseTechniqueHAlignValue(hAlignment: string | undefined | null): HorizontalAlignment {

--- a/@here/harp-mapview/test/PlacementTest.ts
+++ b/@here/harp-mapview/test/PlacementTest.ts
@@ -24,17 +24,21 @@ import { getTestResourceUrl } from "@here/harp-test-utils";
 import {
     FontCatalog,
     HorizontalAlignment,
+    HorizontalPlacement,
+    hPlacementFromAlignment,
     TextCanvas,
     TextLayoutParameters,
     TextLayoutStyle,
+    TextPlacement,
     TextRenderParameters,
     TextRenderStyle,
     VerticalAlignment,
+    VerticalPlacement,
+    vPlacementFromAlignment,
     WrappingMode
 } from "@here/harp-text-canvas";
 import { getAppBaseUrl } from "@here/harp-utils";
 import { ScreenCollisions } from "../lib/ScreenCollisions";
-import { AnchorPlacement } from "../lib/text/LayoutState";
 import { placeIcon, PlacementResult, placePointLabel } from "../lib/text/Placement";
 import { RenderState } from "../lib/text/RenderState";
 import { LoadingState, TextElement } from "../lib/text/TextElement";
@@ -467,7 +471,7 @@ describe("Placement", function() {
                 // Input / base text layout.
                 layout: TextLayoutParameters;
                 // Final placement.
-                placement: AnchorPlacement;
+                placement: TextPlacement;
             }
             const runs: PlacementAlternativesRun[] = [
                 {
@@ -479,8 +483,8 @@ describe("Placement", function() {
                         verticalAlignment: VerticalAlignment.Below
                     },
                     placement: {
-                        h: HorizontalAlignment.Left,
-                        v: VerticalAlignment.Above
+                        h: HorizontalPlacement.Right,
+                        v: VerticalPlacement.Top
                     }
                 },
                 {
@@ -492,8 +496,8 @@ describe("Placement", function() {
                         verticalAlignment: VerticalAlignment.Below
                     },
                     placement: {
-                        h: HorizontalAlignment.Right,
-                        v: VerticalAlignment.Above
+                        h: HorizontalPlacement.Left,
+                        v: VerticalPlacement.Top
                     }
                 },
                 {
@@ -505,8 +509,8 @@ describe("Placement", function() {
                         verticalAlignment: VerticalAlignment.Above
                     },
                     placement: {
-                        h: HorizontalAlignment.Right,
-                        v: VerticalAlignment.Below
+                        h: HorizontalPlacement.Left,
+                        v: VerticalPlacement.Bottom
                     }
                 },
                 {
@@ -518,8 +522,8 @@ describe("Placement", function() {
                         verticalAlignment: VerticalAlignment.Above
                     },
                     placement: {
-                        h: HorizontalAlignment.Left,
-                        v: VerticalAlignment.Below
+                        h: HorizontalPlacement.Right,
+                        v: VerticalPlacement.Bottom
                     }
                 },
                 {
@@ -530,11 +534,11 @@ describe("Placement", function() {
                         horizontalAlignment: HorizontalAlignment.Right,
                         verticalAlignment: VerticalAlignment.Center
                     },
-                    // Layout changed horizontally and vertically (counter clock-wise) to move
+                    // Layout changed horizontally and vertically (clock-wise) to move
                     // text away from screen edge.
                     placement: {
-                        h: HorizontalAlignment.Center,
-                        v: VerticalAlignment.Above
+                        h: HorizontalPlacement.Center,
+                        v: VerticalPlacement.Top
                     }
                 },
                 {
@@ -545,10 +549,10 @@ describe("Placement", function() {
                         horizontalAlignment: HorizontalAlignment.Left,
                         verticalAlignment: VerticalAlignment.Center
                     },
-                    // Layout changed horizontally and vertically (counter clock-wise).
+                    // Layout changed horizontally and vertically (clock-wise).
                     placement: {
-                        h: HorizontalAlignment.Center,
-                        v: VerticalAlignment.Below
+                        h: HorizontalPlacement.Center,
+                        v: VerticalPlacement.Bottom
                     }
                 },
                 {
@@ -560,8 +564,8 @@ describe("Placement", function() {
                         verticalAlignment: VerticalAlignment.Below
                     },
                     placement: {
-                        h: HorizontalAlignment.Right,
-                        v: VerticalAlignment.Center
+                        h: HorizontalPlacement.Left,
+                        v: VerticalPlacement.Center
                     }
                 },
                 {
@@ -573,8 +577,8 @@ describe("Placement", function() {
                         verticalAlignment: VerticalAlignment.Above
                     },
                     placement: {
-                        h: HorizontalAlignment.Left,
-                        v: VerticalAlignment.Center
+                        h: HorizontalPlacement.Right,
+                        v: VerticalPlacement.Center
                     }
                 }
             ];
@@ -613,9 +617,15 @@ describe("Placement", function() {
 
                     // Label out of screen and layout unchanged.
                     let textPlacement = state.textPlacement;
+                    expect(run.layout.horizontalAlignment).to.be.not.undefined;
+                    expect(run.layout.verticalAlignment).to.be.not.undefined;
                     expect(result).to.equal(PlacementResult.Invisible);
-                    expect(textPlacement.h).to.be.equal(run.layout.horizontalAlignment);
-                    expect(textPlacement.v).to.be.equal(run.layout.verticalAlignment);
+                    expect(textPlacement.h).to.be.equal(
+                        hPlacementFromAlignment(run.layout.horizontalAlignment!)
+                    );
+                    expect(textPlacement.v).to.be.equal(
+                        vPlacementFromAlignment(run.layout.verticalAlignment!)
+                    );
 
                     // Place again with multi-placement support.
                     result = placePointLabel(
@@ -655,7 +665,7 @@ describe("Placement", function() {
                     // Move offset as percent of (relative to) label size.
                     move: THREE.Vector2;
                     // Final placement.
-                    placement: AnchorPlacement;
+                    placement: TextPlacement;
                 }>;
             }
             const runsNoFading: AlternativesWithMovementRun[] = [
@@ -672,10 +682,10 @@ describe("Placement", function() {
                         {
                             move: new THREE.Vector2(0, 0),
                             // Label placed, layout changed horizontally and vertically
-                            // (counter clock-wise) in order to move text out of screen edge.
+                            // (clock-wise) in order to move text out of screen edge.
                             placement: {
-                                h: HorizontalAlignment.Center,
-                                v: VerticalAlignment.Above
+                                h: HorizontalPlacement.Center,
+                                v: VerticalPlacement.Top
                             }
                         },
                         {
@@ -683,8 +693,8 @@ describe("Placement", function() {
                             // Label placed with anchor changed to moved text even further from
                             // the screen edge.
                             placement: {
-                                h: HorizontalAlignment.Left,
-                                v: VerticalAlignment.Center
+                                h: HorizontalPlacement.Right,
+                                v: VerticalPlacement.Center
                             }
                         }
                     ]
@@ -702,15 +712,15 @@ describe("Placement", function() {
                         {
                             move: new THREE.Vector2(0, 0),
                             placement: {
-                                h: HorizontalAlignment.Center,
-                                v: VerticalAlignment.Below
+                                h: HorizontalPlacement.Center,
+                                v: VerticalPlacement.Bottom
                             }
                         },
                         {
                             move: new THREE.Vector2(0.5, 0),
                             placement: {
-                                h: HorizontalAlignment.Right,
-                                v: VerticalAlignment.Center
+                                h: HorizontalPlacement.Left,
+                                v: VerticalPlacement.Center
                             }
                         }
                     ]
@@ -728,15 +738,15 @@ describe("Placement", function() {
                         {
                             move: new THREE.Vector2(0, 0),
                             placement: {
-                                h: HorizontalAlignment.Right,
-                                v: VerticalAlignment.Center
+                                h: HorizontalPlacement.Left,
+                                v: VerticalPlacement.Center
                             }
                         },
                         {
                             move: new THREE.Vector2(0.0, -0.3),
                             placement: {
-                                h: HorizontalAlignment.Center,
-                                v: VerticalAlignment.Above
+                                h: HorizontalPlacement.Center,
+                                v: VerticalPlacement.Top
                             }
                         }
                     ]
@@ -754,15 +764,15 @@ describe("Placement", function() {
                         {
                             move: new THREE.Vector2(0, 0),
                             placement: {
-                                h: HorizontalAlignment.Left,
-                                v: VerticalAlignment.Center
+                                h: HorizontalPlacement.Right,
+                                v: VerticalPlacement.Center
                             }
                         },
                         {
                             move: new THREE.Vector2(0.0, 0.3),
                             placement: {
-                                h: HorizontalAlignment.Center,
-                                v: VerticalAlignment.Below
+                                h: HorizontalPlacement.Center,
+                                v: VerticalPlacement.Bottom
                             }
                         }
                     ]
@@ -973,8 +983,8 @@ describe("Placement", function() {
                     // alternative placement algorithm - they are excluded.
                     // TODO: HARP-6487 This may be due to change when placements will be
                     // parsed from theme.
-                    expect(states[i].textPlacement.h).to.equal(HorizontalAlignment.Center);
-                    expect(states[i].textPlacement.v).to.equal(VerticalAlignment.Center);
+                    expect(states[i].textPlacement.h).to.equal(HorizontalPlacement.Center);
+                    expect(states[i].textPlacement.v).to.equal(VerticalPlacement.Center);
                 }
                 // First element allocated, second collides, without alternative placement,
                 // centered labels are not handled with multi-anchor placement.

--- a/@here/harp-text-canvas/lib/rendering/TextStyle.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextStyle.ts
@@ -63,12 +63,58 @@ export enum HorizontalAlignment {
 }
 
 /**
+ * Vertical position of text area relative to the placement context (point, line).
+ */
+export enum VerticalPlacement {
+    Top = 0.0,
+    Center = -0.5,
+    Bottom = -1.0
+}
+
+/**
+ * Horizontal position of text element relative to the placement context (point, line).
+ *
+ * @note [[HorizontalPlacement]] value is exactly opposite to [[HorizontalAlignment]] value,
+ * cause when you place text on the right side of point (or icon) it will be left-aligned.
+ */
+export enum HorizontalPlacement {
+    Left = -1.0,
+    Center = -0.5,
+    Right = 0.0
+}
+
+export interface TextPlacement {
+    v: VerticalPlacement;
+    h: HorizontalPlacement;
+}
+
+export type TextPlacements = TextPlacement[];
+
+/**
  * Text wrapping rule used when `lineWidth` is reached.
  */
 export enum WrappingMode {
     None,
     Character,
     Word
+}
+
+/**
+ * @hidden
+ * @internal
+ * Utility function that gets deduced [[HorizontalAlignment]] from [[HorizontalPlacement]].
+ */
+export function hAlignFromPlacement(hP: HorizontalPlacement): HorizontalAlignment {
+    return (hP as unknown) as HorizontalAlignment;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Utility function that gets deduced [[VerticalAlignment]] from [[VerticalPlacement]].
+ */
+export function vAlignFromPlacement(vP: VerticalPlacement): VerticalAlignment {
+    return (vP as unknown) as VerticalAlignment;
 }
 
 /**
@@ -316,6 +362,7 @@ export interface TextLayoutParameters {
     wrappingMode?: WrappingMode;
     verticalAlignment?: VerticalAlignment;
     horizontalAlignment?: HorizontalAlignment;
+    placements?: TextPlacements;
 }
 
 /**
@@ -332,6 +379,12 @@ export class TextLayoutStyle {
      * @returns New `TextLayoutStyle`.
      */
     constructor(params: TextLayoutParameters = {}) {
+        // Solve alignment and placement dependencies and fallbacks.
+        const { horizontalAlignment, verticalAlignment, placements } = resolvePlacementAndAlignment(
+            params.horizontalAlignment,
+            params.verticalAlignment,
+            params.placements
+        );
         this.m_params = {
             tracking:
                 params.tracking !== undefined ? params.tracking : DefaultTextStyle.DEFAULT_TRACKING,
@@ -357,14 +410,9 @@ export class TextLayoutStyle {
                 params.wrappingMode !== undefined
                     ? params.wrappingMode
                     : DefaultTextStyle.DEFAULT_WRAPPING_MODE,
-            verticalAlignment:
-                params.verticalAlignment !== undefined
-                    ? params.verticalAlignment
-                    : DefaultTextStyle.DEFAULT_VERTICAL_ALIGNMENT,
-            horizontalAlignment:
-                params.horizontalAlignment !== undefined
-                    ? params.horizontalAlignment
-                    : DefaultTextStyle.DEFAULT_HORIZONTAL_ALIGNMENT
+            verticalAlignment,
+            horizontalAlignment,
+            placements
         };
     }
 
@@ -469,6 +517,17 @@ export class TextLayoutStyle {
     }
 
     /**
+     * Text placement options relative to label anchor (origin).
+     */
+    get placements(): TextPlacements {
+        return this.m_params.placements!;
+    }
+    set placements(value: TextPlacements) {
+        // Make a deep (one level) copy.
+        this.m_params.placements = value.map(v => ({ ...v }));
+    }
+
+    /**
      * Clone this [[TextLayoutStyle]].
      *
      * @param params Input [[TextLayoutParameters]].
@@ -490,4 +549,31 @@ export class TextLayoutStyle {
         this.params = { ...other.params };
         return this;
     }
+}
+
+function resolvePlacementAndAlignment(
+    hAlignment?: HorizontalAlignment,
+    vAlignment?: VerticalAlignment,
+    placementsOpt?: TextPlacements
+): {
+    horizontalAlignment: HorizontalAlignment;
+    verticalAlignment: VerticalAlignment;
+    placements: TextPlacements;
+} {
+    // Make a deep copy or create new array.
+    const placements: TextPlacements = placementsOpt?.map(v => ({ ...v })) ?? [];
+    // Override alignment attributes with placement (if defined) or provide default
+    // values if none of them is defined.
+    // NOTE: Alignment override may be removed if we decide to support both attributes.
+    const horizontalAlignment =
+        placements.length > 0
+            ? hAlignFromPlacement(placements[0].h)
+            : hAlignment ?? DefaultTextStyle.DEFAULT_HORIZONTAL_ALIGNMENT;
+
+    const verticalAlignment =
+        placements.length > 0
+            ? vAlignFromPlacement(placements[0].v)
+            : vAlignment ?? DefaultTextStyle.DEFAULT_VERTICAL_ALIGNMENT;
+
+    return { horizontalAlignment, verticalAlignment, placements };
 }

--- a/@here/harp-text-canvas/lib/rendering/TextStyle.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextStyle.ts
@@ -103,6 +103,7 @@ export enum WrappingMode {
  * @hidden
  * @internal
  * Utility function that gets deduced [[HorizontalAlignment]] from [[HorizontalPlacement]].
+ * Horizontal alignments are exactly opposite to the placements.
  */
 export function hAlignFromPlacement(hP: HorizontalPlacement): HorizontalAlignment {
     return (hP as unknown) as HorizontalAlignment;
@@ -115,6 +116,25 @@ export function hAlignFromPlacement(hP: HorizontalPlacement): HorizontalAlignmen
  */
 export function vAlignFromPlacement(vP: VerticalPlacement): VerticalAlignment {
     return (vP as unknown) as VerticalAlignment;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Utility function that gets deduced [[HorizontalPlacement]] from [[HorizontalAlignment]].
+ * Horizontal placements are exactly opposite to the alignment values.
+ */
+export function hPlacementFromAlignment(hA: HorizontalAlignment): HorizontalPlacement {
+    return (hA as unknown) as HorizontalPlacement;
+}
+
+/**
+ * @hidden
+ * @internal
+ * Utility function that gets deduced [[VerticalPlacement]] from [[VerticalAlignment]].
+ */
+export function vPlacementFromAlignment(vA: VerticalAlignment): VerticalPlacement {
+    return (vA as unknown) as VerticalPlacement;
 }
 
 /**

--- a/@here/harp-text-canvas/test/TextStyleTest.ts
+++ b/@here/harp-text-canvas/test/TextStyleTest.ts
@@ -1,0 +1,436 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// tslint:disable:only-arrow-functions
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { assert } from "chai";
+
+import * as THREE from "three";
+import {
+    DefaultTextStyle,
+    FontStyle,
+    FontUnit,
+    FontVariant,
+    TextRenderParameters,
+    TextRenderStyle
+} from "../index";
+import {
+    hAlignFromPlacement,
+    HorizontalAlignment,
+    HorizontalPlacement,
+    TextLayoutParameters,
+    TextLayoutStyle,
+    TextPlacements,
+    vAlignFromPlacement,
+    VerticalAlignment,
+    VerticalPlacement,
+    WrappingMode
+} from "../lib/rendering/TextStyle";
+
+describe("TextRenderStyle", () => {
+    let renderParams: TextRenderParameters;
+
+    beforeEach(function() {
+        renderParams = {
+            fontName: "test",
+            fontSize: {
+                unit: FontUnit.Pixel,
+                size: 8.0,
+                backgroundSize: 1.0
+            },
+            fontStyle: FontStyle.Bold,
+            fontVariant: FontVariant.AllCaps,
+            rotation: 90.0,
+            color: new THREE.Color(0xff0000),
+            backgroundColor: new THREE.Color(0x00ff00),
+            opacity: 0.5,
+            backgroundOpacity: 0.2
+        };
+    });
+
+    it("Empty c-tor initializes with default values.", () => {
+        const rs = new TextRenderStyle();
+
+        // Check only if values are equal, non-trivial object references should not be the same.
+        assert.strictEqual(rs.fontName, DefaultTextStyle.DEFAULT_FONT_NAME);
+        assert.deepEqual(rs.fontSize, DefaultTextStyle.DEFAULT_FONT_SIZE);
+        assert.isFalse(Object.is(rs.fontSize, DefaultTextStyle.DEFAULT_FONT_SIZE));
+        assert.strictEqual(rs.fontStyle, DefaultTextStyle.DEFAULT_FONT_STYLE);
+        assert.strictEqual(rs.fontVariant, DefaultTextStyle.DEFAULT_FONT_VARIANT);
+        assert.strictEqual(rs.rotation, DefaultTextStyle.DEFAULT_ROTATION);
+        assert.deepEqual(rs.color, DefaultTextStyle.DEFAULT_COLOR);
+        assert.isFalse(Object.is(rs.color, DefaultTextStyle.DEFAULT_COLOR));
+        assert.strictEqual(rs.opacity, DefaultTextStyle.DEFAULT_OPACITY);
+        assert.deepEqual(rs.backgroundColor, DefaultTextStyle.DEFAULT_BACKGROUND_COLOR);
+        assert.isFalse(Object.is(rs.backgroundColor, DefaultTextStyle.DEFAULT_BACKGROUND_COLOR));
+        assert.strictEqual(rs.backgroundOpacity, DefaultTextStyle.DEFAULT_BACKGROUND_OPACITY);
+    });
+
+    it("C-tor with parameters uses objects copy.", () => {
+        const rs = new TextRenderStyle(renderParams);
+
+        assert.strictEqual(rs.fontName, renderParams.fontName);
+        assert.deepEqual(rs.fontSize, renderParams.fontSize);
+        assert.isFalse(Object.is(rs.fontSize, renderParams.fontSize));
+        assert.strictEqual(rs.fontStyle, renderParams.fontStyle);
+        assert.strictEqual(rs.fontVariant, renderParams.fontVariant);
+        assert.strictEqual(rs.rotation, renderParams.rotation);
+        assert.deepEqual(rs.color, renderParams.color);
+        assert.isFalse(Object.is(rs.color, renderParams.color));
+        assert.strictEqual(rs.opacity, renderParams.opacity);
+        assert.deepEqual(rs.backgroundColor, renderParams.backgroundColor);
+        assert.isFalse(Object.is(rs.backgroundColor, renderParams.backgroundColor));
+        assert.strictEqual(rs.backgroundOpacity, renderParams.backgroundOpacity);
+
+        renderParams.fontName = "test2";
+        renderParams.fontSize!.size += 1;
+        renderParams.fontStyle = FontStyle.BoldItalic;
+        renderParams.fontVariant = FontVariant.SmallCaps;
+        renderParams.rotation! += 1;
+        renderParams.color!.b += 1;
+        renderParams.opacity! += 0.1;
+        renderParams.backgroundColor!.b += 1;
+        renderParams.backgroundOpacity! += 0.1;
+
+        assert.notStrictEqual(rs.fontName, renderParams.fontName);
+        assert.notDeepEqual(rs.fontSize, renderParams.fontSize);
+        assert.notStrictEqual(rs.fontStyle, renderParams.fontStyle);
+        assert.notStrictEqual(rs.fontVariant, renderParams.fontVariant);
+        assert.notStrictEqual(rs.rotation, renderParams.rotation);
+        assert.notDeepEqual(rs.color, renderParams.color);
+        assert.notStrictEqual(rs.opacity, renderParams.opacity);
+        assert.notDeepEqual(rs.backgroundColor, renderParams.backgroundColor);
+        assert.notStrictEqual(rs.backgroundOpacity, renderParams.backgroundOpacity);
+    });
+
+    it("Property setters use objects' deep copy.", () => {
+        const rs = new TextRenderStyle(renderParams);
+
+        const fontSize = {
+            unit: DefaultTextStyle.DEFAULT_FONT_SIZE.unit,
+            size: DefaultTextStyle.DEFAULT_FONT_SIZE.size,
+            backgroundSize: DefaultTextStyle.DEFAULT_FONT_SIZE.backgroundSize
+        };
+        const fontColor = new THREE.Color(0x111111);
+        const fontBgColor = new THREE.Color(0x222222);
+        rs.fontSize = fontSize;
+        rs.color = fontColor;
+        rs.backgroundColor = fontBgColor;
+
+        assert.deepEqual(rs.fontSize, fontSize);
+        assert.isFalse(Object.is(rs.fontSize, fontSize));
+        assert.deepEqual(rs.color, fontColor);
+        assert.isFalse(Object.is(rs.color, fontColor));
+        assert.deepEqual(rs.backgroundColor, fontBgColor);
+        assert.isFalse(Object.is(rs.backgroundColor, fontBgColor));
+    });
+
+    it("Makes a deep copy.", () => {
+        // First instance with defaults.
+        const rs0 = new TextRenderStyle();
+        // Second with test params that are all different.
+        const rs1 = new TextRenderStyle(renderParams);
+
+        assert.notStrictEqual(rs0, rs1);
+        assert.notDeepEqual(rs0, rs1);
+
+        rs0.copy(rs1);
+
+        assert.notStrictEqual(rs0, rs1);
+        assert.isFalse(Object.is(rs0, rs1));
+        assert.deepEqual(rs0, rs1);
+    });
+
+    it("Makes a deep clone.", () => {
+        const rs0 = new TextRenderStyle(renderParams);
+        const rs1 = rs0.clone();
+
+        assert.notStrictEqual(rs0, rs1);
+        assert.isFalse(Object.is(rs0, rs1));
+        assert.deepEqual(rs0, rs1);
+    });
+});
+
+describe("TextLayoutStyle", () => {
+    let layoutParams: TextLayoutParameters;
+
+    beforeEach(function() {
+        layoutParams = {
+            tracking: 1,
+            leading: 2,
+            maxLines: 3,
+            lineWidth: 4,
+            canvasRotation: 90,
+            lineRotation: 15,
+            wrappingMode: WrappingMode.Character,
+            verticalAlignment: VerticalAlignment.Center,
+            horizontalAlignment: HorizontalAlignment.Center,
+            placements: [{ h: HorizontalPlacement.Center, v: VerticalPlacement.Center }]
+        };
+    });
+
+    it("Empty c-tor initializes with default values.", () => {
+        const ls = new TextLayoutStyle();
+
+        // Check only if values are equal, non-trivial object references should not be the same.
+        assert.strictEqual(ls.tracking, DefaultTextStyle.DEFAULT_TRACKING);
+        assert.strictEqual(ls.leading, DefaultTextStyle.DEFAULT_LEADING);
+        assert.strictEqual(ls.maxLines, DefaultTextStyle.DEFAULT_MAX_LINES);
+        assert.strictEqual(ls.lineWidth, DefaultTextStyle.DEFAULT_LINE_WIDTH);
+        assert.strictEqual(ls.canvasRotation, DefaultTextStyle.DEFAULT_CANVAS_ROTATION);
+        assert.strictEqual(ls.lineRotation, DefaultTextStyle.DEFAULT_LINE_ROTATION);
+        assert.strictEqual(ls.wrappingMode, DefaultTextStyle.DEFAULT_WRAPPING_MODE);
+        assert.strictEqual(ls.verticalAlignment, DefaultTextStyle.DEFAULT_VERTICAL_ALIGNMENT);
+        assert.strictEqual(ls.horizontalAlignment, DefaultTextStyle.DEFAULT_HORIZONTAL_ALIGNMENT);
+        assert.deepEqual(ls.placements, DefaultTextStyle.DEFAULT_PLACEMENTS);
+        assert.isFalse(Object.is(ls.placements, DefaultTextStyle.DEFAULT_PLACEMENTS));
+    });
+
+    it("C-tor with parameters uses object's copy.", () => {
+        const ls = new TextLayoutStyle(layoutParams);
+
+        assert.strictEqual(ls.tracking, layoutParams.tracking);
+        assert.strictEqual(ls.leading, layoutParams.leading);
+        assert.strictEqual(ls.maxLines, layoutParams.maxLines);
+        assert.strictEqual(ls.lineWidth, layoutParams.lineWidth);
+        assert.strictEqual(ls.canvasRotation, layoutParams.canvasRotation);
+        assert.strictEqual(ls.lineRotation, layoutParams.lineRotation);
+        assert.strictEqual(ls.wrappingMode, layoutParams.wrappingMode);
+        assert.strictEqual(ls.verticalAlignment, layoutParams.verticalAlignment);
+        assert.strictEqual(ls.horizontalAlignment, layoutParams.horizontalAlignment);
+        assert.deepEqual(ls.placements, layoutParams.placements);
+        assert.isFalse(Object.is(ls.placements, layoutParams.placements));
+
+        layoutParams.tracking! += 1;
+        layoutParams.leading! += 1;
+        layoutParams.maxLines! += 1;
+        layoutParams.lineWidth! += 1;
+        layoutParams.canvasRotation! += 1;
+        layoutParams.lineRotation! += 1;
+        layoutParams.wrappingMode = WrappingMode.None;
+        layoutParams.horizontalAlignment = HorizontalAlignment.Left;
+        layoutParams.verticalAlignment = VerticalAlignment.Above;
+        layoutParams.placements![0].h = HorizontalPlacement.Right;
+
+        // Input parameters changed but object is not.
+        assert.notStrictEqual(ls.tracking, layoutParams.tracking);
+        assert.notStrictEqual(ls.leading, layoutParams.leading);
+        assert.notStrictEqual(ls.maxLines, layoutParams.maxLines);
+        assert.notStrictEqual(ls.lineWidth, layoutParams.lineWidth);
+        assert.notStrictEqual(ls.canvasRotation, layoutParams.canvasRotation);
+        assert.notStrictEqual(ls.lineRotation, layoutParams.lineRotation);
+        assert.notStrictEqual(ls.wrappingMode, layoutParams.wrappingMode);
+        assert.notStrictEqual(ls.verticalAlignment, layoutParams.verticalAlignment);
+        assert.notStrictEqual(ls.horizontalAlignment, layoutParams.horizontalAlignment);
+        assert.notDeepEqual(ls.placements, layoutParams.placements);
+    });
+
+    it("Property setters use objects' deep copy.", () => {
+        const ls = new TextLayoutStyle(layoutParams);
+
+        const placements = [
+            {
+                h: HorizontalPlacement.Left,
+                v: VerticalPlacement.Top
+            }
+        ];
+        ls.placements = placements;
+        assert.deepEqual(ls.placements, placements);
+        assert.isFalse(Object.is(ls.placements, placements));
+    });
+
+    it("Makes a deep copy.", () => {
+        // First instance with defaults.
+        const ls0 = new TextLayoutStyle();
+        // Second with test params that are all different.
+        const ls1 = new TextLayoutStyle(layoutParams);
+
+        assert.notStrictEqual(ls0, ls1);
+        assert.notDeepEqual(ls0, ls1);
+
+        ls0.copy(ls1);
+
+        assert.notStrictEqual(ls0, ls1);
+        assert.isFalse(Object.is(ls0, ls1));
+        assert.deepEqual(ls0, ls1);
+    });
+
+    it("Makes a deep clone.", () => {
+        const ls0 = new TextLayoutStyle(layoutParams);
+        const ls1 = ls0.clone();
+
+        assert.notStrictEqual(ls0, ls1);
+        assert.isFalse(Object.is(ls0, ls1));
+        assert.deepEqual(ls0, ls1);
+    });
+
+    interface PlacementOverrideRun {
+        placements: TextPlacements;
+        hAlignExpected: HorizontalAlignment;
+        vAlignExpected: VerticalAlignment;
+    }
+    const runs: PlacementOverrideRun[] = [
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Left,
+                    v: VerticalPlacement.Top
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Right,
+            vAlignExpected: VerticalAlignment.Above
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Center,
+                    v: VerticalPlacement.Top
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Center,
+            vAlignExpected: VerticalAlignment.Above
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Right,
+                    v: VerticalPlacement.Top
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Left,
+            vAlignExpected: VerticalAlignment.Above
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Right,
+                    v: VerticalPlacement.Center
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Left,
+            vAlignExpected: VerticalAlignment.Center
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Right,
+                    v: VerticalPlacement.Bottom
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Left,
+            vAlignExpected: VerticalAlignment.Below
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Center,
+                    v: VerticalPlacement.Bottom
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Center,
+            vAlignExpected: VerticalAlignment.Below
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Left,
+                    v: VerticalPlacement.Bottom
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Right,
+            vAlignExpected: VerticalAlignment.Below
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Left,
+                    v: VerticalPlacement.Center
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Right,
+            vAlignExpected: VerticalAlignment.Center
+        },
+        {
+            placements: [
+                {
+                    h: HorizontalPlacement.Center,
+                    v: VerticalPlacement.Center
+                }
+            ],
+            hAlignExpected: HorizontalAlignment.Center,
+            vAlignExpected: VerticalAlignment.Center
+        }
+    ];
+
+    context("Placement attributes override alignment in c-tor.", function() {
+        runs.forEach(function(run) {
+            const hPlacement = run.placements[0].h;
+            const vPlacement = run.placements[0].v;
+            const hPlacementStr = HorizontalPlacement[hPlacement];
+            const vPlacementStr = VerticalPlacement[vPlacement];
+            const hAlignStr = HorizontalAlignment[run.hAlignExpected];
+            const vAlignStr = VerticalAlignment[run.vAlignExpected];
+            it(`Placement ${hPlacementStr}-${vPlacementStr} overrides alignment to ${hAlignStr}-${vAlignStr}`, function() {
+                layoutParams.horizontalAlignment = HorizontalAlignment.Center;
+                layoutParams.verticalAlignment = VerticalAlignment.Center;
+                // Copy run placements to layout params.
+                layoutParams.placements = run.placements.map(v => ({ ...v }));
+                // Append few dummy placements
+                layoutParams.placements.push(
+                    {
+                        h: HorizontalPlacement.Center,
+                        v: VerticalPlacement.Center
+                    },
+                    {
+                        h: HorizontalPlacement.Center,
+                        v: VerticalPlacement.Bottom
+                    }
+                );
+                const ls = new TextLayoutStyle(layoutParams);
+                assert.deepEqual(ls.placements, layoutParams.placements);
+                // Test correct alignment deduction.
+                assert.strictEqual(ls.horizontalAlignment, run.hAlignExpected);
+                assert.strictEqual(ls.verticalAlignment, run.vAlignExpected);
+                // Test utilities.
+                assert.strictEqual(
+                    ls.horizontalAlignment,
+                    hAlignFromPlacement(layoutParams.placements[0].h)
+                );
+                assert.strictEqual(
+                    ls.verticalAlignment,
+                    vAlignFromPlacement(layoutParams.placements[0].v)
+                );
+            });
+        });
+    });
+
+    context("Placement attributes override alignment settings via setter.", function() {
+        runs.forEach(function(run) {
+            const hPlacement = run.placements[0].h;
+            const vPlacement = run.placements[0].v;
+            const hPlacementStr = HorizontalPlacement[hPlacement];
+            const vPlacementStr = VerticalPlacement[vPlacement];
+            const hAlignStr = HorizontalAlignment[run.hAlignExpected];
+            const vAlignStr = VerticalAlignment[run.vAlignExpected];
+            it(`Placement ${hPlacementStr}-${vPlacementStr} overrides alignment to ${hAlignStr}-${vAlignStr}`, function() {
+                const ls = new TextLayoutStyle(layoutParams);
+                ls.placements = run.placements;
+                assert.deepEqual(ls.placements, run.placements);
+                assert.isFalse(Object.is(ls.placements, run.placements));
+                // Test correct alignment deduction.
+                assert.strictEqual(ls.horizontalAlignment, run.hAlignExpected);
+                assert.strictEqual(ls.verticalAlignment, run.vAlignExpected);
+                // Test also utility functions.
+                assert.strictEqual(
+                    ls.horizontalAlignment,
+                    hAlignFromPlacement(run.placements[0].h)
+                );
+                assert.strictEqual(ls.verticalAlignment, vAlignFromPlacement(run.placements[0].v));
+            });
+        });
+    });
+});


### PR DESCRIPTION
Introduce new `placement` technique attribute for:
- 'labeled-icon' (PoiTechnique),
- 'line-marker' (LineMarkerTechnique),
techniques that are utilizing LineMarkerTechniqueParams set.
Currently only point labels have support for alternative placements.

The attribute holds an string of possible (alternative) text
placements relative to label origin (anchor) point.
If placements are defined they override hAlignment and vAlignment
settings defined in style. Each placement option is defined in array
as 1 or 2 characters string token that describes text position relative to
origin. i.e. "TR" (top-right), "BL", (bottom-left) or simply
"R" (center-right).

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
