### PR TITLE
HARP-10715: Use api-extractor to generate rollup d.ts typings.

### DIFF
--- a/@here/harp.gl/.npmignore
+++ b/@here/harp.gl/.npmignore
@@ -3,6 +3,7 @@
 test/
 lib/
 tsconfig.json
+api-extractor.json
 webpack.config.ts
 .gitignore
 .gitreview

--- a/@here/harp.gl/api-extractor.json
+++ b/@here/harp.gl/api-extractor.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+
+    "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+
+    "bundledPackages": [
+        "@here/harp-datasource-protocol",
+        "@here/harp-debug-datasource",
+        "@here/harp-features-datasource",
+        "@here/harp-geojson-datasource",
+        "@here/harp-geoutils",
+        "@here/harp-map-controls",
+        "@here/harp-mapview",
+        "@here/harp-mapview-decoder",
+        "@here/harp-omv-datasource",
+        "@here/harp-webtile-datasource",
+        "@here/harp-text-canvas",
+        "@here/harp-utils",
+        "@here/harp-transfer-manager",
+        "@here/harp-lines"
+    ],
+
+    "apiReport": {
+        "enabled": false
+    },
+
+    "docModel": {
+        "enabled": false
+    },
+
+    "dtsRollup": {
+        "enabled": true
+    },
+
+    "tsdocMetadata": {
+        "enabled": false
+    },
+
+    "newlineKind": "lf",
+
+    "messages": {
+        "compilerMessageReporting": {
+            "default": {
+                "logLevel": "none"
+            }
+        },
+
+        "extractorMessageReporting": {
+            "default": {
+                "logLevel": "none",
+                "addToApiReportFile": false
+            },
+
+            "ae-missing-release-tag": {
+                "logLevel": "none",
+                "addToApiReportFile": false
+            },
+            "ae-forgotten-export": {
+                "logLevel": "none",
+                "addToApiReportFile": false
+            },
+            "ae-internal-missing-underscore": {
+                "logLevel": "none",
+                "addToApiReportFile": false
+            },
+            "ae-incompatible-release-tags": {
+                "logLevel": "none",
+                "addToApiReportFile": false
+            }
+        },
+
+        "tsdocMessageReporting": {
+            "default": {
+                "logLevel": "none",
+                "addToApiReportFile": false
+            }
+        }
+    }
+}

--- a/@here/harp.gl/package.json
+++ b/@here/harp.gl/package.json
@@ -12,10 +12,13 @@
         "harpgl"
     ],
     "main": "dist/harp.js",
+    "types": "dist/harp.gl.d.ts",
     "scripts": {
         "prepare": "webpack && NODE_ENV=production webpack",
+        "prepack": "yarn build-typings",
         "profile-min": "NODE_ENV=production webpack --profile --json > webpack-stats-production.json",
         "profile-dev": "webpack --profile --json > webpack-stats-dev.json",
+        "build-typings": "tsc --build && api-extractor run && echo 'export as namespace harp;' >> dist/harp.gl.d.ts",
         "test": "true"
     },
     "repository": {
@@ -48,6 +51,7 @@
         "@here/harp-text-canvas": "^0.16.0",
         "@here/harp-utils": "^0.16.0",
         "@here/harp-webtile-datasource": "^0.16.0",
+        "@microsoft/api-extractor": "^7.8.10",
         "ts-loader": "^7.0.5",
         "typescript": "^3.9.3",
         "webpack": "^4.43.0",

--- a/@here/harp.gl/tsconfig.json
+++ b/@here/harp.gl/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
         "sourceMap": true,
-        "declaration": false
+        "declaration": true,
+        "declarationMap": true
     },
     "references": [
         {

--- a/@here/harp.gl/webpack.config.js
+++ b/@here/harp.gl/webpack.config.js
@@ -30,7 +30,8 @@ const commonConfig = {
                         ? path.resolve(__dirname, "../../tsconfig.json")
                         : path.resolve(__dirname, "./tsconfig.json"),
                     compilerOptions: {
-                        declaration: false
+                        declaration: false,
+                        declarationMap: false
                     }
                 }
             }


### PR DESCRIPTION
This change introduces a simple api-extractor configuration and a npm
script to generate typings information for the bundled @here/harp.gl
package.

The typings are generated in `@here/harp.gl/dist/harp.gl.d.ts` by
the following command:

```
    yarn workspace @here/harp.gl run build-typings
```
