### PR TITLE
Let all CI actions run through

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         node_version: [10, 12, 14]
         os: [ubuntu-latest,macOS-latest,windows-latest]
+      fail-fast: false
 
     steps:
     - name: Reset git settings (Windows)


### PR DESCRIPTION
Right now the windows CI actions is not stable and due to fail-fast, all other platforms were aborted.
Setting fail-fast to false for now to fix it.
