### PR TITLE
HARP-10490: Reset the text label bounds when reusing other label's state.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -182,11 +182,11 @@ export class TextElementState {
         predecessor.m_iconRenderStates = undefined;
 
         if (this.element.glyphs === undefined) {
-            // Use the predecessor glyphs, bounds and case array until proper ones are computed.
+            // Use the predecessor glyphs and case array until proper ones are computed.
             this.element.glyphs = predecessor.element.glyphs;
-            this.element.bounds = predecessor.element.bounds;
             this.element.glyphCaseArray = predecessor.element.glyphCaseArray;
         }
+        this.element.bounds = undefined;
         this.element.textBufferObject = undefined;
     }
 

--- a/@here/harp-mapview/test/TextElementStateTest.ts
+++ b/@here/harp-mapview/test/TextElementStateTest.ts
@@ -222,7 +222,7 @@ describe("TextElementState", function() {
             expect(textElementState["m_textLayoutState"]).to.equal(predecessorLayout);
         });
 
-        it("reuses text element glyphs and bounds", function() {
+        it("reuses text element glyphs", function() {
             const predecessorState = new TextElementState({
                 type: TextElementType.PoiLabel,
                 poiInfo: {
@@ -234,7 +234,6 @@ describe("TextElementState", function() {
             } as any);
             predecessorState.update(0);
             const predecessorGlyphs = predecessorState.element.glyphs;
-            const predecessorBounds = predecessorState.element.bounds;
             const predecessorGlyphCaseArray = predecessorState.element.glyphCaseArray;
 
             const textElementState = new TextElementState({
@@ -247,8 +246,35 @@ describe("TextElementState", function() {
 
             textElementState.replace(predecessorState);
             expect(textElementState.element.glyphs).to.equal(predecessorGlyphs);
-            expect(textElementState.element.bounds).to.equal(predecessorBounds);
             expect(textElementState.element.glyphCaseArray).to.equal(predecessorGlyphCaseArray);
+        });
+
+        it("invalidates text element bounds", function() {
+            const predecessorState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                },
+                bounds: {},
+                glyphCaseArray: []
+            } as any);
+            predecessorState.update(0);
+
+            const textElementState = new TextElementState({
+                type: TextElementType.PoiLabel,
+                poiInfo: {
+                    technique: {}
+                },
+                bounds: {},
+                glyphCaseArray: []
+            } as any);
+            textElementState.update(0);
+
+            expect(textElementState.element.bounds).to.not.undefined;
+            expect(predecessorState.element.bounds).to.not.undefined;
+
+            textElementState.replace(predecessorState);
+            expect(textElementState.element.bounds).to.undefined;
         });
 
         it("invalidates text buffer", function() {


### PR DESCRIPTION
This ensures that bounds are properly calculated in the next frame and
fixes the bug with seldom text offset jumping on zoom level changes.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
