### PR TITLE
Add the `coverage` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 doc/
+coverage/
 test-npm-packages-app/
 .vscode/
 .DS_Store


### PR DESCRIPTION
This change adds the missing `coverage` directory to the gitignore config file.
