### PR TITLE
MINOR: Look-at zoomLevel/distance applies together with bounds

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -3036,6 +3036,19 @@ export class MapView extends THREE.EventDispatcher {
     private lookAtImpl(params: Partial<LookAtParams>): void {
         const tilt = Math.min(getOptionValue(params.tilt, this.tilt), MapViewUtils.MAX_TILT_DEG);
         const heading = getOptionValue(params.heading, this.heading);
+        const distance =
+            params.zoomLevel !== undefined
+                ? MapViewUtils.calculateDistanceFromZoomLevel(
+                      this,
+                      THREE.MathUtils.clamp(
+                          params.zoomLevel,
+                          this.m_minZoomLevel,
+                          this.m_maxZoomLevel
+                      )
+                  )
+                : params.distance !== undefined
+                ? params.distance
+                : this.m_targetDistance;
 
         let target: GeoCoordinates | undefined;
         if (params.bounds !== undefined) {
@@ -3077,6 +3090,16 @@ export class MapView extends THREE.EventDispatcher {
             } else {
                 this.projection.projectPoint(target, worldTarget);
             }
+
+            if (params.zoomLevel !== undefined || params.distance !== undefined) {
+                return this.lookAtImpl({
+                    tilt,
+                    heading,
+                    distance,
+                    target
+                })
+            }
+
             return this.lookAtImpl(
                 MapViewUtils.getFitBoundsLookAtParams(target, worldTarget, worldPoints, {
                     tilt,
@@ -3093,19 +3116,6 @@ export class MapView extends THREE.EventDispatcher {
         target =
             params.target !== undefined ? GeoCoordinates.fromObject(params.target) : this.target;
 
-        const distance =
-            params.zoomLevel !== undefined
-                ? MapViewUtils.calculateDistanceFromZoomLevel(
-                      this,
-                      THREE.MathUtils.clamp(
-                          params.zoomLevel,
-                          this.m_minZoomLevel,
-                          this.m_maxZoomLevel
-                      )
-                  )
-                : params.distance !== undefined
-                ? params.distance
-                : this.m_targetDistance;
 
         // MapViewUtils#setRotation uses pitch, not tilt, which is different in sphere projection.
         // But in sphere, in the tangent space of the target of the camera, pitch = tilt. So, put

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -3097,7 +3097,7 @@ export class MapView extends THREE.EventDispatcher {
                     heading,
                     distance,
                     target
-                })
+                });
             }
 
             return this.lookAtImpl(
@@ -3115,7 +3115,6 @@ export class MapView extends THREE.EventDispatcher {
         }
         target =
             params.target !== undefined ? GeoCoordinates.fromObject(params.target) : this.target;
-
 
         // MapViewUtils#setRotation uses pitch, not tilt, which is different in sphere projection.
         // But in sphere, in the tangent space of the target of the camera, pitch = tilt. So, put

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -149,7 +149,7 @@ describe("MapView", function() {
             epsilon: 1e-13
         }
     ]) {
-        describe.only(`camera positioning - ${projectionName} projection`, function() {
+        describe(`camera positioning - ${projectionName} projection`, function() {
             for (const { testName, lookAtParams } of [
                 {
                     testName: "berlin/18 topView",

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -24,7 +24,8 @@ import {
     GeoCoordinates,
     mercatorProjection,
     sphereProjection,
-    webMercatorTilingScheme
+    webMercatorTilingScheme,
+    GeoBox
 } from "@here/harp-geoutils";
 import * as TestUtils from "@here/harp-test-utils/lib/WebGLStub";
 import { MapView, MapViewEventNames } from "../lib/MapView";
@@ -148,7 +149,7 @@ describe("MapView", function() {
             epsilon: 1e-13
         }
     ]) {
-        describe(`camera positioning - ${projectionName} projection`, function() {
+        describe.only(`camera positioning - ${projectionName} projection`, function() {
             for (const { testName, lookAtParams } of [
                 {
                     testName: "berlin/18 topView",
@@ -196,6 +197,46 @@ describe("MapView", function() {
                         zoom: 5,
                         tilt: 30,
                         heading: -160
+                    }
+                },
+                {
+                    testName: "berlin bounds only",
+                    lookAtParams: {
+                        bounds: new GeoBox(
+                            new GeoCoordinates(52.438917, 13.275001),
+                            new GeoCoordinates(52.590844, 13.522331)
+                        )
+                    }
+                },
+                {
+                    testName: "berlin bounds + zoomLevel",
+                    lookAtParams: {
+                        bounds: new GeoBox(
+                            new GeoCoordinates(52.438917, 13.275001),
+                            new GeoCoordinates(52.590844, 13.522331)
+                        ),
+                        zoomLevel: 10
+                    }
+                },
+                {
+                    testName: "berlin bounds + distance",
+                    lookAtParams: {
+                        bounds: new GeoBox(
+                            new GeoCoordinates(52.438917, 13.275001),
+                            new GeoCoordinates(52.590844, 13.522331)
+                        ),
+                        distance: 38200
+                    }
+                },
+                {
+                    testName: "berlin bounds + distance + angles",
+                    lookAtParams: {
+                        bounds: new GeoBox(
+                            new GeoCoordinates(52.438917, 13.275001),
+                            new GeoCoordinates(52.590844, 13.522331)
+                        ),
+                        tilt: 45,
+                        heading: 45
                     }
                 }
             ]) {
@@ -252,6 +293,18 @@ describe("MapView", function() {
                     }
                     if (lookAtParams.heading !== undefined) {
                         expect(mapView.heading).to.be.closeTo(lookAtParams.heading, epsilon);
+                    }
+                    if (lookAtParams.bounds !== undefined) {
+                        expect(mapView.target.latitude).to.be.closeTo(lookAtParams.bounds.center.latitude, epsilon);
+                        expect(mapView.target.longitude).to.be.closeTo(lookAtParams.bounds.center.longitude, epsilon);
+
+                        if (lookAtParams.zoomLevel) {
+                            expect(mapView.zoomLevel).to.be.closeTo(lookAtParams.zoomLevel, epsilon);
+                        }
+
+                        if (lookAtParams.distance) {
+                            expect(mapView.targetDistance).to.be.closeTo(lookAtParams.distance, 1e-8);
+                        }
                     }
                 });
             }

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -21,11 +21,11 @@ import * as nodeUrl from "url";
 const URL = typeof window !== "undefined" ? window.URL : nodeUrl.URL;
 
 import {
+    GeoBox,
     GeoCoordinates,
     mercatorProjection,
     sphereProjection,
-    webMercatorTilingScheme,
-    GeoBox
+    webMercatorTilingScheme
 } from "@here/harp-geoutils";
 import * as TestUtils from "@here/harp-test-utils/lib/WebGLStub";
 import { MapView, MapViewEventNames } from "../lib/MapView";
@@ -295,15 +295,27 @@ describe("MapView", function() {
                         expect(mapView.heading).to.be.closeTo(lookAtParams.heading, epsilon);
                     }
                     if (lookAtParams.bounds !== undefined) {
-                        expect(mapView.target.latitude).to.be.closeTo(lookAtParams.bounds.center.latitude, epsilon);
-                        expect(mapView.target.longitude).to.be.closeTo(lookAtParams.bounds.center.longitude, epsilon);
+                        expect(mapView.target.latitude).to.be.closeTo(
+                            lookAtParams.bounds.center.latitude,
+                            epsilon
+                        );
+                        expect(mapView.target.longitude).to.be.closeTo(
+                            lookAtParams.bounds.center.longitude,
+                            epsilon
+                        );
 
                         if (lookAtParams.zoomLevel) {
-                            expect(mapView.zoomLevel).to.be.closeTo(lookAtParams.zoomLevel, epsilon);
+                            expect(mapView.zoomLevel).to.be.closeTo(
+                                lookAtParams.zoomLevel,
+                                epsilon
+                            );
                         }
 
                         if (lookAtParams.distance) {
-                            expect(mapView.targetDistance).to.be.closeTo(lookAtParams.distance, 1e-8);
+                            expect(mapView.targetDistance).to.be.closeTo(
+                                lookAtParams.distance,
+                                1e-8
+                            );
                         }
                     }
                 });


### PR DESCRIPTION
zoomLevel/distance are now taken into account when setting via **MapView** constructor or **lookAt** method.