### PR TITLE
HARP-8309 Fix incorrect position access

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1712,7 +1712,7 @@ export class TextElementsRenderer {
         renderParams: RenderParams
     ): boolean {
         const poiLabel = labelState.element;
-        const worldPosition = poiLabel.points as THREE.Vector3;
+        const worldPosition = poiLabel.position;
 
         // Only process labels frustum-clipped labels
         if (this.m_screenProjector.project(worldPosition, tempScreenPosition) === undefined) {


### PR DESCRIPTION
I was searching for references to position and
didn't find how the POI's are placed in world space

This makes it easier to find in future.

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
