### PR TITLE
HARP-8309 Remove unused variable

### DIFF
--- a/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecodedTileEmitter.ts
@@ -241,15 +241,13 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
      * @param geometry The current feature containing the main geometry.
      * @param env The [[MapEnv]] containing the environment information for the map.
      * @param techniques The array of [[Technique]] that will be applied to the geometry.
-     * @param featureId The id of the feature.
      */
     processPointFeature(
         layer: string,
         extents: number,
         geometry: THREE.Vector2[],
         context: AttrEvaluationContext,
-        techniques: IndexedTechnique[],
-        featureId: number | undefined
+        techniques: IndexedTechnique[]
     ): void {
         const env = context.env;
         this.processFeatureCommon(env);
@@ -290,6 +288,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                 }
             }
 
+            const featureId = getFeatureId(env.entries);
             for (const pos of geometry) {
                 if (shouldCreateTextGeometries) {
                     const textTechnique = technique as TextTechnique;
@@ -310,9 +309,7 @@ export class OmvDecodedTileEmitter implements IOmvEmitter {
                     webMercatorTile2TargetTile(extents, this.m_decodeInfo, pos, tmpV3);
                 }
                 positions.push(tmpV3.x, tmpV3.y, tmpV3.z);
-                objInfos.push(
-                    this.m_gatherFeatureAttributes ? env.entries : getFeatureId(env.entries)
-                );
+                objInfos.push(this.m_gatherFeatureAttributes ? env.entries : featureId);
 
                 if (wantsPoi) {
                     if (imageTexture === undefined) {

--- a/@here/harp-omv-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-omv-datasource/lib/OmvDecoder.ts
@@ -89,8 +89,7 @@ export interface IOmvEmitter {
         extents: number,
         geometry: THREE.Vector2[],
         context: AttrEvaluationContext,
-        techniques: IndexedTechnique[],
-        featureId: number | undefined
+        techniques: IndexedTechnique[]
     ): void;
 
     processLineFeature(
@@ -248,16 +247,13 @@ export class OmvDecoder implements IGeometryProcessor {
             cachedExprResults: new Map()
         };
 
-        const featureId = env.lookup("$id") as number | undefined;
-
         if (this.m_decodedTileEmitter) {
             this.m_decodedTileEmitter.processPointFeature(
                 layer,
                 extents,
                 geometry,
                 context,
-                techniques,
-                featureId
+                techniques
             );
         }
     }


### PR DESCRIPTION
Removing featureId as parameter, because it is extracted from the context.