### PR TITLE
Add environment variable HARP_NO_HARD_SOURCE_CACHE.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,8 @@ jobs:
         node-version: ${{ matrix.node_version }}
     - name: Install dependencies
       run: yarn
+    - name: Disable hard-source-webpack-plugin
+      run: echo "::set-env name=HARP_NO_HARD_SOURCE_CACHE::true"
     - name: Pretest
       run: yarn run pre-test
       shell: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ branches:
 
 env:
   - DETECT_CHROMEDRIVER_VERSION=true
+  - HARP_NO_HARD_SOURCE_CACHE=true
 
 before_install:
   - yarn global add codecov

--- a/@here/harp-examples/webpack.config.js
+++ b/@here/harp-examples/webpack.config.js
@@ -102,12 +102,15 @@ const commonConfig = {
     // @ts-ignore
     mode: process.env.NODE_ENV || "development",
     plugins: [
-        new HardSourceWebpackPlugin(),
         new webpack.DefinePlugin({
             THEMES: JSON.stringify(themeList)
         })
     ]
 };
+
+if (!process.env.HARP_NO_HARD_SOURCE_CACHE) {
+    commonConfig.plugins.push(new HardSourceWebpackPlugin());
+}
 
 const decoderConfig = merge(commonConfig, {
     target: "webworker",

--- a/@here/harp.gl/webpack.config.js
+++ b/@here/harp.gl/webpack.config.js
@@ -50,8 +50,7 @@ const commonConfig = {
         new webpack.EnvironmentPlugin({
             // default NODE_ENV to development. Override by setting the environment variable NODE_ENV to 'production'
             NODE_ENV: process.env.NODE_ENV || "development"
-        }),
-        new HardSourceWebpackPlugin()
+        })
     ],
     performance: {
         hints: false
@@ -59,6 +58,10 @@ const commonConfig = {
     // @ts-ignore
     mode: process.env.NODE_ENV || "development"
 };
+
+if (!process.env.HARP_NO_HARD_SOURCE_CACHE) {
+    commonConfig.plugins.push(new HardSourceWebpackPlugin());
+}
 
 const mapComponentConfig = merge(commonConfig, {
     entry: path.resolve(__dirname, "./lib/index.ts"),

--- a/webpack.tests.config.js
+++ b/webpack.tests.config.js
@@ -69,7 +69,6 @@ const browserTestsConfig = {
         filename: "[name].bundle.js"
     },
     plugins: [
-        new HardSourceWebpackPlugin(),
         new webpack.EnvironmentPlugin({
             // default NODE_ENV to development. Override by setting the environment variable NODE_ENV to 'production'
             NODE_ENV: process.env.NODE_ENV || "development"
@@ -142,5 +141,9 @@ const browserTestsConfig = {
     // @ts-ignore
     mode: process.env.NODE_ENV || "development"
 };
+
+if (!process.env.HARP_NO_HARD_SOURCE_CACHE) {
+    browserTestsConfig.plugins.push(new HardSourceWebpackPlugin());
+}
 
 module.exports = browserTestsConfig;

--- a/www/webpack.config.js
+++ b/www/webpack.config.js
@@ -44,8 +44,7 @@ const commonConfig = {
         new webpack.EnvironmentPlugin({
             // default NODE_ENV to development. Override by setting the environment variable NODE_ENV to 'production'
             NODE_ENV: process.env.NODE_ENV || "development"
-        }),
-        new HardSourceWebpackPlugin()
+        })
     ],
     externals: [
         {
@@ -57,6 +56,10 @@ const commonConfig = {
     },
     mode: process.env.NODE_ENV || "development"
 };
+
+if (!process.env.HARP_NO_HARD_SOURCE_CACHE) {
+    commonConfig.plugins.push(new HardSourceWebpackPlugin());
+}
 
 const mainConfig = merge(commonConfig, {
     entry: {


### PR DESCRIPTION
The `HARP_NO_HARD_SOURCE_CACHE` env variable can be used to
control the usage of `hard-source-webpack-plugin`. For example:

    HARP_NO_HARD_SOURCE_CACHE=true yarn start

Also, this change disables the usage of the hard-source cache
in the CI.

Note that the value assigned to `HARP_NO_HARD_SOURCE_CACHE` is
not important, that is, as long as the environment variable
`HARP_NO_HARD_SOURCE_CACHE` is defined the hard-source cache will
be disabled.
