### PR TITLE
Simplify the initialization of OMV Data Sources.

### DIFF
--- a/@here/generator-harp.gl/README.md
+++ b/@here/generator-harp.gl/README.md
@@ -22,14 +22,8 @@ Set you access token in `View.ts`:
 
 ```typescript
 const omvDataSource = new OmvDataSource({
-   baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-   apiFormat: harp.APIFormat.XYZOMV,
-   styleSetName: "tilezen",
-   authenticationCode: "YOUR-APIKEY",
-   authenticationMethod: {
-         method: harp.AuthenticationMethod.QueryString,
-         name: "apikey"
-   }
+    baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+    authenticationCode: "YOUR-APIKEY"
 });
 ```
 Then start it using `webpack-dev-server`:

--- a/@here/harp-examples/src/camera-animations_key-track.ts
+++ b/@here/harp-examples/src/camera-animations_key-track.ts
@@ -10,11 +10,11 @@ import {
     ControlPoint
 } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
 import THREE = require("three");
 
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 
 interface GeoLocations {
     [key: string]: GeoCoordinates;
@@ -245,14 +245,7 @@ export namespace CameraAnimationExample {
 
         const omvDataSource = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
         mapView.addDataSource(omvDataSource);
 

--- a/@here/harp-examples/src/datasource_features_lines-and-points.ts
+++ b/@here/harp-examples/src/datasource_features_lines-and-points.ts
@@ -14,8 +14,8 @@ import {
 import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
-import { apikey, copyrightInfo } from "../config";
+import { OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey } from "../config";
 import { faults, hotspots } from "../resources/geology";
 
 /**
@@ -224,16 +224,8 @@ export namespace LinesPointsFeaturesExample {
         window.addEventListener("resize", () => mapView.resize(innerWidth, innerHeight));
 
         const baseMap = new OmvDataSource({
-            name: "basemap",
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
         mapView.addDataSource(baseMap);
 

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -13,9 +13,9 @@ import {
 import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 import { COUNTRIES } from "../resources/countries";
 
 /**
@@ -333,16 +333,8 @@ export namespace PolygonsFeaturesExample {
         window.addEventListener("resize", () => mapView.resize(innerWidth, innerHeight));
 
         const baseMap = new OmvDataSource({
-            name: "basemap",
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
         mapView.addDataSource(baseMap);
 

--- a/@here/harp-examples/src/datasource_geojson_choropleth.ts
+++ b/@here/harp-examples/src/datasource_geojson_choropleth.ts
@@ -8,14 +8,9 @@ import { StyleDeclaration, StyleSet, Theme } from "@here/harp-datasource-protoco
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import {
-    APIFormat,
-    AuthenticationMethod,
-    GeoJsonDataProvider,
-    OmvDataSource
-} from "@here/harp-omv-datasource";
+import { GeoJsonDataProvider, OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 
 /**
  * This example demonstrates how to generate a heatmap-like [[StyleSet]] for a GeoJson. To do so,
@@ -93,14 +88,7 @@ export namespace GeoJsonHeatmapExample {
 
         const baseMapDataSource = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
 
         mapView.addDataSource(baseMapDataSource);

--- a/@here/harp-examples/src/datasource_geojson_custom-shader.ts
+++ b/@here/harp-examples/src/datasource_geojson_custom-shader.ts
@@ -7,13 +7,8 @@
 import { GeoBox, GeoCoordinates, GeoPointLike } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import {
-    APIFormat,
-    AuthenticationMethod,
-    GeoJsonDataProvider,
-    OmvDataSource
-} from "@here/harp-omv-datasource";
-import { apikey, copyrightInfo } from "../config";
+import { GeoJsonDataProvider, OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey } from "../config";
 
 import * as geojson from "../resources/polygon.json";
 
@@ -125,14 +120,7 @@ export namespace GeoJsonCustomShaderExample {
         private addBaseMap() {
             const dataSource = new OmvDataSource({
                 baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-                apiFormat: APIFormat.XYZOMV,
-                styleSetName: "tilezen",
-                authenticationCode: apikey,
-                authenticationMethod: {
-                    method: AuthenticationMethod.QueryString,
-                    name: "apikey"
-                },
-                copyrightInfo
+                authenticationCode: apikey
             });
 
             this.mapView.addDataSource(dataSource);

--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -8,8 +8,8 @@ import { StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { FeaturesDataSource } from "@here/harp-features-datasource";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
-import { apikey, copyrightInfo } from "../config";
+import { OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey } from "../config";
 
 /**
  * In this example we avail ourselves of the [[FeaturesDataSource]] and its `setFromGeoJson` method
@@ -171,14 +171,7 @@ export namespace GeoJsonExample {
 
         const baseMap = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
         mapView.addDataSource(baseMap);
 

--- a/@here/harp-examples/src/getting-started_free-camera.ts
+++ b/@here/harp-examples/src/getting-started_free-camera.ts
@@ -14,9 +14,9 @@ import {
     MapViewOptions,
     MapViewUtils
 } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import * as THREE from "three";
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 
 // Import the gesture handlers from the three.js additional libraries.
 // The controls are not in common.js they explicitly require a
@@ -102,14 +102,7 @@ export namespace FreeCameraAppDebuggingToolExample {
         start() {
             const omvDataSource = new OmvDataSource({
                 baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-                apiFormat: APIFormat.XYZOMV,
-                styleSetName: "tilezen",
-                authenticationCode: apikey,
-                authenticationMethod: {
-                    method: AuthenticationMethod.QueryString,
-                    name: "apikey"
-                },
-                copyrightInfo
+                authenticationCode: apikey
             });
 
             const debugTileDataSource = new DebugTileDataSource(webMercatorTilingScheme);

--- a/@here/harp-examples/src/getting-started_globe-projection.ts
+++ b/@here/harp-examples/src/getting-started_globe-projection.ts
@@ -7,8 +7,8 @@
 import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
-import { apikey, copyrightInfo } from "../config";
+import { OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey } from "../config";
 
 export namespace GlobeExample {
     // Create a new MapView for the HTMLCanvasElement of the given id.
@@ -37,14 +37,7 @@ export namespace GlobeExample {
 
         const omvDataSource = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
 
         map.addDataSource(omvDataSource);

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -7,8 +7,8 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
-import { apikey, copyrightInfo } from "../config";
+import { OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey } from "../config";
 
 /**
  * MapView initialization sequence enables setting all the necessary elements on a map  and returns
@@ -114,14 +114,7 @@ export namespace HelloWorldExample {
         // snippet:harp_gl_hello_world_example_4.ts
         const omvDataSource = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
         // end:harp_gl_hello_world_example_4.ts
 

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -7,9 +7,9 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, ThemeLoader } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 
 /**
  * This example copies the base example and adds a GUI allowing to switch between all the open-
@@ -48,14 +48,7 @@ export namespace ThemesExample {
 
     const omvDataSource = new OmvDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-        apiFormat: APIFormat.XYZOMV,
-        styleSetName: "tilezen",
-        authenticationCode: apikey,
-        authenticationMethod: {
-            method: AuthenticationMethod.QueryString,
-            name: "apikey"
-        },
-        copyrightInfo
+        authenticationCode: apikey
     });
 
     mapView.addDataSource(omvDataSource);

--- a/@here/harp-examples/src/getting-started_orbiting-view.ts
+++ b/@here/harp-examples/src/getting-started_orbiting-view.ts
@@ -6,9 +6,9 @@
 
 import { GeoCoordinates, mercatorProjection, sphereProjection } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 
 /**
  * In this example we simply use the `lookAt` method to make the camera orbit around a geolocation.
@@ -69,14 +69,7 @@ export namespace CameraOrbitExample {
 
         const omvDataSource = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            copyrightInfo
+            authenticationCode: apikey
         });
         mapView.addDataSource(omvDataSource);
 

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -7,8 +7,8 @@
 import { Theme } from "@here/harp-datasource-protocol";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, PickResult } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
-import { apikey, copyrightInfo } from "../config";
+import { OmvDataSource } from "@here/harp-omv-datasource";
+import { apikey } from "../config";
 
 /**
  * This example showcases how picking works.
@@ -221,15 +221,7 @@ export namespace PickingExample {
 
         const omvDataSource = new OmvDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-            apiFormat: APIFormat.XYZOMV,
-            styleSetName: "tilezen",
-            authenticationCode: apikey,
-            authenticationMethod: {
-                method: AuthenticationMethod.QueryString,
-                name: "apikey"
-            },
-            gatherFeatureAttributes: true,
-            copyrightInfo
+            authenticationCode: apikey
         });
 
         mapView.setDynamicProperty("selection", []);

--- a/@here/harp-examples/src/real-time-shadows.ts
+++ b/@here/harp-examples/src/real-time-shadows.ts
@@ -8,11 +8,11 @@ import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import { OmvDataSource } from "@here/harp-omv-datasource";
 import { GUI } from "dat.gui";
 import * as THREE from "three";
 import "three/examples/js/controls/TrackballControls";
-import { apikey, copyrightInfo } from "../config";
+import { apikey } from "../config";
 
 // tslint:disable-next-line:no-var-requires
 const SunCalc = require("suncalc");
@@ -252,14 +252,7 @@ function initializeMapView(id: string, theme: Theme): MapView {
 const addOmvDataSource = (): Promise<void> => {
     const omvDataSource = new OmvDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
-        apiFormat: APIFormat.XYZOMV,
-        styleSetName: "tilezen",
-        authenticationCode: apikey,
-        authenticationMethod: {
-            method: AuthenticationMethod.QueryString,
-            name: "apikey"
-        },
-        copyrightInfo
+        authenticationCode: apikey
     });
 
     return map.addDataSource(omvDataSource);

--- a/@here/harp-geojson-datasource/lib/GeoJsonDataSource.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonDataSource.ts
@@ -33,7 +33,7 @@ export class GeoJsonDataSource extends OmvDataSource {
      *
      * @param params Data source configuration's parameters.
      */
-    constructor(readonly params: OmvWithRestClientParams | OmvWithCustomDataProvider) {
+    constructor(params: OmvWithRestClientParams | OmvWithCustomDataProvider) {
         super({ styleSetName: "geojson", ...params });
     }
 }


### PR DESCRIPTION
This change introduces service specific default values for
vector-tile based data sources. The default service provider is
configured to `https://vector.hereapi.com/v2/vectortiles/base/mc`,
and the relevant options (e.g. tiling scheme, authetication method,
copyright info, ...) are initialized accordingly.

For most cases the following declaration is enough to get a working
vector tile data source.

```
const omvDataSource = new OmvDataSource({
    baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
    authenticationCode: apikey
});
```
