### PR TITLE
HARP-10184: Fix tile's geo bbox computation.

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -610,9 +610,10 @@ export class Tile implements CachedResource {
         this.m_elevationRange.calculationStatus = elevationRange.calculationStatus;
         this.elevateGeoBox();
 
-        // Only elevate bounding box if tile has already been decoded and a maximum geometry height
+        // Only update bounding box if tile has already been decoded and a maximum geometry height
         // is provided by the data source.
         if (this.m_maxGeometryHeight !== undefined) {
+            assert(this.decodedTile?.boundingBox === undefined);
             this.updateBoundingBox();
         }
     }

--- a/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
+++ b/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
@@ -146,14 +146,6 @@ export function overlayOnElevation(tile: Tile): void {
         return;
     }
 
-    // Refine tile elevation range, which is initially set to the broader range given by
-    // [[ElevationRangeSource]].
-    const geoBox = displacementMap.geoBox;
-    tile.elevationRange = {
-        minElevation: geoBox.minAltitude ?? 0,
-        maxElevation: geoBox.maxAltitude ?? 0
-    };
-
     // TODO: HARP-8808 Apply displacement maps once per material.
     for (const object of tile.objects) {
         overlayObject(object, displacementMap.texture);

--- a/@here/harp-mapview/test/TileTest.ts
+++ b/@here/harp-mapview/test/TileTest.ts
@@ -11,7 +11,6 @@ import { assert, expect } from "chai";
 
 import { DecodedTile } from "@here/harp-datasource-protocol";
 import {
-    GeoBox,
     mercatorProjection,
     OrientedBox3,
     TileKey,
@@ -217,19 +216,15 @@ describe("Tile", function() {
     });
 
     it("decodedTile setter sets decoded tile bbox if defined but does not elevate it", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-
+        const key = new TileKey(5, 5, 5);
+        const tile = new Tile(stubDataSource, key);
+        const expectedGeoBox = tile.dataSource.getTilingScheme().getGeoBox(key);
+        expectedGeoBox.southWest.altitude = 500;
+        expectedGeoBox.northEast.altitude = 1000;
         const expectedBBox = new OrientedBox3(
-            new THREE.Vector3(1, 0, 1),
+            new THREE.Vector3(1, 2, 3),
             new THREE.Matrix4(),
             new THREE.Vector3(1, 1, 1)
-        );
-        const projection = stubDataSource.mapView.projection;
-        const northEast = expectedBBox.position.clone().add(expectedBBox.extents);
-        const southWest = expectedBBox.position.clone().sub(expectedBBox.extents);
-        const expectedGeoBox = new GeoBox(
-            projection.unprojectPoint(southWest),
-            projection.unprojectPoint(northEast)
         );
 
         tile.elevationRange = { minElevation: 500, maxElevation: 1000 };


### PR DESCRIPTION
 HARP-10184: Fix tile's geo bbox computation.
- Use always the geo box computed by the tiling scheme to ensure it covers the whole tile, since it's used later to generate uv coordinates for displacement maps.
- Elevate geo box using elevation range and maximum geometry height (if available).
- Remove wrong unproject of bounding box provided in decodedTile.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

