### PR TITLE
.ort.yml: Exclude test dirs and replace deprecated reason

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,6 +1,15 @@
 excludes:
+  paths:
+  - pattern: "test/**"
+    reason: "TEST_OF"
+    comment: "Directory is only used for testing. Not included in released artifacts."
+  - pattern: "@here/*/test/**"
+    reason: "TEST_OF"
+    comment: "Directory is only used for testing. Not included in released artifacts."
+  - pattern: "@here/harp-test-utils/**"
+    reason: "TEST_OF"
+    comment: "Directory is only used for testing. Not included in released artifacts."
   scopes:
   - name: "devDependencies"
-    reason: "BUILD_TOOL_OF"
-    comment: "These are dependencies only used for development."
-
+    reason: "DEV_DEPENDENCY_OF"
+    comment: "Packages for development only. Not included in released artifacts."


### PR DESCRIPTION
Updating .ort.yml to mark several dirs used for testing as not included in released artifacts to npmjs.com. Replaced scope exclude reason that has been deprecated in OSS Review Toolkit.

See also:
https://github.com/oss-review-toolkit/ort/blob/master/docs/config-file-ort-yml.md.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>