### PR TITLE
HARP-10627: Use csscolorparser to parse CSS color literals.

### DIFF
--- a/@here/harp-datasource-protocol/lib/RGBA.ts
+++ b/@here/harp-datasource-protocol/lib/RGBA.ts
@@ -6,7 +6,7 @@
 
 import { MathUtils } from "three";
 import { ColorUtils } from "./ColorUtils";
-import { StringEncodedColorFormats } from "./StringEncodedNumeral";
+import { parseStringEncodedColor } from "./StringEncodedNumeral";
 
 /**
  * A class representing RGBA colors.
@@ -21,14 +21,13 @@ export class RGBA {
      * @param text - The string color literal
      */
     static parse(text: string) {
-        const format = StringEncodedColorFormats.find(f => f.regExp.test(text));
-        if (format === undefined) {
+        const color = parseStringEncodedColor(text);
+
+        if (color === undefined) {
             return undefined;
         }
 
-        const components = [1, 1, 1, 1];
-        format.decoder(text, components);
-        return new RGBA(...components);
+        return ColorUtils.getRgbaFromHex(color);
     }
 
     /**

--- a/@here/harp-datasource-protocol/package.json
+++ b/@here/harp-datasource-protocol/package.json
@@ -26,7 +26,8 @@
     "dependencies": {
         "@here/harp-geometry": "^0.16.0",
         "@here/harp-geoutils": "^0.16.0",
-        "@here/harp-utils": "^0.16.0"
+        "@here/harp-utils": "^0.16.0",
+        "csscolorparser": "^1.0.3"
     },
     "devDependencies": {
         "@here/harp-test-utils": "^0.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2259,6 +2259,11 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
+csscolorparser@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz#b34f391eea4da8f3e98231e2ccd8df9c041f171b"
+  integrity sha1-s085HupNqPPpgjHizNjfnAQfFxs=
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"


### PR DESCRIPTION
This change replaces most of the code for parsing color string literals.
The new code is based on csscolorparser, as side effect harp.gl gets
support for CSS string literals (e.g. red, yellow, ...) and hsla
strings.

The hex literals are still parsed using an ad hoc regular expression
because csscolorparser doesn't support #rgba and #rrggbbaa hex
formats.
