### PR TITLE
HARP-10876: Fix usage of dynamic color expressions in extruded buildings

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptor.ts
@@ -52,7 +52,7 @@ export type TechniquePropScopes<T> = {
     [P in TechniquePropNames<T>]?: AttrScope;
 };
 
-export interface TechniqueDescriptor<T> {
+export interface TechniqueDescriptor<T = Technique> {
     attrTransparencyColor?: string;
     attrScopes: TechniquePropScopes<T>;
 }


### PR DESCRIPTION
This change ensures that the correct dynamic attribute scope is
selected for extruded-polygon techniques when vertexColors is not
set.
