### PR TITLE
harp-10621: Fix broken non leading zero float color transparency

### DIFF
--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -109,7 +109,7 @@ const StringEncodedRGBA: StringEncodedNumeralFormat = {
     type: StringEncodedNumeralType.RGBA,
     size: 4,
     // tslint:disable-next-line:max-line-length
-    regExp: /^rgba\( ?(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:(0(?:\.[0-9]+)?|1(?:\.0+)?)) ?\)$/,
+    regExp: /^rgba\( ?(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:([0-9]{1,2}|1[0-9]{1,2}|2[0-4][0-9]|25[0-5]), ?)(?:(0?(?:\.[0-9]+)?|1(?:\.0+)?)) ?\)$/,
     decoder: (encodedValue: string, target: number[]) => {
         const channels = StringEncodedRGBA.regExp.exec(encodedValue);
         if (channels === null) {

--- a/@here/harp-datasource-protocol/test/StringDecodersTest.ts
+++ b/@here/harp-datasource-protocol/test/StringDecodersTest.ts
@@ -203,6 +203,8 @@ function testRGBAColor() {
     // cause full alpha (1.0) will be encoded as transparency:
     // T = 255 - (1 * 255) with 24 bits shift.
     assert.strictEqual(parseStringEncodedNumeral(`rgba(0,0,0,0.0)`), 255 << 24);
+    assert.strictEqual(parseStringEncodedNumeral(`rgba(0,0,0,.0)`), 255 << 24);
+    assert.strictEqual(parseStringEncodedNumeral(`rgba(0,0,0,.5)`), 255 << 31);
     assert.strictEqual(parseStringEncodedNumeral(`rgba(0,0,0,1.0)`), 0);
     assert.strictEqual(parseStringEncodedNumeral(`rgba(255,0,0,1.0)`), 255 << 16);
     assert.strictEqual(parseStringEncodedNumeral(`rgba(255,0,0,0.0)`), (255 << 16) | (255 << 24));


### PR DESCRIPTION
While for example the **rgba(0,85,170,.6)** is a valid CSS color, using it throws a **Unsupported color format** error in harp.gl.

The [RGBA alpha value](https://drafts.csswg.org/css-color/#typedef-alpha-value) can also be specified without a leading zero. The following change is a hotfix to cover it.
