### PR TITLE
Fix tsdoc links to MapView.lookAt.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -657,7 +657,7 @@ const MapViewDefaults = {
 };
 
 /**
- * Parameters for {@link MapView.lookAt}.
+ * Parameters for {@link (MapView.lookAt:WITH_PARAMS)}.
  */
 export interface LookAtParams {
     /**
@@ -668,9 +668,9 @@ export interface LookAtParams {
      *
      * As a consequence {@link MapView.target} and {@link MapView.zoomLevel}
      * will not match the values
-     * that were passed into the {@link MapView.lookAt} method.
+     * that were passed into the {@link (MapView.lookAt:WITH_PARAMS)} method.
      * @default `new GeoCoordinates(25, 0)` in {@link MapView.constructor} context.
-     * @default {@link MapView.target} in {@link MapView.lookAt} context.
+     * @default {@link MapView.target} in {@link (MapView.lookAt:WITH_PARAMS)} context.
      */
     target: GeoCoordLike;
 
@@ -695,7 +695,8 @@ export interface LookAtParams {
      * Note in sphere projection some points are not visible if you specify bounds that span more
      * than 180 degreess in any direction.
      *
-     * @see {@link MapView.lookAt} for defails how `bounds` interact with `target` parameter
+     * @see {@link (MapView.lookAt:WITH_PARAMS)} for defails how `bounds`
+     *      interact with `target` parameter
      */
     bounds: GeoBox | GeoBoxExtentLike | GeoCoordLike[];
 
@@ -709,14 +710,14 @@ export interface LookAtParams {
      * Zoomlevel of the MapView.
      * @note Takes precedence over distance.
      * @default 5 in {@link MapView.constructor} context.
-     * @default {@link MapView.zoomLevel} in {@link MapView.lookAt} context.
+     * @default {@link MapView.zoomLevel} in {@link (MapView.lookAt:WITH_PARAMS)} context.
      */
     zoomLevel: number;
 
     /**
      * Tilt angle in degrees. 0 is top down view.
      * @default 0 in {@link MapView.constructor} context.
-     * @default {@link MapView.tilt} in {@link MapView.lookAt} context.
+     * @default {@link MapView.tilt} in {@link (MapView.lookAt:WITH_PARAMS)} context.
      * @note Maximum supported tilt is 89°
      */
     tilt: number;
@@ -724,7 +725,7 @@ export interface LookAtParams {
     /**
      * Heading angle in degrees and clockwise. 0 is north-up.
      * @default 0 in {@link MapView.constructor} context.
-     * @default {@link MapView.heading} in {@link MapView.lookAt} context.
+     * @default {@link MapView.heading} in {@link (MapView.lookAt:WITH_PARAMS)} context.
      */
     heading: number;
 }
@@ -2150,6 +2151,8 @@ export class MapView extends THREE.EventDispatcher {
      * @see More examples in [[LookAtExample]].
      *
      * @param params - {@link LookAtParams}
+     *
+     * {@labels WITH_PARAMS}
      */
     lookAt(params: Partial<LookAtParams>): void;
     // tslint:enable: max-line-length
@@ -2207,7 +2210,7 @@ export class MapView extends THREE.EventDispatcher {
      * @param yawDeg - Camera yaw in degrees, counter-clockwise (as opposed to heading), starting
      * north.
      * @param pitchDeg - Camera pitch in degrees.
-     * @deprecated Use {@link MapView.lookAt} instead.
+     * @deprecated Use {@link (MapView.lookAt:WITH_PARAMS)} instead.
      */
     setCameraGeolocationAndZoom(
         geoPos: GeoCoordinates,

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -75,11 +75,11 @@ const cache = {
  * Rounds a given zoom level up to the nearest integer value if it's close enough.
  *
  * The zoom level set in {@link MapView} after a zoom level
- * target is given to {@link MapView.lookAt} or
+ * target is given to {@link (MapView.lookAt:WITH_PARAMS)} or
  * {@link @here/harp-map-controls#MapControls} never matches
  * exactly the target due to the precision loss caused by the
  * conversion from zoom level to camera distance (done in
- * {@link MapView.lookAt} and {@link @here/harp-map-controls#MapControls})
+ * {@link (MapView.lookAt:WITH_PARAMS)} and {@link @here/harp-map-controls#MapControls})
  * and from distance back to zoom level (done at every frame on camera update).
  * As a result, given a fixed integer zoom level input, the final zoom level computed at every frame
  * may fall sometimes below the integer value and others above. This causes flickering since each
@@ -561,7 +561,7 @@ export namespace MapViewUtils {
      *
      * @param worldTarget - readonly, world target of {@link MapView}
      * @param camera - readonly, camera with proper `position` and rotation set
-     * @returns new distance to camera to be used with {@link MapView.lookAt}
+     * @returns new distance to camera to be used with {@link (MapView.lookAt:WITH_PARAMS)}
      */
     export function getFitBoundsDistance(
         points: THREE.Vector3[],


### PR DESCRIPTION
Mark the main overload of `lookAt` with a @label directive and
explicit target this overload when using tsdoc `@link`s.
