### PR TITLE
HARP-10299: Fix zoom on globe.

### DIFF
--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -133,10 +133,6 @@ export namespace MapViewUtils {
 
         // Get current target position in world space before we zoom.
         const worldTarget = rayCastWorldCoordinates(mapView, targetNDCx, targetNDCy, elevation);
-        if (!worldTarget) {
-            return;
-        }
-
         const groundDistance = calculateDistanceToGroundFromZoomLevel(mapView, zoomLevel);
         const cameraHeight = groundDistance + (elevation ?? 0);
 
@@ -163,7 +159,7 @@ export namespace MapViewUtils {
 
         // Get new target position after the zoom
         const newWorldTarget = rayCastWorldCoordinates(mapView, targetNDCx, targetNDCy, elevation);
-        if (!newWorldTarget) {
+        if (!worldTarget || !newWorldTarget) {
             return;
         }
 


### PR DESCRIPTION
zoomOnTargetPosition was returning if camera target does not intersect the globe,
therefore zoom was not updated.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
