### PR TITLE
Mark the geometries created for the selection with transient

### DIFF
--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -137,32 +137,30 @@ export namespace PickingExample {
             styles: {
                 tilezen: [
                     {
+                        transient: true,
                         layer: "roads",
                         when: ["==", ["geometry-type"], "LineString"],
                         technique: "solid-line",
                         renderOrder: Number.MAX_SAFE_INTEGER,
-                        attr: {
-                            enabled: [
-                                "in",
-                                ["get", "name"],
-                                ["get", "selection", ["dynamic-properties"]]
-                            ],
-                            lineWidth: "2px"
-                        }
+                        enabled: [
+                            "in",
+                            ["get", "name"],
+                            ["get", "selection", ["dynamic-properties"]]
+                        ],
+                        lineWidth: "2px"
                     },
                     {
+                        transient: true,
                         layer: "landuse",
                         when: ["==", ["geometry-type"], "Polygon"],
                         technique: "solid-line",
                         renderOrder: Number.MAX_SAFE_INTEGER,
-                        attr: {
-                            enabled: [
-                                "in",
-                                ["get", "name"],
-                                ["get", "selection", ["dynamic-properties"]]
-                            ],
-                            lineWidth: "2px"
-                        }
+                        enabled: [
+                            "in",
+                            ["get", "name"],
+                            ["get", "selection", ["dynamic-properties"]]
+                        ],
+                        lineWidth: "2px"
                     }
                 ]
             }


### PR DESCRIPTION
This change ensures that the objects created to visualize
the road and landuse selection are marked as trasient. This is
required to discard these geoemtries when picking objects in
the scene.
