### PR TITLE
HARP-7073: Use memoization to reduce the number of expr evaluations.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -53,6 +53,11 @@ export class ExprDependencies {
      * `true` if the expression depends on the feature state.
      */
     featureState?: boolean;
+
+    /**
+     * `true` if this expression cannot be cached.
+     */
+    volatile?: boolean;
 }
 
 class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
@@ -103,12 +108,21 @@ class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
         expr.args.forEach(childExpr => childExpr.accept(this, context));
 
         switch (expr.op) {
+            case "dynamic-properties":
+                context.volatile = true;
+                break;
             case "feature-state":
                 context.featureState = true;
                 context.properties.add("$state");
+                context.properties.add("$id");
                 break;
             case "id":
                 context.properties.add("$id");
+                break;
+            case "zoom":
+            case "world-ppi-scale":
+            case "world-discrete-ppi-scale":
+                context.properties.add("$zoom");
                 break;
             case "geometry-type":
                 context.properties.add("$geometryType");

--- a/@here/harp-datasource-protocol/lib/ExprPool.ts
+++ b/@here/harp-datasource-protocol/lib/ExprPool.ts
@@ -228,6 +228,7 @@ export class ExprPool implements ExprVisitor<Expr, void> {
             }
         }
         const e = new CallExpr(expr.op, expressions);
+        e.descriptor = expr.descriptor;
         calls.push(e);
         return e;
     }

--- a/@here/harp-datasource-protocol/lib/PropertyValue.ts
+++ b/@here/harp-datasource-protocol/lib/PropertyValue.ts
@@ -14,14 +14,14 @@ import { parseStringEncodedNumeral } from "./StringEncodedNumeral";
 const logger = LoggerManager.instance.create("PropertyValue");
 
 /**
-* Get the value of the specified property in given `env`.
-
-* @param property Property of a technique.
-* @param env The [[Env]] used to evaluate the property
-* @param cache An optional expression cache.
-*/
+ * Get the value of the specified property in given `env`.
+ *
+ * @param property Property of a technique.
+ * @param env The [[Env]] used to evaluate the property
+ * @param cache An optional expression cache.
+ */
 export function getPropertyValue(
-    property: Value | Expr | undefined,
+    property: Value | undefined,
     env: Env,
     cache?: Map<Expr, Value>
 ): any {

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -59,12 +59,14 @@ describe("ExprEvaluator", function() {
         const dynamic = expr.isDynamic();
         const deps = expr.dependencies();
         const properties = Array.from(deps.properties).sort();
-        const featureState = deps.featureState;
+        const { volatile, featureState } = deps;
         const featureInfo = featureState !== undefined ? { featureState } : {};
+        const volatileInfo = volatile !== undefined ? { volatile } : {};
         return {
             properties,
             dynamic,
-            ...featureInfo
+            ...featureInfo,
+            ...volatileInfo
         };
     }
 
@@ -209,6 +211,14 @@ describe("ExprEvaluator", function() {
             assert.isTrue(
                 Expr.isExpr(evaluate(["dynamic-properties"], undefined, ExprScope.Condition))
             );
+        });
+
+        it("Dependencies", () => {
+            assert.deepStrictEqual(dependencies(["dynamic-properties"]), {
+                properties: [],
+                dynamic: true,
+                volatile: true
+            });
         });
 
         it("get", function() {
@@ -1293,11 +1303,11 @@ describe("ExprEvaluator", function() {
 
         assert.deepEqual(
             dependencies(["interpolate", ["exponential", 2], ["zoom"], 0, 0, 1, ["get", "max"]]),
-            { properties: ["max"], dynamic: true }
+            { properties: ["$zoom", "max"], dynamic: true }
         );
 
         assert.deepEqual(dependencies(["step", ["zoom"], "default", 5, "a", 10, "b"]), {
-            properties: [],
+            properties: ["$zoom"],
             dynamic: true
         });
 
@@ -1316,7 +1326,7 @@ describe("ExprEvaluator", function() {
                 ["get", "fallback-value"]
             ]),
             {
-                properties: ["fallback-value", "x"],
+                properties: ["$zoom", "fallback-value", "x"],
                 dynamic: true
             }
         );
@@ -1747,7 +1757,7 @@ describe("ExprEvaluator", function() {
 
         it("Dependencies", () => {
             assert.deepStrictEqual(dependencies(["feature-state", "enabled"]), {
-                properties: ["$state"],
+                properties: ["$id", "$state"],
                 dynamic: true,
                 featureState: true
             });

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -247,13 +247,13 @@ describe("StyleSetEvaluator", function() {
             // Expr.isDynamic and Expr.dependencies change the state, so we need to call them before
             // camparing.
             assert.isTrue(expr.isDynamic());
-            assert.isEmpty(expr.dependencies().properties);
+            assert.deepStrictEqual(Array.from(expr.dependencies().properties), ["$zoom"]);
 
             assert.equal(techniques.length, 1);
-            assert.deepNestedInclude(techniques[0], {
+            assert.deepNestedInclude(JSON.parse(JSON.stringify(techniques[0])), {
                 name: "fill",
                 lineWidth: 123,
-                color: expr,
+                color: expr.toJSON(),
                 renderOrder: 0
             });
         });

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Definitions, StyleSet, Theme, ValueMap } from "@here/harp-datasource-protocol";
+import { ExprPool } from "@here/harp-datasource-protocol/lib/ExprPool";
 import { Projection, TileKey, TilingScheme } from "@here/harp-geoutils";
 import { assert, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
@@ -116,6 +117,12 @@ export abstract class DataSource extends THREE.EventDispatcher {
      * The maximum zoom level at which [[DataSource]] is displayed.
      */
     maxDisplayLevel: number = 20;
+
+    /**
+     * @internal
+     * @hidden
+     */
+    readonly exprPool = new ExprPool();
 
     /**
      * The [[MapView]] instance holding a reference to this `DataSource`.

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -12,7 +12,6 @@ import {
     getPropertyValue,
     isExtrudedLineTechnique,
     isExtrudedPolygonTechnique,
-    isJsonExpr,
     isShaderTechnique,
     isStandardTechnique,
     isTerrainTechnique,
@@ -799,28 +798,6 @@ export function evaluateColorProperty(value: Value, env?: Env): number | undefin
 
     logger.error(`Unsupported color format: '${value}'`);
     return undefined;
-}
-
-/**
- * Compile expressions in techniques as they were received from decoder.
- */
-export function compileTechniques(techniques: Technique[]) {
-    techniques.forEach((technique: any) => {
-        for (const propertyName in technique) {
-            if (!technique.hasOwnProperty(propertyName)) {
-                continue;
-            }
-            const value = technique[propertyName];
-            if (isJsonExpr(value) && propertyName !== "kind") {
-                // "kind" is reserved.
-                try {
-                    technique[propertyName] = Expr.fromJSON(value);
-                } catch (error) {
-                    logger.error("#compileTechniques: Failed to compile expression:", error);
-                }
-            }
-        }
-    });
 }
 
 /**


### PR DESCRIPTION
This change introduces a simple `MemoCall` that caches
the previous execution of an Expr.
