### PR TITLE
Mark as internal the global variables exported by datasource-protocol.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -21,6 +21,7 @@ export enum StringEncodedNumeralType {
 /**
  * Interface containing information about a [[StringEncodedNumeral]] format, component size and
  * evaluation.
+ * @internal
  */
 export interface StringEncodedNumeralFormat {
     readonly type: StringEncodedNumeralType;
@@ -86,6 +87,7 @@ const StringEncodedHex: StringEncodedNumeralFormat = {
 
 /**
  * Array of all supported [[StringEncodedNumeralFormat]]s describing sizes, lengths and distances.
+ * @internal
  */
 export const StringEncodedMetricFormats: StringEncodedNumeralFormat[] = [
     StringEncodedMeters,
@@ -99,6 +101,7 @@ const StringEncodedMetricFormatMaxSize = StringEncodedMetricFormats.reduce(
 
 /**
  * Array of all supported [[StringEncodedNumeralFormat]]s describing color data.
+ * @internal
  */
 export const StringEncodedColorFormats: StringEncodedNumeralFormat[] = [StringEncodedHex];
 
@@ -110,12 +113,16 @@ const StringEncodedColorFormatMaxSize = StringEncodedColorFormats.reduce(
 /**
  * Array of supported [[StringEncodedNumeralFormat]]s (intended to be indexed with
  * [[StringEncodedNumeralType]] enum).
+ * @internal
  */
 export const StringEncodedNumeralFormats: StringEncodedNumeralFormat[] = [
     ...StringEncodedMetricFormats,
     ...StringEncodedColorFormats
 ];
 
+/**
+ * @internal
+ */
 export const StringEncodedNumeralFormatMaxSize = Math.max(
     StringEncodedColorFormatMaxSize,
     StringEncodedMetricFormatMaxSize

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -100,6 +100,10 @@ export enum StandardGeometryKind {
  * disabled.
  */
 export type GeometryKind = string | StandardGeometryKind;
+
+/**
+ * @internal
+ */
 export const GeometryKind = StandardGeometryKind;
 
 /**

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -34,6 +34,7 @@ import {
 } from "./TechniqueDescriptor";
 /**
  * Names of the supported texture properties.
+ * @internal
  */
 export const TEXTURE_PROPERTY_KEYS = [
     "map",
@@ -48,6 +49,7 @@ export const TEXTURE_PROPERTY_KEYS = [
 
 /**
  * Names of the properties controlling transparency.
+ * @internal
  */
 export const TRANSPARENCY_PROPERTY_KEYS = ["opacity", "transparent"];
 
@@ -70,8 +72,10 @@ export type MakeTechniqueAttrs<T> = {
         : T[P];
 };
 
+/** @internal  */
 export const techniqueDescriptors: TechniqueDescriptorRegistry = {};
 
+/** @internal  */
 export const baseTechniqueParamsDescriptor: TechniqueDescriptor<BaseTechniqueParams> = {
     // TODO: Choose which techniques should support color with transparency.
     // For now we chosen all, but it maybe not suitable for text or line marker techniques.
@@ -86,6 +90,7 @@ export const baseTechniqueParamsDescriptor: TechniqueDescriptor<BaseTechniquePar
     }
 };
 
+/** @internal  */
 export const pointTechniquePropTypes = mergeTechniqueDescriptor<PointTechniqueParams>(
     baseTechniqueParamsDescriptor,
     {
@@ -107,6 +112,7 @@ export interface SquaresTechnique extends MakeTechniqueAttrs<PointTechniqueParam
     name: "squares";
 }
 
+/** @internal  */
 export const squaresTechniquePropTypes = mergeTechniqueDescriptor<SquaresTechnique>(
     baseTechniqueParamsDescriptor,
     pointTechniquePropTypes
@@ -121,6 +127,7 @@ export interface CirclesTechnique extends MakeTechniqueAttrs<PointTechniqueParam
     name: "circles";
 }
 
+/** @internal  */
 export const circlesTechniquePropTypes = mergeTechniqueDescriptor<CirclesTechnique>(
     baseTechniqueParamsDescriptor,
     pointTechniquePropTypes
@@ -257,6 +264,7 @@ export interface SolidLineTechnique extends MakeTechniqueAttrs<SolidLineTechniqu
     name: "solid-line" | "dashed-line";
 }
 
+/** @internal  */
 export const solidLineTechniqueDescriptor = mergeTechniqueDescriptor<SolidLineTechnique>(
     baseTechniqueParamsDescriptor,
     polygonalTechniqueDescriptor,
@@ -287,6 +295,7 @@ export interface LineTechnique extends MakeTechniqueAttrs<LineTechniqueParams> {
     name: "line";
 }
 
+/** @internal  */
 export const lineTechniqueDescriptor = mergeTechniqueDescriptor<LineTechnique>(
     baseTechniqueParamsDescriptor,
     {


### PR DESCRIPTION
These global variables are consider internal and should not appear
in the user documentation.

Signed-off-by: Roberto Raggi <roberto.raggi@here.com>
