### PR TITLE
HARP-10237 Refactor VisibleTileSet

### DIFF
--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -20,7 +20,7 @@ import { TextElement } from "./text/TextElement";
 import { TextElementGroup } from "./text/TextElementGroup";
 import { TextElementGroupPriorityList } from "./text/TextElementGroupPriorityList";
 import { TileTextStyleCache } from "./text/TileTextStyleCache";
-import { MapViewUtils } from "./Utils";
+import { MapViewUtils, TileOffsetUtils } from "./Utils";
 
 const logger = LoggerManager.instance.create("Tile");
 
@@ -308,6 +308,8 @@ export class Tile implements CachedResource {
     private m_animatedExtrusionTileHandler: AnimatedExtrusionTileHandler | undefined;
 
     private m_textStyleCache: TileTextStyleCache;
+    private m_uniqueKey: number;
+    private m_offset: number;
     /**
      * Creates a new [[Tile]].
      *
@@ -321,7 +323,7 @@ export class Tile implements CachedResource {
     constructor(
         readonly dataSource: DataSource,
         readonly tileKey: TileKey,
-        public offset: number = 0,
+        offset: number = 0,
         localTangentSpace?: boolean
     ) {
         this.geoBox = this.dataSource.getTilingScheme().getGeoBox(this.tileKey);
@@ -329,6 +331,8 @@ export class Tile implements CachedResource {
         this.m_worldCenter.copy(this.boundingBox.position);
         this.m_localTangentSpace = localTangentSpace !== undefined ? localTangentSpace : false;
         this.m_textStyleCache = new TileTextStyleCache(this);
+        this.m_offset = offset;
+        this.m_uniqueKey = TileOffsetUtils.getKeyForTileKeyAndOffset(this.tileKey, this.offset);
     }
 
     /**
@@ -385,6 +389,35 @@ export class Tile implements CachedResource {
      */
     get center(): THREE.Vector3 {
         return this.m_worldCenter;
+    }
+
+    /**
+     * Gets the key to uniquely represent this tile (based on the [[tileKey]] and [[offset]]), note
+     * this key is only unique within the given [[DataSource]], to get a key which is unique across
+     * [[DataSource]]s see [[DataSourceCache.getKeyForTile]].
+     */
+    get uniqueKey(): number {
+        return this.m_uniqueKey;
+    }
+
+    /**
+     * The optional offset, this is an integer which represents what multiple of 360 degrees to
+     * shift, only useful for flat projections, hence optional.
+     */
+    get offset(): number {
+        return this.m_offset;
+    }
+
+    /**
+     * The optional offset, this is an integer which represents what multiple of 360 degrees to
+     * shift, only useful for flat projections, hence optional.
+     * @param offset Which multiple of 360 degrees to apply to the [[Tile]].
+     */
+    set offset(offset: number) {
+        if (this.m_offset !== offset) {
+            this.m_uniqueKey = TileOffsetUtils.getKeyForTileKeyAndOffset(this.tileKey, offset);
+        }
+        this.m_offset = offset;
     }
 
     /**

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -33,6 +33,14 @@ export enum ResourceComputationType {
     NumberOfTiles
 }
 
+// Direction in quad tree to search: up -> shallower levels, down -> deeper levels.
+enum SearchDirection {
+    NONE,
+    UP,
+    DOWN,
+    BOTH
+}
+
 /**
  * Limited set of [[MapViewOptions]] used for [[VisibleTileSet]].
  */
@@ -575,7 +583,7 @@ export class VisibleTileSet {
         this.allVisibleTilesLoaded =
             allVisibleTilesLoaded && visibleTileKeysResult.allBoundingBoxesFinal;
 
-        this.fillMissingTilesFromCache();
+        this.populateRenderedTiles();
 
         this.forEachCachedTile(tile => {
             // Remove all tiles that are still being loaded, but are no longer visible. They have to
@@ -712,7 +720,7 @@ export class VisibleTileSet {
             return tile;
         }
 
-        const { searchLevelsUp, searchLevelsDown } = this.getCacheSearchLevels(
+        const { searchLevelsUp, searchLevelsDown } = this.getSearchDirection(
             dataSource,
             visibleLevel
         );
@@ -855,7 +863,7 @@ export class VisibleTileSet {
             return;
         }
         if (dataSource.isFullyCovering()) {
-            const key = TileOffsetUtils.getKeyForTileKeyAndOffset(tile.tileKey, tile.offset);
+            const key = tile.uniqueKey;
             const entry = this.m_coveringMap.get(key);
             if (entry === undefined) {
                 // We need to reset the flag so that if the covering datasource is disabled, that
@@ -874,10 +882,11 @@ export class VisibleTileSet {
         }
     }
 
-    private getCacheSearchLevels(
+    // Returns the search direction and the number of levels up / down that can be searched.
+    private getSearchDirection(
         dataSource: DataSource,
         visibleLevel: number
-    ): { searchLevelsUp: number; searchLevelsDown: number } {
+    ): { searchDirection: SearchDirection; searchLevelsUp: number; searchLevelsDown: number } {
         const searchLevelsUp = Math.min(
             this.options.quadTreeSearchDistanceUp,
             Math.max(0, visibleLevel - dataSource.minDataLevel)
@@ -886,67 +895,54 @@ export class VisibleTileSet {
             this.options.quadTreeSearchDistanceDown,
             Math.max(0, dataSource.maxDataLevel - visibleLevel)
         );
-
-        return { searchLevelsUp, searchLevelsDown };
+        const searchDirection =
+            searchLevelsDown > 0 && searchLevelsUp > 0
+                ? SearchDirection.BOTH
+                : searchLevelsDown > 0
+                ? SearchDirection.DOWN
+                : searchLevelsUp > 0
+                ? SearchDirection.UP
+                : SearchDirection.NONE;
+        return { searchDirection, searchLevelsUp, searchLevelsDown };
     }
 
     /**
-     * Search cache to replace visible but yet empty tiles with already loaded siblings in nearby
-     * zoom levels.
+     * Populates the list of tiles to render, see "renderedTiles". Tiles that are loaded and which
+     * are an exact match are added straight to the list, tiles that are still loading are replaced
+     * with tiles in the cache that are either a parent or child of the requested tile. This helps
+     * to prevent flickering when zooming in / out. The distance to search is based on the options
+     * [[quadTreeSearchDistanceDown]] and [[quadTreeSearchDistanceUp]].
      *
-     * Useful, when zooming in/out and when "newly elected" tiles are not yet loaded. Prevents
-     * flickering by rendering already loaded tiles from upper/higher zoom levels.
      */
-    private fillMissingTilesFromCache() {
+    private populateRenderedTiles() {
         this.dataSourceTileList.forEach(renderListEntry => {
-            const dataSource = renderListEntry.dataSource;
-            const dataZoomLevel = renderListEntry.zoomLevel;
             const renderedTiles = renderListEntry.renderedTiles;
 
-            // Direction in quad tree to search: up -> shallower levels, down -> deeper levels.
-            enum SearchDirection {
-                NONE,
-                UP,
-                DOWN,
-                BOTH
-            }
-            let defaultSearchDirection = SearchDirection.NONE;
+            // Tiles for which we need to fall(back/forward) to.
+            const incompleteTiles: number[] = [];
 
-            const { searchLevelsUp, searchLevelsDown } = this.getCacheSearchLevels(
-                dataSource,
-                dataZoomLevel
-            );
-
-            defaultSearchDirection =
-                searchLevelsDown > 0 && searchLevelsUp > 0
-                    ? SearchDirection.BOTH
-                    : searchLevelsDown > 0
-                    ? SearchDirection.DOWN
-                    : searchLevelsUp > 0
-                    ? SearchDirection.UP
-                    : SearchDirection.NONE;
-
-            const incompleteTiles: Map<number, SearchDirection> = new Map();
-
+            // Populate the list of tiles which can be shown ("renderedTiles"), and the list of
+            // tiles that are incomplete, and for which we search for an alternative
+            // ("incompleteTiles").
             renderListEntry.visibleTiles.forEach(tile => {
-                const tileCode = TileOffsetUtils.getKeyForTileKeyAndOffset(
-                    tile.tileKey,
-                    tile.offset
-                );
                 tile.levelOffset = 0;
                 if (tile.hasGeometry) {
-                    renderedTiles.set(tileCode, tile);
+                    renderedTiles.set(tile.uniqueKey, tile);
                 } else {
                     // if dataSource supports cache and it was existing before this render
                     // then enable searching for loaded tiles in cache
-                    incompleteTiles.set(tileCode, defaultSearchDirection);
+                    incompleteTiles.push(tile.uniqueKey);
                 }
             });
 
-            if (incompleteTiles.size === 0) {
+            if (incompleteTiles.length === 0) {
                 // short circuit, nothing to be done
                 return;
             }
+
+            const dataSource = renderListEntry.dataSource;
+            const dataZoomLevel = renderListEntry.zoomLevel;
+            const { searchDirection } = this.getSearchDirection(dataSource, dataZoomLevel);
 
             // Minor optimization for the fallback search, only check parent tiles once, otherwise
             // the recursive algorithm checks all parent tiles multiple times, the key is the code
@@ -955,7 +951,7 @@ export class VisibleTileSet {
             // Iterate over incomplete (not loaded tiles) and find their parents or children that
             // are in cache that can be rendered temporarily until tile is loaded. Note, we favour
             // falling back to parent tiles rather than children.
-            for (const [tileKeyCode, searchDirection] of incompleteTiles) {
+            for (const tileKeyCode of incompleteTiles) {
                 if (
                     searchDirection === SearchDirection.BOTH ||
                     searchDirection === SearchDirection.UP


### PR DESCRIPTION
- Cache unique tile key of Tile
- Rename method to improve ease of understanding
- Reorder variable definitions to be closer to their respective usage

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>
