### PR TITLE
HARP-10966 - Moving build-bundle job before build-example job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,11 +107,11 @@ jobs:
         yarn test-browser --headless-firefox --timeout ${{ env.browserTestTimeout }}
       shell: bash
       if: matrix.os == 'ubuntu-latest'
-    - name: Build examples
-      run: yarn run build-examples
-      shell: bash
     - name: Build bundle
       run: yarn run build-bundle
+      shell: bash  
+    - name: Build examples
+      run: yarn run build-examples
       shell: bash
     - name: Generate doc
       run: yarn run typedoc


### PR DESCRIPTION
Signed-off-by: aluni <gairik.aluni@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
