### PR TITLE
Fix ae-internal-mixed-release-tag error.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -101,9 +101,6 @@ export enum StandardGeometryKind {
  */
 export type GeometryKind = string | StandardGeometryKind;
 
-/**
- * @internal
- */
 export const GeometryKind = StandardGeometryKind;
 
 /**


### PR DESCRIPTION
All the declarations of `GeometryKind` must have the same
module visibility.
