### PR TITLE
HARP-11091: Add DataProvider.onDidInvalidate

### DIFF
--- a/@here/harp-mapview-decoder/lib/DataProvider.ts
+++ b/@here/harp-mapview-decoder/lib/DataProvider.ts
@@ -8,9 +8,12 @@ import "@here/harp-fetch";
 import { TileKey } from "@here/harp-geoutils";
 
 /**
- * Interface for all `DataProvider` subclasses. The `DataProvider` is an abstraction of the tile
- * loader which is only responsible for loading the binary data of a specific tile, without any
- * relation to displaying or even decoding the data.
+ * Interface for all `DataProvider` subclasses.
+ *
+ * @remarks
+ * The `DataProvider` is an abstraction of the tile
+ * loader which is only responsible for loading the data of a specific tile,
+ * without any relation to displaying or even decoding the data.
  */
 export interface DataProvider {
     /**
@@ -26,11 +29,26 @@ export interface DataProvider {
     ready(): boolean;
 
     /**
-     * Load the data of a [[Tile]] asynchronously in form of an [[ArrayBufferLike]].
+     * Load the data of a {@link @here/map-view@Tile} asynchronously.
      *
      * @param tileKey - Address of a tile.
      * @param abortSignal - Optional AbortSignal to cancel the request.
      * @returns A promise delivering the data as an [[ArrayBufferLike]], or any object.
      */
     getTile(tileKey: TileKey, abortSignal?: AbortSignal): Promise<ArrayBufferLike | {}>;
+
+    /**
+     * An event which fires when this `DataProvider` is invalidated.
+     *
+     * @param listener - A function to call when this `DataProvider` is invalidated.
+     * @returns The function to call to unregister the listener from this event.
+     *
+     * @example
+     * ```typescript
+     * const dispose = dataProvider.onDidInvalidate?.(() => {
+     *     console.log("invalidated");
+     * });
+     * ```
+     */
+    onDidInvalidate?(listener: () => void): () => void;
 }

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -112,6 +112,7 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
     protected readonly logger: ILogger = LoggerManager.instance.create("TileDataSource");
     protected readonly m_decoder: ITileDecoder;
     private m_isReady: boolean = false;
+    private readonly m_unregisterClearTileCache?: () => void;
 
     /**
      * Set up the `TileDataSource`.
@@ -153,10 +154,15 @@ export class TileDataSource<TileType extends Tile> extends DataSource {
         }
         this.useGeometryLoader = true;
         this.cacheable = true;
+
+        this.m_unregisterClearTileCache = this.dataProvider().onDidInvalidate?.(() =>
+            this.mapView.clearTileCache(this.name)
+        );
     }
 
     /** @override */
     dispose() {
+        this.m_unregisterClearTileCache?.();
         this.decoder.dispose();
     }
 


### PR DESCRIPTION
This change introduces an "invalidated" event to DataProvider
and adds an automatic way to clear caches when the
geojson data provider input is updated.
