### PR TITLE
Fix CI on windows.

### DIFF
--- a/scripts/with-http-server.ts
+++ b/scripts/with-http-server.ts
@@ -69,7 +69,7 @@ server.listen(port, () => {
     const cmdArgs = command;
     console.error(`with-http-server: Running ${cmdFile} ${cmdArgs.join(" ")}`);
     const child = child_process.spawn(cmdFile!, cmdArgs, {
-        shell: false,
+        shell: true,
         stdio: "inherit"
     });
 


### PR DESCRIPTION
Fix CI on windows.
    
On windows, batch files are only recognized if you try to execute them via shell, so trampoline scripts like `npx` or `mocha-webdriver-runner` are not found we attempt to run them directly by system call.
