### PR TITLE
Install the deps using yarn --frozen-lockfile.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       with:
         node-version: ${{ matrix.node_version }}
     - name: Install dependencies
-      run: yarn
+      run: yarn --frozen-lockfile
     - name: Disable hard-source-webpack-plugin
       run: echo "::set-env name=HARP_NO_HARD_SOURCE_CACHE::true"
     - name: Pretest
@@ -85,7 +85,7 @@ jobs:
     - name: Tests on Chrome (Linux)
       run: |
         set -ex
-        yarn
+        yarn --frozen-lockfile
         google-chrome --version
         whereis google-chrome
         yarn test-browser --headless-chrome --timeout ${{ env.browserTestTimeout }}


### PR DESCRIPTION
This change ensures that yarn will not generate a lockfile.

Signed-off-by: Roberto Raggi <roberto.raggi@here