### PR TITLE
Add missing documentation for expressions and environments.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Env.ts
+++ b/@here/harp-datasource-protocol/lib/Env.ts
@@ -5,23 +5,48 @@
  */
 
 /**
- * @hidden
+ * The type representing the value of a property.
  */
 export type Value = null | boolean | number | string | object;
 
 /**
- * @hidden
+ * An interface defining a collection of named properties.
+ *
+ * @example
+ * ```typescript
+ * const properties: ValueMap = {
+ *    $id: 123,
+ *    color: "rgba(255, 0, 0, 1)"
+ * }
+ * ```
  */
 export interface ValueMap {
     [name: string]: Value;
 }
 
 /**
- * @hidden
+ * A class used to lookup properties by name.
+ *
+ * @remarks
+ * Concrete implementation of `Env` like {@link MapEnv} are used
+ * to resolve the property names used in {@link Expr | style expressions}.
+ *
+ * @example
+ * ```typescript
+ * const env = new MapEnv({
+ *     kind: "landuse",
+ * });
+ *
+ * const expr = Expr.fromJson(["get", "kind"]);
+ *
+ * const value = expr.evaluate(env);
+ *
+ * console.log(`kind is '${value}`);
+ * ```
  */
 export class Env {
     /**
-     * Returns `true` if the given object is an instance of [[Env]].
+     * Returns `true` if the given object is an instance of {@link Env}.
      *
      * @param object - The object to test.
      */
@@ -30,11 +55,11 @@ export class Env {
     }
 
     /**
-     * Returns property in [[Env]] by name.
+     * Returns property in {@link Env} by name.
      *
      * @param name - Name of property.
      */
-    lookup(_name: string): Value | undefined {
+    lookup(name: string): Value | undefined {
         return undefined;
     }
     /**
@@ -46,14 +71,31 @@ export class Env {
 }
 
 /**
- * Adds access to map specific environment properties.
+ * `MapEnv` is a concrete implementation of {@link Env} that
+ * creates a lookup environment from a set of properties.
+ *
+ * @example
+ * ```typescript
+ * const baseEnv = new MapEnv({
+ *     $zoom: 14,
+ * });
+ *
+ * // extends baseEnv with a the new binding (kind, "landuse").
+ * const env = new MapEnv({ kind: "landuse" }, baseEnv);
+ *
+ * const zoom = env.lookup("$zoom"); // zoom is 14
+ * const kind = env.lookup("kind"); // kind is is "landuse"
+ *
+ * const expr = Expr.fromJson(["get", "kind"]);
+ * const value = expr.evaluate(env); // value is "landuse"
+ * ```
  */
 export class MapEnv extends Env {
     constructor(readonly entries: ValueMap, private readonly parent?: Env) {
         super();
     }
     /**
-     * Returns property in [[Env]] by name.
+     * Returns property in {@link Env} by name.
      *
      * @param name - Name of property.
      * @override

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -25,6 +25,9 @@ const exprEvaluator = new ExprEvaluator();
 
 const exprInstantiator = new ExprInstantiator();
 
+/**
+ * A visitor for {@link Expr} nodes.
+ */
 export interface ExprVisitor<Result, Context> {
     visitNullLiteralExpr(expr: NullLiteralExpr, context: Context): Result;
     visitBooleanLiteralExpr(expr: BooleanLiteralExpr, context: Context): Result;
@@ -41,11 +44,11 @@ export interface ExprVisitor<Result, Context> {
 }
 
 /**
- * The dependencies of an [[Expr]].
+ * The dependencies of an {@link Expr}.
  */
 export class ExprDependencies {
     /**
-     * The properties needed to evaluate the [[Expr]].
+     * The properties needed to evaluate the {@link Expr}.
      */
     readonly properties = new Set<string>();
 
@@ -64,9 +67,9 @@ class ComputeExprDependencies implements ExprVisitor<void, ExprDependencies> {
     static instance = new ComputeExprDependencies();
 
     /**
-     * Gets the dependencies of an [[Expr]].
+     * Gets the dependencies of an {@link Expr}.
      *
-     * @param expr - The [[Expr]] to process.
+     * @param expr - The {@link Expr} to process.
      * @param scope - The evaluation scope. Defaults to [[ExprScope.Value]].
      * @param dependencies - The output [[Set]] of dependency names.
      */
@@ -176,7 +179,7 @@ export interface JsonObject {
 }
 
 /**
- * The JSON representation of an [[Expr]] object.
+ * The JSON representation of an {@link Expr} object.
  */
 export type JsonExpr = JsonArray;
 
@@ -185,8 +188,7 @@ export function isJsonExpr(v: any): v is JsonExpr {
 }
 
 /**
- * Internal state needed by [[Expr.fromJSON]] to resolve `"ref"` expressions.
- * @hidden
+ * Internal state needed by {@link Expr.fromJSON} to resolve `"ref"` expressions.
  */
 interface ReferenceResolverState {
     definitions: Definitions;
@@ -195,31 +197,35 @@ interface ReferenceResolverState {
 }
 
 /**
- * The evaluation scope of an [[Expr]].
+ * The evaluation scope of an {@link Expr}.
  */
 export enum ExprScope {
     /**
-     * The scope of an [[Expr]] used as value of an attribute.
+     * The scope of an {@link Expr} used as value of an attribute.
      */
     Value,
 
     /**
-     * The scope of an [[Expr]] used in a [[Technique]] `when` condition.
+     * The scope of an {@link Expr} used in a [[Technique]] `when` condition.
      */
     Condition,
 
     /**
-     * The scope of an [[Expr]] used as dynamic property attribute value.
+     * The scope of an {@link Expr} used as dynamic property attribute value.
      */
     Dynamic
 }
 
+// tslint:disable:max-line-length
 /**
- * Abstract class defining a shape of a [[Theme]]'s expression
+ * Abstract class representing the
+ * {@link https://github.com/heremaps/harp.gl/blob/master/%40here/harp-datasource-protocol/StyleExpressions.md | style expressions}
+ * used in {@link Theme}.
  */
+// tslint:enable:max-line-length
 export abstract class Expr {
     /**
-     * Tests of given value is an [[Expr]].
+     * Tests of given value is an {@link Expr}.
      *
      * @param value - The object to test.
      */
@@ -231,7 +237,7 @@ export abstract class Expr {
      * Creates an expression from the given `code`.
      *
      * @param code - The code to parse.
-     * @returns The parsed [[Expr]].
+     * @returns The parsed {@link Expr}.
      * @deprecated `string` encoded expression are deprecated. Use {@link Expr.fromJSON} instead.
      */
     static parse(code: string): Expr | never {
@@ -240,20 +246,29 @@ export abstract class Expr {
         return expr;
     }
 
+    // tslint:disable:max-line-length
     /**
-     * Parse expression in JSON form.
+     * Creates a style expression from JSON.
      *
-     * If `definitions` are defined, then references (`['ref', name]`) are resolved.
+     * @remarks
+     * The optional set of {@link Theme.definitions | definitions} is used
+     * to resolve the {@link https://github.com/heremaps/harp.gl/blob/master/%40here/harp-datasource-protocol/StyleExpressions.md#ref | ref expressions}.
      *
-     * Pass `definitionExprCache` to reuse `Expr` instances created from definitions across
-     * many `fromJSON` calls.
+     * @param json - JSON object representing the expression to parse.
+     * @param definitions - Optional set of definitions used to expand references.
+     * @param definitionExprCache - Optional cache of `Expr` instances
      *
-     * @param node - expression in JSON format to parse
-     * @param definitions - optional set of definitions needed definition resolved by `ref` operator
-     * @param definitionExprCache - optional cache of `Expr` instances derived from `definitions`
+     * @example
+     * ```typescript
+     * const expr = Expr.fromJSON(["all",
+     *     ["==", ["geometry-type"], "LineString"],
+     *     ["has", "text"]
+     * ]);
+     * ```
      */
+    // tslint:enable:max-line-length
     static fromJSON(
-        node: JsonValue,
+        json: JsonValue,
         definitions?: Definitions,
         definitionExprCache?: Map<string, Expr>
     ) {
@@ -266,16 +281,16 @@ export abstract class Expr {
                   }
                 : undefined;
 
-        return parseNode(node, referenceResolverState);
+        return parseNode(json, referenceResolverState);
     }
 
     private m_dependencies?: ExprDependencies;
     private m_isDynamic?: boolean;
 
     /**
-     * Evaluate an expression returning a [[Value]] object.
+     * Evaluate an expression returning a {@link Value} object.
      *
-     * @param env - The [[Env]] used to lookup symbols.
+     * @param env - The {@link Env} used to lookup symbols.
      * @param scope - The evaluation scope. Defaults to [[ExprScope.Value]].
      * @param cache - A cache of previously computed results.
      */
@@ -291,8 +306,10 @@ export abstract class Expr {
     }
 
     /**
-     * Instantiates this [[Expr]] by resolving references to the `get` and
-     * `has` operator using the given instantiation context.
+     * Instantiates this {@link Expr}.
+     *
+     * @remarks
+     * references to the `get` and `has` operator using the given instantiation context.
      *
      * @param context - The [[InstantationContext]] used to resolve names.
      */
@@ -301,7 +318,7 @@ export abstract class Expr {
     }
 
     /**
-     * Gets the dependencies of this [[Expr]].
+     * Gets the dependencies of this {@link Expr}.
      */
     dependencies(): ExprDependencies {
         if (!this.m_dependencies) {
@@ -311,10 +328,10 @@ export abstract class Expr {
     }
 
     /**
-     * Create a unique object that is structurally equivalent to this [[Expr]].
+     * Create a unique object that is structurally equivalent to this {@link Expr}.
      *
      * @param pool - The [[ExprPool]] used to create a unique
-     * equivalent object of this [[Expr]].
+     * equivalent object of this {@link Expr}.
      */
     intern(pool: ExprPool): Expr {
         return pool.add(this);
@@ -325,7 +342,7 @@ export abstract class Expr {
     }
 
     /**
-     * Returns `true` if a dynamic execution context is required to evaluate this [[Expr]].
+     * Returns `true` if a dynamic execution context is required to evaluate this {@link Expr}.
      */
     isDynamic(): boolean {
         if (this.m_isDynamic === undefined) {
@@ -334,39 +351,43 @@ export abstract class Expr {
         return this.m_isDynamic;
     }
 
+    /**
+     * Visits this expression.
+     *
+     * @param visitor The visitor used to visit the expression.
+     * @param context The context passed to the vistor.
+     */
     abstract accept<Result, Context>(
         visitor: ExprVisitor<Result, Context>,
         context: Context
     ): Result;
 
     /**
-     * Update the dynamic state of this [[Expr]].
+     * Update the dynamic state of this {@link Expr}.
      *
-     * [[exprIsDynamic]] must never be called directly.
-     *
-     * @hidden
+     * `exprIsDynamic` must never be called directly.
+     * @internal
      */
     protected abstract exprIsDynamic(): boolean;
 }
 
 /**
- * @hidden
+ * @internal
  */
 export type RelationalOp = "<" | ">" | "<=" | ">=";
 
 /**
- * @hidden
+ * @internal
  */
 export type EqualityOp = "~=" | "^=" | "$=" | "==" | "!=";
 
 /**
- * @hidden
+ * @internal
  */
 export type BinaryOp = RelationalOp | EqualityOp;
 
 /**
- * Var expression.
- * @hidden
+ * A node representing a `get` expression.
  */
 export class VarExpr extends Expr {
     constructor(readonly name: string) {
@@ -384,6 +405,9 @@ export class VarExpr extends Expr {
     }
 }
 
+/**
+ * A node representing a `literal` expression.
+ */
 export abstract class LiteralExpr extends Expr {
     /**
      * Create a [[LiteralExpr]] from the given value.
@@ -415,7 +439,6 @@ export abstract class LiteralExpr extends Expr {
 
 /**
  * Null literal expression.
- * @hidden
  */
 export class NullLiteralExpr extends LiteralExpr {
     static instance = new NullLiteralExpr();
@@ -439,7 +462,6 @@ export class NullLiteralExpr extends LiteralExpr {
 
 /**
  * Boolean literal expression.
- * @hidden
  */
 export class BooleanLiteralExpr extends LiteralExpr {
     constructor(readonly value: boolean) {
@@ -454,7 +476,6 @@ export class BooleanLiteralExpr extends LiteralExpr {
 
 /**
  * Number literal expression.
- * @hidden
  */
 export class NumberLiteralExpr extends LiteralExpr {
     constructor(readonly value: number) {
@@ -469,7 +490,6 @@ export class NumberLiteralExpr extends LiteralExpr {
 
 /**
  * String literal expression.
- * @hidden
  */
 export class StringLiteralExpr extends LiteralExpr {
     private m_promotedValue?: RGBA | Pixels | null;
@@ -496,7 +516,6 @@ export class StringLiteralExpr extends LiteralExpr {
 
 /**
  * Object literal expression.
- * @hidden
  */
 export class ObjectLiteralExpr extends LiteralExpr {
     constructor(readonly value: object) {
@@ -514,8 +533,7 @@ export class ObjectLiteralExpr extends LiteralExpr {
 }
 
 /**
- * A has expression with an attribute, for example `has(ref)`.
- * @hidden
+ * A node reperesenting a `has` expression.
  */
 export class HasAttributeExpr extends Expr {
     constructor(readonly name: string) {
@@ -534,7 +552,7 @@ export class HasAttributeExpr extends Expr {
 }
 
 /**
- * @hidden
+ * A node representing a `call` expression.
  */
 export class CallExpr extends Expr {
     descriptor?: OperatorDescriptor;
@@ -544,7 +562,7 @@ export class CallExpr extends Expr {
     }
 
     /**
-     * Returns the child nodes of this [[Expr]].
+     * Returns the child nodes of this {@link Expr}.
      *
      * @deprecated Use {@link CallExpr.args} instead.
      */
@@ -570,12 +588,12 @@ export class CallExpr extends Expr {
 }
 
 /**
- * @hidden
+ * The labels of a {@link MatchExpr} expression.
  */
 export type MatchLabel = number | string | number[] | string[];
 
 /**
- * @hidden
+ * A node representing a `match` expression.
  */
 export class MatchExpr extends Expr {
     /**
@@ -626,7 +644,7 @@ export class MatchExpr extends Expr {
 }
 
 /**
- * @hidden
+ * A node representing a `case` expression.
  */
 export class CaseExpr extends Expr {
     constructor(readonly branches: Array<[Expr, Expr]>, readonly fallback: Expr) {
@@ -648,7 +666,7 @@ export class CaseExpr extends Expr {
 }
 
 /**
- * @hidden
+ * A node representing a `step` expression.
  */
 export class StepExpr extends Expr {
     constructor(
@@ -676,12 +694,11 @@ export class StepExpr extends Expr {
 
 /**
  * The type of the interpolation mode.
- * @hidden
  */
 export type InterpolateMode = ["discrete"] | ["linear"] | ["cubic"] | ["exponential", number];
 
 /**
- * @hidden
+ * A node representing an `interpolate` expression.
  */
 export class InterpolateExpr extends Expr {
     constructor(
@@ -704,7 +721,9 @@ export class InterpolateExpr extends Expr {
 }
 
 /**
- * @hidden
+ * Serializes the Expr to JSON.
+ *
+ * @internal
  */
 class ExprSerializer implements ExprVisitor<JsonValue, void> {
     serialize(expr: Expr): JsonValue {

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -224,7 +224,7 @@ export class ExprEvaluatorContext {
     /**
      * Evaluate the given expression.
      *
-     * @param expr - The [[Expr]] to evaluate.
+     * @param expr - The {@link Expr} to evaluate.
      */
     evaluate(expr: Expr | undefined) {
         if (expr === undefined) {
@@ -243,7 +243,7 @@ export class ExprEvaluatorContext {
     }
 
     /**
-     * Wraps the given value in an [[Expr]] if needed.
+     * Wraps the given value in an {@link Expr} if needed.
      *
      * @param value -
      */
@@ -253,7 +253,7 @@ export class ExprEvaluatorContext {
 }
 
 /**
- * [[ExprEvaluator]] is used to evaluate [[Expr]] in a given environment.
+ * [[ExprEvaluator]] is used to evaluate {@link Expr} in a given environment.
  *
  * @hidden
  */

--- a/@here/harp-datasource-protocol/lib/ExprInstantiator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprInstantiator.ts
@@ -28,7 +28,7 @@ import { Env } from "./Env";
 
 export interface InstantiationContext {
     /**
-     * The [[Env]] used to lookup for names.
+     * The {@link Env} used to lookup for names.
      */
     env: Env;
 

--- a/@here/harp-datasource-protocol/lib/ExprPool.ts
+++ b/@here/harp-datasource-protocol/lib/ExprPool.ts
@@ -24,7 +24,7 @@ import {
 import { Value } from "./Env";
 
 /**
- * [[ExprPool]] maintains a set of unique interned [[Expr]] objects.
+ * [[ExprPool]] maintains a set of unique interned {@link Expr} objects.
  *
  * @hidden
  */
@@ -43,11 +43,11 @@ export class ExprPool implements ExprVisitor<Expr, void> {
     private readonly m_callExprs = new Map<string, CallExpr[]>();
 
     /**
-     * Add `expr` to this [[ExprPool]] and return a unique [[Expr]]
+     * Add `expr` to this [[ExprPool]] and return a unique {@link Expr}
      * object that is structurally equivalent to `expr`.
      *
-     * @param expr - The [[Expr]] to add to this [[ExprPool]].
-     * @returns A unique [[Expr]] that is structurally equivalent to `expr`.
+     * @param expr - The {@link Expr} to add to this [[ExprPool]].
+     * @returns A unique {@link Expr} that is structurally equivalent to `expr`.
      */
     add(expr: Expr): Expr {
         return expr.accept(this, undefined);

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -8,6 +8,7 @@ import { JsonExpr } from "./Expr";
 
 /**
  * Interpolation mode used when computing a [[InterpolatedProperty]] value for a given zoom level.
+ * @internal
  */
 export enum InterpolationMode {
     Discrete,
@@ -26,6 +27,7 @@ export enum InterpolationMode {
  *  "zoomLevels": [13, 14, 15],
  *  "values": [ 1.5, 1.2, 0.9]
  * }
+ * @internal
  */
 export interface InterpolatedPropertyDefinition<T> {
     interpolation?: "Discrete" | "Linear" | "Cubic" | "Exponential";
@@ -37,6 +39,7 @@ export interface InterpolatedPropertyDefinition<T> {
 /**
  * Checks if a property is interpolated.
  * @param p - property to be checked
+ * @internal
  */
 export function isInterpolatedPropertyDefinition<T>(
     p: any

--- a/@here/harp-datasource-protocol/lib/PropertyValue.ts
+++ b/@here/harp-datasource-protocol/lib/PropertyValue.ts
@@ -17,7 +17,7 @@ const logger = LoggerManager.instance.create("PropertyValue");
  * Get the value of the specified property in given `env`.
  *
  * @param property - Property of a technique.
- * @param env - The [[Env]] used to evaluate the property
+ * @param env - The {@link Env} used to evaluate the property
  * @param cache - An optional expression cache.
  */
 export function getPropertyValue(

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -11,6 +11,7 @@ import { parseCSSColor } from "csscolorparser";
 
 /**
  * Enumeration of supported string encoded numerals.
+ * @internal
  */
 export enum StringEncodedNumeralType {
     Meters,

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -954,7 +954,7 @@ function resolveStyleReferences(
 /**
  * Create transferable representation of dynamic technique.
  *
- * Converts  non-transferable [[Expr]]instances back to JSON form.
+ * Converts  non-transferable {@link Expr}instances back to JSON form.
  */
 export function makeDecodedTechnique(technique: IndexedTechnique): IndexedTechnique {
     const result: Partial<IndexedTechnique> = {};

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -463,6 +463,7 @@ export enum PoiStackMode {
 /**
  * Defines options (tokens) supported for text placements defined via [[placements]] attribute.
  *
+ * @remarks
  * Possible values are defined as vertical placement letter and horizontal letter, where
  * one of the axis may be ignored and then assumed centered. Moving clock-wise, we have:
  * `TL` (top-left), `T` (top-center), `TR` (top-right), `R` (center-right), `BR` (bottom-right),

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -53,7 +53,7 @@ export const TEXTURE_PROPERTY_KEYS = [
  */
 export const TRANSPARENCY_PROPERTY_KEYS = ["opacity", "transparent"];
 
-// TODO: Can be removed, when all when interpolators are implemented as [[Expr]]s
+// TODO: Can be removed, when all when interpolators are implemented as {@link Expr}s
 export type RemoveInterpolatedPropDef<T> = T | InterpolatedPropertyDefinition<any> extends T
     ? Exclude<T, InterpolatedPropertyDefinition<any>>
     : T;

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -127,12 +127,12 @@ export interface Theme {
 
     /**
      * Optional list of symbolic priorities for the object
-     * created using this [[Theme]].
+     * created using this {@link Theme}.
      *
      * @remarks
      * The attribute `styleSet` and `category` of the [[Technique]]
      * are used together with [[Theme.priorities]] to sort
-     * the objects created using this [[Theme]], for example:
+     * the objects created using this {@link Theme}, for example:
      *
      * ```json
      * {
@@ -198,7 +198,7 @@ export interface StylePriority {
  * A type representing HARP themes with all the styleset declarations
  * grouped in one [[Array]].
  *
- * @internal This type will merge with [[Theme]].
+ * @internal This type will merge with {@link Theme}.
  */
 export type FlatTheme = Omit<Theme, "styles"> & {
     /**
@@ -856,7 +856,7 @@ export interface ImageTexture {
 }
 
 /**
- * Definition for a [[PoiTable]] reference as part of the [[Theme]] object.
+ * Definition for a [[PoiTable]] reference as part of the {@link Theme} object.
  */
 export interface PoiTableRef {
     /** Required name of the [[PoiTable]] for later reference. */

--- a/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
@@ -15,8 +15,10 @@ export interface OptionsMap {
 }
 
 /**
- * Allows to cancel and prioritize requests inside the requestQueue. Useful to optimize the order of
- * decoding tiles during animations and camera movements.
+ * Allows to cancel and prioritize requests inside the requestQueue.
+ *
+ * @remarks
+ * Useful to optimize the order of decoding tiles during animations and camera movements.
  *
  * `RequestController` is not extending [[AbortController]], because this is not supported in ES5.
  */

--- a/@here/harp-geoutils/lib/math/MathUtils.ts
+++ b/@here/harp-geoutils/lib/math/MathUtils.ts
@@ -13,7 +13,7 @@ export namespace MathUtils {
     /**
      * Creates a new empty bounding box.
      *
-     * @deprecated Uee {@link https://threejs.org/docs/#api/en/math/Box3 | THREE.Box3} instead.
+     * @deprecated Use {@link https://threejs.org/docs/#api/en/math/Box3 | THREE.Box3} instead.
      */
     export function newEmptyBox3(): Box3Like {
         return {


### PR DESCRIPTION
Add missing documentation for Expr and Env. Also, start to use reference
declaration using `@link` and hide some internal symbols.