### PR TITLE
HARP-9673: Snap zoom level to nearest integer if close enough to it.

### DIFF
--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -8,6 +8,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import {
+    EarthConstants,
     GeoCoordinates,
     mercatorProjection,
     Projection,
@@ -31,7 +32,7 @@ const cameraMock = {
 };
 
 describe("map-view#Utils", function() {
-    it("calculates zoom level", function() {
+    describe("calculateZoomLevelFromDistance", function() {
         const mapViewMock = {
             maxZoomLevel: 20,
             minZoomLevel: 1,
@@ -41,18 +42,28 @@ describe("map-view#Utils", function() {
             pixelRatio: 1.0
         };
         const mapView = (mapViewMock as any) as MapView;
+        it("calculates zoom level", function() {
+            let result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 0);
+            expect(result).to.be.equal(20);
+            result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 1000000000000);
+            expect(result).to.be.equal(1);
+            /*
+             *   23.04.2018 - Zoom level outputs come from HARP
+             */
+            result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 1000);
+            result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 10000);
+            result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 1000000);
+            expect(result).to.be.closeTo(5.32, 0.05);
+        });
 
-        let result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 0);
-        expect(result).to.be.equal(20);
-        result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 1000000000000);
-        expect(result).to.be.equal(1);
-        /*
-         *   23.04.2018 - Zoom level outputs come from HARP
-         */
-        result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 1000);
-        result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 10000);
-        result = MapViewUtils.calculateZoomLevelFromDistance(mapView, 1000000);
-        expect(result).to.be.closeTo(5.32, 0.05);
+        it("snaps zoom level to ceiling integer if close enough to it", function() {
+            const eps = 1e-10;
+            const result = MapViewUtils.calculateZoomLevelFromDistance(
+                mapView,
+                EarthConstants.EQUATORIAL_CIRCUMFERENCE * (0.25 + eps)
+            );
+            expect(result).equals(2);
+        });
     });
 
     it("converts target coordinates from XYZ to camera coordinates", function() {


### PR DESCRIPTION
Conversions from zoom level to camera distance and back to zoom level cause a loss of
precision that makes the actual zoom level at each frame fall sometimes below and others
above a given integer zoom level, causing flickering of some map objects (e.g. extruded buildings).

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
