### PR TITLE
HARP-10753: Use @remarks tsdoc tags.

### DIFF
--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -27,6 +27,7 @@ export interface ClipPlanesEvaluator {
     /**
      * Compute near and far clipping planes distance.
      *
+     * @remarks
      * Evaluation method should be called on every frame  and camera clip planes updated.
      * This is related to evaluator implementation and its input data, that may suddenly change
      * such as camera position or angle, projection type or so.
@@ -50,6 +51,7 @@ export interface ClipPlanesEvaluator {
 /**
  * Simplest camera clip planes evaluator, interpolates near/far planes based on ground distance.
  *
+ * @remarks
  * At general ground distance to camera along the surface normal is used as reference point for
  * planes evaluation, where near plane distance is set as fraction of this distance refereed as
  * [[nearMultiplier]]. Far plane equation has its own multiplier - [[nearFarMultiplier]],
@@ -154,6 +156,7 @@ export class InterpolatedClipPlanesEvaluator implements ClipPlanesEvaluator {
 /**
  * Abstract evaluator class that adds support for elevation constraints.
  *
+ * @remarks
  * Classes derived from this should implement algorithms that takes into account rendered
  * features height (elevations), such as ground plane is no more flat (or spherical), but
  * contains geometry that should be overlapped by frustum planes.
@@ -177,6 +180,7 @@ export abstract class ElevationBasedClipPlanesEvaluator implements ClipPlanesEva
     /**
      * Set maximum elevation above sea level to be rendered.
      *
+     * @remarks
      * @param elevation - the elevation (altitude) value in world units (meters).
      * @note If you set this exactly to the maximum rendered feature height (altitude above
      * the sea, you may notice some flickering or even polygons disappearing related to rounding
@@ -203,6 +207,7 @@ export abstract class ElevationBasedClipPlanesEvaluator implements ClipPlanesEva
     /**
      * Set minimum elevation to be rendered, values beneath the sea level are negative.
      *
+     * @remarks
      * @param elevation - the minimum elevation (depression) in world units (meters).
      * @note If you set this parameter to zero you may not see any features rendered if they are
      * just below the sea level more than half of [[nearFarMargin]] assumed. Similarly if set to
@@ -232,6 +237,7 @@ export abstract class ElevationBasedClipPlanesEvaluator implements ClipPlanesEva
 /**
  * Top view, clip planes evaluator that computes view ranges based on ground distance and elevation.
  *
+ * @remarks
  * This evaluator supports both planar and spherical projections, although it behavior is
  * slightly different in each case. General algorithm sets near plane and far plane close
  * to ground level, but taking into account maximum and minimum elevation of features on the ground.
@@ -259,6 +265,8 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
     /**
      * Allows to setup near/far offsets (margins), rendered geometry elevation relative to sea
      * level as also minimum near plane and maximum far plane distance constraints.
+     *
+     * @remarks
      * It is strongly recommended to set some reasonable [[nearFarMargin]] (offset) between near
      * and far planes to avoid flickering.
      * @param maxElevation - defines near plane offset from the ground in the surface normal
@@ -453,6 +461,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
     /**
      * Calculate distance from a point to the tangent point of a sphere.
      *
+     * @remarks
      * Returns zero if point is below surface or only very slightly above surface of sphere.
      * @param d - Distance from point to center of sphere
      * @param r - Radius of sphere
@@ -472,6 +481,7 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
     /**
      * Calculate far plane depending on furthest visible distance from camera position.
      *
+     * @remarks
      * Furthest visible distance is assumed to be distance from camera to horizon
      * plus distance from elevated geometry to horizon(so that high objects behind horizon
      * remain visible).
@@ -640,12 +650,15 @@ export class TopViewClipPlanesEvaluator extends ElevationBasedClipPlanesEvaluato
 /**
  * Evaluates camera clipping planes taking into account ground distance and camera angles.
  *
+ * @remarks
  * This evaluator provides support for camera with varying tilt (pitch) angle, the angle
  * between camera __look at__ vector and the ground surface normal.
  */
 export class TiltViewClipPlanesEvaluator extends TopViewClipPlanesEvaluator {
     /**
      * Calculate the lengths of frustum planes intersection with the ground plane.
+     *
+     * @remarks
      * This evaluates distances between eye vector (or eye plane in orthographic projection) and
      * ground intersections of top and bottom frustum planes.
      * @note This method assumes the world surface (ground) to be flat and
@@ -1054,5 +1067,6 @@ export class FixedClipPlanesEvaluator implements ClipPlanesEvaluator {
  * on ground distance and camera orientation.
  *
  * Creates {@link TiltViewClipPlanesEvaluator}.
+ * @internal
  */
 export const createDefaultClipPlanesEvaluator = () => new TiltViewClipPlanesEvaluator();

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -88,6 +88,8 @@ export interface MaterialOptions {
  *                               e.g. after texture loading.
  *
  * @returns new material instance that matches `technique.name`
+ *
+ * @internal
  */
 export function createMaterial(
     options: MaterialOptions,
@@ -234,6 +236,7 @@ export function createMaterial(
  * {@link @here/harp-datasource-protocol#BufferAttribute} object.
  *
  * @param attribute - BufferAttribute a WebGL compliant buffer
+ * @internal
  */
 export function getBufferAttribute(attribute: BufferAttribute): THREE.BufferAttribute {
     switch (attribute.type) {
@@ -287,6 +290,7 @@ export function getBufferAttribute(attribute: BufferAttribute): THREE.BufferAttr
  * Determines if a technique uses THREE.Object3D instances.
  * @param technique - The technique to check.
  * @returns true if technique uses THREE.Object3D, false otherwise.
+ * @internal
  */
 export function usesObject3D(technique: Technique): boolean {
     const name = technique.name;
@@ -307,6 +311,8 @@ export function usesObject3D(technique: Technique): boolean {
  * @param material - The object's material.
  * @param tile - The tile where the object is located.
  * @param elevationEnabled - True if elevation is enabled, false otherwise.
+ *
+ * @internal
  */
 export function buildObject(
     technique: Technique,
@@ -376,21 +382,25 @@ export function buildObject(
 }
 
 /**
- * Non material properties of [[BaseTechnique]]
+ * Non material properties of `BaseTechnique`.
+ * @internal
  */
 export const BASE_TECHNIQUE_NON_MATERIAL_PROPS = ["name", "id", "renderOrder", "transient"];
 
 /**
  * Generic material type constructor.
+ * @internal
  */
 export type MaterialConstructor = new (params?: {}) => THREE.Material;
 
 /**
- * Returns a [[MaterialConstructor]] basing on provided technique object.
+ * Returns a `MaterialConstructor` basing on provided technique object.
  *
- * @param technique - [[Technique]] object which the material will be based on.
+ * @param technique - `Technique` object which the material will be based on.
  * @param shadowsEnabled - Whether the material can accept shadows, this is required for some
- * techniques to decide which material to create.
+ *                         techniques to decide which material to create.
+ *
+ * @internal
  */
 export function getMaterialConstructor(
     technique: Technique,
@@ -550,6 +560,7 @@ function getMainMaterialStyledProps(technique: Technique): StyledProperties {
 /**
  * Convert metric style property to expression that accounts {@link MapView.pixelToWorld} if
  * `metricUnit === 'Pixel'`.
+ * @internal
  */
 export function buildMetricValueEvaluator(
     value: Expr | Value | undefined,
@@ -580,15 +591,18 @@ export function buildMetricValueEvaluator(
 /**
  * Allows to easy parse/encode technique's base color property value as number coded color.
  *
+ * @remarks
  * Function takes care about property parsing, interpolation and encoding if neccessary.
  *
  * @see ColorUtils
  * @param technique - the technique where we search for base (transparency) color value
  * @param env - {@link @here/harp-datasource-protocol#Env} instance
  *              used to evaluate {@link @here/harp-datasource-protocol#Expr}
- *              based properties of [[Technique]]
- * @returns [[number]] encoded color value (in custom #TTRRGGBB) format or `undefined` if
+ *              based properties of `Technique`
+ * @returns `number` encoded color value (in custom #TTRRGGBB) format or `undefined` if
  * base color property is not defined in the technique passed.
+ *
+ * @internal
  */
 export function evaluateBaseColorProperty(technique: Technique, env: Env): number | undefined {
     const baseColorProp = getBaseColorProp(technique);
@@ -599,10 +613,12 @@ export function evaluateBaseColorProperty(technique: Technique, env: Env): numbe
 }
 
 /**
- * Apply [[ShaderTechnique]] parameters to material.
+ * Apply `ShaderTechnique` parameters to material.
  *
- * @param technique - the [[ShaderTechnique]] which requires special handling
+ * @param technique - the `ShaderTechnique` which requires special handling
  * @param material - material to which technique will be applied
+ *
+ * @internal
  */
 function applyShaderTechniqueToMaterial(technique: ShaderTechnique, material: THREE.Material) {
     if (technique.transparent) {
@@ -683,6 +699,7 @@ function applyTechniquePropertyToMaterial(
 /**
  * Apply technique color to material taking special care with transparent (RGBA) colors.
  *
+ * @remarks
  * @note This function is intended to be used with secondary, triary etc. technique colors,
  * not the base ones that may contain transparency information. Such colors should be processed
  * with [[applyTechniqueBaseColorToMaterial]] function.
@@ -693,7 +710,9 @@ function applyTechniquePropertyToMaterial(
  * @param value - color value
  * @param env - {@link @here/harp-datasource-protocol#Env} instance used
  *              to evaluate {@link @here/harp-datasource-protocol#Expr}
- *              based properties of [[Technique]]
+ *              based properties of `Technique`.
+ *
+ * @internal
  */
 export function applySecondaryColorToMaterial(
     materialColor: THREE.Color,
@@ -717,6 +736,7 @@ export function applySecondaryColorToMaterial(
 /**
  * Apply technique base color (transparency support) to material with modifying material opacity.
  *
+ * @remarks
  * This method applies main (or base) technique color with transparency support to the corresponding
  * material color, with an effect on entire [[THREE.Material]] __opacity__ and __transparent__
  * attributes.
@@ -731,6 +751,8 @@ export function applySecondaryColorToMaterial(
  * @param value - color value in custom number format
  * @param env - {@link @here/harp-datasource-protocol#Env} instance used to evaluate
  *              {@link @here/harp-datasource-protocol#Expr} based properties of [[Technique]]
+ *
+ * @internal
  */
 export function applyBaseColorToMaterial(
     material: THREE.Material,
@@ -786,6 +808,7 @@ function evaluateProperty(value: any, env?: Env): any {
 /**
  * Calculates the numerical value of the technique defined color property.
  *
+ * @remarks
  * Function takes care about color interpolation (when @param `env is set) as also parsing
  * string encoded colors.
  *
@@ -793,6 +816,7 @@ function evaluateProperty(value: any, env?: Env): any {
  * @param value - the value of color property defined in technique
  * @param env - {@link @here/harp-datasource-protocol#Env} instance used to evaluate
  *              {@link @here/harp-datasource-protocol#Expr} based properties of [[Technique]]
+ * @internal
  */
 export function evaluateColorProperty(value: Value, env?: Env): number | undefined {
     value = evaluateProperty(value, env);

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -14,6 +14,7 @@ import { evaluateBaseColorProperty } from "./DecodedTileHelpers";
 /**
  * Bitmask used for the depth pre-pass to prevent multiple fragments in the same screen position
  * from rendering color.
+ * @internal
  */
 export const DEPTH_PRE_PASS_STENCIL_MASK = 0x01;
 
@@ -25,13 +26,16 @@ const DEPTH_PRE_PASS_RENDER_ORDER_OFFSET = 1e-6;
 /**
  * Check if technique requires (and not disables) use of depth prepass.
  *
+ * @remarks
  * Depth prepass is enabled if correct opacity is specified (in range `(0,1)`) _and_ not explicitly
  * disabled by `enableDepthPrePass` option.
  *
- * @param technique - [[BaseStandardTechnique]] instance to be checked
+ * @param technique - `BaseStandardTechnique` instance to be checked
  * @param env - {@link @here/harp-datasource-protocol#Env} instance used
  *              to evaluate {@link @here/harp-datasource-protocol#Expr}
- *              based properties of [[Technique]]
+ *              based properties of `Technique`
+ *
+ * @internal
  */
 export function isRenderDepthPrePassEnabled(technique: ExtrudedPolygonTechnique, env: Env) {
     // Depth pass explicitly disabled
@@ -68,12 +72,15 @@ export interface DepthPrePassProperties {
 /**
  * Creates material for depth prepass.
  *
+ * @remarks
  * Creates material that writes only to the z-buffer. Updates the original material instance, to
  * support depth prepass.
  *
  * @param baseMaterial - The base material of mesh that is updated to work with depth prepass
  *     and then used. This parameter is a template for depth prepass material that is returned.
  * @returns depth prepass material, which is a clone of `baseMaterial` with the adapted settings.
+ *
+ * @internal
  */
 export function createDepthPrePassMaterial(baseMaterial: THREE.Material): THREE.Material {
     baseMaterial.depthWrite = false;
@@ -94,7 +101,10 @@ export function createDepthPrePassMaterial(baseMaterial: THREE.Material): THREE.
 
 // tslint:disable:max-line-length
 /**
- * Clones a given mesh to render it in the depth prepass with another material. Both the original
+ * Clones a given mesh to render it in the depth prepass with another material.
+ *
+ * @remarks
+ * Both the original
  * and depth prepass meshes, when rendered in the correct order, create the proper depth prepass
  * effect. The original mesh material is slightly modified by [[createDepthPrePassMaterial]] to
  * support the depth prepass. This method is usable only if the material of this mesh has an
@@ -105,6 +115,8 @@ export function createDepthPrePassMaterial(baseMaterial: THREE.Material): THREE.
  *
  * @param mesh - original mesh
  * @returns `Mesh` depth pre pass
+ *
+ * @internal
  */
 // tslint:enable:max-line-length
 export function createDepthPrePassMesh(mesh: THREE.Mesh): THREE.Mesh {
@@ -156,11 +168,13 @@ export function createDepthPrePassMesh(mesh: THREE.Mesh): THREE.Mesh {
 /**
  * Sets up all the needed stencil logic needed for the depth pre-pass.
  *
+ * @remarks
  * This logic is in place to avoid z-fighting artifacts that can appear in geometries that have
  * coplanar triangles inside the same mesh.
  *
  * @param depthMesh - Mesh created by `createDepthPrePassMesh`.
  * @param colorMesh - Original mesh.
+ * @internal
  */
 export function setDepthPrePassStencil(depthMesh: THREE.Mesh, colorMesh: THREE.Mesh) {
     // Set up depth mesh stencil logic.

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -150,7 +150,12 @@ const DEFAULT_CAM_NEAR_PLANE = 0.1;
 const DEFAULT_CAM_FAR_PLANE = 4000000;
 const MAX_FIELD_OF_VIEW = 140;
 const MIN_FIELD_OF_VIEW = 10;
-// All objects in fallback tiles are reduced by this amount.
+
+/**
+ * All objects in fallback tiles are reduced by this amount.
+ *
+ * @internal
+ */
 export const FALLBACK_RENDER_ORDER_OFFSET = 20000;
 
 const DEFAULT_MIN_ZOOM_LEVEL = 1;
@@ -1245,6 +1250,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Disposes this `MapView`.
      *
+     * @remarks
      * This function cleans the resources that are managed manually including those that exist in
      * shared caches.
      *
@@ -1642,7 +1648,9 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * The THREE.js camera used by this `MapView` to render the main scene.
-     * @note When modifying the camera all derived properties like:
+     *
+     * @remarks
+     * When modifying the camera all derived properties like:
      * - {@link MapView.target}
      * - {@link MapView.zoomLevel}
      * - {@link MapView.tilt}
@@ -1744,8 +1752,10 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Get geo coordinates of camera focus (target) point.
+     *
+     * @remarks
      * This point is not necessarily on the ground, i.e.:
-     *  - if the tilt is high and projection is [[sphereProjection]]
+     *  - if the tilt is high and projection is {@link @here/harp-geoutils#sphereProjection}`
      *  - if the camera was modified directly and is not pointing to the ground.
      * In any case the projection of the target point will be in the center of the screen.
      *
@@ -1758,6 +1768,7 @@ export class MapView extends THREE.EventDispatcher {
     /** @internal
      * Get world coordinates of camera focus point.
      *
+     * @remarks
      * @note The focus point coordinates are updated with each camera update so you don't need
      * to re-calculate it, although if the camera started looking to the void, the last focus
      * point is stored.
@@ -1783,6 +1794,8 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Get object describing frustum planes distances and min/max visibility range for actual
      * camera setup.
+     *
+     * @remarks
      * Near and far plane distance are self explanatory while minimum and maximum visibility range
      * describes the extreme near/far planes distances that may be achieved with current camera
      * settings, meaning at current zoom level (ground distance) and any possible orientation.
@@ -1806,6 +1819,8 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * The position in geo coordinates of the center of the scene.
+     *
+     * @remarks
      * Longitude values outside of -180 and +180 are acceptable.
      */
     set geoCenter(geoCenter: GeoCoordinates) {
@@ -1825,7 +1840,9 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * The node in this MapView's scene containing the user [[MapAnchor]]s.
+     * The node in this MapView's scene containing the user {@link MapAnchor}s.
+     *
+     * @remarks
      * All (first level) children of this node will be positioned in world space according to the
      * [[MapAnchor.geoPosition]].
      * Deeper level children can be used to position custom objects relative to the anchor node.
@@ -1916,7 +1933,10 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Sets or clears the view's maximum bounds in geo coordinates. If set, the view will be
+     * Sets or clears the view's maximum bounds in geo coordinates.
+     *
+     * @remarks
+     * If set, the view will be
      * constrained to the given geo bounds.
      */
     set geoMaxBounds(bounds: GeoBox | undefined) {
@@ -1985,6 +2005,7 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Returns the storage level for the given camera setup.
+     * @remarks
      * Actual storage level of the rendered data also depends
      * on {@link DataSource.storageLevelOffset}.
      */
@@ -2022,9 +2043,11 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Set's the way in which the fov is calculated on the map view. Note, for
-     * this to take visual effect, the map should be rendered after calling this
-     * function.
+     * Set's the way in which the fov is calculated on the map view.
+     *
+     * @remarks
+     * Note, for this to take visual effect, the map should be rendered
+     * after calling this function.
      * @param fovCalculation - How the FOV is calculated.
      */
     setFovCalculation(fovCalculation: FovCalculation) {
@@ -2061,9 +2084,9 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Adds a new {@link DataSource} to this `MapView`.
-     * `MapView` needs at least one {@link DataSource} to
-     * display something.
      *
+     * @remarks
+     * `MapView` needs at least one {@link DataSource} to display something.
      * @param dataSource - The data source.
      */
     addDataSource(dataSource: DataSource): Promise<void> {
@@ -2187,6 +2210,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Adjusts the camera to look at a given geo coordinate with tilt and heading angles.
      *
+     * @remarks
      * #### Note on `target` and `bounds`
      *
      * If `bounds` are specified, `zoomLevel` and `distance` parameters are ignored and `lookAt`
@@ -2214,7 +2238,7 @@ export class MapView extends THREE.EventDispatcher {
      *
      * #### Examples
      *
-     * ```
+     * ```typescript
      * mapView.lookAt({heading: 90})
      *     // look east retaining current `target`, `zoomLevel` and `tilt`
      *
@@ -2238,6 +2262,7 @@ export class MapView extends THREE.EventDispatcher {
      * The method that sets the camera to the desired angle (`tiltDeg`) and `distance` (in meters)
      * to the `target` location, from a certain heading (`headingAngle`).
      *
+     * @remarks
      * @param target - The location to look at.
      * @param distance - The distance of the camera to the target in meters.
      * @param tiltDeg - The camera tilt angle in degrees (0 is vertical), curbed below 89deg
@@ -2276,7 +2301,10 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Moves the camera to the specified {@link @here/harp-geoutils#GeoCoordinates},
      * sets the desired `zoomLevel` and
-     * adjusts the yaw and pitch. The pitch of the camera is
+     * adjusts the yaw and pitch.
+     *
+     * @remarks
+     * The pitch of the camera is
      * always curbed so that the camera cannot
      * look above the horizon. This paradigm is necessary
      * in {@link @here/harp-map-controls#MapControls}, where the center of
@@ -2314,6 +2342,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Updates the value of a dynamic property.
      *
+     * @remarks
      * Property names starting with a `$`-sign are reserved and any attempt to change their value
      * will result in an error.
      *
@@ -2336,6 +2365,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Removes the given dynamic property from this {@link MapView}.
      *
+     * @remarks
      * Property names starting with a `$`-sign are reserved and any attempt to change their value
      * will result in an error.
      *
@@ -2448,6 +2478,7 @@ export class MapView extends THREE.EventDispatcher {
      * PixelRatio in the WebGlRenderer. May contain values > 1.0 for high resolution screens
      * (HiDPI).
      *
+     * @remarks
      * A value of `undefined` will make the getter return `window.devicePixelRatio`, setting a value
      * of `1.0` will disable the use of HiDPI on all devices.
      *
@@ -2465,7 +2496,10 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Maximum FPS (Frames Per Second). If VSync in enabled, the specified number may not be
+     * Maximum FPS (Frames Per Second).
+     *
+     * @remarks
+     * If VSync in enabled, the specified number may not be
      * reached, but instead the next smaller number than `maxFps` that is equal to the refresh rate
      * divided by an integer number.
      *
@@ -2484,9 +2518,11 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * PixelRatio ratio for rendering when the camera is moving or an animation is running. Useful
-     * when rendering on high resolution displays with low performance GPUs that may be
-     * fill-rate-limited.
+     * PixelRatio ratio for rendering when the camera is moving or an animation is running.
+     *
+     * @remarks
+     * Useful when rendering on high resolution displays with low performance GPUs
+     * that may be fill-rate-limited.
      *
      * If a value is specified, a low resolution render pass is used to render the scene into a
      * low resolution render target, before it is copied to the screen.
@@ -2545,9 +2581,11 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Returns the world space position from the given screen position. The return value can be
-     * `null`, in case the camera is facing the horizon and the given `(x, y)` value is not
-     * intersecting the ground plane.
+     * Returns the world space position from the given screen position.
+     *
+     * @remarks
+     * The return value can be `null`, in case the camera is facing the horizon
+     * and the given `(x, y)` value is not intersecting the ground plane.
      *
      * @param x - The X position in css/client coordinates (without applied display ratio).
      * @param y - The Y position in css/client coordinates (without applied display ratio).
@@ -2561,7 +2599,10 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Returns the {@link @here/harp-geoutils#GeoCoordinates} from the
-     * given screen position. The return value can be
+     * given screen position.
+     *
+     * @remarks
+     * The return value can be
      * `null`, in case the camera is facing the horizon and
      * the given `(x, y)` value is not
      * intersecting the ground plane.
@@ -2591,8 +2632,11 @@ export class MapView extends THREE.EventDispatcher {
     }
 
     /**
-     * Do a raycast on all objects in the scene. Useful for picking. Limited to objects that
-     * THREE.js can raycast, the solid lines that get their geometry in the shader cannot be tested
+     * Do a raycast on all objects in the scene. Useful for picking.
+     *
+     * @remarks
+     * Limited to objects that THREE.js can raycast, the solid lines
+     * that get their geometry in the shader cannot be tested
      * for intersection.
      *
      * Note, if a {@link DataSource} adds an [[Object3D]]
@@ -2647,6 +2691,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Redraws scene immediately
      *
+     * @remarks
      * @note Before using this method, set `synchronousRendering` to `true`
      * in the {@link MapViewOptions}
      *
@@ -2696,6 +2741,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Clear the tile cache.
      *
+     * @remarks
      * Remove the {@link Tile} objects created by cacheable
      * {@link DataSource}s. If a {@link DataSource} name is
      * provided, this method restricts the eviction the {@link DataSource} with the given name.
@@ -2746,6 +2792,7 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Visit each tile in visible, rendered, and cached sets.
      *
+     * @remarks
      *  * Visible and temporarily rendered tiles will be marked for update and retained.
      *  * Cached but not rendered/visible will be evicted.
      *
@@ -2758,8 +2805,10 @@ export class MapView extends THREE.EventDispatcher {
 
     /**
      * Sets the DataSource which contains the elevations, the elevation range source, and the
-     * elevation provider. Only a single elevation source is possible per {@link MapView}
+     * elevation provider.
      *
+     * @remarks
+     * Only a single elevation source is possible per {@link MapView}.
      * If the terrain-datasource is merged with this repository, we could internally construct
      * the {@link ElevationRangeSource} and the {@link ElevationProvider}
      * and access would be granted to
@@ -3084,6 +3133,8 @@ export class MapView extends THREE.EventDispatcher {
     /**
      * Updates the camera and the projections and resets the screen collisions,
      * note, setupCamera must be called before this is called.
+     *
+     * @remarks
      * @param viewRanges - optional parameter that supplies new view ranges, most importantly
      * near/far clipping planes distance. If parameter is not provided view ranges will be
      * calculated from [[ClipPlaneEvaluator]] used in {@link VisibleTileSet}.

--- a/@here/harp-mapview/lib/MapViewPoints.ts
+++ b/@here/harp-mapview/lib/MapViewPoints.ts
@@ -8,9 +8,11 @@ import * as THREE from "three";
 import { PickingRaycaster } from "./PickingRaycaster";
 
 /**
- * `MapViewPoints` is a class to extend for the `"circles"` and `"squares"` [[Technique]]s to
- * implement raycasting of [[THREE.Points]] as expected in
- * {@link MapView}, that are in screen space.
+ * `MapViewPoints` is a class to extend for the `"circles"` and `"squares"` techniques to
+ * implement raycasting of `THREE.Points` as expected in {@link MapView},
+ * that are in screen space.
+ *
+ * @remarks
  * It copies the behaviour of the `raycast` method in [[THREE.Points]] and dispatches it to its
  * children classes, {@link Circles} and {@link Squares}, who hold the intersection testing in the
  * `testPoint` method. This class also has the ability to dismiss the testing via the
@@ -19,6 +21,8 @@ import { PickingRaycaster } from "./PickingRaycaster";
  * Its main motivation is to handle the point styles of XYZ projects.
  *
  * @see https://github.com/mrdoob/three.js/blob/master/src/objects/Points.js
+ *
+ * @internal
  */
 export abstract class MapViewPoints extends THREE.Points {
     /**
@@ -166,6 +170,7 @@ function getPointInfo(
 
 /**
  * Point object that implements the raycasting of circles in screen space.
+ * @internal
  */
 export class Circles extends MapViewPoints {
     /** @override */
@@ -195,6 +200,7 @@ export class Circles extends MapViewPoints {
 
 /**
  * Point object that implements the raycasting of squares in screen space.
+ * @internal
  */
 export class Squares extends MapViewPoints {
     /** @override */

--- a/@here/harp-mapview/lib/Statistics.ts
+++ b/@here/harp-mapview/lib/Statistics.ts
@@ -174,8 +174,12 @@ export namespace RingBuffer {
 }
 
 /**
- * An interface for a Timer class, that abstracts the basic functions of a Timer. Implemented
- * by SimpleTimer, SampledTimer, and MultiStageTimer.
+ * An interface for a Timer class, that abstracts the basic functions of a Timer.
+ *
+ * @remarks
+ * Implemented by SimpleTimer, SampledTimer, and MultiStageTimer.
+ *
+ * @internal
  */
 export interface Timer {
     readonly name: string;
@@ -215,6 +219,8 @@ export interface Timer {
 
 /**
  * A simple timer that stores only the latest measurement.
+ *
+ * @internal
  */
 export class SimpleTimer implements Timer {
     /** `true` if timer has been started. */
@@ -302,6 +308,8 @@ export class SimpleTimer implements Timer {
 
 /**
  * Simple statistics about the values in an array.
+ *
+ * @internal
  */
 export interface Stats {
     /**
@@ -362,6 +370,8 @@ export interface Stats {
 
 /**
  * A timer that stores the last `n` samples in a ring buffer.
+ *
+ * @internal
  */
 export class SampledTimer extends SimpleTimer {
     /**
@@ -428,11 +438,14 @@ export class SampledTimer extends SimpleTimer {
  * Only exported for testing
  * @ignore
  *
+ * @remarks
  * Compute the [[ArrayStats]] for the passed in array of numbers.
  *
  * @param {number[]} samples Array containing sampled values. Will be modified (!) by sorting the
  *      entries.
  * @returns {(Stats | undefined)}
+ *
+ * @internal
  */
 export function computeArrayStats(samples: number[]): Stats | undefined {
     if (samples.length === 0) {
@@ -504,10 +517,13 @@ export function computeArrayStats(samples: number[]): Stats | undefined {
  * Only exported for testing
  * @ignore
  *
+ * @remarks
  * Compute the averages for the passed in array of numbers.
  *
  * @param {number[]} samples Array containing sampled values.
  * @returns {(Stats | undefined)}
+ *
+ * @internal
  */
 export function computeArrayAverage(samples: number[]): number | undefined {
     if (samples.length === 0) {
@@ -527,11 +543,15 @@ export function computeArrayAverage(samples: number[]): number | undefined {
 
 /**
  * Measures a sequence of connected events, such as multiple processing stages in a function.
+ *
+ * @remarks
  * Each stage is identified with a timer name, that must be a valid timer in the statistics
  * object. Additionally, all timers within a `MultiStageTimer` must be unique.
  *
  * Internally, the `MultiStageTimer` manages a list of timers where at the end of each stage,
  * one timer stops and the next timer starts.
+ *
+ * @internal
  */
 export class MultiStageTimer {
     private currentStage: string | undefined;
@@ -629,8 +649,13 @@ export class MultiStageTimer {
 }
 
 /**
- * Manages a set of timers. The main objective of `Statistics` is to log these timers. You can
+ * Manages a set of timers.
+ *
+ * @remarks
+ * The main objective of `Statistics` is to log these timers. You can
  * disable statistics to minimize their impact on performance.
+ *
+ * @internal
  */
 export class Statistics {
     private readonly timers: Map<string, Timer>;
@@ -758,6 +783,8 @@ export class Statistics {
 
 /**
  * Class containing all counters, timers and events of the current frame.
+ *
+ * @internal
  */
 export class FrameStats {
     readonly entries: Map<string, number> = new Map();
@@ -824,6 +851,7 @@ export class FrameStats {
  * @ignore
  * Only exported for testing.
  *
+ * @remarks
  * Instead of passing around an array of objects, we store the frame statistics as an object of
  * arrays. This allows convenient computations from {@link RingBuffer},
  */
@@ -908,6 +936,9 @@ interface ChromeMemoryInfo {
     jsHeapSizeLimit: number;
 }
 
+/**
+ * @internal
+ */
 export interface SimpleFrameStatistics {
     configs: Map<string, string>;
     appResults: Map<string, number>;
@@ -919,11 +950,14 @@ export interface SimpleFrameStatistics {
 }
 
 /**
- * Performance measurement central. Maintains the current
- * {@link FrameStats}, which holds all individual
- * performance numbers.
+ * Performance measurement central.
  *
- * Implemented as an instance for easy access.
+ * @remarks
+ * Maintains the current. Implemented as an instance for easy access.
+ *
+ * {@link FrameStats}, which holds all individual performance numbers.
+ *
+ * @internal
  */
 export class PerformanceStatistics {
     /**

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -35,6 +35,9 @@ import { SkyCubemapFaceId, SKY_CUBEMAP_FACE_COUNT } from "./SkyCubemapTexture";
 
 import "@here/harp-fetch";
 
+/**
+ * @internal
+ */
 export const DEFAULT_MAX_THEME_INTHERITANCE_DEPTH = 4;
 
 /**

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -77,6 +77,8 @@ const MINIMUM_OBJECT_SIZE_ESTIMATION = 100;
 
 /**
  * Compute the memory footprint of `TileFeatureData`.
+ *
+ * @internal
  */
 export function getFeatureDataSize(featureData: TileFeatureData): number {
     let numBytes = MINIMUM_OBJECT_SIZE_ESTIMATION;
@@ -93,7 +95,7 @@ export function getFeatureDataSize(featureData: TileFeatureData): number {
 }
 
 /**
- * Missing Typedoc
+ * The state the {@link ITileLoader}.
  */
 export enum TileLoaderState {
     Initialized,
@@ -105,6 +107,9 @@ export enum TileLoaderState {
     Failed
 }
 
+/**
+ * The interface for managing tile loading.
+ */
 export interface ITileLoader {
     state: TileLoaderState;
     payload?: ArrayBufferLike | {};
@@ -153,7 +158,10 @@ export interface TileResourceUsage {
 }
 
 /**
- * Simple information about resource usage by the {@link Tile}. Heap and GPU information are
+ * Simple information about resource usage by the {@link Tile}.
+ *
+ * @remarks
+ * Heap and GPU information are
  * estimations.
  */
 export interface TileResourceInfo {
@@ -180,6 +188,9 @@ export interface TileResourceInfo {
     numUserTextElements: number;
 }
 
+/**
+ * @internal
+ */
 export interface TextElementIndex {
     groupIndex: number;
     elementIndex: number;
@@ -379,6 +390,8 @@ export class Tile implements CachedResource {
 
     /**
      * Whether the data of this tile is in local tangent space or not.
+     *
+     * @remarks
      * If the data is in local tangent space (i.e. up vector is (0,0,1) for high zoomlevels) then
      * {@link MapView} will rotate the objects before rendering using the rotation matrix of the
      * oriented [[boundingBox]].
@@ -406,8 +419,10 @@ export class Tile implements CachedResource {
 
     /**
      * Gets the key to uniquely represent this tile (based on
-     * the {@link tileKey} and {@link offset}), note
-     * this key is only unique within the given {@link DataSource},
+     * the {@link tileKey} and {@link offset}).
+     *
+     * @remarks
+     * This key is only unique within the given {@link DataSource},
      * to get a key which is unique across
      * {@link DataSource}s see [[DataSourceCache.getKeyForTile]].
      */
@@ -436,7 +451,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Compute {@link TileResourceInfo} of this `Tile`. May be using a cached value. The method
+     * Compute {@link TileResourceInfo} of this `Tile`.
+     *
+     * @remarks
+     * May be using a cached value. The method
      * `invalidateResourceInfo` can be called beforehand to force a recalculation.
      *
      * @returns `TileResourceInfo` for this `Tile`.
@@ -449,7 +467,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Force invalidation of the cached {@link TileResourceInfo}. Useful after the `Tile` has been
+     * Force invalidation of the cached {@link TileResourceInfo}.
+     *
+     * @remarks
+     * Useful after the `Tile` has been
      * modified.
      */
     invalidateResourceInfo(): void {
@@ -457,8 +478,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Add ownership of a texture to this tile. The texture will be disposed if the `Tile` is
-     * disposed.
+     * Add ownership of a texture to this tile.
+     *
+     * @remarks
+     * The texture will be disposed if the `Tile` is disposed.
      * @param texture - Texture to be owned by the `Tile`
      */
     addOwnedTexture(texture: THREE.Texture): void {
@@ -469,8 +492,10 @@ export class Tile implements CachedResource {
      * @internal
      * @deprecated User text elements are deprecated.
      *
-     * Gets the list of developer-defined {@link TextElement} in this `Tile`. This list is always
-     * rendered first.
+     * Gets the list of developer-defined {@link TextElement} in this `Tile`.
+     *
+     * @remarks
+     * This list is always rendered first.
      */
     get userTextElements(): TextElementGroup {
         let group = this.m_textElementGroups.groups.get(TextElement.HIGHEST_PRIORITY);
@@ -500,7 +525,7 @@ export class Tile implements CachedResource {
     /**
      * Removes a developer-defined {@link TextElement} from this `Tile`.
      *
-     * @deprecated use [[removeTextElement]].
+     * @deprecated use `removeTextElement`.
      *
      * @param textElement - A developer-defined TextElement to remove.
      * @returns `true` if the element has been removed successfully; `false` otherwise.
@@ -512,8 +537,10 @@ export class Tile implements CachedResource {
 
     /**
      * Adds a {@link TextElement} to this `Tile`, which is added to the visible set of
-     * {@link TextElement}s based on the capacity and visibility. The {@link TextElement}'s priority
-     * controls if or when it becomes visible.
+     * {@link TextElement}s based on the capacity and visibility.
+     *
+     * @remarks
+     * The {@link TextElement}'s priority controls if or when it becomes visible.
      *
      * To ensure that a TextElement is visible, use a high value for its priority, such as
      * `TextElement.HIGHEST_PRIORITY`. Since the number of visible TextElements is limited by the
@@ -534,7 +561,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Adds a [[PathBlockingElement]] to this `Tile`. This path has the highest priority and blocks
+     * Adds a `PathBlockingElement` to this `Tile`.
+     *
+     * @remarks
+     * This path has the highest priority and blocks
      * all other labels. There maybe in future a use case to give it a priority, but as that isn't
      * yet required, it is left to be implemented later if required.
      * @param blockingElement - Element which should block all other labels.
@@ -571,7 +601,7 @@ export class Tile implements CachedResource {
     /**
      * @internal
      *
-     * Gets the current [[GroupedPriorityList]] which
+     * Gets the current `GroupedPriorityList` which
      * contains a list of all {@link TextElement}s to be
      * selected and placed for rendering.
      */
@@ -581,8 +611,10 @@ export class Tile implements CachedResource {
 
     /**
      * Gets the current modification state for the list
-     * of {@link TextElement}s in the `Tile`. If the
-     * value is `true` the TextElement is placed for
+     * of {@link TextElement}s in the `Tile`.
+     *
+     * @remarks
+     * If the value is `true` the `TextElement` is placed for
      * rendering during the next frame.
      */
     get textElementsChanged(): boolean {
@@ -610,9 +642,10 @@ export class Tile implements CachedResource {
     /**
      * Called before {@link MapView} starts rendering this `Tile`.
      *
+     * @remarks
      * @param zoomLevel - The current zoom level.
      * @returns Returns `true` if this `Tile` should be rendered. Influenced directly by the
-     * [[skipRendering]] property unless specifically overriden in deriving classes.
+     *      `skipRendering` property unless specifically overriden in deriving classes.
      */
     willRender(_zoomLevel: number): boolean {
         return !this.skipRendering && !this.delayRendering;
@@ -684,6 +717,8 @@ export class Tile implements CachedResource {
 
     /**
      * Applies the decoded tile to the tile.
+     *
+     * @remarks
      * If the geometry is empty, then the tile's forceHasGeometry flag is set.
      * Map is updated.
      * @param decodedTile - The decoded tile to set.
@@ -904,6 +939,7 @@ export class Tile implements CachedResource {
     /**
      * Frees the rendering resources allocated by this `Tile`.
      *
+     * @remarks
      * The default implementation of this method frees the geometries and the materials for all the
      * reachable objects.
      * Textures are freed if they are owned by this `Tile` (i.e. if they where created by this
@@ -980,8 +1016,10 @@ export class Tile implements CachedResource {
     }
 
     /**
-     * Adds a callback that will be called whenever the tile is disposed. Multiple callbacks may be
-     * added.
+     * Adds a callback that will be called whenever the tile is disposed.
+     *
+     * @remarks
+     * Multiple callbacks may be added.
      * @internal
      * @param callback - The callback to be called when the tile is disposed.
      */
@@ -1015,7 +1053,8 @@ export class Tile implements CachedResource {
 
     /**
      * Computes the offset in the x world coordinates corresponding to this tile, based on
-     * its [[offset]].
+     * its {@link offset}.
+     *
      * @returns The x offset.
      */
     computeWorldOffsetX(): number {
@@ -1043,8 +1082,8 @@ export class Tile implements CachedResource {
 
     /**
      * Updates the tile's world bounding box.
-     * @param [newBoundingBox] The new bounding box to set. If undefined, the bounding box will be
-     * computed by projecting the tile's geoBox.
+     * @param newBoundingBox - The new bounding box to set. If undefined, the bounding box will be
+     *                         computed by projecting the tile's geoBox.
      */
     private updateBoundingBox(newBoundingBox?: OrientedBox3) {
         if (newBoundingBox) {

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -310,6 +310,7 @@ export namespace MapViewUtils {
     /**
      * Returns the height of the camera above the earths surface.
      *
+     * @remarks
      * If there is an ElevationProvider, this is used. Otherwise the projection is used to determine
      * how high the camera is above the surface.
      *
@@ -334,7 +335,10 @@ export namespace MapViewUtils {
     }
 
     /**
-     * Constrains given camera target and distance to {@link MapView.maxBounds}. The resulting
+     * Constrains given camera target and distance to {@link MapView.maxBounds}.
+     *
+     * @remarks
+     * The resulting
      * target and distance will keep the view within the maximum bounds for a camera with tilt and
      * yaw set to 0.
      * @param target - The camera target.
@@ -528,6 +532,7 @@ export namespace MapViewUtils {
      *
      * Add offset to geo points for minimal view box in flat projection with tile wrapping.
      *
+     * @remarks
      * In flat projection, with wrap around enabled, we should detect clusters of points around that
      * wrap antimeridian.
      *
@@ -584,6 +589,7 @@ export namespace MapViewUtils {
      * Given `cameraPos`, force all points that lie on non-visible sphere half to be "near" max
      * possible viewable circle from given camera position.
      *
+     * @remarks
      * Assumes that shpere projection with world center is in `(0, 0, 0)`.
      */
     export function wrapWorldPointsToView(points: THREE.Vector3[], cameraPos: THREE.Vector3) {
@@ -604,8 +610,8 @@ export namespace MapViewUtils {
      * @hidden
      * @internal
      *
-     * Return [[GeoPoints]] bounding {@link @here/harp-geoutils#GeoBox}
-     * applicable for [[getFitBoundsDistance]].
+     * Return `GeoPoints` bounding {@link @here/harp-geoutils#GeoBox}
+     * applicable for {@link getFitBoundsDistance}.
      *
      * @returns {@link @here/harp-geoutils#GeoCoordinates} set that covers `box`
      */

--- a/@here/harp-mapview/lib/geometry/TileGeometry.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometry.ts
@@ -58,6 +58,7 @@ export interface ILineAccessor {
  * Helper function to check if an accessor is of type `ILineAccessor`.
  *
  * @param arg - `true` if `arg` is `ILineAccessor`.
+ * @internal
  */
 export function isLineAccessor(arg: any): arg is ILineAccessor {
     /**
@@ -107,6 +108,7 @@ export interface IObject3dAccessor {
  * Helper function to check if an accessor is of type `IObject3dAccessor`.
  *
  * @param arg - `true` if `arg` is `IObject3dAccessor`.
+ * @internal
  */
 export function isObject3dAccessor(arg: any): arg is IObject3dAccessor {
     return typeof arg.isObject3dAccessor === "function" && arg.isObject3dAccessor() === true;

--- a/@here/harp-mapview/lib/image/ImageCache.ts
+++ b/@here/harp-mapview/lib/image/ImageCache.ts
@@ -49,8 +49,11 @@ class ImageCacheItem {
 }
 
 /**
- * `ImageCache` is a singleton, so it can be used with multiple MapViews on a single page. This
- * allows to have an image loaded only once for multiple views. THREE is doing something similar,
+ * `ImageCache` is a singleton, so it can be used with multiple MapViews on a single page.
+ *
+ * @remarks
+ * This allows to have an image loaded only once for multiple views.
+ * THREE is doing something similar,
  * but does not allow to share images that have been loaded from a canvas (which we may need to do
  * if we use SVG images for textures).
  *
@@ -71,8 +74,10 @@ export class ImageCache {
     }
 
     /**
-     * Dispose the singleton object. Not normally implemented for singletons, but good for
-     * debugging.
+     * Dispose the singleton object.
+     *
+     * @remarks
+     * Not normally implemented for singletons, but good for debugging.
      */
     static dispose(): void {
         ImageCache.m_instance = undefined;
@@ -156,7 +161,10 @@ export class ImageCache {
     }
 
     /**
-     * Clear all {@link ImageItem}s belonging to a {@link MapView}. May remove cached items if no
+     * Clear all {@link ImageItem}s belonging to a {@link MapView}.
+     *
+     * @remarks
+     * May remove cached items if no
      * {@link MapView} are registered anymore.
      *
      * @param mapView - MapView to remove all {@link ImageItem}s from.
@@ -194,8 +202,10 @@ export class ImageCache {
     }
 
     /**
-     * Load an {@link ImageItem}. If the loading process is already running, it returns the current
-     * promise.
+     * Load an {@link ImageItem}.
+     *
+     * @remarks
+     * If the loading process is already running, it returns the current promise.
      *
      * @param imageItem - `ImageItem` containing the URL to load image from.
      * @returns An {@link ImageItem} if the image has already been loaded, a promise otherwise.
@@ -254,10 +264,10 @@ export class ImageCache {
 
     /**
      * Render the `ImageItem` by using `createImageBitmap()` or by rendering the image into a
-     * [[HTMLCanvasElement]].
+     * `HTMLCanvasElement`.
      *
      * @param imageItem - {@link ImageItem} to assign image data to.
-     * @param image - [[HTMLImageElement]] to
+     * @param image - `HTMLImageElement`
      */
     private renderImage(
         imageItem: ImageItem,

--- a/@here/harp-mapview/lib/poi/PoiTableManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiTableManager.ts
@@ -114,7 +114,10 @@ class PoiTableEntry implements PoiTableEntryDef {
 }
 
 /**
- * The `PoiTable` stores individual information for each POI type. If a {@link TextElement} has a
+ * The `PoiTable` stores individual information for each POI type.
+ *
+ * @remarks
+ * If a {@link TextElement} has a
  * reference to a PoiTable (if TextElement.poiInfo.poiTableName is set), information for the
  * TextElement and its icon are read from the PoiTable.
  *

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -191,6 +191,7 @@ export interface PoiInfo {
  * Return 'true' if the POI has been successfully prepared for rendering.
  *
  * @param poiInfo - PoiInfo containing information for rendering the POI icon.
+ * @internal
  */
 export function poiIsRenderable(poiInfo: PoiInfo): boolean {
     return poiInfo.poiRenderBatch !== undefined;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -85,6 +85,7 @@ enum Pass {
 /**
  * Default distance scale. Will be applied if distanceScale is not defined in the technique.
  * Defines the scale that will be applied to labeled icons (icon and text) in the distance.
+ * @internal
  */
 export const DEFAULT_TEXT_DISTANCE_SCALE = 0.5;
 


### PR DESCRIPTION
Also fix the visibility of some of the internal symbols that
don't have documentation and break the docs layout.
