### PR TITLE
HARP-10466: Traffic icons fade to white not transp

### DIFF
--- a/@here/harp-mapview/lib/poi/BoxBuffer.ts
+++ b/@here/harp-mapview/lib/poi/BoxBuffer.ts
@@ -270,9 +270,10 @@ export class BoxBuffer {
         const { s0, t0, s1, t1 } = uvBox;
         const { x, y, w, h } = screenBox;
 
-        const r = Math.round(color.r * 255);
-        const g = Math.round(color.g * 255);
-        const b = Math.round(color.b * 255);
+        // Premultiply alpha into vertex colors
+        const r = Math.round(color.r * opacity * 255);
+        const g = Math.round(color.g * opacity * 255);
+        const b = Math.round(color.b * opacity * 255);
         const a = Math.round(opacity * 255);
 
         const positionAttribute = this.positionAttribute!;

--- a/@here/harp-materials/lib/IconMaterial.ts
+++ b/@here/harp-materials/lib/IconMaterial.ts
@@ -76,8 +76,7 @@ export class IconMaterial extends THREE.RawShaderMaterial {
             transparent: true,
 
             vertexColors: true,
-            premultipliedAlpha: true,
-            blending: THREE.NormalBlending
+            premultipliedAlpha: true
         };
         super(shaderParams);
     }


### PR DESCRIPTION
* premultiplied textures now render properly,
  where they were blending to white before

Signed-off-by: StefanDachwitz <stefan.dachwitz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
