### PR TITLE
HARP-10183: Fix empty payload check in TileLoader.onloaded().

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileLoader.ts
+++ b/@here/harp-mapview-decoder/lib/TileLoader.ts
@@ -211,14 +211,12 @@ export class TileLoader {
         this.state = TileLoaderState.Loaded;
         this.payload = payload;
 
-        if ((payload as ArrayBufferLike).byteLength !== undefined) {
-            if ((payload as ArrayBufferLike).byteLength === 0) {
-                this.onDone(TileLoaderState.Ready);
-                return;
-            }
-        }
-        // Object is empty
-        if (payload.constructor === Object && Object.keys(payload).length === 0) {
+        const byteLength = (payload as ArrayBufferLike).byteLength;
+        if (
+            byteLength === 0 ||
+            (payload.constructor === Object && Object.keys(payload).length === 0)
+        ) {
+            // Object is empty
             this.onDone(TileLoaderState.Ready);
             return;
         }

--- a/@here/harp-mapview-decoder/lib/TileLoader.ts
+++ b/@here/harp-mapview-decoder/lib/TileLoader.ts
@@ -218,7 +218,7 @@ export class TileLoader {
             }
         }
         // Object is empty
-        if ((payload as {}) === {}) {
+        if (payload.constructor === Object && Object.keys(payload).length === 0) {
             this.onDone(TileLoaderState.Ready);
             return;
         }

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -192,6 +192,12 @@ export class TileGeometryLoader {
             return;
         }
 
+        // Finish loading if tile has no data.
+        if (tile.tileLoader?.isFinished && tile.decodedTile === undefined) {
+            this.finish();
+            return;
+        }
+
         // Geometry kinds have changed when loading, if so reset entire loading because
         // this geometry loader generates all geometry at once.
         if (


### PR DESCRIPTION
Empty payloads (empty objects) were not detected and they were
sent down to the decoder. In the case of the terrain that's triggered
the decoding of an invalid terrain tile unnecessarily.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
