### PR TITLE
HARP-10979: Discard the point geometries outside the tile bounds.

### DIFF
--- a/@here/harp-omv-datasource/lib/DecodeInfo.ts
+++ b/@here/harp-omv-datasource/lib/DecodeInfo.ts
@@ -53,6 +53,16 @@ export class DecodeInfo {
     readonly tileSizeOnScreen: number;
 
     /**
+     * The maximum number of columns.
+     */
+    readonly columnCount: number;
+
+    /**
+     * The maximum number of rows.
+     */
+    readonly rowCount: number;
+
+    /**
      * Constructs a new [[DecodeInfo]].
      *
      * @param adapterId - The id of the [[OmvDataAdapter]] used for decoding.
@@ -72,6 +82,14 @@ export class DecodeInfo {
         this.tilingScheme.getWorldBox(tileKey, this.tileBounds);
         this.tileBounds.getSize(this.tileSize);
         this.tileSizeOnScreen = 256 * Math.pow(2, -this.storageLevelOffset);
+
+        this.columnCount = webMercatorTilingScheme.subdivisionScheme.getLevelDimensionX(
+            this.tileKey.level
+        );
+
+        this.rowCount = webMercatorTilingScheme.subdivisionScheme.getLevelDimensionY(
+            this.tileKey.level
+        );
     }
 
     /**


### PR DESCRIPTION
Geometries with tile space coordinates outside the [0...extent]
range should be discarded at decoding time.
This is needed to avoid possible glitches when rendering
semi-transparent points.
