### PR TITLE
HARP-10184: Remove unused MAX_TILT_ANGLE contant from MapView.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -185,7 +185,6 @@ const DEFAULT_CAM_NEAR_PLANE = 0.1;
 const DEFAULT_CAM_FAR_PLANE = 4000000;
 const MAX_FIELD_OF_VIEW = 140;
 const MIN_FIELD_OF_VIEW = 10;
-export const MAX_TILT_ANGLE = 89;
 // All objects in fallback tiles are reduced by this amount.
 export const FALLBACK_RENDER_ORDER_OFFSET = 20000;
 

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -20,7 +20,7 @@ import { MapMeshBasicMaterial, MapMeshStandardMaterial } from "@here/harp-materi
 import { assert, LoggerManager } from "@here/harp-utils";
 import { ElevationProvider } from "./ElevationProvider";
 import { LodMesh } from "./geometry/LodMesh";
-import { MapView, MAX_TILT_ANGLE } from "./MapView";
+import { MapView } from "./MapView";
 import { getFeatureDataSize, TileFeatureData } from "./Tile";
 
 const logger = LoggerManager.instance.create("MapViewUtils");
@@ -42,7 +42,6 @@ const groundNormalPlanarProj = new THREE.Vector3(0, 0, 1);
 const groundPlane = new THREE.Plane(groundNormalPlanarProj.clone());
 const groundSphere = new THREE.Sphere(undefined, EarthConstants.EQUATORIAL_RADIUS);
 const rayCaster = new THREE.Raycaster();
-const maxTiltAngleAllowed = THREE.MathUtils.degToRad(MAX_TILT_ANGLE);
 const epsilon = 1e-5;
 
 /**
@@ -120,7 +119,7 @@ export namespace MapViewUtils {
         targetPositionOnScreenXinNDC: number,
         targetPositionOnScreenYinNDC: number,
         zoomLevel: number,
-        maxTiltAngle: number = maxTiltAngleAllowed
+        maxTiltAngle: number = MAX_TILT_RAD
     ): void {
         // Get current target position in world space before we zoom.
         const targetPosition = rayCastWorldCoordinates(
@@ -184,7 +183,7 @@ export namespace MapViewUtils {
         mapView: MapView,
         deltaAzimuthDeg: number,
         deltaTiltDeg: number,
-        maxTiltAngleRad = maxTiltAngleAllowed
+        maxTiltAngleRad = MAX_TILT_RAD
     ) {
         const target = mapView.target;
         const sphericalCoordinates = extractSphericalCoordinatesFromLocation(
@@ -936,9 +935,9 @@ export namespace MapViewUtils {
             } else {
                 logger.warn(
                     "MapView camera is pointing in the void, using maxTilt: ",
-                    maxTiltAngleAllowed
+                    MAX_TILT_RAD
                 );
-                return maxTiltAngleAllowed;
+                return MAX_TILT_RAD;
             }
         }
     }


### PR DESCRIPTION
It was only used in MapView utils, and there's a duplicated constant there.
Also, maxTiltAngleRad was set to NaN, MAX_TILT_ANGLE is undefined when the expression
for that constant is executed.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>
