### PR TITLE
Remove verbose log messages.

### DIFF
--- a/@here/harp-test-utils/lib/rendering/DomImageUtils.ts
+++ b/@here/harp-test-utils/lib/rendering/DomImageUtils.ts
@@ -87,7 +87,6 @@ export function loadImageData(url: string): Promise<ImageData> {
         new THREE.ImageLoader().load(
             url,
             image => {
-                logger.info(`#loadImageData loaded: ${url}, size=${image.width},${image.height}`);
                 const canvas = document.createElement("canvas");
                 canvas.width = image.width;
                 canvas.height = image.height;

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultReporter.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultReporter.ts
@@ -24,8 +24,6 @@ export class RenderingTestResultReporter {
         _referenceImage?: ImageData, // server already has reference image
         comparisonResult?: ImageComparisonResult
     ) {
-        logger.log("reporting test result", imageProps);
-
         const url = `${this.backendUrl}/ibct-feedback`;
         const payload: ImageTestResultRequest = {
             imageProps,


### PR DESCRIPTION
When testing harp.gl the console is full of diagnostic messages
coming from DomImageUtils and RenderingTestResultReporter. These
messages are too many and they make it difficult to spot other
error messages.
