### PR TITLE
GH/Travis CI: Skip downloads for packages already available in env.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ env:
   nodeTestTimeout: 4000
   browserTestTimeout: 8000
   DETECT_CHROMEDRIVER_VERSION: true
+  # GitHub actions machines already have Chrome installed, so no need to download it by yarn.
+  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
 jobs:
   test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ branches:
     - release
 
 env:
-  - DETECT_CHROMEDRIVER_VERSION=true
+  global:
+    - DETECT_CHROMEDRIVER_VERSION=true
+    # chrome is already present in env, so no need to download it by yarn.
+    - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 before_install:
   - yarn global add codecov


### PR DESCRIPTION
CI environment already hs some packages downloaded automagically by some npm packages i.e
 - Google Chrome - required by `pupetter` dep

This patch skips download of these packages to save some bandwith/time.