### PR TITLE
Build and deploy the api reference.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ jobs:
       script:
         - cross-env NODE_ENV=production yarn run build
         - yarn run typedoc
+        - yarn docs
         - cross-env NODE_ENV=production yarn run build-www
         - yarn prepare-doc-deploy
         # debug: lerna publish expects clean workspace

--- a/scripts/prepare_doc_deploy.ts
+++ b/scripts/prepare_doc_deploy.ts
@@ -36,6 +36,7 @@ const targetFolderS3 = `dist/s3_deploy/${folderName}`;
 removeSync(targetFolderGh);
 ensureDirSync(targetFolderGh);
 copySync("www/dist/", `${targetFolderGh}/`);
+copySync("markdown/", `${targetFolderGh}/api/`);
 
 removeSync(targetFolderS3);
 ensureDirSync(targetFolderS3);


### PR DESCRIPTION
This change extracts the APIs using api-extractor/documenter and
it deploys the generated API reference in the gh pages under the
directory `api`.
