### PR TITLE
HARP-10772: Add enablePicking to DataSourceOptions

### DIFF
--- a/@here/harp-debug-datasource/lib/DebugTileDataSource.ts
+++ b/@here/harp-debug-datasource/lib/DebugTileDataSource.ts
@@ -125,6 +125,7 @@ export class DebugTileDataSource extends DataSource {
         super({ name, minDataLevel: 1, maxDataLevel: 20, storageLevelOffset: -1 });
 
         this.cacheable = true;
+        this.enablePicking = false;
     }
 
     /** @override */

--- a/@here/harp-mapview/lib/BackgroundDataSource.ts
+++ b/@here/harp-mapview/lib/BackgroundDataSource.ts
@@ -21,6 +21,7 @@ export class BackgroundDataSource extends DataSource {
         super({ name: "background" });
         this.cacheable = true;
         this.addGroundPlane = true;
+        this.enablePicking = false;
     }
 
     updateStorageLevelOffset() {

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -69,6 +69,14 @@ export interface DataSourceOptions {
      * @default true
      */
     allowOverlappingTiles?: boolean;
+
+    /**
+     * Whether features from these data source can picked by calling
+     * {@link MapView.intersectMapObjects}. Disabling picking for data sources that don't need it
+     * will improve picking performance.
+     * @default true
+     */
+    enablePicking?: boolean;
 }
 
 /**
@@ -130,6 +138,9 @@ export abstract class DataSource extends THREE.EventDispatcher {
     maxDisplayLevel: number = 20;
 
     allowOverlappingTiles: boolean = true;
+
+    enablePicking: boolean = true;
+
     /**
      * @internal
      * @hidden
@@ -177,7 +188,8 @@ export abstract class DataSource extends THREE.EventDispatcher {
             minDisplayLevel,
             maxDisplayLevel,
             storageLevelOffset,
-            allowOverlappingTiles
+            allowOverlappingTiles,
+            enablePicking
         } = options;
         if (name === undefined || name.length === 0) {
             name = `anonymous-datasource#${++DataSource.uniqueNameCounter}`;
@@ -211,6 +223,10 @@ export abstract class DataSource extends THREE.EventDispatcher {
         }
         if (allowOverlappingTiles !== undefined) {
             this.allowOverlappingTiles = allowOverlappingTiles;
+        }
+
+        if (enablePicking !== undefined) {
+            this.enablePicking = enablePicking;
         }
     }
 

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -227,6 +227,10 @@ export class PickHandler {
 
         const tileList = this.mapView.visibleTileSet.dataSourceTileList;
         tileList.forEach(dataSourceTileList => {
+            if (!dataSourceTileList.dataSource.enablePicking) {
+                return;
+            }
+
             dataSourceTileList.renderedTiles.forEach(tile => {
                 tmpOBB.copy(tile.boundingBox);
                 tmpOBB.position.sub(this.mapView.worldCenter);

--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -84,6 +84,7 @@ export class PolarTileDataSource extends DataSource {
         this.m_geometryLevelOffset = geometryLevelOffset;
         this.m_debugTiles = debugTiles;
         this.cacheable = false;
+        this.enablePicking = false;
     }
 
     /** @override */

--- a/@here/harp-omv-datasource/test/MapViewPickingTest.ts
+++ b/@here/harp-omv-datasource/test/MapViewPickingTest.ts
@@ -261,6 +261,30 @@ describe("MapView Picking", async function() {
     });
 
     describe("Picking tests", async function() {
+        const pickPolygonAt: number[] = [13.084716796874998, 22.61401087437029];
+        const pickLineAt: number[] = ((GEOJSON_DATA.features[1].geometry as any)
+            .coordinates as number[][])[0];
+        const pickLabelAt: number[] = (GEOJSON_DATA.features[2].geometry as any).coordinates;
+        const offCenterLabelLookAt: number[] = [pickLabelAt[0] + 10.0, pickLabelAt[1] + 10.0];
+
+        it("Features in a data source with picking disabled are not picked", async () => {
+            geoJsonDataSource.enablePicking = false;
+            const target = new GeoCoordinates(pickPolygonAt[1], pickPolygonAt[0]);
+            mapView.lookAt({ target, tilt: 60, zoomLevel: 2 });
+            await waitForEvent(mapView, MapViewEventNames.FrameComplete);
+
+            const screenPointLocation = mapView.getScreenPosition(target) as THREE.Vector2;
+            assert.isDefined(screenPointLocation);
+
+            mapView.scene.updateWorldMatrix(false, true);
+
+            const usableIntersections = mapView
+                .intersectMapObjects(screenPointLocation.x, screenPointLocation.y)
+                .filter(item => item.userData !== undefined);
+
+            assert.equal(usableIntersections.length, 0);
+        });
+
         interface TestCase {
             name: string;
             rayOrigGeo: number[];
@@ -272,11 +296,6 @@ describe("MapView Picking", async function() {
             // Whether to test a shift of 360.0 degrees
             shiftLongitude: boolean;
         }
-        const pickPolygonAt: number[] = [13.084716796874998, 22.61401087437029];
-        const pickLineAt: number[] = ((GEOJSON_DATA.features[1].geometry as any)
-            .coordinates as number[][])[0];
-        const pickLabelAt: number[] = (GEOJSON_DATA.features[2].geometry as any).coordinates;
-        const offCenterLabelLookAt: number[] = [pickLabelAt[0] + 10.0, pickLabelAt[1] + 10.0];
 
         const testCases: TestCase[] = [];
 

--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -91,6 +91,7 @@ export class WebTileDataSource extends DataSource {
 
         this.dataProvider = this.m_options.dataProvider;
         this.cacheable = true;
+        this.enablePicking = false;
         this.storageLevelOffset = -1;
         this.m_resolution = getOptionValue(
             m_options.resolution,


### PR DESCRIPTION
Disabling picking for data sources that don't need it will make it faster.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
