### PR TITLE
.ort.yml: Remove @here/harp-test-utils as it's publisbed

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -6,9 +6,6 @@ excludes:
   - pattern: "@here/*/test/**"
     reason: "TEST_OF"
     comment: "Directory is only used for testing. Not included in released artifacts."
-  - pattern: "@here/harp-test-utils/**"
-    reason: "TEST_OF"
-    comment: "Directory is only used for testing. Not included in released artifacts."
   scopes:
   - name: "devDependencies"
     reason: "DEV_DEPENDENCY_OF"


### PR DESCRIPTION
@here/harp-test-utils is part of the released artifacts, see
https://www.npmjs.com/package/@here/harp-test-utils.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>

