### PR TITLE
HARP-10756: Use @link tags instead of [[..]] to reference declarations.

### DIFF
--- a/@here/harp-geoutils/lib/coordinates/GeoBoxExtentLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoBoxExtentLike.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Represents an object that carry [[GeoBox]] extents like interface.
+ * Represents an object that carry {@link GeoBox} extents like interface.
  */
 export interface GeoBoxExtentLike {
     /**
@@ -20,7 +20,7 @@ export interface GeoBoxExtentLike {
 }
 
 /**
- * Type guard to assert that `object` conforms to [[GeoBoxExtentLike]] interface.
+ * Type guard to assert that `object` conforms to {@link GeoBoxExtentLike} interface.
  */
 export function isGeoBoxExtentLike(obj: any): obj is GeoBoxExtentLike {
     return (

--- a/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
@@ -46,19 +46,19 @@ export class GeoCoordinates implements GeoCoordinatesLike {
     }
 
     /**
-     * Creates a [[GeoCoordinates]] from a [[LatLngLike]] literal.
+     * Creates a {@link GeoCoordinates} from a {@link LatLngLike} literal.
      * ```typescript
      * const center = { lat: 53.3, lng: 13.4 };
      * mapView.geoCenter = GeoCoordinates.fromLatLng(center);
      * ```
-     * @param latLng - A [[LatLngLike]] object literal.
+     * @param latLng - A {@link LatLngLike} object literal.
      */
     static fromLatLng(latLng: LatLngLike) {
         return new GeoCoordinates(latLng.lat, latLng.lng);
     }
 
     /**
-     * Creates a [[GeoCoordinates]] from a [[GeoPointLike]] tuple.
+     * Creates a {@link GeoCoordinates} from a [[GeoPointLike]] tuple.
      *
      * Example:
      * ```typescript
@@ -78,7 +78,7 @@ export class GeoCoordinates implements GeoCoordinatesLike {
     }
 
     /**
-     * Creates a [[GeoCoordinates]] from different types of geo coordinate objects.
+     * Creates a {@link GeoCoordinates} from different types of geo coordinate objects.
      *
      * Example:
      * ```typescript
@@ -88,8 +88,8 @@ export class GeoCoordinates implements GeoCoordinatesLike {
      * const fromLatLngLike = GeoCoordinates.fromObject({ lat: latitude , lng: longitude });
      * ```
      *
-     * @param geoPoint - Either [[GeoPointLike]], [[GeoCoordinatesLike]]
-     * or [[LatLngLike]] object literal.
+     * @param geoPoint - Either [[GeoPointLike]], {@link GeoCoordinatesLike}
+     * or {@link LatLngLike} object literal.
      */
     static fromObject(geoPoint: GeoCoordLike): GeoCoordinates {
         if (isGeoPointLike(geoPoint)) {
@@ -242,14 +242,14 @@ export class GeoCoordinates implements GeoCoordinatesLike {
     }
 
     /**
-     * Returns this [[GeoCoordinates]] as [[LatLngLike]] literal.
+     * Returns this {@link GeoCoordinates} as {@link LatLngLike} literal.
      */
     toLatLng(): LatLngLike {
         return { lat: this.latitude, lng: this.longitude };
     }
 
     /**
-     * Converts this [[GeoCoordinates]] to a [[GeoPointLike]].
+     * Converts this {@link GeoCoordinates} to a [[GeoPointLike]].
      */
     toGeoPoint(): GeoPointLike {
         return this.altitude !== undefined

--- a/@here/harp-geoutils/lib/coordinates/GeoCoordinatesLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordinatesLike.ts
@@ -19,7 +19,7 @@ export interface GeoCoordinatesLike {
 }
 
 /**
- * Type guard to assert that `object` conforms to [[GeoCoordinatesLike]] data interface.
+ * Type guard to assert that `object` conforms to {@link GeoCoordinatesLike} data interface.
  */
 export function isGeoCoordinatesLike(object: any): object is GeoCoordinatesLike {
     return (

--- a/@here/harp-geoutils/lib/coordinates/LatLngLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/LatLngLike.ts
@@ -16,7 +16,7 @@ export interface LatLngLike {
 }
 
 /**
- * Type guard to assert that `object` conforms to [[LatLngLike]] interface.
+ * Type guard to assert that `object` conforms to {@link LatLngLike} interface.
  */
 export function isLatLngLike(object: any): object is LatLngLike {
     return object && typeof object.lat === "number" && typeof object.lng === "number";

--- a/@here/harp-geoutils/lib/math/Box3Like.ts
+++ b/@here/harp-geoutils/lib/math/Box3Like.ts
@@ -22,7 +22,7 @@ export interface Box3Like {
 }
 
 /**
- * Returns true if the given object implements the [[Box3Like]] interface.
+ * Returns true if the given object implements the {@link Box3Like} interface.
  *
  * @param object - A valid object.
  */

--- a/@here/harp-geoutils/lib/math/OrientedBox3.ts
+++ b/@here/harp-geoutils/lib/math/OrientedBox3.ts
@@ -118,8 +118,8 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
-     * Copies the values of `other` to this [[OrientedBox3]].
-     * @param other - The other [[OrientedBox3]] to copy.
+     * Copies the values of `other` to this {@link OrientedBox3}.
+     * @param other - The other {@link OrientedBox3} to copy.
      */
     copy(other: OrientedBox3) {
         this.position.copy(other.position);
@@ -130,7 +130,7 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
-     * Gets the center position of this [[OrientedBox3]].
+     * Gets the center position of this {@link OrientedBox3}.
      *
      * @param center - The returned center position.
      */
@@ -139,7 +139,7 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
-     * Gets the size of this [[OrientedBox3]].
+     * Gets the size of this {@link OrientedBox3}.
      *
      * @param size - The returned size.
      */
@@ -206,7 +206,7 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
-     * Returns true if this [[OrientedBox3]] contains the given point.
+     * Returns true if this {@link OrientedBox3} contains the given point.
      *
      * @param point - A valid point.
      */
@@ -224,7 +224,7 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
-     * Returns the distance from this [[OrientedBox3]] and the given `point`.
+     * Returns the distance from this {@link OrientedBox3} and the given `point`.
      *
      * @param point - A point.
      */
@@ -233,7 +233,7 @@ export class OrientedBox3 implements OrientedBox3Like {
     }
 
     /**
-     * Returns the squared distance from this [[OrientedBox3]] and the given `point`.
+     * Returns the squared distance from this {@link OrientedBox3} and the given `point`.
      *
      * @param point - A point.
      */

--- a/@here/harp-geoutils/lib/math/OrientedBox3Like.ts
+++ b/@here/harp-geoutils/lib/math/OrientedBox3Like.ts
@@ -8,7 +8,7 @@ import { TransformLike } from "./TransformLike";
 import { Vector3Like } from "./Vector3Like";
 
 /**
- * The interface [[OrientedBox3Like]] is used to represent oriented bounding box.
+ * The interface {@link OrientedBox3Like} is used to represent oriented bounding box.
  */
 export interface OrientedBox3Like extends TransformLike {
     /**
@@ -18,7 +18,7 @@ export interface OrientedBox3Like extends TransformLike {
 }
 
 /**
- * Returns true if the given object implements the interface [[OrientedBox3Like]].
+ * Returns true if the given object implements the interface {@link OrientedBox3Like}.
  *
  * @param object - The object.
  */

--- a/@here/harp-geoutils/lib/math/TransformLike.ts
+++ b/@here/harp-geoutils/lib/math/TransformLike.ts
@@ -7,7 +7,7 @@
 import { Vector3Like } from "./Vector3Like";
 
 /**
- * The interface [[TransformLike]] is used to represent transforms with
+ * The interface {@link TransformLike} is used to represent transforms with
  * only translation and rotation.
  */
 export interface TransformLike {
@@ -33,7 +33,7 @@ export interface TransformLike {
 }
 
 /**
- * Returns true if the given object implements the interface [[TransformLike]].
+ * Returns true if the given object implements the interface {@link TransformLike}.
  *
  * @param object - The object.
  */

--- a/@here/harp-geoutils/lib/projection/EquirectangularProjection.ts
+++ b/@here/harp-geoutils/lib/projection/EquirectangularProjection.ts
@@ -165,13 +165,13 @@ class EquirectangularProjection extends Projection {
 }
 
 /**
- * Equirectangular [[Projection]] used to convert geo coordinates to unit coordinates and vice
+ * Equirectangular {@link Projection} used to convert geo coordinates to unit coordinates and vice
  * versa.
  */
 export const normalizedEquirectangularProjection: Projection = new EquirectangularProjection(1);
 
 /**
- * Equirectangular [[Projection]] used to convert geo coordinates to world coordinates and vice
+ * Equirectangular {@link Projection} used to convert geo coordinates to world coordinates and vice
  * versa.
  */
 export const equirectangularProjection: Projection = new EquirectangularProjection(

--- a/@here/harp-geoutils/lib/projection/IdentityProjection.ts
+++ b/@here/harp-geoutils/lib/projection/IdentityProjection.ts
@@ -135,6 +135,6 @@ class IdentityProjection extends Projection {
 }
 
 /**
- * Identity [[Projection]] used to convert geo coordinates to unit coordinates and vice versa.
+ * Identity {@link Projection} used to convert geo coordinates to unit coordinates and vice versa.
  */
 export const identityProjection: Projection = new IdentityProjection(1);

--- a/@here/harp-geoutils/lib/projection/MercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/MercatorProjection.ts
@@ -343,14 +343,15 @@ export class MercatorConstants {
 }
 
 /**
- * Mercator [[Projection]] used to convert geo coordinates to world coordinates and vice versa.
+ * Mercator {@link Projection} used to convert geo coordinates to world coordinates and vice versa.
  */
 export const mercatorProjection: Projection = new MercatorProjection(
     EarthConstants.EQUATORIAL_CIRCUMFERENCE
 );
 
 /**
- * Web Mercator [[Projection]] used to convert geo coordinates to world coordinates and vice versa.
+ * Web Mercator {@link Projection} used to convert geo coordinates to world coordinates
+ * and vice versa.
  */
 export const webMercatorProjection: Projection = new WebMercatorProjection(
     EarthConstants.EQUATORIAL_CIRCUMFERENCE

--- a/@here/harp-geoutils/lib/projection/Projection.ts
+++ b/@here/harp-geoutils/lib/projection/Projection.ts
@@ -72,7 +72,7 @@ export abstract class Projection {
      *
      * @param geoPoint - The position in geo coordinates.
      * @param result - The optional object used to store the resulting world position, result must
-     * implement [[Vector3Like]].
+     * implement {@link Vector3Like}.
      */
     abstract projectPoint<WorldCoordinates extends Vector3Like>(
         geoPoint: GeoCoordinatesLike,
@@ -80,10 +80,10 @@ export abstract class Projection {
     ): WorldCoordinates;
 
     /**
-     * Gets the [[TransformLike]] of the local tangent space at the given point.
+     * Gets the {@link TransformLike} of the local tangent space at the given point.
      *
      * @param point - The geo / world coordinates.
-     * @param result - The [[TransformLike]].
+     * @param result - The {@link TransformLike}.
      */
     localTangentSpace(
         point: GeoCoordinatesLike | Vector3Like,
@@ -144,7 +144,7 @@ export abstract class Projection {
      * ```
      *
      * @param geoBox - The bounding box in geo coordinates.
-     * @param result - The resulting [[OrientedBox3Like]].
+     * @param result - The resulting {@link OrientedBox3Like}.
      */
     abstract projectBox<WorldBoundingBox extends Box3Like | OrientedBox3Like>(
         geoBox: GeoBox,
@@ -206,20 +206,20 @@ export abstract class Projection {
     abstract scalePointToSurface(worldPoint: Vector3Like): Vector3Like;
 
     /**
-     * Reproject a world position from the given source [[Projection]].
+     * Reproject a world position from the given source {@link Projection}.
      *
      * @param sourceProjection - The source projection.
      * @param worldPos - A valid world position for the given source projection.
-     * @returns The world position reprojected using this [[Projection]].
+     * @returns The world position reprojected using this {@link Projection}.
      */
     reprojectPoint(sourceProjection: Projection, worldPos: Vector3Like): Vector3Like;
 
     /**
-     * Reproject a world position from the given source [[Projection]].
+     * Reproject a world position from the given source {@link Projection}.
      *
      * @param sourceProjection - The source projection.
      * @param worldPos - A valid position in the world space defined by the source projection.
-     * @param result - The resulting position reprojected using this [[Projection]].
+     * @param result - The resulting position reprojected using this {@link Projection}.
      */
     reprojectPoint<WorldCoordinates extends Vector3Like>(
         sourceProjection: Projection,
@@ -228,12 +228,12 @@ export abstract class Projection {
     ): WorldCoordinates;
 
     /**
-     * Reproject a world position from the given source [[Projection]].
+     * Reproject a world position from the given source {@link Projection}.
      * Implementations should be aware of worldPos and result may be one object
      *
      * @param sourceProjection - The source projection.
      * @param worldPos - A valid position in the world space defined by the source projection.
-     * @param result - The resulting position reprojected using this [[Projection]].
+     * @param result - The resulting position reprojected using this {@link Projection}.
      * @hidden
      */
     reprojectPoint(

--- a/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
@@ -390,7 +390,7 @@ export class TransverseMercatorUtils {
 }
 
 /**
- * Transverse Mercator [[Projection]] used to convert geo coordinates to world coordinates
+ * Transverse Mercator {@link Projection} used to convert geo coordinates to world coordinates
  * and vice versa.
  */
 export const transverseMercatorProjection: Projection = new TransverseMercatorProjection(

--- a/@here/harp-geoutils/lib/tiling/FlatTileBoundingBoxGenerator.ts
+++ b/@here/harp-geoutils/lib/tiling/FlatTileBoundingBoxGenerator.ts
@@ -26,7 +26,7 @@ export class FlatTileBoundingBoxGenerator {
      * Creates a new `FlatTileBoundingBoxGenerator` that can generate bounding boxes for the given
      * TilingScheme.
      *
-     * @param tilingScheme - The [[TilingScheme]] used to compute bounding boxes.
+     * @param tilingScheme - The {@link TilingScheme} used to compute bounding boxes.
      * @param minElevation - The minimum elevation in meters.
      * @param maxElevation - The maximum elevation in meters.
      */
@@ -42,21 +42,21 @@ export class FlatTileBoundingBoxGenerator {
     }
 
     /**
-     * Returns the [[Projection]] of the [[TilingScheme]].
+     * Returns the {@link Projection} of the {@link TilingScheme}.
      */
     get projection(): Projection {
         return this.m_tilingScheme.projection;
     }
 
     /**
-     * Returns the [[SubdivisionScheme]] of the [[TilingScheme]].
+     * Returns the {@link SubdivisionScheme} of the {@link TilingScheme}.
      */
     get subdivisionScheme(): SubdivisionScheme {
         return this.m_tilingScheme.subdivisionScheme;
     }
 
     /**
-     * Returns the bounding box in world coordinates of the given [[TileKey]].
+     * Returns the bounding box in world coordinates of the given {@link TileKey}.
      *
      * Example:
      * ```typescript
@@ -92,7 +92,7 @@ export class FlatTileBoundingBoxGenerator {
     }
 
     /**
-     * Returns the bounding box in geo coordinates for the given [[TileKey]].
+     * Returns the bounding box in geo coordinates for the given {@link TileKey}.
      *
      * Example:
      * ```typescript
@@ -100,7 +100,7 @@ export class FlatTileBoundingBoxGenerator {
      * console.log(geoBox.center);
      * ```
      *
-     * @param tileKey - The [[TileKey]].
+     * @param tileKey - The {@link TileKey}.
      */
     getGeoBox(tileKey: TileKey): GeoBox {
         const worldBox = this.getWorldBox(tileKey);

--- a/@here/harp-geoutils/lib/tiling/HalfQuadTreeSubdivisionScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/HalfQuadTreeSubdivisionScheme.ts
@@ -24,7 +24,8 @@ class HalfQuadTreeSubdivisionScheme implements SubdivisionScheme {
 }
 
 /**
- * A [[SubdivisionScheme]] used to represent half quadtrees. This particular subdivision scheme is
+ * A {@link SubdivisionScheme} used to represent half quadtrees.
+ * This particular subdivision scheme is
  * used by the HERE tiling scheme.
  */
 export const halfQuadTreeSubdivisionScheme: SubdivisionScheme = new HalfQuadTreeSubdivisionScheme();

--- a/@here/harp-geoutils/lib/tiling/HereTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/HereTilingScheme.ts
@@ -9,7 +9,7 @@ import { halfQuadTreeSubdivisionScheme } from "./HalfQuadTreeSubdivisionScheme";
 import { TilingScheme } from "./TilingScheme";
 
 /**
- * [[TilingScheme]] used by most of the data published by HERE.
+ * {@link TilingScheme} used by most of the data published by HERE.
  *
  * The `hereTilingScheme` features a half quadtree subdivision scheme and an equirectangular
  * projection.

--- a/@here/harp-geoutils/lib/tiling/MercatorTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/MercatorTilingScheme.ts
@@ -9,7 +9,7 @@ import { quadTreeSubdivisionScheme } from "./QuadTreeSubdivisionScheme";
 import { TilingScheme } from "./TilingScheme";
 
 /**
- * The [[TilingScheme]] used by the HERE web tiles.
+ * The {@link TilingScheme} used by the HERE web tiles.
  *
  * The `mercatorTilingScheme` features a quadtree subdivision scheme and a Mercator projection.
  */

--- a/@here/harp-geoutils/lib/tiling/PolarTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/PolarTilingScheme.ts
@@ -9,7 +9,7 @@ import { quadTreeSubdivisionScheme } from "./QuadTreeSubdivisionScheme";
 import { TilingScheme } from "./TilingScheme";
 
 /**
- * A [[TilingScheme]] featuring quadtree subdivision scheme and
+ * A {@link TilingScheme} featuring quadtree subdivision scheme and
  * transverse Mercator projection.
  */
 export const polarTilingScheme = new TilingScheme(

--- a/@here/harp-geoutils/lib/tiling/QuadTree.ts
+++ b/@here/harp-geoutils/lib/tiling/QuadTree.ts
@@ -13,7 +13,7 @@ import { TilingScheme } from "./TilingScheme";
  */
 export class QuadTree {
     /**
-     * Constructs a new `QuadTree` for the given [[TilingScheme]].
+     * Constructs a new `QuadTree` for the given {@link TilingScheme}.
      *
      * Example:
      * ```typescript
@@ -27,7 +27,8 @@ export class QuadTree {
     constructor(readonly tilingScheme: TilingScheme) {}
 
     /**
-     * Visits this `QuadTree` and invoke the given accept method with the current [[TileKey]] and
+     * Visits this `QuadTree` and invoke the given accept method
+     * with the current {@link TileKey} and
      * its bounding box in geo coordinates.
      *
      * Example:
@@ -44,8 +45,10 @@ export class QuadTree {
      * });
      * ```
      *
-     * @param accept - A function that takes a [[TileKey]] and its bounding box in geo coordinates
-     * and returns `true` if the visit of the `QuadTree` should continue; otherwise `false`.
+     * @param accept - A function that takes a {@link TileKey}
+     * and its bounding box in geo coordinates
+     * and returns `true` if the visit of the `QuadTree`
+     * should continue; otherwise `false`.
      */
     visit(accept: (tileKey: TileKey, geoBox: GeoBox) => boolean) {
         this.visitTileKey(TileKey.fromRowColumnLevel(0, 0, 0), accept);
@@ -55,8 +58,10 @@ export class QuadTree {
      * Visits the subtree starting from the given tile.
      *
      * @param tileKey - The root of the subtree that should be visited.
-     * @param accept - A function that takes a [[TileKey]] and its bounding box in geo coordinates
-     * and returns `true` if the visit of the `QuadTree` should continue; otherwise `false`.
+     * @param accept - A function that takes a {@link TileKey}
+     *                 and its bounding box in geo coordinates
+     *                 and returns `true` if the visit of the
+     *                 `QuadTree` should continue; otherwise `false`.
      */
     visitTileKey(tileKey: TileKey, accept: (tileKey: TileKey, geoBox: GeoBox) => boolean) {
         const geoBox = this.tilingScheme.getGeoBox(tileKey);

--- a/@here/harp-geoutils/lib/tiling/QuadTreeSubdivisionScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/QuadTreeSubdivisionScheme.ts
@@ -24,6 +24,6 @@ class QuadTreeSubdivisionScheme implements SubdivisionScheme {
 }
 
 /**
- * [[SubdivisionScheme]] representing a quadtree.
+ * {@link SubdivisionScheme} representing a quadtree.
  */
 export const quadTreeSubdivisionScheme: SubdivisionScheme = new QuadTreeSubdivisionScheme();

--- a/@here/harp-geoutils/lib/tiling/TileKey.ts
+++ b/@here/harp-geoutils/lib/tiling/TileKey.ts
@@ -135,7 +135,7 @@ export class TileKey {
      * You can convert a tile key into a numeric Morton code with [[mortonCode]].
      *
      * @param quadKey64 - The Morton code to be converted.
-     * @returns A new instance of [[TileKey]].
+     * @returns A new instance of {@link TileKey}.
      */
     static fromMortonCode(quadKey64: number): TileKey {
         let level = 0;
@@ -242,7 +242,7 @@ export class TileKey {
     /**
      * Constructs a new immutable instance of a `TileKey`.
      *
-     * For the better readability, [[TileKey.fromRowColumnLevel]] should be preferred.
+     * For the better readability, {@link TileKey.fromRowColumnLevel} should be preferred.
      *
      * Note - row and column must not be greater than the maximum rows/columns for the given level.
      *

--- a/@here/harp-geoutils/lib/tiling/TilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/TilingScheme.ts
@@ -35,7 +35,7 @@ export class TilingScheme {
     /**
      * Returns the sub tile keys of the given tile.
      *
-     * @param tileKey - The [[TileKey]].
+     * @param tileKey - The {@link TileKey}.
      * @returns The list of the sub tile keys.
      */
     getSubTileKeys(tileKey: TileKey): Iterable<TileKey> {
@@ -43,7 +43,7 @@ export class TilingScheme {
     }
 
     /**
-     * Gets the [[TileKey]] from the given geo position and level.
+     * Gets the {@link TileKey} from the given geo position and level.
      *
      * @param geoPoint - The position in geo coordinates.
      * @param level - The level of the resulting `TileKey`.
@@ -53,7 +53,7 @@ export class TilingScheme {
     }
 
     /**
-     * Gets the list of [[TileKey]]s contained in the given [[GeoBox]].
+     * Gets the list of {@link TileKey}s contained in the given {@link GeoBox}.
      *
      * @param geoBox - The bounding box in geo coordinates.
      * @param level - The level of the resulting `TileKey`.
@@ -63,7 +63,7 @@ export class TilingScheme {
     }
 
     /**
-     * Returns the bounding box in geo coordinates for the given [[TileKey]].
+     * Returns the bounding box in geo coordinates for the given {@link TileKey}.
      *
      * @param tileKey - The `TileKey`.
      */

--- a/@here/harp-geoutils/lib/tiling/WebMercatorTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/WebMercatorTilingScheme.ts
@@ -9,7 +9,7 @@ import { quadTreeSubdivisionScheme } from "./QuadTreeSubdivisionScheme";
 import { TilingScheme } from "./TilingScheme";
 
 /**
- * A [[TilingScheme]] featuring quadtree subdivision scheme and web Mercator projection.
+ * A {@link TilingScheme} featuring quadtree subdivision scheme and web Mercator projection.
  */
 export const webMercatorTilingScheme = new TilingScheme(
     quadTreeSubdivisionScheme,

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -34,7 +34,7 @@ interface TileExtrusionState {
 }
 
 /**
- * Handles animated extrusion effect of the buildings in [[MapView]].
+ * Handles animated extrusion effect of the buildings in {@link MapView}.
  */
 export class AnimatedExtrusionHandler {
     /**
@@ -55,9 +55,9 @@ export class AnimatedExtrusionHandler {
     private m_startTime: number = -1;
 
     /**
-     * Creates an [[AnimatedExtrusionHandler]] in [[MapView]].
+     * Creates an {@link AnimatedExtrusionHandler} in {@link MapView}.
      *
-     * @param m_mapView - Instance of [[MapView]] on which the animation will run.
+     * @param m_mapView - Instance of {@link MapView} on which the animation will run.
      */
     constructor(private m_mapView: MapView) {}
 

--- a/@here/harp-mapview/lib/CameraMovementDetector.ts
+++ b/@here/harp-mapview/lib/CameraMovementDetector.ts
@@ -16,7 +16,7 @@ const DEFAULT_THROTTLING_TIMEOUT = 300;
 
 /**
  * The `CameraMovementDetector` class checks for changes in camera position and orientation, to
- * detect continuous movements without the animation mode activated in [[MapView]]. If the
+ * detect continuous movements without the animation mode activated in {@link MapView}. If the
  * interaction is not continuous enough, you can use a throttling timer to reduce the number of
  * callbacks.
  */
@@ -29,7 +29,7 @@ export class CameraMovementDetector {
     private m_movementDetectorDeadline: number = 0;
 
     /**
-     * Initializes the detector with timeout value and callbacks. [[MapView]] also provides
+     * Initializes the detector with timeout value and callbacks. {@link MapView} also provides
      * events for client code to be notified when these cues occur.
      *
      * @param m_throttlingTimeout - The delay, in milliseconds, between the last user interaction
@@ -109,7 +109,7 @@ export class CameraMovementDetector {
     }
 
     /**
-     * Returns `true` if the camera of this [[MapView]] is currently moving. In this case the
+     * Returns `true` if the camera of this {@link MapView} is currently moving. In this case the
      * `m_movementFinishedFunc` is waiting to be called after the throttling timer runs out.
      */
     get cameraIsMoving() {

--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -280,8 +280,8 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
      * anyway.
      * @note You may treat [[minElevation]] and [[maxElevation]] parameters as the maximum and
      * minimum renderable elevation respectively along the surface normal, when camera is
-     * constantly looking downwards (top-down view). If you need [[ClipPlanesEvaluator]] for
-     * cameras that support tilt or yaw please use [[TiltViewClipPlanesEvaluator]].
+     * constantly looking downwards (top-down view). If you need {@link ClipPlanesEvaluator} for
+     * cameras that support tilt or yaw please use {@link TiltViewClipPlanesEvaluator}.
      * @note [[nearFarMaxRatio]] does not limit far plane when spherical projection is in use,
      * the algorithm used there estimates distance to point on tangent where line from camera
      * touches the sphere horizon and there is no reason to clamp it.
@@ -1049,9 +1049,10 @@ export class FixedClipPlanesEvaluator implements ClipPlanesEvaluator {
 }
 
 /**
- * Factory function that creates default [[ClipPlanesEvaluator]] that calculates near plane based
+ * Factory function that creates default {@link ClipPlanesEvaluator}
+ * that calculates near plane based
  * on ground distance and camera orientation.
  *
- * Creates [[TiltViewClipPlanesEvaluator]].
+ * Creates {@link TiltViewClipPlanesEvaluator}.
  */
 export const createDefaultClipPlanesEvaluator = () => new TiltViewClipPlanesEvaluator();

--- a/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
@@ -12,7 +12,7 @@ import { WorkerBasedDecoder } from "./WorkerBasedDecoder";
  * Default concurrent decoder helper.
  *
  * A convenient singleton that maintains a separate [[ConcurrentWorkerSet]] for each bundle
- * requested. Provides easy access to [[WorkerBasedDecoder]]s for data sources.
+ * requested. Provides easy access to {@link WorkerBasedDecoder}s for data sources.
  */
 export class ConcurrentDecoderFacade {
     /**
@@ -27,7 +27,7 @@ export class ConcurrentDecoderFacade {
     static defaultWorkerCount?: number = undefined;
 
     /**
-     * Returns a [[WorkerBasedDecoder]] instance.
+     * Returns a {@link WorkerBasedDecoder} instance.
      *
      * @param decoderServiceType - The name of the decoder service type.
      * @param scriptUrl - The optional URL with the workers' script.

--- a/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
@@ -12,7 +12,7 @@ import { WorkerBasedTiler } from "./WorkerBasedTiler";
  * Default concurrent tiler helper.
  *
  * A convenient singleton that maintains a separate [[ConcurrentWorkerSet]] for each bundle
- * requested. Provides easy access to [[WorkerBasedTiler]]s for data sources.
+ * requested. Provides easy access to {@link WorkerBasedTiler}s for data sources.
  */
 export class ConcurrentTilerFacade {
     /**
@@ -27,7 +27,7 @@ export class ConcurrentTilerFacade {
     static defaultWorkerCount: number = 1;
 
     /**
-     * Returns a [[WorkerBasedTiler]] instance.
+     * Returns a {@link WorkerBasedTiler} instance.
      *
      * @param tilerServiceType - The name of the tiler service type.
      * @param scriptUrl - The optional URL with the workers' script.

--- a/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
+++ b/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
@@ -82,7 +82,7 @@ const DEFAULT_WORKER_COUNT = 2;
 /**
  * The default timeout for first message from worker.
  *
- * @see [[WorkerLoader.startWorker]]
+ * @see {@link WorkerLoader.startWorker}
  */
 export const DEFAULT_WORKER_INITIALIZATION_TIMEOUT = 10000;
 

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -15,11 +15,11 @@ const logger = LoggerManager.instance.create("DataSource");
 const UPDATE_EVENT = { type: "update" };
 
 /**
- * Options for a [[DataSource]].
+ * Options for a {@link DataSource}.
  */
 export interface DataSourceOptions {
     /**
-     * The unique name of a [[DataSource]] instance.
+     * The unique name of a {@link DataSource} instance.
      */
     name?: string;
     /**
@@ -28,13 +28,13 @@ export interface DataSourceOptions {
     styleSetName?: string;
     /**
      * The minimum zoom level at which data is available or displayed at
-     * (depending on [[DataSource]] subclass).
+     * (depending on {@link DataSource} subclass).
      * @deprecated Use [[minDataLevel]] and [[minDisplayLevel]] instead.
      */
     minZoomLevel?: number;
     /**
      * The maximum zoom level at which data is available or displayed at
-     * (depending on [[DataSource]] subclass).
+     * (depending on {@link DataSource} subclass).
      * @deprecated Use [[maxDataLevel]] and [[maxDisplayLevel]] instead.
      */
     maxZoomLevel?: number;
@@ -47,11 +47,11 @@ export interface DataSourceOptions {
      */
     maxDataLevel?: number;
     /**
-     * The minimum zoom level at which [[DataSource]] is displayed.
+     * The minimum zoom level at which {@link DataSource} is displayed.
      */
     minDisplayLevel?: number;
     /**
-     * The maximum zoom level at which [[DataSource]] is displayed.
+     * The maximum zoom level at which {@link DataSource} is displayed.
      */
     maxDisplayLevel?: number;
     /**
@@ -72,7 +72,7 @@ export interface DataSourceOptions {
 }
 
 /**
- * Derive a class from `DataSource` to contribute data and geometries to the [[MapView]].
+ * Derive a class from `DataSource` to contribute data and geometries to the {@link MapView}.
  */
 export abstract class DataSource extends THREE.EventDispatcher {
     /**
@@ -87,7 +87,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     enabled: boolean = true;
 
     /**
-     * Set to `true` if the [[MapView]] can cache tiles produced by this `DataSource`.
+     * Set to `true` if the {@link MapView} can cache tiles produced by this `DataSource`.
      */
     cacheable: boolean = false;
 
@@ -120,12 +120,12 @@ export abstract class DataSource extends THREE.EventDispatcher {
     maxDataLevel: number = 20;
 
     /**
-     * The minimum zoom level at which [[DataSource]] is displayed.
+     * The minimum zoom level at which {@link DataSource} is displayed.
      */
     minDisplayLevel: number = 1;
 
     /**
-     * The maximum zoom level at which [[DataSource]] is displayed.
+     * The maximum zoom level at which {@link DataSource} is displayed.
      */
     maxDisplayLevel: number = 20;
 
@@ -137,7 +137,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     readonly exprPool = new ExprPool();
 
     /**
-     * The [[MapView]] instance holding a reference to this `DataSource`.
+     * The {@link MapView} instance holding a reference to this `DataSource`.
      */
     private m_mapView?: MapView;
 
@@ -224,7 +224,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Clears the state of all the features of this [[DataSource]].
+     * Clears the state of all the features of this {@link DataSource}.
      */
     clearFeatureState() {
         this.m_featureStateMap.clear();
@@ -261,9 +261,11 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Sets the name of the [[StyleSet]] to use for the decoding. If this [[DataSource]] is already
-     * attached to a [[MapView]], this setter then reapplies [[StyleSet]] with this name found in
-     * [[MapView]]s theme.
+     * Sets the name of the [[StyleSet]] to use for the decoding.
+     * If this {@link DataSource} is already
+     * attached to a {@link MapView}, this setter then reapplies
+     * [[StyleSet]] with this name found in
+     * {@link MapView}s theme.
      */
     set styleSetName(styleSetName: string | undefined) {
         this.m_styleSetName = styleSetName;
@@ -287,16 +289,20 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Boolean which says whether a [[DataSource]] produces tiles that fully cover the tile, i.e.
-     * tiles underneath are completely hidden. Must be overriden for [[DataSource]]'s that don't
-     * have a ground plane, but which still fully cover the tile, e.g. web tiles.
+     * Boolean which says whether a {@link DataSource} produces
+     * tiles that fully cover the tile, i.e.
+     * tiles underneath are completely hidden. Must be
+     * overriden for {@link DataSource}'s that don't
+     * have a ground plane, but which still fully
+     * cover the tile, e.g. web tiles.
      */
     isFullyCovering(): boolean {
         return this.addGroundPlane;
     }
 
     /**
-     * Returns `true` if this `DataSource` is ready and the [[MapView]] can invoke `getTile()` to
+     * Returns `true` if this `DataSource` is ready
+     * and the {@link MapView} can invoke `getTile()` to
      * start requesting data.
      */
     ready(): boolean {
@@ -304,7 +310,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * The [[MapView]] that is holding this `DataSource`.
+     * The {@link MapView} that is holding this `DataSource`.
      */
     get mapView(): MapView {
         if (this.m_mapView === undefined) {
@@ -315,17 +321,19 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * The [[Projection]] used by the [[MapView]] that is holding this `DataSource`.
+     * The {@link @here/harp-geoutils#Projection} used by
+     * the {@link MapView} that is holding this `DataSource`.
      *
-     * An `Error` is thrown if you call this method before this `DataSource` has been added
-     * to a [[MapView]].
+     * An `Error` is thrown if you call this method
+     * before this `DataSource` has been added
+     * to a {@link MapView}.
      */
     get projection(): Projection {
         return this.mapView.projection;
     }
 
     /**
-     * This method is called when the `DataSource` is added to a [[MapView]]. Reimplement this
+     * This method is called when the `DataSource` is added to a {@link MapView}. Reimplement this
      * method to provide any custom initialization, such as, to establish a network connection,
      * or to initialize complex data structures.
      */
@@ -334,27 +342,27 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the [[TilingScheme]] used by this `DataSource`.
+     * Returns the {@link @here/harp-geoutils#TilingScheme} used by this `DataSource`.
      */
     abstract getTilingScheme(): TilingScheme;
 
     /**
-     * This method is called when this `DataSource` is added to a [[MapView]].
+     * This method is called when this `DataSource` is added to a {@link MapView}.
      *
      * Reimplementations of this method must invoke the definition of the super class.
      *
-     * @param mapView - The instance of the [[MapView]].
+     * @param mapView - The instance of the {@link MapView}.
      */
     attach(mapView: MapView): void {
         this.m_mapView = mapView;
     }
 
     /**
-     * This method is called when this `DataSource` is removed from a [[MapView]].
+     * This method is called when this `DataSource` is removed from a {@link MapView}.
      *
      * Reimplementations of this method must invoke the definition of the super class.
      *
-     * @param mapView - The instance of the [[MapView]].
+     * @param mapView - The instance of the {@link MapView}.
      */
     detach(mapView: MapView) {
         assert(this.m_mapView === mapView);
@@ -362,13 +370,15 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Invoked by [[MapView]] to notify when the [[Theme]] has been changed.
+     * Invoked by {@link MapView} to notify when the
+     * {@link @here/harp-datasource-protocol#Theme} has been changed.
      *
+     * @remarks
      * If `DataSource` depends on a `styleSet` or `languages`, it must update its tiles' geometry.
      *
      * @deprecated Use [[setTheme]].
      *
-     * @param styleSet - The new theme that [[MapView]] uses.
+     * @param styleSet - The new theme that {@link MapView} uses.
      * @param languages - An optional list of languages for the `DataSource`.
      */
     // tslint:disable-next-line:no-unused-variable
@@ -377,7 +387,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Apply the [[Theme]] to this data source.
+     * Apply the {@link @here/harp-datasource-protocol#Theme} to this data source.
      *
      * If `DataSource` depends on a `styleSet` defined by this theme or `languages`, it must update
      * its tiles' geometry.
@@ -410,18 +420,19 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * This method is called when [[MapView]] needs to visualize or preload the content of a
-     * [[TileKey]].
+     * This method is called when {@link MapView} needs to visualize or preload the content of a
+     * {@link @here/harp-geoutils#TileKey}.
      *
      * @param tileKey - The unique identifier for a map tile.
      */
     abstract getTile(tileKey: TileKey): Tile | undefined;
 
     /**
-     * This method is called by [[MapView]] before the tile needs to be updated, for example after
+     * This method is called by {@link MapView} before the
+     * tile needs to be updated, for example after
      * a theme change.
      *
-     * @param tile - The [[Tile]] to update.
+     * @param tile - The {@link Tile} to update.
      */
     // tslint:disable-next-line:no-unused-variable
     updateTile(tile: Tile) {
@@ -429,10 +440,10 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * This method is called by the [[MapView]] to determine if the content of the surrounding
+     * This method is called by the {@link MapView} to determine if the content of the surrounding
      * tiles must be preloaded.
      *
-     * @returns `true` if the [[MapView]] should try to preload tiles surrounding the visible
+     * @returns `true` if the {@link MapView} should try to preload tiles surrounding the visible
      * tiles; `false` otherwise. The default is `false`.
      */
     shouldPreloadTiles(): boolean {
@@ -441,7 +452,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
 
     /**
      * The minimum zoom level at which data is available or displayed at
-     * (depending on [[DataSource]] subclass).
+     * (depending on {@link DataSource} subclass).
      * @deprecated Use [[minDataLevel]] and [[minDisplayLevel]] instead.
      */
     get minZoomLevel(): number {
@@ -460,7 +471,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
 
     /**
      * The maximum zoom level at which data is available or displayed at
-     * (depending on [[DataSource]] subclass).
+     * (depending on {@link DataSource} subclass).
      * @deprecated Use [[maxDataLevel]] and [[maxDisplayLevel]] instead.
      */
     get maxZoomLevel(): number {
@@ -480,7 +491,8 @@ export abstract class DataSource extends THREE.EventDispatcher {
     /**
      * Maximum geometry height above ground level this `DataSource` can produce.
      *
-     * Used in first stage of frustum culling before [[Tile.maxGeometryHeight]] data is available.
+     * Used in first stage of frustum culling before
+     * {@link Tile.maxGeometryHeight} data is available.
      *
      * @default 0.
      */
@@ -525,7 +537,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     /**
      * Computes the data zoom level to use.
      *
-     * @param zoomLevel - The zoom level of the [[MapView]].
+     * @param zoomLevel - The zoom level of the {@link MapView}.
      * @returns The data zoom level to use.
      */
     getDataZoomLevel(zoomLevel: number): number {
@@ -537,31 +549,33 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns `true` if [[DataSource]] should be displayed for the zoom level.
-     * @param zoomLevel - The zoom level of the [[MapView]].
+     * Returns `true` if {@link DataSource} should be displayed for the zoom level.
+     * @param zoomLevel - The zoom level of the {@link MapView}.
      */
     isVisible(zoomLevel: number): boolean {
         return zoomLevel >= this.minDisplayLevel && zoomLevel <= this.maxDisplayLevel;
     }
 
     /**
-     * Returns `true` if [[DataSource]] can load tile with given [[TileKey]] and zoom level.
+     * Returns `true` if {@link DataSource} can load tile with
+     * given {@link @here/harp-geoutils#TileKey} and zoom level.
      *
-     * @param zoomLevel - The zoom level of the [[MapView]].
+     * @param zoomLevel - The zoom level of the {@link MapView}.
      * @param tileKey - The unique identifier for a map tile.
-     * @returns `true` if the tile for the given [[TileKey]] can be loaded.
+     * @returns `true` if the tile for the given {@link @here/harp-geoutils#TileKey} can be loaded.
      */
     canGetTile(zoomLevel: number, tileKey: TileKey): boolean {
         return tileKey.level <= zoomLevel;
     }
 
     /**
-     * Returns `true` if [[MapView]] should traverse tiles further with given [[TileKey]] and
+     * Returns `true` if {@link MapView} should traverse tiles
+     * further with given {@link @here/harp-geoutils#TileKey} and
      * zoom level.
      *
-     * @param zoomLevel - The zoom level of the [[MapView]].
+     * @param zoomLevel - The zoom level of the {@link MapView}.
      * @param tileKey - The unique identifier for a map tile.
-     * @returns `true` if the subtiles of the given [[TileKey]] should be
+     * @returns `true` if the subtiles of the given {@link @here/harp-geoutils#TileKey} should be
      * checked for collisions.
      */
     shouldSubdivide(zoomLevel: number, tileKey: TileKey): boolean {
@@ -569,15 +583,18 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns `true` if [[MapView]] should render the text elements with the given [[TileKey]] and
+     * Returns `true` if {@link MapView} should render the text
+     * elements with the given {@link @here/harp-geoutils#TileKey} and
      * zoom level.
      *
+     * @remarks
      * This is an additional check for the tiles that are already selected for rendering so the
      * default implementation returns `true`.
      *
      * @param zoomLevel - The zoom level.
      * @param tileKey - The unique identifier for a map tile.
-     * @returns `true` if the text elements created for the given [[TileKey]] should be rendered.
+     * @returns `true` if the text elements created for the
+     *          given {@link @here/harp-geoutils#TileKey} should be rendered.
      */
     // tslint:disable-next-line:no-unused-variable
     shouldRenderText(zoomLevel: number, tileKey: TileKey): boolean {
@@ -585,7 +602,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
     }
 
     /**
-     * Sends a request to the [[MapView]] to redraw the scene.
+     * Sends a request to the {@link MapView} to redraw the scene.
      */
     requestUpdate() {
         this.dispatchEvent(UPDATE_EVENT);

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -57,7 +57,7 @@ export interface MaterialOptions {
     /**
      * Environment used to evaluate dynamic technique attributes.
      *
-     * Usually [[MapView.mapEnv]].
+     * Usually {@link MapView.env}.
      */
     env: Env;
 
@@ -230,7 +230,8 @@ export function createMaterial(
 }
 
 /**
- * Returns a [[THREE.BufferAttribute]] created from a provided [[BufferAttribute]] object.
+ * Returns a [[THREE.BufferAttribute]] created from a provided
+ * {@link @here/harp-datasource-protocol#BufferAttribute} object.
  *
  * @param attribute - BufferAttribute a WebGL compliant buffer
  */
@@ -547,7 +548,7 @@ function getMainMaterialStyledProps(technique: Technique): StyledProperties {
 }
 
 /**
- * Convert metric style property to expression that accounts [[MapView.pixelToWorld]] if
+ * Convert metric style property to expression that accounts {@link MapView.pixelToWorld} if
  * `metricUnit === 'Pixel'`.
  */
 export function buildMetricValueEvaluator(
@@ -583,7 +584,9 @@ export function buildMetricValueEvaluator(
  *
  * @see ColorUtils
  * @param technique - the technique where we search for base (transparency) color value
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance
+ *              used to evaluate {@link @here/harp-datasource-protocol#Expr}
+ *              based properties of [[Technique]]
  * @returns [[number]] encoded color value (in custom #TTRRGGBB) format or `undefined` if
  * base color property is not defined in the technique passed.
  */
@@ -652,7 +655,9 @@ function applyShaderTechniqueToMaterial(technique: ShaderTechnique, material: TH
  * @param material - target material
  * @param propertyName - material and technique parameter name (or index) that is to be transferred
  * @param techniqueAttrValue - technique property value which will be applied to material attribute
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance used
+ *              to evaluate {@link @here/harp-datasource-protocol#Expr}
+ *              based properties of [[Technique]]
  */
 function applyTechniquePropertyToMaterial(
     material: THREE.Material,
@@ -686,7 +691,9 @@ function applyTechniquePropertyToMaterial(
  * @param material - the material to which color is applied
  * @param prop - technique property (color) name
  * @param value - color value
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance used
+ *              to evaluate {@link @here/harp-datasource-protocol#Expr}
+ *              based properties of [[Technique]]
  */
 export function applySecondaryColorToMaterial(
     materialColor: THREE.Color,
@@ -722,7 +729,8 @@ export function applySecondaryColorToMaterial(
  * @param material - the material to which color is applied
  * @param prop - technique property (color) name
  * @param value - color value in custom number format
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance used to evaluate
+ *              {@link @here/harp-datasource-protocol#Expr} based properties of [[Technique]]
  */
 export function applyBaseColorToMaterial(
     material: THREE.Material,
@@ -765,7 +773,8 @@ export function applyBaseColorToMaterial(
  *
  * @note Use with care, because function does not recognize property type.
  * @param value - the value of color property defined in technique
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance used to evaluate
+ *              {@link @here/harp-datasource-protocol#Expr} based properties of [[Technique]]
  */
 function evaluateProperty(value: any, env?: Env): any {
     if (env !== undefined && Expr.isExpr(value)) {
@@ -782,7 +791,8 @@ function evaluateProperty(value: any, env?: Env): any {
  *
  * @note Use with care, because function does not recognize property type.
  * @param value - the value of color property defined in technique
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance used to evaluate
+ *              {@link @here/harp-datasource-protocol#Expr} based properties of [[Technique]]
  */
 export function evaluateColorProperty(value: Value, env?: Env): number | undefined {
     value = evaluateProperty(value, env);

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -29,7 +29,9 @@ const DEPTH_PRE_PASS_RENDER_ORDER_OFFSET = 1e-6;
  * disabled by `enableDepthPrePass` option.
  *
  * @param technique - [[BaseStandardTechnique]] instance to be checked
- * @param env - [[Env]] instance used to evaluate [[Expr]] based properties of [[Technique]]
+ * @param env - {@link @here/harp-datasource-protocol#Env} instance used
+ *              to evaluate {@link @here/harp-datasource-protocol#Expr}
+ *              based properties of [[Technique]]
  */
 export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique, env: Env) {
     // Depth pass explicitly disabled

--- a/@here/harp-mapview/lib/ElevationProvider.ts
+++ b/@here/harp-mapview/lib/ElevationProvider.ts
@@ -48,7 +48,7 @@ export interface ElevationProvider {
 
     /**
      * @returns the TilingScheme used for the DisplacementMaps returned by [[getDisplacementMap]] or
-     * undefined if there is no elevation [[DataSource]] attached to the [[MapView]].
+     * undefined if there is no elevation {@link DataSource} attached to the {@link MapView}.
      */
     getTilingScheme(): TilingScheme | undefined;
 

--- a/@here/harp-mapview/lib/ElevationRangeSource.ts
+++ b/@here/harp-mapview/lib/ElevationRangeSource.ts
@@ -32,14 +32,18 @@ export interface ElevationRange {
  */
 export interface ElevationRangeSource {
     /**
-     * Compute the elevation range for a given [[TileKey]].
+     * Compute the elevation range for a given {@link @here/harp-geoutils#TileKey}.
      * @param tileKey - The tile for which the elevation range should be computed.
      */
     getElevationRange(tileKey: TileKey): ElevationRange;
 
     /**
-     * The tiling scheme of this [[ElevationRangeSource]]. [[MapView]] will only apply the elevation
-     * ranges returned by [[getElevationRange]] that have the same [[TilingScheme]].
+     * The tiling scheme of this {@link ElevationRangeSource}.
+     *
+     * @remarks
+     * {@link MapView} will only apply the elevation
+     * ranges returned by [[getElevationRange]] that have
+     * the same {@link @here/harp-geoutils#TilingScheme}.
      */
     getTilingScheme(): TilingScheme;
 
@@ -49,7 +53,7 @@ export interface ElevationRangeSource {
     connect(): Promise<void>;
 
     /**
-     * Returns `true` if this `ElevationRangeSource` is ready and the [[MapView]] can invoke
+     * Returns `true` if this `ElevationRangeSource` is ready and the {@link MapView} can invoke
      * `getElevationRange()` to start requesting data.
      */
     ready(): boolean;

--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -343,7 +343,7 @@ export class FrustumIntersection {
 
     /**
      * Create a list of root nodes to test against the frustum. The root nodes each start at level 0
-     * and have an offset (see [[Tile]]) based on:
+     * and have an offset (see {@link Tile}) based on:
      * - the current position [[worldCenter]].
      * - the height of the camera above the world.
      * - the field of view of the camera (the maximum value between the horizontal / vertical
@@ -423,7 +423,7 @@ export class FrustumIntersection {
             ),
             0,
             // We can store currently up to 16 unique keys(2^4, where 4 is the default bit-shift
-            // value which is used currently in the [[VisibleTileSet]] methods) hence we can have a
+            // value which is used currently in the VisibleTileSet methods) hence we can have a
             // maximum range of 7 (because 2*7+1 = 15).
             7
         );

--- a/@here/harp-mapview/lib/MapAnchors.ts
+++ b/@here/harp-mapview/lib/MapAnchors.ts
@@ -17,8 +17,11 @@ import {
 import * as THREE from "three";
 
 /**
- * An interface describing [[THREE.Object3D]]s anchored on given [[GeoCoordinates]].
+ * An interface describing [[THREE.Object3D]]s anchored on
+ * given {@link @here/harp-geoutils#GeoCoordinates}.
  *
+ * @remarkks
+ * @example
  * Example:
  * ```typescript
  * const mesh: MapAnchor<THREE.Mesh> = new THREE.Mesh(geometry, material);
@@ -28,13 +31,14 @@ import * as THREE from "three";
  */
 export type MapAnchor<T extends THREE.Object3D = THREE.Object3D> = T & {
     /**
-     * The position of this [[MapAnchor]] in [[GeoCoordinates]].
+     * The position of this [[MapAnchor]] in {@link @here/harp-geoutils#GeoCoordinates}.
      * @deprecated Use [[anchor]] instead.
      */
     geoPosition?: GeoCoordinates;
 
     /**
-     * The anchor of this Object3D in [[GeoCoordinates]] or world coordinates.
+     * The anchor of this Object3D in {@link @here/harp-geoutils#GeoCoordinates}
+     * or world coordinates.
      */
     anchor?: GeoCoordLike | Vector3Like;
 

--- a/@here/harp-mapview/lib/MapMaterialAdapter.ts
+++ b/@here/harp-mapview/lib/MapMaterialAdapter.ts
@@ -14,7 +14,7 @@ import { MapView } from "./MapView";
 /**
  * @hidden
  *
- * Pick of [[MapView]] properties required to update materials used [[MapMaterialAdapter]].
+ * Pick of {@link MapView} properties required to update materials used [[MapMaterialAdapter]].
  */
 export type MapAdapterUpdateEnv = Pick<MapView, "env" | "frameNumber">;
 
@@ -38,7 +38,7 @@ export interface StyledProperties {
 /**
  * @hidden
  *
- * [[MapView]] specific data assigned to `THREE.Material` instance in installed in `userData`.
+ * {@link MapView} specific data assigned to `THREE.Material` instance in installed in `userData`.
  *
  * [[MapMaterialAdapter]] is registered in `usedData.mapAdapter` property of `THREE.Material`.
  */
@@ -131,7 +131,7 @@ export class MapMaterialAdapter {
     }
 
     /**
-     * Ensure that underlying object is updated to current state of [[MapView]].
+     * Ensure that underlying object is updated to current state of {@link MapView}.
      *
      * Updates dynamically styled properties of material by evaluating scene dependent expressions.
      *

--- a/@here/harp-mapview/lib/MapObjectAdapter.ts
+++ b/@here/harp-mapview/lib/MapObjectAdapter.ts
@@ -25,7 +25,7 @@ export interface MapObjectAdapterParams {
 /**
  * @hidden
  *
- * [[MapView]] specific data assigned to `THREE.Object3D` instance in installed in `userData`.
+ * {@link MapView} specific data assigned to `THREE.Object3D` instance in installed in `userData`.
  *
  * [[MapObjectAdapter]] is registered in `usedData.mapAdapter` property of `THREE.Object3D`.
  */
@@ -92,7 +92,7 @@ export class MapObjectAdapter {
     }
 
     /**
-     * Ensure that underlying object is updated to current state of [[MapView]].
+     * Ensure that underlying object is updated to current state of {@link MapView}.
      *
      * Updates object and attachments like materials to current state by evaluating scene dependent
      * expressions.

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -107,7 +107,7 @@ export enum MapViewEventNames {
     FirstFrame = "first-render",
     /** Called when the first view has all the necessary tiles loaded and rendered. */
     FrameComplete = "frame-complete",
-    /** Called when the theme has been loaded with the internal [[ThemeLoader]]. */
+    /** Called when the theme has been loaded with the internal {@link ThemeLoader}. */
     ThemeLoaded = "theme-loaded",
     /** Called when the animation mode has started. */
     AnimationStarted = "animation-started",
@@ -152,7 +152,7 @@ const DEFAULT_MAX_ZOOM_LEVEL = 20;
 const DEFAULT_MIN_CAMERA_HEIGHT = 20;
 
 /**
- * Style set used by [[PolarTileDataSource]] by default.
+ * Style set used by {@link PolarTileDataSource} by default.
  */
 const DEFAULT_POLAR_STYLE_SET_NAME = "polar";
 
@@ -266,7 +266,7 @@ export enum MapViewPowerPreference {
 }
 
 /**
- * User configuration for the [[MapView]].
+ * User configuration for the {@link MapView}.
  */
 export interface MapViewOptions extends TextElementsRendererOptions, Partial<LookAtParams> {
     /**
@@ -329,7 +329,7 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
     decoderCount?: number;
 
     /**
-     * The [[Theme]] used by Mapview.
+     * The {@link @here/harp-datasource-protocol#Theme} used by Mapview.
      *
      * This Theme can be one of the following:
      *  - `string` : the URI of the theme file used to style this map
@@ -346,7 +346,7 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
      * Custom URIs (of theme itself and of resources referenced by theme) may be resolved with help
      * of [[uriResolver]].
      *
-     * @see [[ThemeLoader.load]] for details how theme is loaded
+     * @see {@link ThemeLoader.load} for details how theme is loaded
      */
     theme?: string | Theme | Promise<Theme>;
 
@@ -368,8 +368,8 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
      * })
      * ```
      *
-     * @see [[UriResolver]]
-     * @See [[PrefixMapUriResolver]]
+     * @see {@link @here/harp-utils#UriResolver}
+     * @See {@link @here/harp-utils#PrefixMapUriResolver}
      */
     uriResolver?: UriResolver;
 
@@ -390,9 +390,9 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
 
     /**
      * User-defined camera clipping planes distance evaluator.
-     * If not defined, [[TiltViewClipPlanesEvaluator]] will be used by [[MapView]].
+     * If not defined, {@link TiltViewClipPlanesEvaluator} will be used by {@link MapView}.
      *
-     * @default [[TiltViewClipPlanesEvaluator]]
+     * @default {@link TiltViewClipPlanesEvaluator}
      */
     clipPlanesEvaluator?: ClipPlanesEvaluator;
 
@@ -426,10 +426,13 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
     resourceComputationType?: ResourceComputationType;
 
     /**
-     * Limits the number of reduced zoom levels (lower detail) to be searched for fallback tiles.
+     * Limits the number of reduced zoom levels (lower detail)
+     * to be searched for fallback tiles.
      *
-     * When zooming in, newly elected tiles may have not yet loaded. [[MapView]] searches through
-     * the tile cache for tiles ready to be displayed in lower zoom levels. The tiles may be
+     * When zooming in, newly elected tiles may have not
+     * yet loaded. {@link MapView} searches through
+     * the tile cache for tiles ready to be displayed in
+     * lower zoom levels. The tiles may be
      * located shallower in the quadtree.
      *
      * To disable a cache search, set the value to `0`.
@@ -439,10 +442,13 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
     quadTreeSearchDistanceUp?: number;
 
     /**
-     * Limits the number of higher zoom levels (more detailed) to be searched for fallback tiles.
+     * Limits the number of higher zoom levels (more detailed)
+     * to be searched for fallback tiles.
      *
-     * When zooming out, newly elected tiles may have not yet loaded. [[MapView]] searches through
-     * the tile cache for tiles ready to be displayed in higher zoom levels. These tiles may be
+     * When zooming out, newly elected tiles may have not
+     * yet loaded. {@link MapView} searches through
+     * the tile cache for tiles ready to be displayed in
+     * higher zoom levels. These tiles may be
      * located deeper in the quadtree.
      *
      * To disable a cache search, set the value to `0`.
@@ -459,7 +465,8 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
     /**
      * Preserve the buffers until they are cleared manually or overwritten.
      *
-     * Set to `true` in order to copy [[MapView]] canvas contents to an image or another canvas.
+     * Set to `true` in order to copy {@link MapView} canvas contents
+     * to an image or another canvas.
      *
      * @default `false`.
      * @see https://threejs.org/docs/#api/renderers/WebGLRenderer.preserveDrawingBuffer
@@ -564,20 +571,21 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
     backgroundTilingScheme?: TilingScheme;
 
     /**
-     * Should be the [[PolarTileDataSource]] used on spherical projection.
+     * Should be the {@link PolarTileDataSource} used on spherical projection.
      * Default is `true`.
      */
     enablePolarDataSource?: boolean;
 
     /**
-     * The name of the [[StyleSet]] used by [[PolarTileDataSource]] to evaluate for the decoding.
+     * The name of the [[StyleSet]] used by {@link PolarTileDataSource}
+     * to evaluate for the decoding.
      * Default is `"polar"`.
      */
     polarStyleSetName?: string;
 
     /**
      * Storage level offset of regular tiles from reference datasource to align
-     * [[PolarTileDataSource]] tiles to.
+     * {@link PolarTileDataSource} tiles to.
      * Default is `-1`.
      */
     polarGeometryLevelOffset?: number;
@@ -594,7 +602,7 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
      * `update` method requests redraw and waits for the next animation frame.
      *
      * You need to set up your own render loop controller.
-     * Event `MapViewEventNames.Update` fired when [[MapView]] requests for an redraw.
+     * Event `MapViewEventNames.Update` fired when {@link MapView} requests for an redraw.
      * E.g.: When tiles loaded asynchronously and ready for rendering.
      *
      * @note Internal `maxFps` will be overridden and may not work properly as `renderSync`
@@ -622,7 +630,7 @@ export interface MapViewOptions extends TextElementsRendererOptions, Partial<Loo
 }
 
 /**
- * Default settings used by [[MapView]] collected in one place.
+ * Default settings used by {@link MapView} collected in one place.
  * @internal
  */
 const MapViewDefaults = {
@@ -649,19 +657,20 @@ const MapViewDefaults = {
 };
 
 /**
- * Parameters for [[MapView.lookAt]].
+ * Parameters for {@link MapView.lookAt}.
  */
 export interface LookAtParams {
     /**
      * Target/look at point of the MapView.
      *
-     * @note If the given point is not on the ground (altitude != 0) [[MapView]] will do a
+     * @note If the given point is not on the ground (altitude != 0) {@link MapView} will do a
      * raycasting internally to find a target on the ground.
      *
-     * As a consequence [[MapView.target]] and [[MapView.zoomLevel]] will not match the values
-     * that were passed into the [[MapView.lookAt]] method.
-     * @default `new GeoCoordinates(25, 0)` in [[MapView.constructor]] context.
-     * @default [[MapView.target]] in [[MapView.lookAt]] context.
+     * As a consequence {@link MapView.target} and {@link MapView.zoomLevel}
+     * will not match the values
+     * that were passed into the {@link MapView.lookAt} method.
+     * @default `new GeoCoordinates(25, 0)` in {@link MapView.constructor} context.
+     * @default {@link MapView.target} in {@link MapView.lookAt} context.
      */
     target: GeoCoordLike;
 
@@ -671,20 +680,22 @@ export interface LookAtParams {
      * If specified, `zoomLevel` and `distance` parameters are ignored and `lookAt` calculates best
      * `zoomLevel` to fit given bounds.
      *
-     * * if `bounds` is [[GeoBox]], then `lookAt` use [[LookAtParams.target]] or `bounds.target` and
+     * * if `bounds` is {@link @here/harp-geoutils#GeoBox}, then `lookAt`
+     *   use {@link LookAtParams.target} or `bounds.target` and
      *   ensure whole box is visible
      *
-     * * if `bounds` is [[GeoBoxExtentLike]], then `lookAt` will use [[LookAtParams.target]] or
-     *   current [[MapView.target]] and ensure whole extents are visible
+     * * if `bounds` is {@link @here/harp-geoutils#GeoBoxExtentLike},
+     *   then `lookAt` will use {@link LookAtParams.target} or
+     *   current {@link MapView.target} and ensure whole extents are visible
      *
-     * * if `bounds` is [[GeoCoordLike]][], then `lookAt` will use [[LookAtParams.target]] or
+     * * if `bounds` is [[GeoCoordLike]][], then `lookAt` will use {@link LookAtParams.target} or
      *   calculated `target` as center of world box covering given points and ensure all points are
      *   visible
      *
      * Note in sphere projection some points are not visible if you specify bounds that span more
      * than 180 degreess in any direction.
      *
-     * @see [[MapView.lookAt]] for defails how `bounds` interact with `target` parameter
+     * @see {@link MapView.lookAt} for defails how `bounds` interact with `target` parameter
      */
     bounds: GeoBox | GeoBoxExtentLike | GeoCoordLike[];
 
@@ -697,23 +708,23 @@ export interface LookAtParams {
     /**
      * Zoomlevel of the MapView.
      * @note Takes precedence over distance.
-     * @default 5 in [[MapView.constructor]] context.
-     * @default [[MapView.zoomLevel]] in [[MapView.lookAt]] context.
+     * @default 5 in {@link MapView.constructor} context.
+     * @default {@link MapView.zoomLevel} in {@link MapView.lookAt} context.
      */
     zoomLevel: number;
 
     /**
      * Tilt angle in degrees. 0 is top down view.
-     * @default 0 in [[MapView.constructor]] context.
-     * @default [[MapView.tilt]] in [[MapView.lookAt]] context.
+     * @default 0 in {@link MapView.constructor} context.
+     * @default {@link MapView.tilt} in {@link MapView.lookAt} context.
      * @note Maximum supported tilt is 89°
      */
     tilt: number;
 
     /**
      * Heading angle in degrees and clockwise. 0 is north-up.
-     * @default 0 in [[MapView.constructor]] context.
-     * @default [[MapView.heading]] in [[MapView.lookAt]] context.
+     * @default 0 in {@link MapView.constructor} context.
+     * @default {@link MapView.heading} in {@link MapView.lookAt} context.
      */
     heading: number;
 }
@@ -735,7 +746,7 @@ export class MapView extends THREE.EventDispatcher {
     maxFps: number;
 
     /**
-     * The instance of [[MapRenderingManager]] managing the rendering of the map. It is a public
+     * The instance of {@link MapRenderingManager} managing the rendering of the map. It is a public
      * property to allow access and modification of some parameters of the rendering process at
      * runtime.
      */
@@ -1136,7 +1147,7 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * @hidden
-     * The [[TextElementsRenderer]] select the visible [[TextElement]]s and renders them.
+     * The {@link TextElementsRenderer} select the visible {@link TextElement}s and renders them.
      */
     get textElementsRenderer(): TextElementsRenderer {
         return this.m_textElementsRenderer;
@@ -1144,7 +1155,7 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * @hidden
-     * The [[CameraMovementDetector]] detects camera movements. Made available for performance
+     * The {@link CameraMovementDetector} detects camera movements. Made available for performance
      * measurements.
      */
     get cameraMovementDetector(): CameraMovementDetector {
@@ -1152,8 +1163,8 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * The [[AnimatedExtrusionHandler]] controls animated extrusion effect
-     * of the extruded objects in the [[Tile]]
+     * The {@link AnimatedExtrusionHandler} controls animated extrusion effect
+     * of the extruded objects in the {@link Tile}
      */
     get animatedExtrusionHandler(): AnimatedExtrusionHandler {
         return this.m_animatedExtrusionHandler;
@@ -1316,7 +1327,7 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * The abstraction of the [[MapRenderingManager]] API for post effects.
+     * The abstraction of the {@link MapRenderingManager} API for post effects.
      */
     get postEffects(): PostEffects | undefined {
         return this.m_postEffects;
@@ -1408,8 +1419,8 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * [[UriResolver]] used to resolve application/deployment specific `URI`s into actual `URLs`
-     * that can be loaded with `fetch`.
+     * {@link @here/harp-utils#UriResolver} used to resolve application/deployment
+     * specific `URI`s into actual `URLs` that can be loaded with `fetch`.
      */
     get uriResolver(): UriResolver | undefined {
         return this.m_uriResolver;
@@ -1584,10 +1595,10 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * The THREE.js camera used by this `MapView` to render the main scene.
      * @note When modifying the camera all derived properties like:
-     * - [[MapView.target]]
-     * - [[MapView.zoomLevel]]
-     * - [[MapView.tilt]]
-     * - [[MapView.heading]]
+     * - {@link MapView.target}
+     * - {@link MapView.zoomLevel}
+     * - {@link MapView.tilt}
+     * - {@link MapView.heading}
      * could change.
      * These properties are cached internaly and will only be updated in the next animation frame.
      * FIXME: Unfortunatley THREE.js is not dispatching any events when camera properties change
@@ -1644,7 +1655,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Changes the projection at run time.
      *
-     * @param projection - The [[Projection]] instance to use.
+     * @param projection - The {@link @here/harp-geoutils#Projection} instance to use.
      */
     set projection(projection: Projection) {
         // Remember tilt and heading before setting the projection.
@@ -1788,7 +1799,7 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Get the [[ImageCache]] that belongs to this `MapView`.
+     * Get the {@link ImageCache} that belongs to this `MapView`.
      */
     get imageCache(): MapViewImageCache {
         return this.m_imageCache;
@@ -1796,7 +1807,7 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * @hidden
-     * Get the [[PoiManager]] that belongs to this `MapView`.
+     * Get the {@link PoiManager} that belongs to this `MapView`.
      */
     get poiManager(): PoiManager {
         return this.m_poiManager;
@@ -1804,7 +1815,7 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * @hidden
-     * Get the array of [[PoiTableManager]] that belongs to this `MapView`.
+     * Get the array of {@link PoiTableManager} that belongs to this `MapView`.
      */
     get poiTableManager(): PoiTableManager {
         return this.m_poiTableManager;
@@ -1897,7 +1908,8 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Returns the storage level for the given camera setup.
-     * Actual storage level of the rendered data also depends on [[DataSource.storageLevelOffset]].
+     * Actual storage level of the rendered data also depends
+     * on {@link DataSource.storageLevelOffset}.
      */
     get storageLevel(): number {
         return THREE.MathUtils.clamp(
@@ -1926,7 +1938,7 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns [[DataSource]]s displayed by this `MapView`.
+     * Returns {@link DataSource}s displayed by this `MapView`.
      */
     get dataSources(): DataSource[] {
         return this.m_tileDataSources;
@@ -1945,21 +1957,21 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the unique [[DataSource]] matching the given name.
+     * Returns the unique {@link DataSource} matching the given name.
      */
     getDataSourceByName(dataSourceName: string): DataSource | undefined {
         return this.m_tileDataSources.find(ds => ds.name === dataSourceName);
     }
 
     /**
-     * Returns the array of [[DataSource]]s referring to the same [[StyleSet]].
+     * Returns the array of {@link DataSource}s referring to the same [[StyleSet]].
      */
     getDataSourcesByStyleSetName(styleSetName: string): DataSource[] {
         return this.m_tileDataSources.filter(ds => ds.styleSetName === styleSetName);
     }
 
     /**
-     * Returns true if the specified [[DataSource]] is enabled.
+     * Returns true if the specified {@link DataSource} is enabled.
      */
     isDataSourceEnabled(dataSource: DataSource): boolean {
         return (
@@ -1971,7 +1983,8 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Adds a new [[DataSource]] to this `MapView`. `MapView` needs at least one [[DataSource]] to
+     * Adds a new {@link DataSource} to this `MapView`.
+     * `MapView` needs at least one {@link DataSource} to
      * display something.
      *
      * @param dataSource - The data source.
@@ -2044,7 +2057,7 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Removes [[DataSource]] from this `MapView`.
+     * Removes {@link DataSource} from this `MapView`.
      *
      * @param dataSource - The data source to be removed
      */
@@ -2077,7 +2090,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Adds new overlay text elements to this `MapView`.
      *
-     * @param textElements - Array of [[TextElement]] to be added.
+     * @param textElements - Array of {@link TextElement} to be added.
      */
     addOverlayText(textElements: TextElement[]): void {
         this.m_textElementsRenderer.addOverlayText(textElements);
@@ -2087,7 +2100,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Adds new overlay text elements to this `MapView`.
      *
-     * @param textElements - Array of [[TextElement]] to be added.
+     * @param textElements - Array of {@link TextElement} to be added.
      */
     clearOverlayText(): void {
         this.m_textElementsRenderer.clearOverlayText();
@@ -2106,17 +2119,17 @@ export class MapView extends THREE.EventDispatcher {
      *
      * | `bounds`             | `target`    | actual `target`
      * | ------               | ------      | --------
-     * | [[GeoBox]]           | _defined_   | `params.target` is used
-     * | [[GeoBox]]           | `undefined` | `bounds.center` is used as new `target`
-     * | [[GeoBoxExtentLike]] | `undefined` | current `MapView.target` is used
-     * | [[GeoBoxExtentLike]] | _defined_   | `params.target` is used
+     * | {@link @here/harp-geoutils#GeoBox}           | _defined_   | `params.target` is used
+     * | {@link @here/harp-geoutils#GeoBox}           | `undefined` | `bounds.center` is used as new `target`
+     * | {@link @here/harp-geoutils#GeoBoxExtentLike} | `undefined` | current `MapView.target` is used
+     * | {@link @here/harp-geoutils#GeoBoxExtentLike} | _defined_   | `params.target` is used
      * | [[GeoCoordLike]][]   | `undefined` | new `target` is calculated as center of world box covering given points
      * | [[GeoCoordLike]][]   | _defined_   | `params.target` is used and zoomLevel is adjusted to view all given geo points
      *
      * In each case, `lookAt` finds minimum `zoomLevel` that covers given extents or geo points.
      *
      * With flat projection, if `bounds` represents points on both sides of antimeridian, and
-     * [[MapViewOptions.tileWrappingEnabled]] is used, `lookAt` will use this knowledge and find
+     * {@link MapViewOptions.tileWrappingEnabled} is used, `lookAt` will use this knowledge and find
      * minimal view that may cover "next" or "previous" world.
      *
      * With sphere projection if `bounds` represents points on both sides of globe, best effort
@@ -2137,7 +2150,7 @@ export class MapView extends THREE.EventDispatcher {
      *
      * @see More examples in [[LookAtExample]].
      *
-     * @param params - [[LookAtParams]]
+     * @param params - {@link LookAtParams}
      */
     lookAt(params: Partial<LookAtParams>): void;
     // tslint:enable: max-line-length
@@ -2153,7 +2166,7 @@ export class MapView extends THREE.EventDispatcher {
      * @param headingDeg - The camera heading angle in degrees and clockwise (as opposed to yaw)
      *                   @default 0
      * starting north.
-     * @deprecated Use lookAt version with [[LookAtParams]] object parameter.
+     * @deprecated Use lookAt version with {@link LookAtParams} object parameter.
      */
     lookAt(target: GeoCoordLike, distance: number, tiltDeg?: number, headingDeg?: number): void;
 
@@ -2182,9 +2195,12 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Moves the camera to the specified [[GeoCoordinates]], sets the desired `zoomLevel` and
-     * adjusts the yaw and pitch. The pitch of the camera is always curbed so that the camera cannot
-     * look above the horizon. This paradigm is necessary in [[MapControls]], where the center of \
+     * Moves the camera to the specified {@link @here/harp-geoutils#GeoCoordinates},
+     * sets the desired `zoomLevel` and
+     * adjusts the yaw and pitch. The pitch of the camera is
+     * always curbed so that the camera cannot
+     * look above the horizon. This paradigm is necessary
+     * in {@link @here/harp-map-controls#MapControls}, where the center of
      * the screen is used for the orbiting interaction (3 fingers / right mouse button).
      *
      * @param geoPos - Geolocation to move the camera to.
@@ -2192,7 +2208,7 @@ export class MapView extends THREE.EventDispatcher {
      * @param yawDeg - Camera yaw in degrees, counter-clockwise (as opposed to heading), starting
      * north.
      * @param pitchDeg - Camera pitch in degrees.
-     * @deprecated Use [[MapView.lookAt]] instead.
+     * @deprecated Use {@link MapView.lookAt} instead.
      */
     setCameraGeolocationAndZoom(
         geoPos: GeoCoordinates,
@@ -2239,7 +2255,7 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Removes the given dynamic property from this [[MapView]].
+     * Removes the given dynamic property from this {@link MapView}.
      *
      * Property names starting with a `$`-sign are reserved and any attempt to change their value
      * will result in an error.
@@ -2446,8 +2462,10 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the [[GeoCoordinates]] from the given screen position. The return value can be
-     * `null`, in case the camera is facing the horizon and the given `(x, y)` value is not
+     * Returns the {@link @here/harp-geoutils#GeoCoordinates} from the
+     * given screen position. The return value can be
+     * `null`, in case the camera is facing the horizon and
+     * the given `(x, y)` value is not
      * intersecting the ground plane.
      *
      * @param x - The X position in css/client coordinates (without applied display ratio).
@@ -2479,8 +2497,10 @@ export class MapView extends THREE.EventDispatcher {
      * THREE.js can raycast, the solid lines that get their geometry in the shader cannot be tested
      * for intersection.
      *
-     * Note, if a [[DataSource]] adds an [[Object3D]] to a [[Tile]], it will be only pickable once
-     * [[MapView.render]] has been called, this is because [[MapView.render]] method creates the
+     * Note, if a {@link DataSource} adds an [[Object3D]]
+     * to a {@link Tile}, it will be only pickable once
+     * {@link MapView.render} has been called, this is because
+     * {@link MapView.render} method creates the
      * internal three.js root [[Object3D]] which is used in the [[PickHandler]] internally.
      * This method will not test for intersection custom objects added to the scene by for
      * example calling directly the [[scene.add]] method from THREE.
@@ -2530,7 +2550,7 @@ export class MapView extends THREE.EventDispatcher {
      * Redraws scene immediately
      *
      * @note Before using this method, set `synchronousRendering` to `true`
-     * in the [[MapViewOptions]]
+     * in the {@link MapViewOptions}
      *
      * @param frameStartTime - Optional timestamp for start of frame.
      * Default: [[PerformanceTimer.now()]]
@@ -2578,10 +2598,11 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Clear the tile cache.
      *
-     * Remove the [[Tile]] objects created by cacheable [[DataSource]]s. If a [[DataSource]] name is
-     * provided, this method restricts the eviction the [[DataSource]] with the given name.
+     * Remove the {@link Tile} objects created by cacheable
+     * {@link DataSource}s. If a {@link DataSource} name is
+     * provided, this method restricts the eviction the {@link DataSource} with the given name.
      *
-     * @param dataSourceName - The name of the [[DataSource]].
+     * @param dataSourceName - The name of the {@link DataSource}.
      */
     clearTileCache(dataSourceName?: string) {
         if (this.m_visibleTiles === undefined) {
@@ -2629,8 +2650,8 @@ export class MapView extends THREE.EventDispatcher {
      *  * Visible and temporarily rendered tiles will be marked for update and retained.
      *  * Cached but not rendered/visible will be evicted.
      *
-     * @param dataSource - If passed, only the tiles from this [[DataSource]] instance
-     * are processed. If `undefined`, tiles from all [[DataSource]]s are processed.
+     * @param dataSource - If passed, only the tiles from this {@link DataSource} instance
+     * are processed. If `undefined`, tiles from all {@link DataSource}s are processed.
      */
     markTilesDirty(dataSource?: DataSource) {
         this.m_visibleTiles.markTilesDirty(dataSource);
@@ -2638,10 +2659,11 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Sets the DataSource which contains the elevations, the elevation range source, and the
-     * elevation provider. Only a single elevation source is possible per [[MapView]]
+     * elevation provider. Only a single elevation source is possible per {@link MapView}
      *
      * If the terrain-datasource is merged with this repository, we could internally construct
-     * the [[ElevationRangeSource]] and the [[ElevationProvider]] and access would be granted to
+     * the {@link ElevationRangeSource} and the {@link ElevationProvider}
+     * and access would be granted to
      * the application when it asks for it, to simplify the API.
      *
      * @param elevationSource - The datasource containing the terrain tiles.
@@ -2696,7 +2718,7 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Public access to [[MapViewFog]] allowing to toggle it by setting its `enabled` property.
+     * Public access to {@link MapViewFog} allowing to toggle it by setting its `enabled` property.
      */
     get fog(): MapViewFog {
         return this.m_fog;
@@ -2930,7 +2952,7 @@ export class MapView extends THREE.EventDispatcher {
      * note, setupCamera must be called before this is called.
      * @param viewRanges - optional parameter that supplies new view ranges, most importantly
      * near/far clipping planes distance. If parameter is not provided view ranges will be
-     * calculated from [[ClipPlaneEvaluator]] used in [[VisibleTileSet]].
+     * calculated from [[ClipPlaneEvaluator]] used in {@link VisibleTileSet}.
      */
     private updateCameras(viewRanges?: ViewRanges) {
         // Update look at settings first, so that other components (e.g. ClipPlanesEvaluator) get
@@ -3536,7 +3558,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Process the features owned by the given [[TileObject]].
      *
-     * @param tile - The [[Tile]] owning the [[TileObject]]'s features.
+     * @param tile - The {@link Tile} owning the [[TileObject]]'s features.
      * @param object - The [[TileObject]] to process.
      * @returns `false` if the given [[TileObject]] should not be added to the scene.
      */
@@ -3589,7 +3611,7 @@ export class MapView extends THREE.EventDispatcher {
                 // the state of current feature.
                 const featureState = tile.dataSource.getFeatureState(featureId);
 
-                // create a new [[Env]] that can be used
+                // create a new {@link @here/harp-datasource-protocol#Env} that can be used
                 // to evaluate expressions that access the feature state.
                 const $state = featureState ? new MapEnv(featureState) : null;
 

--- a/@here/harp-mapview/lib/MapViewAtmosphere.ts
+++ b/@here/harp-mapview/lib/MapViewAtmosphere.ts
@@ -58,7 +58,7 @@ const cache = {
 };
 
 /**
- * Class that provides [[MapView]]'s atmospheric scattering effect.
+ * Class that provides {@link MapView}'s atmospheric scattering effect.
  */
 export class MapViewAtmosphere {
     /**
@@ -112,7 +112,7 @@ export class MapViewAtmosphere {
      *
      * @note Currently works only with globe projection.
      *
-     * @param m_mapAnchors - The [[MapAnchors]] instance where the effect will be added.
+     * @param m_mapAnchors - The {@link MapAnchors} instance where the effect will be added.
      * @param m_sceneCamera - The camera used to render entire scene.
      * @param m_projection - The geo-projection used to transform geo coordinates to
      *                       cartesian space.
@@ -226,13 +226,14 @@ export class MapViewAtmosphere {
     }
 
     /**
-     * Sets the atmosphere depending on the [[Theme]] instance provided.
+     * Sets the atmosphere depending on the
+     * {@link @here/harp-datasource-protocol#Theme} instance provided.
      *
      * This function is called when a theme is loaded. Atmosphere is added only if the theme
      * contains a atmosphere definition with a:
      * - `color` property, used to set the atmosphere color.
      *
-     * @param theme - A [[Theme]] instance.
+     * @param theme - A {@link @here/harp-datasource-protocol#Theme} instance.
      */
     reset(theme: Theme) {
         //this.m_cachedTheme = theme;
@@ -254,7 +255,7 @@ export class MapViewAtmosphere {
             mapAnchors.add(createMapAnchor(this.m_groundMesh, Number.MAX_SAFE_INTEGER));
         }
 
-        // Request an update once the anchor is added to [[MapView]].
+        // Request an update once the anchor is added to {@link MapView}.
         if (this.m_updateCallback) {
             this.m_updateCallback();
         }

--- a/@here/harp-mapview/lib/MapViewFog.ts
+++ b/@here/harp-mapview/lib/MapViewFog.ts
@@ -11,7 +11,7 @@ import * as THREE from "three";
 import { MapView } from "./MapView";
 
 /**
- * Manages the fog display in [[MapView]].
+ * Manages the fog display in {@link MapView}.
  */
 export class MapViewFog {
     private m_enabled: boolean = true;
@@ -22,7 +22,7 @@ export class MapViewFog {
     /**
      * Constructs a `MapViewFog` instance.
      *
-     * @param m_scene - The scene used in [[MapView]] that contains the map objects.
+     * @param m_scene - The scene used in {@link MapView} that contains the map objects.
      */
     constructor(private m_scene: THREE.Scene) {}
 
@@ -50,13 +50,14 @@ export class MapViewFog {
     }
 
     /**
-     * Sets the fog depending on the [[Theme]] instance provided. This function is called when a
+     * Sets the fog depending on the {@link @here/harp-datasource-protocol#Theme}
+     * instance provided. This function is called when a
      * theme is loaded. Fog is added only if the theme contains a fog definition with a:
      * - `color` property, used to set the fog color.
      * - `startRatio` property, used to set the start distance of the fog as a ratio of the far
      * clipping plane distance.
      *
-     * @param theme - A [[Theme]] instance.
+     * @param theme - A {@link @here/harp-datasource-protocol#Theme} instance.
      */
     reset(theme: Theme) {
         this.m_cachedTheme = theme;

--- a/@here/harp-mapview/lib/MapViewPoints.ts
+++ b/@here/harp-mapview/lib/MapViewPoints.ts
@@ -9,9 +9,10 @@ import { PickingRaycaster } from "./PickingRaycaster";
 
 /**
  * `MapViewPoints` is a class to extend for the `"circles"` and `"squares"` [[Technique]]s to
- * implement raycasting of [[THREE.Points]] as expected in [[MapView]], that are in screen space. It
- * copies the behaviour of the `raycast` method in [[THREE.Points]] and dispatches it to its
- * children classes, [[Circles]] and [[Squares]], who hold the intersection testing in the
+ * implement raycasting of [[THREE.Points]] as expected in
+ * {@link MapView}, that are in screen space.
+ * It copies the behaviour of the `raycast` method in [[THREE.Points]] and dispatches it to its
+ * children classes, {@link Circles} and {@link Squares}, who hold the intersection testing in the
  * `testPoint` method. This class also has the ability to dismiss the testing via the
  * `enableRayTesting` flag.
  *
@@ -26,9 +27,10 @@ export abstract class MapViewPoints extends THREE.Points {
     enableRayTesting: boolean = true;
 
     /**
-     * Implements the intersection testing in screen space between the drawn points and the ray. The
-     * drawing of the points being different between [[Circles]] and [[Squares]], this method is
-     * implemented in these child classes.
+     * Implements the intersection testing in screen space between the drawn points and the ray.
+     *
+     * @remarks The drawing of the points being different between {@link Circles}
+     * and {@link Squares}, this method is implemented in these child classes.
      *
      * @param point - The point to test.
      * @param screenPosition - The point position on screen.

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -37,12 +37,12 @@ export enum PickObjectType {
     Area,
 
     /**
-     * The text part of a [[TextElement]]
+     * The text part of a {@link TextElement}
      */
     Text,
 
     /**
-     * The Icon of a [[TextElement]].
+     * The Icon of a {@link TextElement}.
      */
     Icon,
 
@@ -90,8 +90,12 @@ export interface PickResult {
     technique?: Technique;
 
     /**
-     * Optional user data that has been defined in the picked object. This object points directly to
-     * information contained in the original [[TileFeatureData]] stored in [[MapView]], and should
+     * Optional user data that has been defined in the picked object.
+     *
+     * @remarks
+     * This object points directly to
+     * information contained in the original {@link TileFeatureData}
+     * stored in {@link MapView}, and should
      * not be modified.
      */
     userData?: any;

--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -48,7 +48,7 @@ interface TechniqueEntry {
 }
 
 /**
- * [[DataSource]] providing geometry for poles
+ * {@link DataSource} providing geometry for poles
  */
 export class PolarTileDataSource extends DataSource {
     private m_tilingScheme: TilingScheme = polarTilingScheme;

--- a/@here/harp-mapview/lib/SkyBackground.ts
+++ b/@here/harp-mapview/lib/SkyBackground.ts
@@ -12,7 +12,7 @@ import { SkyGradientTexture } from "./SkyGradientTexture";
 import * as THREE from "three";
 
 /**
- * Class that handles [[MapView]]'s sky background.
+ * Class that handles {@link MapView}'s sky background.
  */
 export class SkyBackground {
     private m_skyTexture?: SkyGradientTexture | SkyCubemapTexture;
@@ -21,8 +21,8 @@ export class SkyBackground {
      * Constructs a new `SkyBackground`.
      *
      * @param m_sky - Sky configuration parameters.
-     * @param m_projectionType - [[MapView]]'s projection type.
-     * @param camera - [[MapView]]'s camera.
+     * @param m_projectionType - {@link MapView}'s projection type.
+     * @param camera - {@link MapView}'s camera.
      */
     constructor(
         private m_sky: GradientSky | CubemapSky,

--- a/@here/harp-mapview/lib/SkyGradientTexture.ts
+++ b/@here/harp-mapview/lib/SkyGradientTexture.ts
@@ -63,7 +63,7 @@ export class SkyGradientTexture {
      * Constructs a new `SkyGradientTexture`.
      *
      * @param sky - Initial [[GradientSky]] configuration.
-     * @param m_projectionType - [[MapView]]'s projection type.
+     * @param m_projectionType - {@link MapView}'s projection type.
      * @param m_height - Optional height parameter.
      */
     constructor(
@@ -120,7 +120,7 @@ export class SkyGradientTexture {
 
     /**
      * `SkyGradientTexture`'s texture resource (simple texture or cubemap depending on
-     * [[MapView]]'s projection).
+     * {@link MapView}'s projection).
      */
     get texture(): Texture {
         return this.m_projectionType === ProjectionType.Planar ? this.m_faces[0] : this.m_skybox!;

--- a/@here/harp-mapview/lib/Statistics.ts
+++ b/@here/harp-mapview/lib/Statistics.ts
@@ -821,7 +821,7 @@ export class FrameStats {
  * Only exported for testing.
  *
  * Instead of passing around an array of objects, we store the frame statistics as an object of
- * arrays. This allows convenient computations from [[RingBuffer]],
+ * arrays. This allows convenient computations from {@link RingBuffer},
  */
 export class FrameStatsArray {
     readonly frameEntries: Map<string, RingBuffer<number>> = new Map();
@@ -915,7 +915,8 @@ export interface SimpleFrameStatistics {
 }
 
 /**
- * Performance measurement central. Maintains the current [[FrameStats]], which holds all individual
+ * Performance measurement central. Maintains the current
+ * {@link FrameStats}, which holds all individual
  * performance numbers.
  *
  * Implemented as an instance for easy access.

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -38,9 +38,9 @@ import "@here/harp-fetch";
 export const DEFAULT_MAX_THEME_INTHERITANCE_DEPTH = 4;
 
 /**
- * Options to customize [[Theme]] loading process.
+ * Options to customize {@link @here/harp-datasource-protocol#Theme} loading process.
  *
- * @see [[ThemeLoader.load]]
+ * @see {@link ThemeLoader.load}
  */
 export interface ThemeLoadOptions {
     /**
@@ -76,7 +76,8 @@ export interface ThemeLoadOptions {
     signal?: AbortSignal;
 
     /**
-     * Maximum recursion depth when resolving base themes through [[[Theme]]s `extends` property.
+     * Maximum recursion depth when resolving base themes
+     * through [{@link @here/harp-datasource-protocol#Theme}s `extends` property.
      *
      * @default [[DEFAULT_MAX_THEME_INTHERITANCE_DEPTH]]
      */
@@ -85,7 +86,7 @@ export interface ThemeLoadOptions {
     /**
      * Custom logging channel on which diagnostics and warnings will be reported.
      *
-     * If not specified, [[ThemeLoader.load]] will log to `console`.
+     * If not specified, {@link ThemeLoader.load} will log to `console`.
      */
     logger?: ISimpleChannel;
 
@@ -100,7 +101,8 @@ export interface ThemeLoadOptions {
  */
 export class ThemeLoader {
     /**
-     * Loads a [[Theme]] from a remote resource, provided as a URL that points to a
+     * Loads a {@link @here/harp-datasource-protocol#Theme} from a
+     * remote resource, provided as a URL that points to a
      * JSON-encoded theme.
      *
      * By default, resolves following features of theme:
@@ -113,11 +115,14 @@ export class ThemeLoader {
      * (see [[resolveUrls]]).
      *
      * Custom URIs (of theme itself and of resources referenced by theme) may be resolved with by
-     * providing [[UriResolver]] using [[ThemeLoadOptions.uriResolver]] option.
+     * providing {@link @here/harp-utils#UriResolver} using {@link ThemeLoadOptions.uriResolver}
+     * option.
      *
-     * @param theme - [[Theme]] instance or theme URL to the theme.
-     * @param options - Optional, a [[ThemeLoadOptions]] objects containing any custom settings for
-     *    this load request.
+     * @param theme - {@link @here/harp-datasource-protocol#Theme} instance or theme URL
+     *                to the theme.
+     * @param options - Optional, a {@link ThemeLoadOptions} objects
+     *                  containing any custom settings for
+     *                  this load request.
      */
     static async load(
         theme: string | Theme | FlatTheme,
@@ -172,7 +177,8 @@ export class ThemeLoader {
     /**
      * @deprecated Please use `ThemeLoader.load`
      *
-     * Loads a [[Theme]] from a remote resource, provided as a URL that points to a JSON-encoded
+     * Loads a {@link @here/harp-datasource-protocol#Theme} from a remote resource,
+     * provided as a URL that points to a JSON-encoded
      * theme.
      *
      * @param themeUrl - The URL to the theme.
@@ -183,12 +189,13 @@ export class ThemeLoader {
     }
 
     /**
-     * Resolves all [[Theme]]'s relatives URLs to full URL using the [[Theme]]'s URL
+     * Resolves all {@link @here/harp-datasource-protocol#Theme}'s relatives URLs
+     * to full URL using the {@link @here/harp-datasource-protocol#Theme}'s URL
      * (see: https://www.w3.org/TR/WD-html40-970917/htmlweb.html#h-5.1.2).
      *
      * This method mutates original `theme` instance.
      *
-     * @param theme - The [[Theme]] to resolve.
+     * @param theme - The {@link @here/harp-datasource-protocol#Theme} to resolve.
      */
     private static resolveUrls(theme: Theme | FlatTheme, options?: ThemeLoadOptions): Theme {
         // Ensure that all resources referenced in theme by relative URIs are in fact relative to
@@ -256,8 +263,10 @@ export class ThemeLoader {
     }
 
     /**
-     * Expand all `ref` expressions in [[Theme]] basing on `definitions`.
+     * Expand all `ref` expressions in {@link @here/harp-datasource-protocol#Theme}
+     * basing on `definitions`.
      *
+     * @remarks
      * This method mutates original `theme` instance.
      */
     private static resolveThemeReferences(theme: Theme, contextLogger: IContextLogger): Theme {
@@ -463,11 +472,13 @@ export class ThemeLoader {
     }
 
     /**
-     * Realize `extends` clause by merging `theme` with its base [[Theme]].
+     * Realize `extends` clause by merging `theme` with
+     * its base {@link @here/harp-datasource-protocol#Theme}.
      *
-     * @param theme - [Theme] object
-     * @param options - Optional, a [[ThemeLoadOptions]] objects containing any custom settings for
-     *    this load request.
+     * @param theme - {@link @here/harp-datasource-protocol#Theme} object
+     * @param options - Optional, a {@link ThemeLoadOptions} objects
+     *                  containing any custom settings for
+     *                  this load request.
      */
     private static async resolveBaseThemes(
         theme: Theme,

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -25,7 +25,7 @@ const logger = LoggerManager.instance.create("Tile");
 
 export type TileObject = THREE.Object3D & {
     /**
-     * Distance of this object from the [[Tile]]'s center.
+     * Distance of this object from the {@link Tile}'s center.
      */
     displacement?: THREE.Vector3;
 
@@ -151,7 +151,7 @@ export interface TileResourceUsage {
 }
 
 /**
- * Simple information about resource usage by the [[Tile]]. Heap and GPU information are
+ * Simple information about resource usage by the {@link Tile}. Heap and GPU information are
  * estimations.
  */
 export interface TileResourceInfo {
@@ -168,12 +168,12 @@ export interface TileResourceInfo {
      */
     num3dObjects: number;
     /**
-     * Number of [[TextElement]]s in this tile.
+     * Number of {@link TextElement}s in this tile.
      */
     numTextElements: number;
     /**
      * @deprecated This counter has been merged with numTextElements.
-     * Number of user [[TextElement]]s in this tile.
+     * Number of user {@link TextElement}s in this tile.
      */
     numUserTextElements: number;
 }
@@ -186,7 +186,7 @@ export interface TextElementIndex {
 type TileCallback = (tile: Tile) => void;
 
 /**
- * The class that holds the tiled data for a [[DataSource]].
+ * The class that holds the tiled data for a {@link DataSource}.
  */
 export class Tile implements CachedResource {
     /**
@@ -211,9 +211,10 @@ export class Tile implements CachedResource {
     copyrightInfo?: CopyrightInfo[];
 
     /**
-     * Keeping some stats for the individual [[Tile]]s to analyze caching behavior.
+     * Keeping some stats for the individual {@link Tile}s to analyze caching behavior.
      *
-     * The frame the [[Tile]] was last requested. This is required to know when the given [[Tile]]
+     * The frame the {@link Tile} was last requested. This is
+     * required to know when the given {@link Tile}
      * can be removed from the cache.
      */
     frameNumLastRequested: number = -1;
@@ -249,7 +250,7 @@ export class Tile implements CachedResource {
      *
      * levelOffset is in in the range [-quadTreeSearchDistanceUp,
      * quadTreeSearchDistanceDown], where these values come from the
-     * [[VisibleTileSetOptions]]
+     * {@link VisibleTileSetOptions}
      */
     levelOffset: number = 0;
 
@@ -283,14 +284,14 @@ export class Tile implements CachedResource {
     private m_decodedTile?: DecodedTile;
     private m_tileGeometryLoader?: TileGeometryLoader;
 
-    // Used for [[TextElement]]s that are stored in the data, and that are placed explicitly,
+    // Used for {@link TextElement}s that are stored in the data, and that are placed explicitly,
     // fading in and out.
     private m_textElementGroups = new TextElementGroupPriorityList();
 
     // Blocks other labels from showing.
     private readonly m_pathBlockingElements: PathBlockingElement[] = [];
 
-    // If `true`, the text content of the [[Tile]] changed after the last time it was rendered.
+    // If `true`, the text content of the {@link Tile} changed after the last time it was rendered.
     // It's `Undefined` when no text content has been added yet.
     private m_textElementsChanged: boolean | undefined;
 
@@ -311,13 +312,14 @@ export class Tile implements CachedResource {
     private m_uniqueKey: number;
     private m_offset: number;
     /**
-     * Creates a new [[Tile]].
+     * Creates a new {@link Tile}.
      *
-     * @param dataSource - The [[DataSource]] that created this [[Tile]].
-     * @param tileKey - The unique identifier for this [[Tile]]. Currently only up to level 24 is
-     * supported, because of the use of the upper bits for the offset.
+     * @param dataSource - The {@link DataSource} that created this {@link Tile}.
+     * @param tileKey - The unique identifier for this {@link Tile}.
+     *                  Currently only up to level 24 is
+     *                  supported, because of the use of the upper bits for the offset.
      * @param offset - The optional offset, this is an integer which represents what multiple of 360
-     * degrees to shift, only useful for flat projections, hence optional.
+     *                 degrees to shift, only useful for flat projections, hence optional.
      * @param localTangentSpace - Whether the tile geometry is in local tangent space or not.
      */
     constructor(
@@ -336,11 +338,12 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * The visibility status of the [[Tile]]. It is actually visible or planned to become visible.
+     * The visibility status of the {@link Tile}. It is actually
+     * visible or planned to become visible.
      */
     get isVisible(): boolean {
         // Tiles are not evaluated as invisible until the second frame they aren't requested.
-        // This happens in order to prevent that, during [[VisibleTileSet]] visibility evaluation,
+        // This happens in order to prevent that, during VisibleTileSet visibility evaluation,
         // visible tiles that haven't yet been evaluated for the current frame are preemptively
         // removed from [[DataSourceCache]].
         return this.frameNumLastRequested >= this.dataSource.mapView.frameNumber - 1;
@@ -351,14 +354,14 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * The [[Projection]] currently used by the [[MapView]].
+     * The {@link @here/harp-geoutils#Projection} currently used by the {@link MapView}.
      */
     get projection(): Projection {
         return this.dataSource.projection;
     }
 
     /**
-     * The [[MapView]] this `Tile` belongs to.
+     * The {@link MapView} this `Tile` belongs to.
      */
     get mapView(): MapView {
         return this.dataSource.mapView;
@@ -367,7 +370,7 @@ export class Tile implements CachedResource {
     /**
      * Whether the data of this tile is in local tangent space or not.
      * If the data is in local tangent space (i.e. up vector is (0,0,1) for high zoomlevels) then
-     * [[MapView]] will rotate the objects before rendering using the rotation matrix of the
+     * {@link MapView} will rotate the objects before rendering using the rotation matrix of the
      * oriented [[boundingBox]].
      */
     get localTangentSpace(): boolean {
@@ -392,9 +395,11 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Gets the key to uniquely represent this tile (based on the [[tileKey]] and [[offset]]), note
-     * this key is only unique within the given [[DataSource]], to get a key which is unique across
-     * [[DataSource]]s see [[DataSourceCache.getKeyForTile]].
+     * Gets the key to uniquely represent this tile (based on
+     * the {@link tileKey} and {@link offset}), note
+     * this key is only unique within the given {@link DataSource},
+     * to get a key which is unique across
+     * {@link DataSource}s see [[DataSourceCache.getKeyForTile]].
      */
     get uniqueKey(): number {
         return this.m_uniqueKey;
@@ -411,7 +416,7 @@ export class Tile implements CachedResource {
     /**
      * The optional offset, this is an integer which represents what multiple of 360 degrees to
      * shift, only useful for flat projections, hence optional.
-     * @param offset - Which multiple of 360 degrees to apply to the [[Tile]].
+     * @param offset - Which multiple of 360 degrees to apply to the {@link Tile}.
      */
     set offset(offset: number) {
         if (this.m_offset !== offset) {
@@ -421,7 +426,7 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Compute [[TileResourceInfo]] of this `Tile`. May be using a cached value. The method
+     * Compute {@link TileResourceInfo} of this `Tile`. May be using a cached value. The method
      * `invalidateResourceInfo` can be called beforehand to force a recalculation.
      *
      * @returns `TileResourceInfo` for this `Tile`.
@@ -434,7 +439,7 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Force invalidation of the cached [[TileResourceInfo]]. Useful after the `Tile` has been
+     * Force invalidation of the cached {@link TileResourceInfo}. Useful after the `Tile` has been
      * modified.
      */
     invalidateResourceInfo(): void {
@@ -454,7 +459,7 @@ export class Tile implements CachedResource {
      * @internal
      * @deprecated User text elements are deprecated.
      *
-     * Gets the list of developer-defined [[TextElement]] in this `Tile`. This list is always
+     * Gets the list of developer-defined {@link TextElement} in this `Tile`. This list is always
      * rendered first.
      */
     get userTextElements(): TextElementGroup {
@@ -467,7 +472,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Adds a developer-defined [[TextElement]] to this `Tile`. The [[TextElement]] is always
+     * Adds a developer-defined {@link TextElement} to this `Tile`.
+     *
+     * @remarks
+     * The {@link TextElement} is always
      * visible, if it's in the map's currently visible area.
      *
      * @deprecated use [[addTextElement]].
@@ -480,7 +488,7 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Removes a developer-defined [[TextElement]] from this `Tile`.
+     * Removes a developer-defined {@link TextElement} from this `Tile`.
      *
      * @deprecated use [[removeTextElement]].
      *
@@ -493,8 +501,8 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Adds a [[TextElement]] to this `Tile`, which is added to the visible set of
-     * [[TextElement]]s based on the capacity and visibility. The [[TextElement]]'s priority
+     * Adds a {@link TextElement} to this `Tile`, which is added to the visible set of
+     * {@link TextElement}s based on the capacity and visibility. The {@link TextElement}'s priority
      * controls if or when it becomes visible.
      *
      * To ensure that a TextElement is visible, use a high value for its priority, such as
@@ -526,8 +534,11 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Removes a [[TextElement]] from this `Tile`. For the element to be removed successfully, the
-     * priority of the [[TextElement]] has to be equal to its priority when it was added.
+     * Removes a {@link TextElement} from this `Tile`.
+     *
+     * @remarks
+     * For the element to be removed successfully, the
+     * priority of the {@link TextElement} has to be equal to its priority when it was added.
      *
      * @param textElement - The TextElement to remove.
      * @returns `true` if the TextElement has been removed successfully; `false` otherwise.
@@ -550,7 +561,8 @@ export class Tile implements CachedResource {
     /**
      * @internal
      *
-     * Gets the current [[GroupedPriorityList]] which contains a list of all [[TextElement]]s to be
+     * Gets the current [[GroupedPriorityList]] which
+     * contains a list of all {@link TextElement}s to be
      * selected and placed for rendering.
      */
     get textElementGroups(): TextElementGroupPriorityList {
@@ -558,8 +570,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Gets the current modification state for the list of [[TextElement]]s in the `Tile`. If the
-     * value is `true` the TextElement is placed for rendering during the next frame.
+     * Gets the current modification state for the list
+     * of {@link TextElement}s in the `Tile`. If the
+     * value is `true` the TextElement is placed for
+     * rendering during the next frame.
      */
     get textElementsChanged(): boolean {
         return this.m_textElementsChanged ?? false;
@@ -584,7 +598,7 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Called before [[MapView]] starts rendering this `Tile`.
+     * Called before {@link MapView} starts rendering this `Tile`.
      *
      * @param zoomLevel - The current zoom level.
      * @returns Returns `true` if this `Tile` should be rendered. Influenced directly by the
@@ -595,7 +609,7 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Called after [[MapView]] has rendered this `Tile`.
+     * Called after {@link MapView} has rendered this `Tile`.
      */
     didRender(): void {
         // to be overridden by subclasses
@@ -707,8 +721,12 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Called by the [[TileLoader]] after the `Tile` has finished loading its map data. Can be used
-     * to add content to the `Tile`. The [[DecodedTile]] should still be available.
+     * Called by the {@link @here/harp-mapview-decoder#TileLoader}
+     *
+     * @remarks
+     * after the `Tile` has finished loading its map data. Can be used
+     * to add content to the `Tile`.
+     * The {@link @here/harp-datasource-protocol#DecodedTile} should still be available.
      */
     loadingFinished() {
         // To be used in subclasses.
@@ -823,16 +841,17 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Gets the [[ITileLoader]] that manages this tile.
+     * Gets the {@link ITileLoader} that manages this tile.
      */
     get tileLoader(): ITileLoader | undefined {
         return this.m_tileLoader;
     }
 
     /**
-     * Sets the [[ITileLoader]] to manage this tile.
+     * Sets the {@link ITileLoader} to manage this tile.
      *
-     * @param tileLoader - A [[ITileLoader]] instance to manage the loading process for this tile.
+     * @param tileLoader - A {@link ITileLoader} instance to manage
+     *                     the loading process for this tile.
      */
     set tileLoader(tileLoader: ITileLoader | undefined) {
         this.m_tileLoader = tileLoader;
@@ -939,7 +958,7 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Removes all [[TextElement]] from the tile.
+     * Removes all {@link TextElement} from the tile.
      */
     clearTextElements() {
         if (!this.hasTextElements()) {

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -74,9 +74,12 @@ const cache = {
 /**
  * Rounds a given zoom level up to the nearest integer value if it's close enough.
  *
- * The zoom level set in [[MapView]] after a zoom level target is given to [[MapView.lookAt]] or
- * [[MapControls]] never matches exactly the target due to the precision loss caused by the
- * conversion from zoom level to camera distance (done in [[MapView.lookAt]] and [[MapControls]])
+ * The zoom level set in {@link MapView} after a zoom level
+ * target is given to {@link MapView.lookAt} or
+ * {@link @here/harp-map-controls#MapControls} never matches
+ * exactly the target due to the precision loss caused by the
+ * conversion from zoom level to camera distance (done in
+ * {@link MapView.lookAt} and {@link @here/harp-map-controls#MapControls})
  * and from distance back to zoom level (done at every frame on camera update).
  * As a result, given a fixed integer zoom level input, the final zoom level computed at every frame
  * may fall sometimes below the integer value and others above. This causes flickering since each
@@ -197,7 +200,7 @@ export namespace MapViewUtils {
     /**
      * Orbits the camera around the focus point of the camera.
      *
-     * @param mapView - The [[MapView]] instance to manipulate.
+     * @param mapView - The {@link MapView} instance to manipulate.
      * @param deltaAzimuthDeg - Delta azimuth in degrees.
      * @param deltaTiltDeg - Delta tilt in degrees.
      * @param maxTiltAngleRad - The maximum tilt between the camera and its target in radian.
@@ -378,7 +381,8 @@ export namespace MapViewUtils {
     }
 
     /**
-     * Returns the [[GeoCoordinates]] of the camera, given its target coordinates on the map and its
+     * Returns the {@link @here/harp-geoutils#GeoCoordinates} of the camera,
+     * given its target coordinates on the map and its
      * zoom, yaw and pitch.
      *
      * @param targetCoordinates - Coordinates of the center of the view.
@@ -526,9 +530,10 @@ export namespace MapViewUtils {
      * @hidden
      * @internal
      *
-     * Return [[GeoPoints]] bounding [[GeoBox]] applicable for [[getFitBoundsDistance]].
+     * Return [[GeoPoints]] bounding {@link @here/harp-geoutils#GeoBox}
+     * applicable for [[getFitBoundsDistance]].
      *
-     * @returns [[GeoCoordinates]] set that covers `box`
+     * @returns {@link @here/harp-geoutils#GeoCoordinates} set that covers `box`
      */
     export function geoBoxToGeoPoints(box: GeoBox): GeoCoordinates[] {
         const center = box.center;
@@ -554,9 +559,9 @@ export namespace MapViewUtils {
      *
      * @param points - points which shall are to be covered by view
      *
-     * @param worldTarget - readonly, world target of [[MapView]]
+     * @param worldTarget - readonly, world target of {@link MapView}
      * @param camera - readonly, camera with proper `position` and rotation set
-     * @returns new distance to camera to be used with [[MapView.lookAt]]
+     * @returns new distance to camera to be used with {@link MapView.lookAt}
      */
     export function getFitBoundsDistance(
         points: THREE.Vector3[],
@@ -660,13 +665,14 @@ export namespace MapViewUtils {
      * @hidden
      * @internal
      *
-     * Get [[LookAtParams]] that fit all `worldPoints` giving that [[MapView]] will target at
+     * Get {@link LookAtParams} that fit all `worldPoints`
+     * giving that {@link MapView} will target at
      * `geoTarget`.
      *
-     * @param geoTarget - desired target (see [[MapView.target]]) as geo point
+     * @param geoTarget - desired target (see {@link MapView.target}) as geo point
      * @param worldTarget - same as `geoTarget` but in world space
      * @param worldPoints - points we want to see
-     * @param params - other params derived from [[MapView]].
+     * @param params - other params derived from {@link MapView}.
      */
     export function getFitBoundsLookAtParams(
         geoTarget: GeoCoordinates,
@@ -797,7 +803,8 @@ export namespace MapViewUtils {
     }
 
     /**
-     * The function doing a pan in the spherical space when [[MapView]]'s active [[ProjectionType]]
+     * The function doing a pan in the spherical space
+     * when {@link MapView}'s active [[ProjectionType]]
      * is spherical. In other words, the function that rotates the camera around the globe.
      *
      * @param mapView - MapView instance.
@@ -821,7 +828,7 @@ export namespace MapViewUtils {
      * Rotates the camera by the given delta yaw and delta pitch. The pitch will be clamped to the
      * maximum possible tilt to the new target, and under the horizon in sphere projection.
      *
-     * @param mapView - The [[MapView]] instance in use.
+     * @param mapView - The {@link MapView} instance in use.
      * @param deltaYawDeg - Delta yaw in degrees.
      * @param deltaPitchDeg - Delta pitch in degrees.
      * @param maxTiltAngleRad - Max tilt angle in radians.
@@ -931,7 +938,8 @@ export namespace MapViewUtils {
      * Extracts current camera tilt angle in radians.
      *
      * @param camera - The [[Camera]] in use.
-     * @param projection - The [[Projection]] used to convert between geo and world coordinates.
+     * @param projection - The {@link @here/harp-geoutils#Projection} used to
+     *                     convert between geo and world coordinates.
      *
      * @deprecated Use MapView.tilt
      */
@@ -978,7 +986,7 @@ export namespace MapViewUtils {
      *
      * @see https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
      *
-     * @param options - Subset of necessary [[MapView]] properties.
+     * @param options - Subset of necessary {@link MapView} properties.
      * @param object - The [[THREE.Object3D]] instance to extract the rotations from.
      */
     export function extractAttitude(
@@ -1040,7 +1048,7 @@ export namespace MapViewUtils {
      * is the target of that object, by adding PI to it. Otherwise it only returns the spherical
      * coordinates of `object` in the tangent space of `location`.
      *
-     * @param mapView - The [[MapView]] instance to consider.
+     * @param mapView - The {@link MapView} instance to consider.
      * @param object - The object to get the coordinates from.
      * @param location - The reference point.
      */
@@ -1094,7 +1102,8 @@ export namespace MapViewUtils {
      * is the target of that object, by adding PI to it. Otherwise it only returns the tilt angle
      * (in radians) of `object` in the tangent space of `location`.
      *
-     * @param projection - The [[Projection]] used when converting from geo to world coordinates.
+     * @param projection - The {@link @here/harp-geoutils#Projection} used when
+     *                     converting from geo to world coordinates.
      * @param object - The object to get the coordinates from.
      * @param location - The reference point.
      */
@@ -1199,7 +1208,7 @@ export namespace MapViewUtils {
      * level.
      *
      * @param mapView - Instance of MapView.
-     * @param options - Subset of necessary [[MapView]] properties.
+     * @param options - Subset of necessary {@link MapView} properties.
      */
     export function calculateDistanceToGroundFromZoomLevel(
         options: { projection: Projection; focalLength: number; camera: THREE.Object3D },
@@ -1236,8 +1245,8 @@ export namespace MapViewUtils {
      * set the zoom level of the camera to 14, then you are able to see the whole tile in front of
      * you.
      *
-     * @param options - Subset of necessary [[MapView]] properties.
-     * @param distance - The distance in meters, which are scene units in [[MapView]].
+     * @param options - Subset of necessary {@link MapView} properties.
+     * @param distance - The distance in meters, which are scene units in {@link MapView}.
      */
     export function calculateZoomLevelFromDistance(
         options: { focalLength: number; minZoomLevel: number; maxZoomLevel: number },
@@ -1360,7 +1369,7 @@ export namespace MapViewUtils {
      * and/or attributes will be counted multiple times.
      *
      * @param object - The mesh object to evaluate
-     * @param size - The [[MemoryUsage]] to update.
+     * @param size - The {@link MemoryUsage} to update.
      * @param visitedObjects - Optional map to store large objects that could be shared.
      *
      * @returns Estimate of object size in bytes for heap and GPU.
@@ -1743,8 +1752,9 @@ export namespace TileOffsetUtils {
      * bitshift reduces this accordingly, so given the default bitshift of four, we support up to 24
      * levels. Given the current support up to level 19 this should be fine.
      *
-     * @param tileKey - The unique [[TileKey]] from which to compute the unique key.
-     * @param offset - How much the given [[TileKey]] is offset
+     * @param tileKey - The unique {@link @here/harp-geoutils#TileKey}
+     *                  from which to compute the unique key.
+     * @param offset - How much the given {@link @here/harp-geoutils#TileKey} is offset
      * @param bitshift - How much space we have to store the offset. The default of 4 means we have
      *      enough space to store 16 unique tiles in a single view.
      */

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -42,7 +42,7 @@ enum SearchDirection {
 }
 
 /**
- * Limited set of [[MapViewOptions]] used for [[VisibleTileSet]].
+ * Limited set of {@link MapViewOptions} used for {@link VisibleTileSet}.
  */
 export interface VisibleTileSetOptions {
     /**
@@ -91,14 +91,14 @@ const MB_FACTOR = 1.0 / (1024.0 * 1024.0);
 type TileCacheId = string;
 
 /**
- * Wrapper for LRU cache that encapsulates tiles caching for any [[DataSource]] used.
+ * Wrapper for LRU cache that encapsulates tiles caching for any {@link DataSource} used.
  *
  * Provides LRU based caching mechanism where each tile is identified by its tile key
  * (morton code) and data source name.
  * Tiles are kept in the cache based on last recently used policy, cached tile may be evicted
  * only when cache reaches full saturation and tile is no longer visible.
  * @note Currently cached entries (tiles) are identified by unique tile code (morton code) and
- * data source name, thus it is required that each [[DataSource]] used should have unique
+ * data source name, thus it is required that each {@link DataSource} used should have unique
  * name, but implementation could be improved to omit this limitation.
  */
 class DataSourceCache {
@@ -107,7 +107,7 @@ class DataSourceCache {
      *
      * @param mortonCode - The tile morton code.
      * @param offset - The tile offset.
-     * @param dataSource - The [[DataSource]] from which tile was loaded.
+     * @param dataSource - The {@link DataSource} from which tile was loaded.
      */
     static getKey(mortonCode: number, offset: number, dataSource: DataSource): TileCacheId {
         return `${dataSource.name}_${mortonCode}_${offset}`;
@@ -219,7 +219,7 @@ class DataSourceCache {
      *
      * @param mortonCode - An unique tile morton code.
      * @param offset - Tile offset.
-     * @param dataSource - A [[DataSource]] the tile comes from.
+     * @param dataSource - A {@link DataSource} the tile comes from.
      */
     get(mortonCode: number, offset: number, dataSource: DataSource): Tile | undefined {
         return this.m_tileCache.get(DataSourceCache.getKey(mortonCode, offset, dataSource));
@@ -230,7 +230,7 @@ class DataSourceCache {
      *
      * @param mortonCode - En unique tile code (morton code).
      * @param offset - The tile offset.
-     * @param dataSource - A [[DataSource]] the tile comes from.
+     * @param dataSource - A {@link DataSource} the tile comes from.
      * @param tile - The tile reference.
      */
     set(mortonCode: number, offset: number, dataSource: DataSource, tile: Tile) {
@@ -252,7 +252,7 @@ class DataSourceCache {
      * Delete tile using its unique identifier.
      *
      * @note Tile identifier its constructed using information about tile code (morton code) and its
-     * [[DataSource]].
+     * {@link DataSource}.
      * @note This is explicit removal thus eviction callback will not be processed.
      * @see DataSourceCache.getKey.
      * @param tileKey - The unique tile identifier.
@@ -303,10 +303,10 @@ class DataSourceCache {
     /**
      * Call functor (callback) on each tile store in cache.
      *
-     * Optionally you may specify from which [[DataSource]] tiles should be processed.
-     * This limits the tiles visited to a sub-set originating from single [[DataSource]].
+     * Optionally you may specify from which {@link DataSource} tiles should be processed.
+     * This limits the tiles visited to a sub-set originating from single {@link DataSource}.
      * @param callback - The function to be called for each visited tile.
-     * @param inDataSource - The optional [[DataSource]] to which tiles should belong.
+     * @param inDataSource - The optional {@link DataSource} to which tiles should belong.
      */
     forEach(callback: (tile: Tile, key: TileCacheId) => void, inDataSource?: DataSource): void {
         this.m_tileCache.forEach((entry: Tile, key: TileCacheId) => {
@@ -318,7 +318,7 @@ class DataSourceCache {
 }
 
 /**
- * List of visible tiles for a [[DataSource]].
+ * List of visible tiles for a {@link DataSource}.
  */
 export interface DataSourceTileList {
     /**
@@ -327,7 +327,7 @@ export interface DataSourceTileList {
     dataSource: DataSource;
 
     /**
-     * The current [[MapView]] zoom level.
+     * The current {@link MapView} zoom level.
      */
     zoomLevel: number;
 
@@ -363,7 +363,7 @@ export interface DataSourceTileList {
 }
 
 /**
- * Manages visible [[Tile]]s for [[MapView]].
+ * Manages visible {@link Tile}s for {@link MapView}.
  *
  * Responsible for election of rendered tiles:
  *  - quad-tree traversal
@@ -414,7 +414,7 @@ export class VisibleTileSet {
      * Sets cache size.
      *
      * @param size - cache size
-     * @param computationType - Optional value specifying the way a [[Tile]]s cache usage is
+     * @param computationType - Optional value specifying the way a {@link Tile}s cache usage is
      *      computed, either based on size in MB (mega bytes) or in number of tiles. Defaults to
      *      `ResourceComputationType.EstimationInMb`.
      */
@@ -485,7 +485,7 @@ export class VisibleTileSet {
 
     /**
      * Calculates a new set of visible tiles.
-     * @param storageLevel - The camera storage level, see [[MapView.storageLevel]].
+     * @param storageLevel - The camera storage level, see {@link MapView.storageLevel}.
      * @param zoomLevel - The camera zoom level.
      * @param dataSources - The data sources for which the visible tiles will be calculated.
      * @param elevationRangeSource - Source of elevation range data if any.
@@ -760,7 +760,7 @@ export class VisibleTileSet {
     /**
      * Removes all internal bookkeeping entries and cache related to specified datasource.
      *
-     * Called by [[MapView]] when [[DataSource]] has been removed from [[MapView]].
+     * Called by {@link MapView} when {@link DataSource} has been removed from {@link MapView}.
      */
     removeDataSource(dataSource: DataSource) {
         this.clearTileCache(dataSource);
@@ -772,10 +772,12 @@ export class VisibleTileSet {
     /**
      * Clear the tile cache.
      *
-     * Remove the [[Tile]] objects created by cacheable [[DataSource]]. If a [[DataSource]] name is
-     * provided, this method restricts the eviction the [[DataSource]] with the given name.
+     * Remove the {@link Tile} objects created by cacheable {@link DataSource}.
+     * If a {@link DataSource} name is
+     * provided, this method restricts the eviction
+     * the {@link DataSource} with the given name.
      *
-     * @param dataSourceName - The name of the [[DataSource]].
+     * @param dataSourceName - The name of the {@link DataSource}.
      */
     clearTileCache(dataSource?: DataSource) {
         if (dataSource !== undefined) {
@@ -793,8 +795,8 @@ export class VisibleTileSet {
      *  * Visible and temporarily rendered tiles will be marked for update and retained.
      *  * Cached but not rendered/visible will be evicted.
      *
-     * @param dataSource - If passed, only the tiles from this [[DataSource]] instance
-     *      are processed. If `undefined`, tiles from all [[DataSource]]s are processed.
+     * @param dataSource - If passed, only the tiles from this {@link DataSource} instance
+     *      are processed. If `undefined`, tiles from all {@link DataSource}s are processed.
      */
     markTilesDirty(dataSource?: DataSource) {
         if (dataSource === undefined) {
@@ -811,7 +813,7 @@ export class VisibleTileSet {
     }
 
     /**
-     * Dispose tiles that are marked for removal by [[LRUCache]] algorithm.
+     * Dispose tiles that are marked for removal by {@link @here/harp-lrucache#LRUCache} algorithm.
      */
     disposePendingTiles() {
         this.m_dataSourceCache.disposeTiles();
@@ -851,8 +853,8 @@ export class VisibleTileSet {
     }
 
     /**
-     * Skips rendering of tiles that are overlapped. The overlapping [[Tile]] comes from a
-     * [[DataSource]] which is fully covering, i.e. there it is fully opaque.
+     * Skips rendering of tiles that are overlapped. The overlapping {@link Tile} comes from a
+     * {@link DataSource} which is fully covering, i.e. there it is fully opaque.
      **/
     private skipOverlappedTiles(dataSource: DataSource, tile: Tile) {
         if (this.options.projection.type === ProjectionType.Spherical) {
@@ -869,7 +871,7 @@ export class VisibleTileSet {
                 tile.skipRendering = false;
                 this.m_coveringMap.set(key, tile);
             } else {
-                // Skip the [[Tile]] if either the stored entry or the tile to consider is from the
+                // Skip the Tile if either the stored entry or the tile to consider is from the
                 // [[BackgroundDataSource]]
                 if (entry.dataSource instanceof BackgroundDataSource) {
                     entry.skipRendering = true;
@@ -911,7 +913,7 @@ export class VisibleTileSet {
      * to prevent flickering when zooming in / out. The distance to search is based on the options
      * [[quadTreeSearchDistanceDown]] and [[quadTreeSearchDistanceUp]].
      *
-     * Each [[DataSource]] can also switch this behaviour on / off using the
+     * Each {@link DataSource} can also switch this behaviour on / off using the
      * [[allowOverlappingTiles]] flag.
      *
      */

--- a/@here/harp-mapview/lib/WorkerBasedDecoder.ts
+++ b/@here/harp-mapview/lib/WorkerBasedDecoder.ts
@@ -90,9 +90,11 @@ export class WorkerBasedDecoder implements ITileDecoder {
     }
 
     /**
-     * Get [[Tile]] from tile decoder service in worker.
+     * Get {@link Tile} from tile decoder service in worker.
      *
-     * Invokes [[DecodeTileRequest]] on [[TileDecoderService]] running in worker pool.
+     * @remarks
+     * Invokes {@link @here/harp-datasource-protocol#DecodeTileRequest} on
+     * [[TileDecoderService]] running in worker pool.
      */
     decodeTile(
         data: ArrayBufferLike,
@@ -120,9 +122,11 @@ export class WorkerBasedDecoder implements ITileDecoder {
     }
 
     /**
-     * Get [[TileInfo]] from tile decoder service in worker.
+     * Get {@link @here/harp-datasource-protocol#TileInfo} from tile decoder service in worker.
      *
-     * Invokes [[TileInfoRequest]] on [[TileDecoderService]] running in worker pool.
+     * @remarks
+     * Invokes {@link @here/harp-datasource-protocol#TileInfoRequest}
+     * on [[TileDecoderService]] running in worker pool.
      */
     getTileInfo(
         data: ArrayBufferLike,
@@ -151,7 +155,9 @@ export class WorkerBasedDecoder implements ITileDecoder {
     /**
      * Configure tile decoder service in workers.
      *
-     * Broadcasts [[ConfigurationMessage]] to all [[TileDecoderService]]s running in worker pool.
+     * @remarks
+     * Broadcasts {@link @here/harp-datasource-protocol#ConfigurationMessage}
+     * to all [[TileDecoderService]]s running in worker pool.
      *
      * @param styleSet -  new [[StyleSet]], undefined means no change
      * @param languages - new list of languages

--- a/@here/harp-mapview/lib/WorkerBasedTiler.ts
+++ b/@here/harp-mapview/lib/WorkerBasedTiler.ts
@@ -120,7 +120,7 @@ export class WorkerBasedTiler implements ITiler {
      * Retrieves a tile for a previously registered index.
      *
      * @param indexId - Index identifier.
-     * @param tileKey - The [[TileKey]] that identifies the tile.
+     * @param tileKey - The {@link @here/harp-geoutils#TileKey} that identifies the tile.
      */
     getTile(indexId: string, tileKey: TileKey): Promise<{}> {
         const tileKeyCode = tileKey.mortonCode();

--- a/@here/harp-mapview/lib/composing/IPassManager.ts
+++ b/@here/harp-mapview/lib/composing/IPassManager.ts
@@ -7,7 +7,8 @@
 import * as THREE from "three";
 
 /**
- * `IPassManager` provides a base interface for [[Pass]] managers like [[MapRenderingManager]].
+ * `IPassManager` provides a base interface for {@link Pass}
+ * managers like {@link MapRenderingManager}.
  */
 export interface IPassManager {
     /**
@@ -17,7 +18,8 @@ export interface IPassManager {
     render(renderer: THREE.WebGLRenderer, ...args: any[]): void;
 
     /**
-     * The resize method to extend in [[Pass]] implementations to resize the render targets to match
+     * The resize method to extend in {@link Pass} implementations
+     * to resize the render targets to match
      * the size of the visible canvas. It should be called on resize events.
      *
      * @param width - Width to resize to.

--- a/@here/harp-mapview/lib/composing/MSAARenderPass.ts
+++ b/@here/harp-mapview/lib/composing/MSAARenderPass.ts
@@ -9,8 +9,10 @@ import * as THREE from "three";
 import { Pass } from "./Pass";
 
 /**
- * This enum represents the sampling level to apply to a [[MSAARenderPass]] instance. At level 0,
- * only one sample is performed, which is like disabling the MSAA pass.
+ * This enum represents the sampling level to apply to
+ * a {@link MSAARenderPass} instance. At level 0,
+ * only one sample is performed, which is like
+ * disabling the MSAA pass.
  */
 export enum MSAASampling {
     "Level_0",
@@ -22,7 +24,10 @@ export enum MSAASampling {
 }
 
 /**
- * [[MapView]]'s MSAA implementation. MSAA stands for Multi Sampling Anti-Aliasing, and its concept
+ * {@link MapView}'s MSAA implementation.
+ *
+ * @remarks
+ * MSAA stands for Multi Sampling Anti-Aliasing, and its concept
  * is to provide a rendering engine with additional color values for each pixel, so they can include
  * the missing bits between them on a screen. WebGL already comes with a native MSAA implementation
  * with four samples. Because of its native nature, it is more efficient and one may not want to use
@@ -85,8 +90,11 @@ export class MSAARenderPass extends Pass {
     }
 
     /**
-     * The render function of `MSAARenderPass`. At each call of this method, and for each sample,
-     * the [[MapView]] camera provided in the `render` method is offset within the dimension of a
+     * The render function of `MSAARenderPass`.
+     *
+     * @remarks
+     * At each call of this method, and for each sample the {@link MapView}
+     * camera provided in the `render method is offset within the dimension of a
      * pixel on screen. It then renders the whole scene with this offset to a local
      * `WebGLRenderTarget` instance, via a `WebGLRenderer` instance. Finally the local camera
      * created in the constructor shoots the quad and renders to the write buffer or to the frame
@@ -95,7 +103,7 @@ export class MSAARenderPass extends Pass {
      *
      * The number of samples can be modified at runtime through the enum [[SamplingLevel]].
      *
-     * If there is no further pass, the [[Pass.renderToScreen]] flag can be set to `true` to
+     * If there is no further pass, the {@link Pass.renderToScreen} flag can be set to `true` to
      * output directly to the framebuffer.
      *
      * @param renderer - The ThreeJS WebGLRenderer instance to render the scene with.

--- a/@here/harp-mapview/lib/composing/MapRenderingManager.ts
+++ b/@here/harp-mapview/lib/composing/MapRenderingManager.ts
@@ -23,8 +23,12 @@ const DEFAULT_DYNAMIC_MSAA_SAMPLING_LEVEL = MSAASampling.Level_1;
 const DEFAULT_STATIC_MSAA_SAMPLING_LEVEL = MSAASampling.Level_4;
 
 /**
- * Interface for the antialias settings passed when instantiating a [[MapView]], and transferred to
- * the [[MapRenderingManager]] instance. These parameters can be changed at runtime as opposed to
+ * Interface for the antialias settings passed when instantiating
+ * a {@link MapView}, and transferred to
+ * the {@link MapRenderingManager} instance.
+ *
+ * @remarks
+ * These parameters can be changed at runtime as opposed to
  * the native WebGL antialiasing.
  */
 export interface IMapAntialiasSettings {
@@ -52,8 +56,10 @@ export interface IMapAntialiasSettings {
 
 /**
  * The `MapRenderingManager` class manages the map rendering (as opposed to text) by dispatching the
- * [[MapRenderingManager.render]] call to a set of internal [[Pass]] instances. It provides an API
- * to modify some of the rendering processes like the antialiasing behaviour at runtime.
+ * {@link MapRenderingManager.render} call to a set of internal {@link Pass} instances.
+ *
+ * @remarks It provides an API to modify some of the rendering
+ * processes like the antialiasing behaviour at runtime.
  */
 export interface IMapRenderingManager extends IPassManager {
     /**
@@ -91,7 +97,7 @@ export interface IMapRenderingManager extends IPassManager {
 
     /**
      * Enable or disable the MSAA. If disabled, `MapRenderingManager` will use the renderer provided
-     * in the [[MapRenderingManager.render]] method to render the scene.
+     * in the {@link MapRenderingManager.render} method to render the scene.
      */
     msaaEnabled: boolean;
 
@@ -127,7 +133,7 @@ export interface IMapRenderingManager extends IPassManager {
     /**
      * Updating the outline rebuilds the outline materials of every outlined mesh.
      *
-     * @param options - outline options from the [[Theme]].
+     * @param options - outline options from the {@link @here/harp-datasource-protocol#Theme}.
      */
     updateOutline(options: {
         thickness: number;
@@ -137,7 +143,8 @@ export interface IMapRenderingManager extends IPassManager {
 }
 
 /**
- * The implementation of [[IMapRenderingManager]] to instantiate in [[MapView]] and manage the map
+ * The implementation of {@link IMapRenderingManager} to
+ * instantiate in {@link MapView} and manage the map
  * rendering.
  */
 export class MapRenderingManager implements IMapRenderingManager {
@@ -391,7 +398,7 @@ export class MapRenderingManager implements IMapRenderingManager {
 
     /**
      * Enable or disable the MSAA. If disabled, `MapRenderingManager` will use the renderer provided
-     * in the [[MapRenderingManager.render]] method to render the scene.
+     * in the {@link MapRenderingManager.render} method to render the scene.
      *
      * @param value - If `true`, MSAA is enabled, disabled otherwise.
      */

--- a/@here/harp-mapview/lib/composing/Pass.ts
+++ b/@here/harp-mapview/lib/composing/Pass.ts
@@ -7,11 +7,11 @@
 import * as THREE from "three";
 
 /**
- * The interface for the [[Pass]] class.
+ * The interface for the {@link Pass} class.
  */
 export interface IPass {
     /**
-     * Whether the [[Pass]] instance is active or not.
+     * Whether the {@link Pass} instance is active or not.
      * @default `true`.
      */
     enabled: boolean;
@@ -23,8 +23,10 @@ export interface IPass {
     renderToScreen: boolean;
 
     /**
-     * The resize method to extend in [[Pass]] implementations. It resizes the render targets. Call
-     * on resize events.
+     * The resize method to extend in {@link Pass} implementations.
+     *
+     * @remarks
+     * It resizes the render targets. Call on resize events.
      *
      * @param width - Width to resize to.
      * @param height - Height to resize to.
@@ -32,7 +34,10 @@ export interface IPass {
     setSize(width: number, height: number): void;
 
     /**
-     * The render method to extend in [[Pass]] implementations. This is the place where the desired
+     * The render method to extend in {@link Pass} implementations.
+     *
+     * @remarks
+     * This is the place where the desired
      * effects or render operations are executed.
      *
      * @param renderer - The WebGLRenderer instance in use.
@@ -53,8 +58,11 @@ export interface IPass {
 }
 
 /**
- * The base class to extend for further passes in [[MapView]], like the [[MSAARenderPass]], possibly
- * a text pass, an AO effect etc. `Pass` provides the core logic for both :
+ * The base class to extend for further passes in {@link MapView},
+ * like the {@link MSAARenderPass},
+ *
+ * @remarks
+ * `Pass` provides the core logic for both :
  * - render passes (proper scene renders),
  * - and shader passes (quad renders, i.e. effects added on top of the render output as a
  * postprocess).

--- a/@here/harp-mapview/lib/copyrights/CopyrightElementHandler.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightElementHandler.ts
@@ -9,7 +9,7 @@ import { MapView, MapViewEventNames } from "../MapView";
 import { CopyrightInfo } from "./CopyrightInfo";
 
 /**
- * Helper class that maintains up-to-date [[MapView]] copyright information in DOM element.
+ * Helper class that maintains up-to-date {@link MapView} copyright information in DOM element.
  *
  * @example
  *
@@ -22,11 +22,11 @@ import { CopyrightInfo } from "./CopyrightInfo";
  */
 export class CopyrightElementHandler {
     /**
-     * Install [[CopyrightElementHandler]] on DOM element and - optionally - attach to a [[MapView]]
-     * instance.
+     * Install {@link CopyrightElementHandler} on DOM element and - optionally -
+     * attach to a {@link MapView} instance.
      *
      * @param element - HTML DOM element or a HTML DOM element id
-     * @param mapView -, optional, [[attach]] to this [[MapView]]
+     * @param mapView -, optional, [[attach]] to this {@link MapView}
      */
     static install(element: string | HTMLElement, mapView?: MapView): CopyrightElementHandler {
         return new CopyrightElementHandler(element, mapView);
@@ -35,7 +35,7 @@ export class CopyrightElementHandler {
     /**
      * Static copyright info.
      *
-     * Use when [[MapView]]'s [[DataSource]]'s do not provide proper copyright information.
+     * Use when {@link MapView}'s {@link DataSource}'s do not provide proper copyright information.
      */
     staticInfo: CopyrightInfo[] | undefined;
 
@@ -48,10 +48,10 @@ export class CopyrightElementHandler {
      * of the given `mapView`.
      *
      * Note: Generally, the static [[install]] method can be used to create and attach a new
-     * `CopyrightElementHandler` to a [[MapView]]
+     * `CopyrightElementHandler` to a {@link MapView}
      *
      * @param element - HTML DOM element or a HTML DOM element id
-     * @param mapView - optional, [[attach]] to this [[MapView]] instance
+     * @param mapView - optional, [[attach]] to this {@link MapView} instance
      */
     constructor(element: string | HTMLElement, mapView?: MapView) {
         if (typeof element === "string") {
@@ -70,7 +70,7 @@ export class CopyrightElementHandler {
     }
 
     /**
-     * Destroys this object by removing all event listeners from the attached [[MapView]]s.
+     * Destroys this object by removing all event listeners from the attached {@link MapView}s.
      */
     destroy() {
         for (const mapView of this.m_mapViews) {
@@ -79,7 +79,7 @@ export class CopyrightElementHandler {
     }
 
     /**
-     * Attaches this [[CopyrightInfo]] updates from [[MapView]] instance.
+     * Attaches this {@link CopyrightInfo} updates from {@link MapView} instance.
      */
     attach(mapView: MapView): this {
         this.m_mapViews.push(mapView);
@@ -91,7 +91,7 @@ export class CopyrightElementHandler {
     }
 
     /**
-     * Stop following [[CopyrightInfo]] updates from [[MapView]] instance.
+     * Stop following {@link CopyrightInfo} updates from {@link MapView} instance.
      */
     detach(mapView: MapView): this {
         mapView.removeEventListener(MapViewEventNames.CopyrightChanged, this.update);
@@ -103,11 +103,13 @@ export class CopyrightElementHandler {
     }
 
     /**
-     * Set [[CopyrightInfo]] defaults to be used in case [[DataSource]] does not provide deatailed
+     * Set {@link CopyrightInfo} defaults to be used in case
+     * {@link DataSource} does not provide deatailed
      * copyright information.
      *
+     * @remarks
      * The defaults will applied to all undefined `year`, `label` and `link` values in the copyright
-     * information retrieved from [[MapView]].
+     * information retrieved from {@link MapView}.
      */
     setDefaults(defaults: CopyrightInfo[] | undefined): this {
         this.m_defaults.clear();
@@ -124,9 +126,10 @@ export class CopyrightElementHandler {
      * Sets the [[staticInfo]] property.
      *
      * A `CopyrightElementHandler` always displays a deduplicated sum of static copyright info and
-     * copyright information obtained from attached [[MapView]]s.
+     * copyright information obtained from attached {@link MapView}s.
      *
-     * This information is used when [[DataSource]] instances of given [[MapView]] do not provide
+     * This information is used when {@link DataSource}
+     * instances of given {@link MapView} do not provide
      * copyright information.
      */
     setStaticCopyightInfo(staticInfo: CopyrightInfo[] | undefined): this {

--- a/@here/harp-mapview/lib/copyrights/CopyrightInfo.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightInfo.ts
@@ -7,18 +7,19 @@
 import { getOptionValue, MathUtils } from "@here/harp-utils";
 
 /**
- * Copyright info attached to data displayed on map. Provided by [[DataSource]] and attached
- * to [[Tile]]s.
+ * Copyright info attached to data displayed on map. Provided by {@link DataSource} and attached
+ * to {@link Tile}s.
  *
- * In most cases, an application should display this information on [[MapView]] to conform with
+ * In most cases, an application should display this information on {@link MapView} to conform with
  * licencing terms of its map data providers.
  *
- * @see [[CopyrightElementHandler]]
+ * @see {@link CopyrightElementHandler}
  */
 export interface CopyrightInfo {
     /**
      * Unique id of the copyright holder.
      *
+     * @remarks
      * `id`s should be unique. It is recommended to build them from unique identifiers like
      * registered domain names.
      *
@@ -27,10 +28,11 @@ export interface CopyrightInfo {
      *  * `openstreetmap.org` - for data originating from OpenStreetMap project
      *  * `naturalearthdata.com` - for data originating from Natural Earth dataset
      *
-     * Note: [[DataSource]] may return [[CopyrightInfo]] with only `id`, thus defining only holder
+     * Note: {@link DataSource} may return {@link CopyrightInfo}
+     * with only `id`, thus defining only holder
      * of copyright, however, valid attribution may require proper `label` and `link`.
      *
-     * Entries with same `id` are deduplicated by [[CopyrightInfo.mergeArrays]].
+     * Entries with same `id` are deduplicated by {@link CopyrightInfo.mergeArrays}.
      */
     id: string;
 
@@ -55,7 +57,7 @@ export interface CopyrightInfo {
 
 export namespace CopyrightInfo {
     /**
-     * Merge [[CopyrightInfo]] arrays, removing duplicates.
+     * Merge {@link CopyrightInfo} arrays, removing duplicates.
      *
      * `id` and `label` are considered keys in deduplication algorithm.
      *

--- a/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
+++ b/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
@@ -84,7 +84,7 @@ export interface ITileDataVisitor {
 }
 
 /**
- * An interface that provides options for [[TileDataAccessor]].
+ * An interface that provides options for {@link TileDataAccessor}.
  */
 export interface TileDataAccessorOptions {
     /** Limit to objects that have `featureID`s. */
@@ -102,8 +102,12 @@ export interface TileDataAccessorOptions {
 }
 
 /**
- * An accessor for all geometries in a tile. This class uses a client-provided [[ITileDataVisitor]]
- * to visit all objects, based on filtering options specified by both, the `TileDataAccessor` and
+ * An accessor for all geometries in a tile.
+ *
+ * @remarks
+ * This class uses a client-provided {@link ITileDataVisitor}
+ * to visit all objects, based on filtering options specified
+ * by both, the `TileDataAccessor` and
  * the visitor itself.
  */
 export class TileDataAccessor {

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -216,7 +216,7 @@ export interface PolygonFadingParameters extends FadingParameters {
 }
 
 /**
- * Support class to create geometry for a [[Tile]] from a [[DecodedTile]].
+ * Support class to create geometry for a {@link Tile} from a {@link @here/harp-datasource-protocol#DecodedTile}.
  */
 export class TileGeometryCreator {
     private static m_instance: TileGeometryCreator;
@@ -282,7 +282,7 @@ export class TileGeometryCreator {
      *
      * @see [[TileGeometryCreator#initDecodedTile]]
      *
-     * @param tile - The [[Tile]] to process.
+     * @param tile - The {@link Tile} to process.
      * @param decodedTile - The decodedTile containing the actual tile map data.
      */
     createAllGeometries(tile: Tile, decodedTile: DecodedTile) {
@@ -389,7 +389,7 @@ export class TileGeometryCreator {
      * Sets the owning tiles datasource.name and the `tileKey` in the `userData` property of the
      * object, such that the tile it belongs to can be identified during picking.
      *
-     * @param tile - The [[Tile]] to add the object to.
+     * @param tile - The {@link Tile} to add the object to.
      * @param object - The object to add to the root of the tile.
      * @param geometryKind - The kind of object. Can be used for filtering.
      * @param custom - additional parameters for [[MapObjectAdapter]]
@@ -430,7 +430,7 @@ export class TileGeometryCreator {
     /**
      * Splits the text paths that contain sharp corners.
      *
-     * @param tile - The [[Tile]] to process paths on.
+     * @param tile - The {@link Tile} to process paths on.
      * @param textPathGeometries - The original path geometries that may have defects.
      * @param textFilter -: Optional filter. Should return true for any text technique that is
      *      applicable.
@@ -464,11 +464,11 @@ export class TileGeometryCreator {
     }
 
     /**
-     * Creates [[TextElement]] objects from the decoded tile and list of materials specified. The
-     * priorities of the [[TextElement]]s are updated to simplify label placement.
+     * Creates {@link TextElement} objects from the decoded tile and list of materials specified. The
+     * priorities of the {@link TextElement}s are updated to simplify label placement.
      *
-     * @param tile - The [[Tile]] to create the testElements on.
-     * @param decodedTile - The [[DecodedTile]].
+     * @param tile - The {@link Tile} to create the testElements on.
+     * @param decodedTile - The {@link @here/harp-datasource-protocol#DecodedTile}.
      * @param textFilter -: Optional filter. Should return true for any text technique that is
      *      applicable.
      */
@@ -662,8 +662,8 @@ export class TileGeometryCreator {
     /**
      * Creates `Tile` objects from the decoded tile and list of materials specified.
      *
-     * @param tile - The [[Tile]] to create the geometry on.
-     * @param decodedTile - The [[DecodedTile]].
+     * @param tile - The {@link Tile} to create the geometry on.
+     * @param decodedTile - The {@link @here/harp-datasource-protocol#DecodedTile}.
      * @param techniqueFilter -: Optional filter. Should return true for any technique that is
      *      applicable.
      */
@@ -1174,7 +1174,7 @@ export class TileGeometryCreator {
     }
 
     /**
-     * Prepare the [[Tile]]s pois. Uses the [[PoiManager]] in [[MapView]].
+     * Prepare the {@link Tile}s pois. Uses the {@link PoiManager} in {@link MapView}.
      */
     preparePois(tile: Tile, decodedTile: DecodedTile) {
         if (decodedTile.poiGeometries !== undefined) {
@@ -1341,9 +1341,9 @@ export class TileGeometryCreator {
     }
 
     /**
-     * Gets the attachments of the given [[DecodedTile]].
+     * Gets the attachments of the given {@link @here/harp-datasource-protocol#DecodedTile}.
      *
-     * @param decodedTile - The [[DecodedTile]].
+     * @param decodedTile - The {@link @here/harp-datasource-protocol#DecodedTile}.
      */
     private *getAttachments(decodedTile: DecodedTile): Generator<AttachmentInfo> {
         const cache = new AttachmentCache();
@@ -1370,10 +1370,10 @@ export class TileGeometryCreator {
     }
 
     /**
-     * Process the given [[Tile]] and assign default values to render orders
+     * Process the given {@link Tile} and assign default values to render orders
      * and label priorities.
      *
-     * @param tile - The [[Tile]] to process.
+     * @param tile - The {@link Tile} to process.
      */
     private processPriorities(tile: Tile) {
         const decodedTile = tile.decodedTile;

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -25,7 +25,7 @@ import { Tile } from "../Tile";
 import { TileGeometryCreator } from "./TileGeometryCreator";
 
 /**
- * Loads the geometry for its [[Tile]]. Loads all geometry in a single step.
+ * Loads the geometry for its {@link Tile}. Loads all geometry in a single step.
  */
 export class TileGeometryLoader {
     /**
@@ -107,7 +107,7 @@ export class TileGeometryLoader {
     constructor(private m_tile: Tile) {}
 
     /**
-     * The [[Tile]] this `TileGeometryLoader` is managing.
+     * The {@link Tile} this `TileGeometryLoader` is managing.
      */
     get tile(): Tile {
         return this.m_tile;
@@ -145,7 +145,10 @@ export class TileGeometryLoader {
     }
 
     /**
-     * Set the [[DecodedTile]] of the tile. Is called after the decoded tile has been loaded, and
+     * Set the {@link @here/harp-datasource-protocol#DecodedTile} of the tile.
+     *
+     * @remarks
+     * Is called after the decoded tile has been loaded, and
      * prepares its content for later processing in the 'updateXXX' methods.
      *
      * @param {DecodedTile} decodedTile The decoded tile with the flat geometry data belonging to
@@ -164,7 +167,7 @@ export class TileGeometryLoader {
     }
 
     /**
-     * The kinds of geometry stored in this [[Tile]].
+     * The kinds of geometry stored in this {@link Tile}.
      */
     get availableGeometryKinds(): GeometryKindSet | undefined {
         return this.m_availableGeometryKinds;
@@ -256,7 +259,8 @@ export class TileGeometryLoader {
     }
 
     /**
-     * Called by [[VisibleTileSet]] to mark that [[Tile]] is visible and it should prepare geometry.
+     * Called by {@link VisibleTileSet} to mark that {@link Tile} is
+     * visible and it should prepare geometry.
      */
     private prepareForRender(
         enabledKinds: GeometryKindSet | undefined,

--- a/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
@@ -75,12 +75,12 @@ export class TileGeometryManager {
     private m_visibilityCounter: number = 1;
 
     /**
-     * Creates an instance of `TileGeometryManager` with a reference to the [[MapView]].
+     * Creates an instance of `TileGeometryManager` with a reference to the {@link MapView}.
      */
     constructor(protected mapView: MapView) {}
 
     /**
-     * Initialize the [[Tile]] with the TileGeometryManager.
+     * Initialize the {@link Tile} with the TileGeometryManager.
      */
     initTile(tile: Tile): void {
         if (tile.dataSource.useGeometryLoader) {
@@ -89,7 +89,7 @@ export class TileGeometryManager {
     }
 
     /**
-     * Process the [[Tile]]s for rendering. May alter the content of the tile per frame.
+     * Process the {@link Tile}s for rendering. May alter the content of the tile per frame.
      */
     updateTiles(tiles: Tile[]): void {
         for (const tile of tiles) {

--- a/@here/harp-mapview/lib/image/Image.ts
+++ b/@here/harp-mapview/lib/image/Image.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * `ImageItem` is used to identify an image in the [[ImageCache]].
+ * `ImageItem` is used to identify an image in the {@link ImageCache}.
  */
 export interface ImageItem {
     /** URL of the image, or unique identifier. */

--- a/@here/harp-mapview/lib/image/ImageCache.ts
+++ b/@here/harp-mapview/lib/image/ImageCache.ts
@@ -26,19 +26,20 @@ declare function createImageBitmap(
 ): Promise<ImageBitmap>;
 
 /**
- * Combines an [[ImageItem]] with a list of [[MapViews]] that reference it.
+ * Combines an {@link ImageItem} with a list of [[MapViews]] that reference it.
  */
 class ImageCacheItem {
     /**
-     * The list of [[MapView]]s referencing the [[ImageItem]].
+     * The list of {@link MapView}s referencing the {@link ImageItem}.
      */
     mapViews: MapView[] = [];
 
     /**
      * Instantiates `ImageCacheItem`.
      *
-     * @param imageItem - The [[ImageItem]] referenced by the associated [[MapView]]s instances.
-     * @param mapView - An optional first [[MapView]] referencing the [[ImageItem]].
+     * @param imageItem - The {@link ImageItem} referenced by
+     *                    the associated {@link MapView}s instances.
+     * @param mapView - An optional first {@link MapView} referencing the {@link ImageItem}.
      */
     constructor(public imageItem: ImageItem, mapView?: MapView) {
         if (mapView !== undefined) {
@@ -84,7 +85,7 @@ export class ImageCache {
     /**
      * Add an image definition to the global cache. Useful when the image data is already loaded.
      *
-     * @param mapView - Specifiy which [[MapView]] requests the image.
+     * @param mapView - Specifiy which {@link MapView} requests the image.
      * @param url - URL of image.
      * @param imageData - Optional [ImageData]] containing the image content.
      */
@@ -123,7 +124,7 @@ export class ImageCache {
     /**
      * Add an image definition, and optionally start loading the content.
      *
-     * @param mapView - [[MapView]] requesting the image.
+     * @param mapView - {@link MapView} requesting the image.
      * @param url - URL of image.
      * @param startLoading - Optional flag. If `true` the image will be loaded in the background.
      */
@@ -141,7 +142,7 @@ export class ImageCache {
     }
 
     /**
-     * Find [[ImageItem]] for the specified URL.
+     * Find {@link ImageItem} for the specified URL.
      *
      * @param url - URL of image.
      * @returns `ImageItem` for the URL if the URL is registered, `undefined` otherwise.
@@ -155,10 +156,10 @@ export class ImageCache {
     }
 
     /**
-     * Clear all [[ImageItem]]s belonging to a [[MapView]]. May remove cached items if no
-     * [[MapView]] are registered anymore.
+     * Clear all {@link ImageItem}s belonging to a {@link MapView}. May remove cached items if no
+     * {@link MapView} are registered anymore.
      *
-     * @param mapView - MapView to remove all [[ImageItem]]s from.
+     * @param mapView - MapView to remove all {@link ImageItem}s from.
      */
     clear(mapView: MapView) {
         const itemsToRemove: string[] = [];
@@ -179,25 +180,25 @@ export class ImageCache {
     }
 
     /**
-     * Clear all [[ImageItem]]s from all [[MapView]]s.
+     * Clear all {@link ImageItem}s from all {@link MapView}s.
      */
     clearAll() {
         this.m_images = new Map();
     }
 
     /**
-     * Returns the number of all cached [[ImageItem]]s.
+     * Returns the number of all cached {@link ImageItem}s.
      */
     get size(): number {
         return this.m_images.size;
     }
 
     /**
-     * Load an [[ImageItem]]. If the loading process is already running, it returns the current
+     * Load an {@link ImageItem}. If the loading process is already running, it returns the current
      * promise.
      *
      * @param imageItem - `ImageItem` containing the URL to load image from.
-     * @returns An [[ImageItem]] if the image has already been loaded, a promise otherwise.
+     * @returns An {@link ImageItem} if the image has already been loaded, a promise otherwise.
      */
     loadImage(imageItem: ImageItem): ImageItem | Promise<ImageItem | undefined> {
         if (imageItem.imageData !== undefined) {
@@ -243,7 +244,7 @@ export class ImageCache {
     }
 
     /**
-     * Find the cached [[ImageItem]] by URL.
+     * Find the cached {@link ImageItem} by URL.
      *
      * @param url - URL of image.
      */
@@ -255,7 +256,7 @@ export class ImageCache {
      * Render the `ImageItem` by using `createImageBitmap()` or by rendering the image into a
      * [[HTMLCanvasElement]].
      *
-     * @param imageItem - [[ImageItem]] to assign image data to.
+     * @param imageItem - {@link ImageItem} to assign image data to.
      * @param image - [[HTMLImageElement]] to
      */
     private renderImage(

--- a/@here/harp-mapview/lib/image/MapViewImageCache.ts
+++ b/@here/harp-mapview/lib/image/MapViewImageCache.ts
@@ -9,11 +9,15 @@ import { ImageItem } from "./Image";
 import { ImageCache } from "./ImageCache";
 
 /**
- * Cache images wrapped into [[ImageItem]]s for a [[MapView]]. An image may have multiple names in
- * a theme, the `MapViewImageCache` will take care of that. Registering multiple images with the
+ * Cache images wrapped into {@link ImageItem}s for a {@link MapView}.
+ *
+ * @remarks
+ * An image may have multiple names in
+ * a theme, the `MapViewImageCache` will take care of that.
+ * Registering multiple images with the
  * same name is invalid.
  *
- * The `MapViewImageCache` uses a global [[ImageCache]] to actually store (and generate) the
+ * The `MapViewImageCache` uses a global {@link ImageCache} to actually store (and generate) the
  * image data.
  */
 export class MapViewImageCache {
@@ -23,14 +27,14 @@ export class MapViewImageCache {
     /**
      * The constructor for `MapViewImageCache`.
      *
-     * @param mapView - a [[MapView]] instance.
+     * @param mapView - a {@link MapView} instance.
      */
     constructor(public mapView: MapView) {}
 
     /**
      * Register an existing image by name.
      *
-     * @param name - Name of the image from [[Theme]].
+     * @param name - Name of the image from {@link @here/harp-datasource-protocol#Theme}.
      * @param url - URL of image.
      * @param image - Optional [[ImageData]] of image.
      */
@@ -64,9 +68,9 @@ export class MapViewImageCache {
 
     /**
      * Add an image and optionally start loading it. Once done, the [[ImageData]] or [[ImageBitmap]]
-     * will be stored in the [[ImageItem]].
+     * will be stored in the {@link ImageItem}.
      *
-     * @param name - Name of image from [[Theme]].
+     * @param name - Name of image from {@link @here/harp-datasource-protocol#Theme}.
      * @param url - URL of image.
      * @param startLoading - Optional. Pass `true` to start loading the image in the background.
      */
@@ -84,7 +88,7 @@ export class MapViewImageCache {
     }
 
     /**
-     * Find [[ImageItem]] by its name.
+     * Find {@link ImageItem} by its name.
      *
      * @param name - Name of image.
      */
@@ -97,7 +101,7 @@ export class MapViewImageCache {
     }
 
     /**
-     * Find [[ImageItem]] by URL.
+     * Find {@link ImageItem} by URL.
      *
      * @param url - Url of image.
      */
@@ -106,7 +110,7 @@ export class MapViewImageCache {
     }
 
     /**
-     * Load an [[ImageItem]]. Returns a promise or a loaded [[ImageItem]].
+     * Load an {@link ImageItem}. Returns a promise or a loaded {@link ImageItem}.
      *
      * @param imageItem - ImageItem to load.
      */
@@ -115,8 +119,11 @@ export class MapViewImageCache {
     }
 
     /**
-     * Remove all [[ImageItem]]s from the cache. Also removes all [[ImageItem]]s that belong to this
-     * [[MapView]] from the global [[ImageCache]].
+     * Remove all {@link ImageItem}s from the cache.
+     *
+     * @remarks
+     * Also removes all {@link ImageItem}s that belong to this
+     * {@link MapView} from the global {@link ImageCache}.
      */
     clear() {
         ImageCache.instance.clear(this.mapView);

--- a/@here/harp-mapview/lib/poi/BoxBuffer.ts
+++ b/@here/harp-mapview/lib/poi/BoxBuffer.ts
@@ -102,28 +102,29 @@ export class BoxBufferMesh extends THREE.Mesh {
  */
 export class BoxBuffer {
     /**
-     * [[BufferAttribute]] holding the `BoxBuffer` position data.
+     * {@link @here/harp-datasource-protocol#BufferAttribute} holding the `BoxBuffer` position data.
      */
     protected positionAttribute?: THREE.BufferAttribute;
 
     /**
-     * [[BufferAttribute]] holding the `BoxBuffer` color data.
+     * {@link @here/harp-datasource-protocol#BufferAttribute} holding the `BoxBuffer` color data.
      */
     protected colorAttribute?: THREE.BufferAttribute;
 
     /**
-     * [[BufferAttribute]] holding the `BoxBuffer` uv data.
+     * {@link @here/harp-datasource-protocol#BufferAttribute} holding the `BoxBuffer` uv data.
      */
     protected uvAttribute?: THREE.BufferAttribute;
 
     /**
-     * [[BufferAttribute]] holding the `BoxBuffer` index data.
+     * {@link @here/harp-datasource-protocol#BufferAttribute} holding the `BoxBuffer` index data.
      */
     protected indexAttribute?: THREE.BufferAttribute;
     protected pickInfos: Array<any | undefined>;
 
     /**
-     * [[BufferGeometry]] holding all the different [[BufferAttribute]]s.
+     * [[BufferGeometry]] holding all the different
+     * {@link @here/harp-datasource-protocol#BufferAttribute}s.
      */
     protected geometry: THREE.BufferGeometry | undefined;
 
@@ -451,7 +452,10 @@ export class BoxBuffer {
     }
 
     /**
-     * Creates a new [[Geometry]] object from all the attribute data stored in this `BoxBuffer`.
+     * Creates a new {@link @here/harp-datasource-protocol#Geometry} object
+     * from all the attribute data stored in this `BoxBuffer`.
+     *
+     * @remarks
      * The [[Mesh]] object may be created if it is not initialized already.
      *
      * @param newSize - Optional number of elements to resize the buffer to.

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -32,7 +32,8 @@ import { PoiTable } from "./PoiTableManager";
 const logger = LoggerManager.instance.create("PoiManager");
 
 /**
- * Interface for the [[ImageTexture]]s that are defined in the atlas.
+ * Interface for the {@link @here/harp-datasource-protocol#ImageTexture}s
+ * that are defined in the atlas.
  */
 interface ImageTextureDef {
     x: number;
@@ -43,8 +44,13 @@ interface ImageTextureDef {
 }
 
 /**
- * POI manager class, responsible for loading the [[PoiGeometry]] objects from the [[DecodedTile]],
- * and preparing them for rendering. Also loads and manages the texture atlases for the icons.
+ * POI manager class, responsible for loading the
+ * {@link @here/harp-datasource-protocol#PoiGeometry} objects
+ * from the {@link @here/harp-datasource-protocol#DecodedTile},
+ * and preparing them for rendering.
+ *
+ * @remarks
+ * Also loads and manages the texture atlases for the icons.
  */
 export class PoiManager {
     // Keep track of the missing POI table names, but only warn once.
@@ -100,18 +106,19 @@ export class PoiManager {
     /**
      * The constructor of the `PoiManager`.
      *
-     * @param mapView - The [[MapView]] instance that should display the POIs.
+     * @param mapView - The {@link MapView} instance that should display the POIs.
      */
     constructor(readonly mapView: MapView) {}
 
     /**
-     * Add all POIs from a decoded tile and store them as [[TextElement]]s in the [[Tile]].
+     * Add all POIs from a decoded tile and store them as {@link TextElement}s in the {@link Tile}.
      *
      * Also handles LineMarkers, which is a recurring marker along a line (road).
      *
      * @param tile - Tile to add POIs to.
-     * @param decodedTile - DecodedTile containing the raw [[PoiGeometry]] objects describing the
-     *  POIs.
+     * @param decodedTile - DecodedTile containing the raw
+     *                      {@link @here/harp-datasource-protocol#PoiGeometry}
+     *                      objects describing the POIs.
      */
     addPois(tile: Tile, decodedTile: DecodedTile): void {
         const poiGeometries = assertExists(decodedTile.poiGeometries);
@@ -150,7 +157,11 @@ export class PoiManager {
 
     /**
      * Load the texture atlas that defines the segments of the texture that should be used for
-     * specific icons. Creates an [[ImageTexture]] for every element in the atlas, such that it can
+     * specific icons.
+     *
+     * @remarks
+     * Creates an {@link @here/harp-datasource-protocol#ImageTexture}
+     * for every element in the atlas, such that it can
      * be addressed in the theme file.
      *
      * @param imageName - Name of the image from the theme (NOT the url!).
@@ -205,10 +216,11 @@ export class PoiManager {
     }
 
     /**
-     * Add an [[ImageTexture]] such that it is available as a named entity for techniques in theme
-     * files.
+     * Add an {@link @here/harp-datasource-protocol#ImageTexture} such that it
+     * is available as a named entity for techniques in theme files.
      *
-     * @param imageTexture - [[ImageTexture]] that should be available for POIs.
+     * @param imageTexture - {@link @here/harp-datasource-protocol#ImageTexture}
+     *                       that should be available for POIs.
      */
     addImageTexture(imageTexture: ImageTexture) {
         if (imageTexture.name === undefined) {
@@ -225,29 +237,30 @@ export class PoiManager {
     }
 
     /**
-     * Return the [[ImageTexture]] registered under the specified name.
+     * Return the {@link @here/harp-datasource-protocol#ImageTexture}
+     * registered under the specified name.
      *
-     * @param name - Name of the [[ImageTexture]].
+     * @param name - Name of the {@link @here/harp-datasource-protocol#ImageTexture}.
      */
     getImageTexture(name: string): ImageTexture | undefined {
         return this.m_imageTextures.get(name);
     }
 
     /**
-     * Update the [[TextElement]] with the information taken from the [[PoiTable]] which is
-     * referenced in the [[PoiInfo]] of the pointLabel.
+     * Update the {@link TextElement} with the information taken from the {@link PoiTable} which is
+     * referenced in the {@link PoiInfo} of the pointLabel.
      *
-     * If the requested [[PoiTable]] is not available yet, the function returns `false`.
-     * If the [[PoiTable]] is not defined, or if the references POI has no entry in
-     * the [[PoiTable]], no action is taken, and the function returns `false`.
+     * If the requested {@link PoiTable} is not available yet, the function returns `false`.
+     * If the {@link PoiTable} is not defined, or if the references POI has no entry in
+     * the {@link PoiTable}, no action is taken, and the function returns `false`.
      *
-     * If the [[PoiTable]] has been processed, it returns `true`, indicating that this function
+     * If the {@link PoiTable} has been processed, it returns `true`, indicating that this function
      * doesn't have to be called again.
      *
-     * @param pointLabel - The [[TextElement]] to update.
+     * @param pointLabel - The {@link TextElement} to update.
      *
-     * @returns `true` if the [[PoiTable]] has been processed, and the function does not have to be
-     *          called again.
+     * @returns `true` if the {@link PoiTable} has been processed, and the
+     *          function does not have to be called again.
      */
     updatePoiFromPoiTable(pointLabel: TextElement): boolean {
         const poiInfo = pointLabel.poiInfo;
@@ -412,7 +425,7 @@ export class PoiManager {
     }
 
     /**
-     * Create and add POI [[TextElement]]s to tile with a series of positions.
+     * Create and add POI {@link TextElement}s to tile with a series of positions.
      */
     private addPoi(
         tile: Tile,
@@ -489,9 +502,12 @@ export class PoiManager {
     }
 
     /**
-     * Create the [[TextElement]] for a POI. Even if the POI has no text, it is required that there
-     * is a [[TextElement]], since POIs are hooked onto [[TextElement]]s for sorting.(Sorted by
-     * priority attribute).
+     * Create the {@link TextElement} for a POI.
+     *
+     * @remarks
+     * Even if the POI has no text, it is required that there
+     * is a {@link TextElement}, since POIs are hooked onto {@link TextElement}s
+     * for sorting.(Sorted by priority attribute).
      */
     private checkCreateTextElement(
         tile: Tile,

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -35,7 +35,10 @@ const tmpIconColor = new THREE.Color();
 
 /**
  * The `PoiRenderBufferBatch` contains the geometry and the material for all POIs that share the
- * same icon image ([[ImageTexture]]). If the image is the same, all the objects in this batch can
+ * same icon image ({@link @here/harp-datasource-protocol#ImageTexture}).
+ *
+ * @remarks
+ * If the image is the same, all the objects in this batch can
  * share the same material, which makes them renderable in the same draw call, whatever the number
  * of actual objects (WebGL limits apply!).
  *
@@ -53,7 +56,7 @@ class PoiRenderBufferBatch {
     /**
      * Create the `PoiRenderBufferBatch`.
      *
-     * @param mapView - The [[MapView]] instance.
+     * @param mapView - The {@link MapView} instance.
      * @param scene - The three.js scene to add the POIs to.
      * @param imageItem - The icon that will have his material shared.
      * @param renderOrder - RenderOrder of the batch geometry's [[Mesh]].
@@ -66,7 +69,10 @@ class PoiRenderBufferBatch {
     ) {}
 
     /**
-     * Initialize with the [[ImageTexture]]. Loads the image and sets up the icon size, the texture
+     * Initialize with the {@link @here/harp-datasource-protocol#ImageTexture}.
+     *
+     * @remarks
+     * Loads the image and sets up the icon size, the texture
      * coordinates and material of the batch. Since image loading is done asynchronously, this
      * batch cannot be rendered right away. MapView#update is being triggered if it loaded
      * successfully.
@@ -160,11 +166,11 @@ class PoiRenderBuffer {
     /**
      * Create the `PoiRenderBuffer`.
      *
-     * @param mapView - The [[MapView]] to be rendered to.
+     * @param mapView - The {@link MapView} to be rendered to.
      * @param textCanvas - The [[TextCanvas]] to which scenes this `PoiRenderBuffer`
      *                     adds geometry to.
-     * The actual scene a [[TextElement]] is added to is specified by the renderOrder of the
-     * [[TextElement]].
+     * The actual scene a {@link TextElement} is added to is specified by the renderOrder of the
+     * {@link TextElement}.
      */
     constructor(readonly mapView: MapView, readonly textCanvas: TextCanvas) {}
 
@@ -305,7 +311,7 @@ class PoiRenderBuffer {
 
     /**
      * Fill the picking results for the pixel with the given screen coordinate. If multiple
-     * [[PoiInfo]]s are found, the order of the results is unspecified.
+     * {@link PoiInfo}s are found, the order of the results is unspecified.
      *
      * @param screenPosition - Screen coordinate of picking position.
      * @param pickCallback - Callback to be called for every picked element.
@@ -396,7 +402,7 @@ export class PoiRenderer {
     private m_tempScreenBox = new Math2D.Box();
 
     /**
-     * Create the `PoiRenderer` for the specified [[MapView]].
+     * Create the `PoiRenderer` for the specified {@link MapView}.
      *
      * @param mapView - The MapView to be rendered to.
      * @param textCanvas - The [[TextCanvas]] this `PoiRenderer` is associated to. POIs are added to
@@ -411,7 +417,7 @@ export class PoiRenderer {
      * `poiRenderBatch` is assigned, the POI is ready to be rendered.
      *
      * @param pointLabel - TextElement with PoiInfo for rendering the POI icon.
-     * @param env - TODO! The current zoomLevel level of [[MapView]]
+     * @param env - TODO! The current zoomLevel level of {@link MapView}
      *
      * @returns `True` if the space is not already allocated by another object (text label or POI)
      */
@@ -475,7 +481,7 @@ export class PoiRenderer {
 
     /**
      * Fill the picking results for the pixel with the given screen coordinate. If multiple
-     * [[PoiInfo]]s are found, the order of the results is unspecified.
+     * {@link PoiInfo}s are found, the order of the results is unspecified.
      *
      * @param screenPosition - Screen coordinate of picking position.
      * @param pickCallback - Callback to be called for every picked element.
@@ -577,10 +583,11 @@ export class PoiRenderer {
     /**
      * Setup texture and material for the batch.
      *
-     * @param poiInfo - [[PoiInfo]] to initialize.
-     * @param imageTexture - Shared [[ImageTexture]], defines used area in atlas.
-     * @param imageItem - Shared [[ImageItem]], contains cached image for texture.
-     * @param env - The current zoom level of [[MapView]]
+     * @param poiInfo - {@link PoiInfo} to initialize.
+     * @param imageTexture - Shared {@link @here/harp-datasource-protocol#ImageTexture},
+     *                       defines used area in atlas.
+     * @param imageItem - Shared {@link ImageItem}, contains cached image for texture.
+     * @param env - The current zoom level of {@link MapView}
      */
     private setupPoiInfo(
         poiInfo: PoiInfo,

--- a/@here/harp-mapview/lib/poi/PoiTableManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiTableManager.ts
@@ -17,7 +17,7 @@ import { MapView } from "../MapView";
 const logger = LoggerManager.instance.create("PoiTable");
 
 /**
- * Class to store and maintain individual POI information for the [[PoiTable]].
+ * Class to store and maintain individual POI information for the {@link PoiTable}.
  */
 class PoiTableEntry implements PoiTableEntryDef {
     /**
@@ -114,15 +114,15 @@ class PoiTableEntry implements PoiTableEntryDef {
 }
 
 /**
- * The `PoiTable` stores individual information for each POI type. If a [[TextElement]] has a
+ * The `PoiTable` stores individual information for each POI type. If a {@link TextElement} has a
  * reference to a PoiTable (if TextElement.poiInfo.poiTableName is set), information for the
  * TextElement and its icon are read from the PoiTable.
  *
  * The key to look up the POI is taken from the data, in case of OSM data with TileZen data, the
  * `poiNameField` is set to `kind`, which makes the content of the field `kind` in the data the key
- * to look up the POIs in the [[PoiTable]].
+ * to look up the POIs in the {@link PoiTable}.
  *
- * On the side of the [[PoiTable]], the key to look up the PoiTableEntry is either the property
+ * On the side of the {@link PoiTable}, the key to look up the PoiTableEntry is either the property
  * "name" of the [[PoiTableEntry]] (which should be unique), or the alternative list of names
  * `altNames`, where each value should also be unique. If the property `useAltNamesForKey` is set to
  * `true`, the `altNames` will be used.
@@ -289,8 +289,8 @@ export class PoiTable {
 }
 
 /**
- * The `PoiTableManager` manages the list of [[PoiTables]] that can be defined in the [[Theme]]
- * file.
+ * The `PoiTableManager` manages the list of [[PoiTables]] that
+ * can be defined in the {@link @here/harp-datasource-protocol#Theme} sfile.
  */
 export class PoiTableManager {
     private m_isLoading = false;
@@ -298,18 +298,23 @@ export class PoiTableManager {
 
     /**
      * Creates an instance of PoiTableManager.
-     * @param {MapView} mapView Owning [[MapView]].
+     * @param {MapView} mapView Owning {@link MapView}.
      */
     constructor(readonly mapView: MapView) {}
 
     /**
-     * Load the [[PoiTable]]s that are stored in the [[MapView]]s [[Theme]]. Note that duplicate
-     * names of [[PoiTable]]s in the [[Theme]] will lead to inaccessible [[PoiTable]]s.
+     * Load the {@link PoiTable}s that are stored in the {@link MapView}s
+     * {@link @here/harp-datasource-protocol#Theme}.
      *
-     * @param {Theme} theme [[Theme]] containing all [[PoiTable]]s to load.
+     * @remarks
+     * Note that duplicate names of {@link PoiTable}s in the
+     * {@link @here/harp-datasource-protocol#Theme} will lead to inaccessible {@link PoiTable}s.
      *
-     * @returns {Promise<void>} Resolved once all the [[PoiTable]]s in the [[Theme]] have been
-     *          loaded.
+     * @param theme - {@link @here/harp-datasource-protocol#Theme}
+     *                containing all {@link PoiTable}s to load.
+     *
+     * @returns Resolved once all the {@link PoiTable}s in
+     *          the {@link @here/harp-datasource-protocol#Theme} have been loaded.
      */
     async loadPoiTables(theme: Theme): Promise<void> {
         const finished = new Promise<void>(resolve => {
@@ -362,21 +367,24 @@ export class PoiTableManager {
     }
 
     /**
-     * Clear the list of [[PoiTable]]s.
+     * Clear the list of {@link PoiTable}s.
      */
     clear() {
         this.m_poiTables = new Map();
     }
 
     /**
-     * Return the map of [[PoiTable]]s.
+     * Return the map of {@link PoiTable}s.
      */
     get poiTables(): Map<string, PoiTable> {
         return this.m_poiTables;
     }
 
     /**
-     * Manually add a [[PoiTable]]. Normally, the [[PoiTables]]s are specified in the [[Theme]].
+     * Manually add a {@link PoiTable}. Normally, the [[PoiTables]]s
+     * are specified in the {@link @here/harp-datasource-protocol#Theme}.
+     *
+     * @remarks
      * Ensure that the name is unique.
      */
     addTable(poiTable: PoiTable) {
@@ -384,9 +392,9 @@ export class PoiTableManager {
     }
 
     /**
-     * Retrieve a [[PoiTable]] by name.
+     * Retrieve a {@link PoiTable} by name.
      *
-     * @param {(string | undefined)} poiTableName Name of the [[PoiTable]].
+     * @param {(string | undefined)} poiTableName Name of the {@link PoiTable}.
      *
      * @returns {(PoiTable | undefined)} The found [[poiTable]] if it could be found, `undefined`
      *          otherwise.
@@ -396,7 +404,7 @@ export class PoiTableManager {
     }
 
     /**
-     * Return `true` if the [[PoiTable]]s have finished loading.
+     * Return `true` if the {@link PoiTable}s have finished loading.
      *
      * @readonly
      */

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -235,7 +235,8 @@ export function checkReadyForPlacement(
  * label with [[layoutStyle]] and [[bounds]] already computed.
  * @param placement - The relative anchor placement (may be different then original alignment).
  * @param scale - The scaling factor (due to distance, etc.).
- * @param env - The [[Env]] used to evaluate technique attributes.
+ * @param env - The {@link @here/harp-datasource-protocol#Env} used
+ *                  to evaluate technique attributes.
  * @param offset - The offset result.
  */
 function computePointTextOffset(
@@ -405,7 +406,8 @@ export function placeIcon(
  * @param screenPosition - Position of the label in screen coordinates.
  * @param scale - Scale factor to be applied to label dimensions.
  * @param textCanvas - The text canvas where the label will be placed.
- * @param env - The [[Env]] used to evaluate technique attributes.
+ * @param env - The {@link @here/harp-datasource-protocol#Env} used
+ *              to evaluate technique attributes.
  * @param screenCollisions - Used to check collisions with other labels.
  * @param isRejected - Whether the label is already rejected (e.g. because its icon was rejected).
  * If `true`, text won't be checked for collision, result will be either `PlacementResult.Invisible`
@@ -480,7 +482,8 @@ export function placePointLabel(
  * @param screenPosition - Position of the label in screen coordinates.
  * @param scale - Scale factor to be applied to label dimensions.
  * @param textCanvas - The text canvas where the label will be placed.
- * @param env - The [[Env]] used to evaluate technique attributes.
+ * @param env - The {@link @here/harp-datasource-protocol#Env}
+ *              used to evaluate technique attributes.
  * @param screenCollisions - Used to check collisions with other labels.
  * @param outScreenPosition - The final label screen position after applying any offsets.
  * @returns `PlacementResult.Ok` if label can be placed at the base or optional anchor point,
@@ -586,7 +589,8 @@ function placePointLabelChoosingAnchor(
  * @param screenPosition - Position of the label in screen coordinates.
  * @param scale - Scale factor to be applied to label dimensions.
  * @param textCanvas - The text canvas where the label will be placed.
- * @param env - The [[Env]] used to evaluate technique attributes.
+ * @param env - The {@link @here/harp-datasource-protocol#Env}
+ *              used to evaluate technique attributes.
  * @param screenCollisions - Used to check collisions with other labels.
  * @param isRejected - Whether the label is already rejected (e.g. because its icon was rejected).
  * If `true`, text won't be checked for collision, result will be either `PlacementResult.Invisible`
@@ -636,7 +640,8 @@ function placePointLabelAtCurrentAnchor(
  * @param placement - Text placement relative to the label position.
  * @param scale - Scale factor to be applied to label dimensions.
  * @param textCanvas - The text canvas where the label will be placed.
- * @param env - The [[Env]] used to evaluate technique attributes.
+ * @param env - The {@link @here/harp-datasource-protocol#Env}
+ *              used to evaluate technique attributes.
  * @param screenCollisions - Used to check collisions with other labels.
  * @param isRejected - Whether the label is already rejected (e.g. because its icon was rejected).
  * If `true`, text won't be checked for collision, result will be either `PlacementResult.Invisible`

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -29,7 +29,7 @@ import { PickResult } from "../PickHandler";
 import { TextElementType } from "./TextElementType";
 
 /**
- * Additional information for an icon that is to be rendered along with a [[TextElement]].
+ * Additional information for an icon that is to be rendered along with a {@link TextElement}.
  */
 export interface PoiInfo {
     /**
@@ -38,31 +38,31 @@ export interface PoiInfo {
     technique: PoiTechnique | LineMarkerTechnique;
 
     /**
-     * Name of the [[ImageTexture]].
+     * Name of the {@link @here/harp-datasource-protocol#ImageTexture}.
      */
     imageTextureName: string;
 
     /**
      * Icon color override
      *
-     * @see [[MarkerTechniqueParams.iconColor]];
+     * @see {@link @here/harp-datasource-protocol#MarkerTechniqueParams.iconColor};
      */
     iconColor?: THREE.Color;
 
     /**
      * Icon brightness.
      *
-     * @see [[MarkerTechniqueParams.iconBrightness]];
+     * @see {@link @here/harp-datasource-protocol#MarkerTechniqueParams.iconBrightness};
      */
     iconBrightness?: number;
 
     /**
-     * Name of the POI table [[PoiTable]].
+     * Name of the POI table {@link PoiTable}.
      */
     poiTableName?: string;
 
     /**
-     * Name of the POI description in the [[PoiTable]].
+     * Name of the POI description in the {@link PoiTable}.
      */
     poiName?: string;
 
@@ -126,7 +126,7 @@ export interface PoiInfo {
     featureId?: number;
 
     /**
-     * Reference back to owning [[TextElement]].
+     * Reference back to owning {@link TextElement}.
      */
     textElement: TextElement;
 
@@ -138,13 +138,13 @@ export interface PoiInfo {
 
     /**
      * @hidden
-     * Direct access to [[ImageItem]] once it is resolved.
+     * Direct access to {@link ImageItem} once it is resolved.
      */
     imageItem?: ImageItem;
 
     /**
      * @hidden
-     * Direct access to [[ImageTexture]] once it is resolved.
+     * Direct access to {@link @here/harp-datasource-protocol#ImageTexture} once it is resolved.
      */
     imageTexture?: ImageTexture;
 
@@ -181,8 +181,8 @@ export interface PoiInfo {
 
     /**
      * @hidden
-     * Computed from owning [[TextElement]]. Value is set when `PoiInfo` is assigned to
-     * [[TextElement]].
+     * Computed from owning {@link TextElement}. Value is set when `PoiInfo` is assigned to
+     * {@link TextElement}.
      */
     renderOrder?: number;
 }
@@ -198,7 +198,7 @@ export function poiIsRenderable(poiInfo: PoiInfo): boolean {
 
 export interface TextPickResult extends PickResult {
     /**
-     * Text of the picked [[TextElement]]
+     * Text of the picked {@link TextElement}
      */
     text?: string;
 }
@@ -306,28 +306,34 @@ export class TextElement {
 
     /**
      * @hidden
-     * Array storing the style [[GlyphData]] for this `TextElement` to speed up label placement in
-     * [[TextElementsRenderer]]. Valid after `loadingState` is `Initialized`.
+     * Array storing the style {@link @here/harp-text-canvas#GlyphData} for
+     * this `TextElement` to speed up label placement in
+     * {@link TextElementsRenderer}. Valid after `loadingState` is `Initialized`.
      */
     glyphs?: GlyphData[];
 
     /**
      * @hidden
-     * Array storing the casing (`true`: uppercase, `false`: lowercase) for this `TextElement`.
-     * Used by labels in [[TextElementsRenderer]] to support `SmallCaps`. Valid after `loadingState`
+     * Array storing the casing (`true`: uppercase, `false`: lowercase)
+     * for this `TextElement`.
+     * Used by labels in {@link TextElementsRenderer} to support
+     * `SmallCaps`. Valid after `loadingState`
      * is `Initialized`.
      */
     glyphCaseArray?: boolean[];
 
     /**
-     * Screen space bounds for this `TextElement`. Used by point labels in [[TextElementsRenderer]].
+     * Screen space bounds for this `TextElement`.
+     *
+     * @remarks
+     * Used by point labels in {@link TextElementsRenderer}.
      * Valid after `loadingState` is `Initialized`.
      */
     bounds?: THREE.Box2;
 
     /**
      * @hidden
-     * Pre-computed text vertex buffer. Used by point labels in [[TextElementsRenderer]]. Valid
+     * Pre-computed text vertex buffer. Used by point labels in {@link TextElementsRenderer}. Valid
      * after label becomes visible for the first time.
      */
     textBufferObject?: TextBufferObject;
@@ -503,7 +509,7 @@ export class TextElement {
     }
 
     /**
-     * Update the minZoomLevel and maxZoomLevel from the values set in [[PoiInfo]].
+     * Update the minZoomLevel and maxZoomLevel from the values set in {@link PoiInfo}.
      * Selects the smaller/larger one of the two min/max values for icon and text, because the
      * TextElement is a container for both.
      */

--- a/@here/harp-mapview/lib/text/TextElementGroup.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroup.ts
@@ -8,6 +8,6 @@ import { PriorityListGroup } from "@here/harp-utils";
 import { TextElement } from "./TextElement";
 
 /**
- * Group of [[TextElement]] sharing same priority.
+ * Group of {@link TextElement} sharing same priority.
  */
 export class TextElementGroup extends PriorityListGroup<TextElement> {}

--- a/@here/harp-mapview/lib/text/TextElementGroupPriorityList.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupPriorityList.ts
@@ -8,6 +8,6 @@ import { GroupedPriorityList } from "@here/harp-utils";
 import { TextElement } from "./TextElement";
 
 /**
- * List of [[TextElement]] groups sorted by priority.
+ * List of {@link TextElement} groups sorted by priority.
  */
 export class TextElementGroupPriorityList extends GroupedPriorityList<TextElement> {}

--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -55,8 +55,8 @@ export class TextElementGroupState {
     }
 
     /**
-     * Indicates whether the group has been submitted to the [[TextElementsRenderer]] in the current
-     * frame.
+     * Indicates whether the group has been submitted to the
+     * {@link TextElementsRenderer} in the current frame.
      */
     get visited(): boolean {
         return this.m_visited;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -91,7 +91,7 @@ export const DEFAULT_TEXT_DISTANCE_SCALE = 0.5;
 /**
  * Maximum number of recommended labels. If more labels are encountered, the "overloaded" mode is
  * set, which modifies the behavior of label placement and rendering, trying to keep delivering an
- * interactive performance. The overloaded mode should not be activated if the [[MapView]] is
+ * interactive performance. The overloaded mode should not be activated if the {@link MapView} is
  * rendering a static image (camera not moving and no animation running).
  */
 const OVERLOAD_LABEL_LIMIT = 20000;
@@ -330,7 +330,7 @@ export class TextElementsRenderer {
     /**
      * Create the `TextElementsRenderer` which selects which labels should be placed on screen as
      * a preprocessing step, which is not done every frame, and also renders the placed
-     * [[TextElement]]s every frame.
+     * {@link TextElement}s every frame.
      *
      * @param m_viewState - State of the view for which this renderer will draw text.
      * @param m_viewCamera - Camera used by the view for which this renderer will draw text.
@@ -438,7 +438,7 @@ export class TextElementsRenderer {
     }
 
     /**
-     * Is `true` if number of [[TextElement]]s in visible tiles is larger than the recommended
+     * Is `true` if number of {@link TextElement}s in visible tiles is larger than the recommended
      * number `OVERLOAD_LABEL_LIMIT`.
      */
     get overloaded(): boolean {
@@ -500,7 +500,7 @@ export class TextElementsRenderer {
     /**
      * Adds new overlay text elements to this `MapView`.
      *
-     * @param textElements - Array of [[TextElement]] to be added.
+     * @param textElements - Array of {@link TextElement} to be added.
      */
     addOverlayText(textElements: TextElement[]): void {
         if (textElements.length === 0) {
@@ -515,7 +515,7 @@ export class TextElementsRenderer {
     /**
      * Adds new overlay text elements to this `MapView`.
      *
-     * @param textElements - Array of [[TextElement]] to be added.
+     * @param textElements - Array of {@link TextElement} to be added.
      */
     clearOverlayText(): void {
         this.m_overlayTextElements = [];
@@ -534,9 +534,10 @@ export class TextElementsRenderer {
 
     /**
      * Fill the picking results for the pixel with the given screen coordinate. If multiple
-     * [[TextElement]]s are found, the order of the results is unspecified.
+     * {@link TextElement}s are found, the order of the results is unspecified.
      *
-     * Note: [[TextElement]]s with identical `featureId` or identical `userData` will only appear
+     * Note: {@link TextElement}s with identical `featureId` or
+     * identical `userData` will only appear
      * once in the list `pickResults`.
      *
      * @param screenPosition - Screen coordinate of picking position.
@@ -615,7 +616,10 @@ export class TextElementsRenderer {
     }
 
     /**
-     * Reset the current text render states of all visible tiles. All [[TextElement]]s will fade in
+     * Reset the current text render states of all visible tiles.
+     *
+     * @remarks
+     * All {@link TextElement}s will fade in
      * after that as if they have just been added.
      */
     clearRenderStates() {
@@ -1079,11 +1083,15 @@ export class TextElementsRenderer {
     }
 
     /**
-     * Visit all visible tiles and add/ their text elements to cache. The update of
-     * [[TextElement]]s is a time consuming process, and cannot be done every frame, but should only
+     * Visit all visible tiles and add/ their text elements to cache.
+     *
+     * @remarks
+     * The update of {@link TextElement}s is a time consuming process,
+     * and cannot be done every frame, but should only
      * be done when the camera moved (a lot) of whenever the set of visible tiles change.
      *
-     * The actually rendered [[TextElement]]s are stored internally until the next update is done
+     * The actually rendered {@link TextElement}s are stored internally
+     * until the next update is done
      * to speed up rendering when no camera movement was detected.
      * @param dataSourceTileList - List of tiles to be rendered for each data source.
      */

--- a/@here/harp-mapview/lib/text/TextElementsRendererOptions.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRendererOptions.ts
@@ -58,40 +58,40 @@ export interface TextElementsRendererOptions {
      */
     maxNumGlyphs?: number;
     /**
-     * Limits the number of [[DataSource]] labels visible, such as road names and POIs.
+     * Limits the number of {@link DataSource} labels visible, such as road names and POIs.
      * On small devices, you can reduce this number to to increase performance.
      * @default [[DEFAULT_MAX_NUM_RENDERED_TEXT_ELEMENTS]].
      */
     maxNumVisibleLabels?: number;
     /**
-     * The number of [[TextElement]]s that the [[TextElementsRenderer]] tries to render even
-     * if they were not visible during placement. This property only applies to [[TextElement]]s
+     * The number of {@link TextElement}s that the {@link TextElementsRenderer} tries to render even
+     * if they were not visible during placement. This property only applies to {@link TextElement}s
      * that were culled by the frustum; useful for map movements and animations.
      * @default [[DEFAULT_MAX_NUM_SECOND_CHANCE_ELEMENTS]].
      */
     numSecondChanceLabels?: number;
     /**
-     * The maximum distance for [[TextElement]] to be rendered, expressed as a fraction of
+     * The maximum distance for {@link TextElement} to be rendered, expressed as a fraction of
      * the distance between the near and far plane [0, 1.0].
      * @default [[DEFAULT_MAX_DISTANCE_RATIO_FOR_LABELS]].
      */
     maxDistanceRatioForTextLabels?: number;
     /**
-     * The maximum distance for [[TextElement]] with icons to be rendered,
+     * The maximum distance for {@link TextElement} with icons to be rendered,
      * expressed as a fraction of the distance
      * between the near and far plane [0, 1.0].
      * @default [[DEFAULT_MAX_DISTANCE_RATIO_FOR_LABELS]].
      */
     maxDistanceRatioForPoiLabels?: number;
     /**
-     * The minimum scaling factor that may be applied to [[TextElement]]s due to their distance.
-     * If not defined the default value specified in [[TextElementsRenderer]] will be used.
+     * The minimum scaling factor that may be applied to {@link TextElement}s due to their distance.
+     * If not defined the default value specified in {@link TextElementsRenderer} will be used.
      * @default [[DEFAULT_LABEL_DISTANCE_SCALE_MIN]].
      */
     labelDistanceScaleMin?: number;
     /**
-     * The maximum scaling factor that may be applied to [[TextElement]]s due to their distance.
-     * If not defined the default value specified in [[TextElementsRenderer]] will be used.
+     * The maximum scaling factor that may be applied to {@link TextElement}s due to their distance.
+     * If not defined the default value specified in {@link TextElementsRenderer} will be used.
      * @default [[DEFAULT_LABEL_DISTANCE_SCALE_MAX]].
      */
     labelDistanceScaleMax?: number;

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -66,7 +66,8 @@ const defaultTextLayoutStyle = new TextLayoutStyle({
 const DEFAULT_STYLE_NAME = "default";
 
 /**
- * [[TextElementsRenderer]] representation of a [[Theme]]'s TextStyle.
+ * {@link TextElementsRenderer} representation of a
+ * {@link @here/harp-datasource-protocol#Theme}'s TextStyle.
  */
 export interface TextElementStyle {
     name: string;
@@ -181,7 +182,8 @@ export class TextStyleCache {
     }
 
     /**
-     * Retrieves a [[TextElementStyle]] for [[Theme]]'s [[TextStyle]] id.
+     * Retrieves a {@link TextElementStyle} for {@link @here/harp-datasource-protocol#Theme}'s
+     * [[TextStyle]] id.
      */
     getTextElementStyle(styleId?: string): TextElementStyle {
         let result;
@@ -197,7 +199,8 @@ export class TextStyleCache {
     }
 
     /**
-     * Gets the appropriate [[TextRenderStyle]] to use for a label. Depends heavily on the label's
+     * Gets the appropriate {@link @here/harp-text-canvas#TextRenderStyle}
+     * to use for a label. Depends heavily on the label's
      * [[Technique]] and the current zoomLevel.
      */
     createRenderStyle(
@@ -326,10 +329,11 @@ export class TextStyleCache {
     }
 
     /**
-     * Create the appropriate [[TextLayoutStyle]] to use for a label. Depends heavily on the label's
+     * Create the appropriate {@link @here/harp-text-canvas#TextLayoutStyle}
+     * to use for a label. Depends heavily on the label's
      * [[Technique]] and the current zoomLevel.
      *
-     * @param tile - The [[Tile]] to process.
+     * @param tile - The {@link Tile} to process.
      * @param technique - Label's technique.
      */
     createLayoutStyle(

--- a/@here/harp-mapview/lib/workers/WorkerLoader.ts
+++ b/@here/harp-mapview/lib/workers/WorkerLoader.ts
@@ -13,8 +13,8 @@ const logger = LoggerManager.instance.create("WorkerLoader");
 
 /**
  * Set of `Worker` loading and initialization helpers:
- *  - starting Worker from URL with fallback to XHR+blob [[WorkerLoader.startWorker]]
- *  - waiting for proper worker initialization, see [[WorkerLoader.waitWorkerInitialized]]
+ *  - starting Worker from URL with fallback to XHR+blob {@link WorkerLoader.startWorker}
+ *  - waiting for proper worker initialization, see {@link WorkerLoader.waitWorkerInitialized}
  */
 export class WorkerLoader {
     static directlyFallbackToBlobBasedLoading: boolean = false;

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -153,12 +153,12 @@ describe("VisibleTileSet", function() {
     }
 
     /**
-     * Fake [[DataSource]] which provides tiles with the ground plane geometry.
+     * Fake {@link DataSource} which provides tiles with the ground plane geometry.
      */
     class FakeCoveringTileWMTS extends DataSource {
         /**
-         * Construct a fake [[DataSource]].
-         * @param isFullyCovering - If this [[DataSource]] should be fully covering.
+         * Construct a fake {@link DataSource}.
+         * @param isFullyCovering - If this {@link DataSource} should be fully covering.
          */
         constructor(isFullyCovering?: boolean) {
             super();
@@ -184,8 +184,8 @@ describe("VisibleTileSet", function() {
     }
 
     /**
-     * Fake [[DataSource]] with no backgroundPlane geometry, but which registers
-     * that it is fully covering, because its geometry fully covers the [[Tile]], an example
+     * Fake {@link DataSource} with no backgroundPlane geometry, but which registers
+     * that it is fully covering, because its geometry fully covers the {@link Tile}, an example
      * is satellite data or terrain.
      */
     class FakeWebTile extends DataSource {

--- a/@here/harp-materials/lib/CirclePointsMaterial.ts
+++ b/@here/harp-materials/lib/CirclePointsMaterial.ts
@@ -37,7 +37,7 @@ void main() {
 }`;
 
 /**
- * Parameters used when constructing a new [[HighPrecisionPointMaterial]].
+ * Parameters used when constructing a new {@link HighPrecisionPointMaterial}.
  */
 export interface CirclePointsMaterialParameters extends THREE.ShaderMaterialParameters {
     /**

--- a/@here/harp-materials/lib/CopyMaterial.ts
+++ b/@here/harp-materials/lib/CopyMaterial.ts
@@ -6,9 +6,9 @@
 import * as THREE from "three";
 
 /**
- * The base shader to use for [[MapView]]'s composing passes, like [[MSAAMaterial]].
+ * The base shader to use for {@link @here/harp-mapview#MapView}'s
+ * composing passes, like {@link MSAAMaterial}.
  */
-
 export const CopyShader: THREE.Shader = {
     uniforms: {
         tDiffuse: { value: null },

--- a/@here/harp-materials/lib/DisplacementFeature.ts
+++ b/@here/harp-materials/lib/DisplacementFeature.ts
@@ -7,7 +7,7 @@
 import { HiddenThreeJSMaterialProperties } from "./MapMeshMaterials";
 
 /**
- * Parameters used when constructing a new implementor of [[DisplacementFeature]].
+ * Parameters used when constructing a new implementor of {@link DisplacementFeature}.
  */
 export interface DisplacementFeatureParameters {
     /**

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -110,7 +110,7 @@ void main() {
 }`;
 
 /**
- * Parameters used when constructing a new [[EdgeMaterial]].
+ * Parameters used when constructing a new {@link EdgeMaterial}.
  */
 export interface EdgeMaterialParameters
     extends FadingFeatureParameters,

--- a/@here/harp-materials/lib/HighPrecisionLineMaterial.ts
+++ b/@here/harp-materials/lib/HighPrecisionLineMaterial.ts
@@ -53,7 +53,7 @@ void main() {
 }`;
 
 /**
- * Parameters used when constructing a new [[SolidLineMaterial]].
+ * Parameters used when constructing a new {@link SolidLineMaterial}.
  */
 export interface HighPrecisionLineMaterialParameters {
     /**

--- a/@here/harp-materials/lib/HighPrecisionPointMaterial.ts
+++ b/@here/harp-materials/lib/HighPrecisionPointMaterial.ts
@@ -37,7 +37,7 @@ void main() {
 }`;
 
 /**
- * Parameters used when constructing a new [[HighPrecisionPointMaterial]].
+ * Parameters used when constructing a new {@link HighPrecisionPointMaterial}.
  */
 export interface HighPrecisionPointMaterialParameters extends THREE.PointsMaterialParameters {
     /**

--- a/@here/harp-materials/lib/IconMaterial.ts
+++ b/@here/harp-materials/lib/IconMaterial.ts
@@ -43,7 +43,7 @@ void main() {
 }`;
 
 /**
- * Parameters used when constructing a new [[IconMaterial]].
+ * Parameters used when constructing a new {@link IconMaterial}.
  */
 export interface IconMaterialParameters {
     /**

--- a/@here/harp-materials/lib/MSAAMaterial.ts
+++ b/@here/harp-materials/lib/MSAAMaterial.ts
@@ -8,7 +8,8 @@ import * as THREE from "three";
 import { CopyShader } from "./CopyMaterial";
 
 /**
- * The material to use for the quad of the [[MSAARenderPass]] in the composing.
+ * The material to use for the quad of the {@link @here/harp-mapview#MSAARenderPass}
+ * in the composing.
  */
 export class MSAAMaterial extends THREE.ShaderMaterial {
     /**

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -23,13 +23,13 @@ const emptyTexture = new THREE.Texture();
  * [[THREE.MeshBasicMaterial]] and [[THREE.MeshStandardMaterial]], with the addition functionality
  * of fading out the geometry between a fadeNear and fadeFar value.
  *
- * The implementation is designed around a mixin class [[FadingFeatureMixin]], which requires
+ * The implementation is designed around a mixin class {@link FadingFeatureMixin}, which requires
  * a bit of care when adding the FadingFeature to the existing mesh classes, but it is safe to use
  * and also reduces code duplication.
  */
 
 /**
- * Parameters used when constructing a new implementor of [[FadingFeature]].
+ * Parameters used when constructing a new implementor of {@link FadingFeature}.
  */
 export interface FadingFeatureParameters {
     /**
@@ -56,7 +56,7 @@ export interface ShadowFeatureParameters {
 }
 
 /**
- * Parameters used when constructing a new implementor of [[ExtrusionFeature]].
+ * Parameters used when constructing a new implementor of {@link ExtrusionFeature}.
  */
 export interface ExtrusionFeatureParameters {
     /**
@@ -211,7 +211,7 @@ function linkMixinWithShader(mixin: MixinShaderProperties, shader: THREE.Shader)
 
 /**
  * Base interface for all objects that should fade in the distance. The implementation of the actual
- * FadingFeature is done with the help of the mixin class [[FadingFeatureMixin]] and a set of
+ * FadingFeature is done with the help of the mixin class {@link FadingFeatureMixin} and a set of
  * supporting functions in the namespace of the same name.
  */
 export interface FadingFeature extends HiddenThreeJSMaterialProperties, MixinShaderProperties {
@@ -228,8 +228,11 @@ export interface FadingFeature extends HiddenThreeJSMaterialProperties, MixinSha
 }
 
 /**
- * Base interface for all objects that should have animated extrusion effect. The implementation of
- * the actual ExtrusionFeature is done with the help of the mixin class [[ExtrusionFeatureMixin]]
+ * Base interface for all objects that should have animated extrusion effect.
+ *
+ * @remarks
+ * The implementation of the actual ExtrusionFeature is done with
+ * the help of the mixin class {@link ExtrusionFeatureMixin}
  * and a set of supporting functions in the namespace of the same name.
  */
 export interface ExtrusionFeature extends HiddenThreeJSMaterialProperties, MixinShaderProperties {
@@ -756,7 +759,7 @@ export class FadingFeatureMixin implements FadingFeature {
 
 export namespace ExtrusionFeature {
     /**
-     * Checks if feature is enabled based on [[ExtrusionFeature]] properties.
+     * Checks if feature is enabled based on {@link ExtrusionFeature} properties.
      *
      * @param extrusionMaterial -
      */
@@ -867,8 +870,10 @@ export namespace ExtrusionFeature {
 /**
  * Mixin class for extended THREE materials. Adds new properties required for `extrusionRatio`.
  *
+ * @remarks
  * There is some special handling for the extrusionRatio property, which is animated via
- * [[AnimatedExtrusionHandler]] that is using [[extrusionRatio]] setter and getter to update
+ * {@link @here/harp-mapview#AnimatedExtrusionHandler} that is
+ * using [[extrusionRatio]] setter and getter to update
  * extrusion in a way that works well with the mixin and EdgeMaterial.
  */
 export class ExtrusionFeatureMixin implements ExtrusionFeature {
@@ -1013,7 +1018,7 @@ export class MapMeshBasicMaterial extends THREE.MeshBasicMaterial
     }
 
     // Only here to make the compiler happy, these methods will be overriden: The actual
-    // implementations are those in [[FadingFeatureMixin]] and [[ExtrusionFeatureMixin]], see below:
+    // implementations are those in FadingFeatureMixin and ExtrusionFeatureMixin, see below:
     //
     // applyMixinsWithoutProperties(FadingMeshBasicMaterial, [FadingFeatureMixin]);
     // applyMixinsWithoutProperties(ExtrudionMeshBasicMaterial, [ExtrusionFeatureMixin]);
@@ -1118,7 +1123,7 @@ export class MapMeshDepthMaterial extends THREE.MeshDepthMaterial implements Ext
     }
 
     // Only here to make the compiler happy, these methods will be overriden: The actual
-    // implementations are those in[[ExtrusionFeatureMixin]], see below:
+    // implementations are those in{@link ExtrusionFeatureMixin}, see below:
     //
     // applyMixinsWithoutProperties(...);
     //
@@ -1231,7 +1236,7 @@ export class MapMeshStandardMaterial extends THREE.MeshStandardMaterial
     }
 
     // Only here to make the compiler happy, these methods will be overriden: The actual
-    // implementations are those in [[FadingFeatureMixin]] and [[ExtrusionFeatureMixin]], see below:
+    // implementations are those in FadingFeatureMixin and ExtrusionFeatureMixin, see below:
     //
     // applyMixinsWithoutProperties(FadingMeshBasicMaterial, [FadingFeatureMixin]);
     // applyMixinsWithoutProperties(ExtrudionMeshBasicMaterial, [ExtrusionFeatureMixin]);

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -299,7 +299,7 @@ void main() {
 }`;
 
 /**
- * Parameters used when constructing a new [[SolidLineMaterial]].
+ * Parameters used when constructing a new {@link SolidLineMaterial}.
  */
 export interface SolidLineMaterialParameters
     extends FadingFeatureParameters,

--- a/@here/harp-utils/lib/ContextLogger.ts
+++ b/@here/harp-utils/lib/ContextLogger.ts
@@ -14,7 +14,7 @@ export interface ISimpleChannel {
 }
 
 /**
- * Extension of [[ISimpleChannel]] to support contextual logging by adding stack of prefixes.
+ * Extension of {@link ISimpleChannel} to support contextual logging by adding stack of prefixes.
  */
 export interface IContextLogger extends ISimpleChannel {
     /**

--- a/@here/harp-utils/lib/GroupedPriorityList.ts
+++ b/@here/harp-utils/lib/GroupedPriorityList.ts
@@ -18,7 +18,7 @@ export interface PriorityListElement {
 }
 
 /**
- * The `PriorityListGroup` contains a list of [[PriorityListElement]]s that all have the same
+ * The `PriorityListGroup` contains a list of {@link PriorityListElement}s that all have the same
  * (integer) priority.
  */
 export class PriorityListGroup<T extends PriorityListElement> {
@@ -49,7 +49,7 @@ export class PriorityListGroup<T extends PriorityListElement> {
 }
 
 /**
- * The `PriorityListGroupMap` is a map to map the (integer) priority to a [[PriorityListGroup]].
+ * The `PriorityListGroupMap` is a map to map the (integer) priority to a {@link PriorityListGroup}.
  */
 export type PriorityListGroupMap<T extends PriorityListElement> = Map<number, PriorityListGroup<T>>;
 
@@ -90,14 +90,14 @@ export class GroupedPriorityList<T extends PriorityListElement> {
     }
 
     /**
-     * Remove all internal [[PriorityListGroup]]s.
+     * Remove all internal {@link PriorityListGroup}s.
      */
     clear(): void {
         this.groups.clear();
     }
 
     /**
-     * Merge another [[GroupedPriorityList]] into this one.
+     * Merge another {@link GroupedPriorityList} into this one.
      *
      * @param other - Other group to merge.
      */

--- a/@here/harp-utils/lib/UriResolver.ts
+++ b/@here/harp-utils/lib/UriResolver.ts
@@ -27,7 +27,7 @@ export interface PrefixUriResolverDefinition {
 }
 
 /**
- * Basic, import-map like [[UriResolver]].
+ * Basic, import-map like {@link UriResolver}.
  *
  * Resolves `uris` basing on exact or prefix match of `key` from `definitions`.
  *
@@ -78,7 +78,7 @@ export class RelativeUriResolver implements UriResolver {
 /**
  * Compose URI resolvers.
  *
- * Creates new [[UriResolver]] that applies resolvers in orders or arguments.
+ * Creates new {@link UriResolver} that applies resolvers in orders or arguments.
  *
  * Example:
  *


### PR DESCRIPTION
Reference declarations using @link instead of `[[...]]`
    
This change replaces the usages of code re{ferences, e.g. `[[MapView]]`
with the tsdoc standard `@link` tag (e.g. {@link MapView}).