### PR TITLE
HARP-10179: Add `iconBrightness` and `iconColor` support for POIs.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -497,6 +497,26 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
      * Maximum zoomLevel at which to display the label icon. No default.
      */
     iconMaxZoomLevel?: number;
+
+    /**
+     * Icon color.
+     *
+     * If specified, combined using multiplication with color value read from icon texture.
+     *
+     * Works best for grayscale or monochromatic textures.
+     */
+    iconColor?: StyleColor;
+
+    /**
+     * Icon brightness.
+     *
+     * Factor that multiplies a color on top of the icon texture (and `iconColor`) with `0` being
+     * fully black as final output, `1` being the original rgb colors of the texture.
+     *
+     * @default `1`
+     */
+    iconBrightness?: number;
+
     /**
      * Scaling factor of icon. Defaults to 0.5, reducing the size ot 50% in the distance.
      */

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -184,6 +184,8 @@ const lineMarkerTechniquePropTypes = mergeTechniqueDescriptor<LineMarkerTechniqu
             imageTextureField: AttrScope.TechniqueGeometry,
             imageTexturePrefix: AttrScope.TechniqueGeometry,
             imageTexturePostfix: AttrScope.TechniqueGeometry,
+            iconColor: AttrScope.TechniqueRendering,
+            iconBrightness: AttrScope.TechniqueRendering,
             style: AttrScope.TechniqueGeometry,
             fontName: AttrScope.TechniqueGeometry,
             fontStyle: AttrScope.TechniqueGeometry,

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +22,7 @@ import {
 import { ContextualArabicConverter } from "@here/harp-text-canvas";
 import { assert, assertExists, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+import { ColorCache } from "../ColorCache";
 import { MapView } from "../MapView";
 import { TextElement } from "../text/TextElement";
 import { DEFAULT_TEXT_DISTANCE_SCALE } from "../text/TextElementsRenderer";
@@ -552,6 +553,12 @@ export class PoiManager {
                     ? textElement.textReservesSpace
                     : technique.iconReserveSpace !== false;
 
+            const iconColorRaw = technique.iconColor
+                ? getPropertyValue(technique.iconColor, env)
+                : null;
+            const iconColor =
+                iconColorRaw !== null ? ColorCache.instance.getColor(iconColorRaw) : undefined;
+
             textElement.poiInfo = {
                 technique,
                 imageTextureName,
@@ -565,6 +572,8 @@ export class PoiManager {
                 mayOverlap: iconMayOverlap,
                 reserveSpace: iconReserveSpace,
                 featureId,
+                iconBrightness: technique.iconBrightness,
+                iconColor,
                 iconMinZoomLevel: technique.iconMinZoomLevel,
                 iconMaxZoomLevel: technique.iconMaxZoomLevel,
                 textMinZoomLevel: technique.textMinZoomLevel,

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,6 +41,20 @@ export interface PoiInfo {
      * Name of the [[ImageTexture]].
      */
     imageTextureName: string;
+
+    /**
+     * Icon color override
+     *
+     * @see [[MarkerTechniqueParams.iconColor]];
+     */
+    iconColor?: THREE.Color;
+
+    /**
+     * Icon brightness.
+     *
+     * @see [[MarkerTechniqueParams.iconBrightness]];
+     */
+    iconBrightness?: number;
 
     /**
      * Name of the POI table [[PoiTable]].

--- a/@here/harp-materials/lib/IconMaterial.ts
+++ b/@here/harp-materials/lib/IconMaterial.ts
@@ -35,7 +35,7 @@ varying vec2 vUv;
 void main() {
 
     vec4 color = texture2D(map, vUv.xy);
-    color *= vColor.a;
+    color *= vColor;
     if (color.a < 0.05) {
         discard;
     }
@@ -63,6 +63,7 @@ export class IconMaterial extends THREE.RawShaderMaterial {
      * @param params `IconMaterial` parameters.
      */
     constructor(params: IconMaterialParameters) {
+        // tslint:disable-next-line: deprecation
         const shaderParams: THREE.ShaderMaterialParameters = {
             name: "IconMaterial",
             vertexShader: vertexSource,

--- a/test/rendering/StylingTest.ts
+++ b/test/rendering/StylingTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2017-2020 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,7 @@ import {
     FillStyle,
     GeometryCollection,
     Light,
+    PoiStyle,
     SolidLineStyle,
     StyleDeclaration,
     TextTechniqueStyle,
@@ -232,6 +233,20 @@ describe("MapView Styling Test", function() {
                 name: "fira",
                 url: "../@here/harp-fontcatalog/resources/Default_FontCatalog.json"
             }
+        ],
+        images: {
+            "my-marker-icon": {
+                // tslint:disable-next-line:max-line-length
+                url:
+                    "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHdpZHRoPSI0OHB4IiBoZWlnaHQ9IjQ4cHgiIHZlcnNpb249IjEuMSIgaWQ9Imx1aS1pY29uLWRlc3RpbmF0aW9ucGluLW9uZGFyay1zb2xpZC1sYXJnZSIKCSB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIgdmlld0JveD0iMCAwIDQ4IDQ4IgoJIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDQ4IDQ4IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPGc+Cgk8ZyBpZD0ibHVpLWljb24tZGVzdGluYXRpb25waW4tb25kYXJrLXNvbGlkLWxhcmdlLWJvdW5kaW5nLWJveCIgb3BhY2l0eT0iMCI+CgkJPHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTTQ3LDF2NDZIMVYxSDQ3IE00OCwwSDB2NDhoNDhWMEw0OCwweiIvPgoJPC9nPgoJPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNmZmZmZmYiIGQ9Ik0yNCwyQzEzLjg3MDgsMiw1LjY2NjcsMTAuMTU4NCw1LjY2NjcsMjAuMjIzMwoJCWMwLDUuMDMyNSwyLjA1MzMsOS41ODg0LDUuMzcxNywxMi44ODgzTDI0LDQ2bDEyLjk2MTctMTIuODg4M2MzLjMxODMtMy4zLDUuMzcxNy03Ljg1NTgsNS4zNzE3LTEyLjg4ODMKCQlDNDIuMzMzMywxMC4xNTg0LDM0LjEyOTIsMiwyNCwyeiBNMjQsMjVjLTIuNzY1LDAtNS0yLjIzNS01LTVzMi4yMzUtNSw1LTVzNSwyLjIzNSw1LDVTMjYuNzY1LDI1LDI0LDI1eiIvPgo8L2c+Cjwvc3ZnPgo=",
+                preload: true
+            }
+        },
+        imageTextures: [
+            {
+                name: "my-marker-icon",
+                image: "my-marker-icon"
+            }
         ]
     };
 
@@ -301,6 +316,40 @@ describe("MapView Styling Test", function() {
                 });
             }
         }
+        function makePointPoiTestCases(
+            testCases: { [name: string]: PoiStyle["attr"] },
+            options?: Partial<GeoJsonMapViewRenderingTestOptions>
+        ) {
+            // tslint:disable-next-line:forin
+            for (const testCase in testCases) {
+                const attr: PoiStyle["attr"] = testCases[testCase]!;
+                mapViewFeaturesRenderingTest(`poi-styling-${testCase}`, {
+                    geoJson: {
+                        type: "FeatureCollection",
+                        features: [
+                            // tested horizontal line
+                            ...points,
+                            referenceBackground
+                        ]
+                    },
+                    theme: {
+                        ...themeTextSettings,
+                        clearColor: "#a0a0a0",
+                        styles: {
+                            geojson: [
+                                referenceBackroundStyle,
+                                {
+                                    when: "$geometryType == 'point'",
+                                    technique: "labeled-icon",
+                                    attr
+                                }
+                            ]
+                        }
+                    },
+                    ...options
+                });
+            }
+        }
         function makePointTestCases(
             testCases: { [name: string]: CirclesStyle["attr"] },
             options?: Partial<GeoJsonMapViewRenderingTestOptions>
@@ -349,6 +398,39 @@ describe("MapView Styling Test", function() {
                 },
                 {
                     margin: 0.5
+                }
+            );
+        });
+
+        describe("poi", function() {
+            makePointPoiTestCases(
+                {
+                    "poi-basic-icon-only": {
+                        imageTexture: "my-marker-icon",
+                        size: 10,
+                        screenHeight: 20,
+                        screenWidth: 20,
+                        text: "",
+                        iconBrightness: 0.7
+                    },
+                    "poi-basic-text-only": {
+                        color: "#fe09",
+                        size: 16,
+                        screenHeight: 20,
+                        screenWidth: 20
+                    },
+                    "poi-basic-both": {
+                        color: "#fe0",
+                        size: 16,
+                        imageTexture: "my-marker-icon",
+                        screenHeight: 20,
+                        screenWidth: 20,
+                        iconYOffset: 16,
+                        iconColor: "#e22"
+                    }
+                },
+                {
+                    margin: 0.1
                 }
             );
         });
@@ -427,6 +509,7 @@ describe("MapView Styling Test", function() {
                 });
             }
         }
+
         describe("solid-line technique", function() {
             describe("basic", function() {
                 makeLineTestCase({


### PR DESCRIPTION
PoiTechnique aka `labeled-icon` technique:

 * Add `iconColor` support for easy coloring monochromatic/opaque icons.
 * Add `iconBrightness` property that adapts brightness of texture/`iconColor`

* Added basic poi/labeled-icon techinique rendering tests.

Signed-off-by: Zbigniew Zagorski <ext-zbyszek.zagorski@here.com>
