### PR TITLE
HARP-9926: Suppress labels flickering while panning on 2d view.

### DIFF
--- a/@here/harp-mapview/lib/text/MapViewState.ts
+++ b/@here/harp-mapview/lib/text/MapViewState.ts
@@ -6,6 +6,7 @@
 
 import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { Projection } from "@here/harp-geoutils";
+import * as THREE from "three";
 import { ElevationProvider } from "../ElevationProvider";
 import { MapView } from "../MapView";
 import { ViewState } from "./ViewState";
@@ -14,6 +15,7 @@ import { ViewState } from "./ViewState";
  * View state obtained from a MapView instance.
  */
 export class MapViewState implements ViewState {
+    private readonly m_lookAtVector = new THREE.Vector3();
     constructor(
         private readonly m_mapView: MapView,
         private readonly m_renderedTilesChangeCheck: () => boolean
@@ -36,6 +38,9 @@ export class MapViewState implements ViewState {
     }
     get frameNumber(): number {
         return this.m_mapView.frameNumber;
+    }
+    get lookAtVector(): THREE.Vector3 {
+        return this.m_mapView.camera.getWorldDirection(this.m_lookAtVector);
     }
     get lookAtDistance(): number {
         return this.m_mapView.targetDistance;

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -41,26 +41,29 @@ const MIN_AVERAGE_CHAR_WIDTH = 5;
 
 const tmpPosition = new THREE.Vector3(0, 0, 0);
 const tmpCameraDir = new THREE.Vector3(0, 0, 0);
+const tmpPointDir = new THREE.Vector3(0, 0, 0);
 const COS_TEXT_ELEMENT_FALLOFF_ANGLE = 0.5877852522924731; // Math.cos(0.3 * Math.PI)
 
 /**
- * Checks whether the distance of the specified text element to the center of the given view is
- * lower than a maximum threshold.
+ * Checks whether the distance of the text element to the camera plane meets threshold criterias.
+ *
  * @param textElement The textElement of which the view distance will be checked, with coordinates
  * in world space.
- * @param mapView The view that will be used as reference to calculate the distance.
+ * @param eyePos The eye (or camera) position that will be used as reference to calculate
+ * the distance.
+ * @param eyeLookAt The eye looking direction - normalized.
  * @param maxViewDistance The maximum distance value.
  * @returns The text element view distance if it's lower than the maximum value, otherwise
  * `undefined`.
  */
 function checkViewDistance(
-    worldCenter: THREE.Vector3,
     textElement: TextElement,
+    eyePos: THREE.Vector3,
+    eyeLookAt: THREE.Vector3,
     projectionType: ProjectionType,
-    camera: THREE.Camera,
     maxViewDistance: number
 ): number | undefined {
-    const textDistance = computeViewDistance(worldCenter, textElement);
+    const textDistance = computeViewDistance(textElement, eyePos, eyeLookAt);
 
     if (projectionType !== ProjectionType.Spherical) {
         return textDistance <= maxViewDistance ? textDistance : undefined;
@@ -68,7 +71,7 @@ function checkViewDistance(
 
     // For sphere projection: Filter labels that are close to the horizon
     tmpPosition.copy(textElement.position).normalize();
-    camera.getWorldPosition(tmpCameraDir).normalize();
+    tmpCameraDir.copy(eyePos).normalize();
     const cosAlpha = tmpPosition.dot(tmpCameraDir);
     const viewDistance =
         cosAlpha > COS_TEXT_ELEMENT_FALLOFF_ANGLE && textDistance <= maxViewDistance
@@ -79,28 +82,60 @@ function checkViewDistance(
 }
 
 /**
- * Computes the distance of the specified text element to the given position.
- * @param refPosition The world coordinates used a reference position to calculate the distance.
+ * Computes distance of the specified text element to camera plane given with position and normal.
+ *
+ * The distance is measured as projection of the vector between @param eyePosition and text element
+ * onto the @param eyeLookAt vector, so it actually computes the distance to plane that
+ * contains @param eyePosition and is described with @param eyeLookAt as normal.
+ *
+ * @note Used for measuring the distances to camera, results in the metric that describes
+ * distance to camera near plane (assuming near = 0). Such metric is better as input for labels
+ * scaling or fading factors then simple euclidean distance because it does not fluctuate during
+ * simple camera panning.
+ *
  * @param textElement The textElement of which the view distance will be checked. It must have
  * coordinates in world space.
+ * @param eyePosition The world eye coordinates used a reference position to calculate the distance.
+ * @param eyeLookAt The eye looking direction or simply said projection plane normal.
  * @returns The text element view distance.
- * `undefined`.
  */
-export function computeViewDistance(refPosition: THREE.Vector3, textElement: TextElement): number {
+export function computeViewDistance(
+    textElement: TextElement,
+    eyePosition: THREE.Vector3,
+    eyeLookAt: THREE.Vector3
+): number {
     let viewDistance: number;
 
-    if (Array.isArray(textElement.points) && textElement.points.length > 1) {
-        const viewDistance0 = refPosition.distanceTo(textElement.points[0]);
-        const viewDistance1 = refPosition.distanceTo(
-            textElement.points[textElement.points.length - 1]
-        );
+    // Compute the distances as the distance along plane normal.
+    const path = textElement.path;
+    if (path && path.length > 1) {
+        const viewDistance0 = pointToPlaneDistance(path[0], eyePosition, eyeLookAt);
+        const viewDistance1 = pointToPlaneDistance(path[path.length - 1], eyePosition, eyeLookAt);
 
         viewDistance = Math.min(viewDistance0, viewDistance1);
     } else {
-        viewDistance = refPosition.distanceTo(textElement.points as THREE.Vector3);
+        viewDistance = pointToPlaneDistance(textElement.position, eyePosition, eyeLookAt);
     }
 
     return viewDistance;
+}
+
+/**
+ * Computes distance between the given point and a plane.
+ *
+ * May be used to measure distance of point labels to the camera projection (near) plane.
+ *
+ * @param pointPos The position to measure distance to.
+ * @param planePos The position of any point on the plane.
+ * @param planeNorm The plane normal vector (have to be normalized already).
+ */
+export function pointToPlaneDistance(
+    pointPos: THREE.Vector3,
+    planePos: THREE.Vector3,
+    planeNorm: THREE.Vector3
+) {
+    const labelCamVec = tmpPointDir.copy(pointPos).sub(planePos);
+    return labelCamVec.dot(planeNorm);
 }
 
 /**
@@ -177,12 +212,12 @@ export function checkReadyForPlacement(
 
     viewDistance =
         maxViewDistance === undefined
-            ? computeViewDistance(viewState.worldCenter, textElement)
+            ? computeViewDistance(textElement, viewState.worldCenter, viewState.lookAtVector)
             : checkViewDistance(
-                  viewState.worldCenter,
                   textElement,
+                  viewState.worldCenter,
+                  viewState.lookAtVector,
                   viewState.projection.type,
-                  viewCamera,
                   maxViewDistance
               );
 

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -758,7 +758,8 @@ export class TextElementsRenderer {
                     ++placementStats.total;
                 }
             }
-            if (
+            // Limit labels only in new labels pass (Pass.NewLabels).
+            else if (
                 maxNumPlacedLabels >= 0 &&
                 renderParams.numRenderedTextElements >= maxNumPlacedLabels
             ) {
@@ -1485,7 +1486,7 @@ export class TextElementsRenderer {
         // remains unchanged, the farther is label from that point the smaller size it is
         // rendered in screen space. This method is unaffected by near and far clipping planes
         // distances, but may be improved by taking FOV into equation or customizing the
-        // focus point screen position based on horizont, actual ground, tilt ets.
+        // focus point screen position based on horizon, actual ground, tilt ets.
         let factor = lookAtDistance / distance;
         // The label.distanceScale property defines the influence ratio at which
         // distance affects the final scaling of label.

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -48,6 +48,7 @@ import {
     PlacementResult,
     placePathLabel,
     placePointLabel,
+    pointToPlaneDistance,
     PrePlacementResult
 } from "./Placement";
 import { PlacementStats } from "./PlacementStats";
@@ -318,7 +319,6 @@ export class TextElementsRenderer {
 
     private m_tmpVector = new THREE.Vector2();
     private m_tmpVector3 = new THREE.Vector3();
-    private m_tmpLabelCamVec = new THREE.Vector3();
     private m_cameraLookAt = new THREE.Vector3();
     private m_overloaded: boolean = false;
     private m_cacheInvalidated: boolean = false;
@@ -1547,11 +1547,12 @@ export class TextElementsRenderer {
         tempScreenPosition.x = tempPoiScreenPosition.x = screenPosition.x;
         tempScreenPosition.y = tempPoiScreenPosition.y = screenPosition.y;
 
-        // Scale the text depending on the label's distance to the camera "zero" plane - near
-        // plane at zero distance. The result is the same as taking the distance from "Z"
-        // coordinate in camera space. This way we avoid co-planar labels' scale variation.
-        const labelCamVec = this.m_tmpLabelCamVec.copy(position).sub(this.m_viewState.worldCenter);
-        const textDistance = labelCamVec.dot(this.m_cameraLookAt);
+        // Scale the text depending on the label's distance to the camera "zero" plane.
+        const textDistance = pointToPlaneDistance(
+            position,
+            this.m_viewState.worldCenter,
+            this.m_cameraLookAt
+        );
         if (
             pointLabel.fadeFar !== undefined &&
             (pointLabel.fadeFar <= 0.0 ||
@@ -1896,7 +1897,9 @@ export class TextElementsRenderer {
         }
 
         // Update the real rendering distance to have smooth fading and scaling
-        labelState.setViewDistance(computeViewDistance(this.m_viewState.worldCenter, pathLabel));
+        labelState.setViewDistance(
+            computeViewDistance(pathLabel, this.m_viewState.worldCenter, this.m_cameraLookAt)
+        );
         const textRenderDistance = -labelState.renderDistance;
 
         // Scale the text depending on the label's distance to the camera.

--- a/@here/harp-mapview/lib/text/ViewState.ts
+++ b/@here/harp-mapview/lib/text/ViewState.ts
@@ -18,6 +18,7 @@ export interface ViewState {
     zoomLevel: number; // View's zoom level.
     env: Env;
     frameNumber: number; // Current frame number.
+    lookAtVector: THREE.Vector3; // Normalized camera viewing direction.
     lookAtDistance: number; // Distance to the lookAt point.
     isDynamic: boolean; // Whether a new frame for the view is already requested.
     hiddenGeometryKinds?: GeometryKindSet; // Kinds of geometries that are disabled.

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -52,6 +52,7 @@ function createViewState(worldCenter: THREE.Vector3, sandbox: sinon.SinonSandbox
         zoomLevel: 20,
         env: new MapEnv({ $zoom: 20 }),
         frameNumber: 0,
+        lookAtVector: new THREE.Vector3(0, 0, -1),
         lookAtDistance: 0,
         isDynamic: false,
         hiddenGeometryKinds: undefined,


### PR DESCRIPTION
Some text labels do appear/disappear showing the current solution unstable
even when camera parameters are not changed and user performs top view (2D)
panning.
This problem is caused by labels distance scaling and changes in their
bounds. Because labels closer to screen center becomes bigger they need
more screen space and thus labels' collisions algorithm may drop them out.
The second problem was caused by limiting the number of labels being placed
from now this limit will be applied only to the new labels to be processed.

Signed-off-by: Krystian Kostecki <ext-krystian.kostecki@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
