### PR TITLE
HARP-10210: OmvProtobufDataAdapter emits proper polygon rings.

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvData.ts
+++ b/@here/harp-omv-datasource/lib/OmvData.ts
@@ -573,7 +573,10 @@ export class OmvProtobufDataAdapter implements OmvDataAdapter, OmvVisitor {
                 } else if (isLineToCommand(command)) {
                     currentRing.push(command.position);
                 } else if (isClosePathCommand(command)) {
-                    currentPolygon.rings.push(currentRing);
+                    if (currentRing !== undefined && currentRing.length > 0) {
+                        currentRing.push(currentRing[0].clone());
+                        currentPolygon.rings.push(currentRing);
+                    }
                 }
             }
         });


### PR DESCRIPTION
OmvProtobufDataAdapter emits proper polygon rings.

Fix long-standing bug where OMV/MVT extruded-buildings were lacking
last/first edge because edge geometry creator expected that polygon
`Ring`s have first and last positions are equivalent (they represent
equivalent points).

This patch aligns geometry emitted by MVT adapter to match concept of
"linear ring" definition from GeoJSON standard.

[1] https://tools.ietf.org/html/rfc7946#page-9