### PR TITLE
HARP-10298: Avoid zoom button double click propagation to canvas.

### DIFF
--- a/@here/harp-map-controls/lib/MapControlsUI.ts
+++ b/@here/harp-map-controls/lib/MapControlsUI.ts
@@ -209,9 +209,19 @@ export class MapControlsUI {
             const zoomLevel = controls.zoomLevelTargeted + controls.zoomLevelDeltaOnControl;
             controls.setZoomLevel(zoomLevel);
         });
+        zoomInButton.addEventListener("dblclick", event => {
+            // HARP-10298: Avoid double click event propagation to canvas in WebKit-based browsers
+            // when a zoom button is quickly clicked multiple times.
+            event.stopPropagation();
+        });
         zoomOutButton.addEventListener("click", event => {
             const zoomLevel = controls.zoomLevelTargeted - controls.zoomLevelDeltaOnControl;
             controls.setZoomLevel(zoomLevel);
+        });
+        zoomOutButton.addEventListener("dblclick", event => {
+            // HARP-10298: Avoid double click event propagation to canvas in WebKit-based browsers
+            // when a zoom button is quickly clicked multiple times.
+            event.stopPropagation();
         });
         tiltButton.addEventListener("click", event => {
             controls.toggleTilt();


### PR DESCRIPTION
If zoom buttons are quickly pressed twice in WebKit-based browser, the
generated double click event is propagated to canvas, triggering a zoom in
movement in addition to zoom button action.

Signed-off-by: Andres Mandado Almajano <andres.mandado-almajano@here.com>
