### PR TITLE
HARP-10772: Add pickable flag to object's userData.

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1091,7 +1091,7 @@ export class MapView extends THREE.EventDispatcher {
         // setup camera with initial position
         this.setupCamera();
 
-        this.m_raycaster = new PickingRaycaster(width, height);
+        this.m_raycaster = new PickingRaycaster(width, height, this.m_env);
 
         this.m_movementDetector = new CameraMovementDetector(
             this.m_options.movementThrottleTimeout,

--- a/@here/harp-mapview/lib/PickingRaycaster.ts
+++ b/@here/harp-mapview/lib/PickingRaycaster.ts
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeometryKind } from "@here/harp-datasource-protocol";
 import * as THREE from "three";
-import { isDepthPrePassMesh } from "./DepthPrePass";
 import { MapObjectAdapter } from "./MapObjectAdapter";
 
 function intersectObject(
@@ -15,11 +13,7 @@ function intersectObject(
     intersects: THREE.Intersection[],
     recursive?: boolean
 ) {
-    const isBackground =
-        object.userData.kind &&
-        (object.userData.kind as GeometryKind[]).some(kind => kind === GeometryKind.Background);
-
-    const isPickable = object.visible && !isDepthPrePassMesh(object) && !isBackground;
+    const isPickable = object.visible && object.userData.pickable !== false;
 
     if (object.layers.test(raycaster.layers) && isPickable) {
         const mapObjectAdapter = MapObjectAdapter.get(object);

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -393,14 +393,12 @@ export class TileGeometryCreator {
      * @param object - The object to add to the root of the tile.
      * @param geometryKind - The kind of object. Can be used for filtering.
      * @param mapAdapterParams - additional parameters for [[MapObjectAdapter]]
-     * @param pickable - whether the object should be pickable by {@link PickHandler}.
      */
     registerTileObject(
         tile: Tile,
         object: THREE.Object3D,
         geometryKind: GeometryKind | GeometryKindSet | undefined,
-        mapAdapterParams?: MapObjectAdapterParams,
-        pickable: boolean = true
+        mapAdapterParams?: MapObjectAdapterParams
     ) {
         const kind =
             geometryKind instanceof Set
@@ -424,7 +422,6 @@ export class TileGeometryCreator {
         userData.dataSource = tile.dataSource.name;
 
         userData.kind = kind;
-        userData.pickable = pickable;
 
         // Force a visibility check of all objects.
         tile.resetVisibilityCounter();
@@ -936,15 +933,10 @@ export class TileGeometryCreator {
                     const depthPassMesh = createDepthPrePassMesh(object as THREE.Mesh);
                     // Set geometry kind for depth pass mesh so that it gets the displacement map
                     // for elevation overlay.
-                    this.registerTileObject(
-                        tile,
-                        depthPassMesh,
-                        techniqueKind,
-                        {
-                            technique
-                        },
-                        false
-                    );
+                    this.registerTileObject(tile, depthPassMesh, techniqueKind, {
+                        technique,
+                        pickable: false
+                    });
                     objects.push(depthPassMesh);
 
                     if (extrusionAnimationEnabled) {
@@ -956,15 +948,10 @@ export class TileGeometryCreator {
 
                 // register all objects as pickable except solid lines with outlines, in that case
                 // it's enough to make outlines pickable.
-                this.registerTileObject(
-                    tile,
-                    object,
-                    techniqueKind,
-                    {
-                        technique
-                    },
-                    !hasSolidLinesOutlines
-                );
+                this.registerTileObject(tile, object, techniqueKind, {
+                    technique,
+                    pickable: !hasSolidLinesOutlines
+                });
                 objects.push(object);
 
                 // Add the extruded building edges as a separate geometry.
@@ -1032,15 +1019,10 @@ export class TileGeometryCreator {
                         addToExtrudedMaterials(edgeObj.material, extrudedMaterials);
                     }
 
-                    this.registerTileObject(
-                        tile,
-                        edgeObj,
-                        techniqueKind,
-                        {
-                            technique
-                        },
-                        false
-                    );
+                    this.registerTileObject(tile, edgeObj, techniqueKind, {
+                        technique,
+                        pickable: false
+                    });
                     MapMaterialAdapter.create(edgeMaterial, {
                         color: buildingTechnique.lineColor,
                         objectColor: buildingTechnique.color,
@@ -1093,15 +1075,10 @@ export class TileGeometryCreator {
                         false
                     );
 
-                    this.registerTileObject(
-                        tile,
-                        outlineObj,
-                        techniqueKind,
-                        {
-                            technique
-                        },
-                        false
-                    );
+                    this.registerTileObject(tile, outlineObj, techniqueKind, {
+                        technique,
+                        pickable: false
+                    });
                     MapMaterialAdapter.create(outlineMaterial, {
                         color: fillTechnique.lineColor,
                         objectColor: fillTechnique.color,
@@ -1348,7 +1325,7 @@ export class TileGeometryCreator {
         const mesh = this.createGroundPlane(tile, material, false, shadowsEnabled);
         mesh.receiveShadow = shadowsEnabled;
         mesh.renderOrder = renderOrder;
-        this.registerTileObject(tile, mesh, GeometryKind.Background, undefined, false);
+        this.registerTileObject(tile, mesh, GeometryKind.Background, { pickable: false });
         tile.objects.push(mesh);
     }
 

--- a/@here/harp-mapview/test/PickingRaycasterTest.ts
+++ b/@here/harp-mapview/test/PickingRaycasterTest.ts
@@ -9,6 +9,7 @@
 // tslint:disable:no-unused-expression
 //    Chai uses properties instead of functions for some expect checks.
 
+import { MapEnv } from "@here/harp-datasource-protocol";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
@@ -26,7 +27,7 @@ describe("PickingRaycaster", function() {
     let raycaster: PickingRaycaster;
 
     beforeEach(function() {
-        raycaster = new PickingRaycaster(0, 0);
+        raycaster = new PickingRaycaster(0, 0, new MapEnv({}));
     });
 
     describe("intersectObject(s)", function() {
@@ -60,7 +61,7 @@ describe("PickingRaycaster", function() {
 
         it("skips non-pickable objects", function() {
             const object = createFakeObject(THREE.Object3D);
-            object.userData.pickable = false;
+            MapObjectAdapter.create(object, { pickable: false });
             {
                 const intersections = raycaster.intersectObject(object);
                 expect(intersections).to.be.empty;
@@ -72,16 +73,18 @@ describe("PickingRaycaster", function() {
         });
 
         it("tests pickable objects", function() {
-            const object1 = createFakeObject(THREE.Object3D);
-            const object2 = createFakeObject(THREE.Object3D);
-            object2.userData.pickable = true;
+            const object = createFakeObject(THREE.Object3D);
+            const mesh = createFakeObject(THREE.Mesh);
+            mesh.material = new THREE.Material();
+            mesh.material.opacity = 1;
+            MapObjectAdapter.create(mesh, { pickable: true });
 
             {
-                const intersections = raycaster.intersectObject(object1);
+                const intersections = raycaster.intersectObject(object);
                 expect(intersections).to.have.length(1);
             }
             {
-                const intersections = raycaster.intersectObjects([object1, object2]);
+                const intersections = raycaster.intersectObjects([object, mesh]);
                 expect(intersections).to.have.length(2);
             }
         });

--- a/@here/harp-mapview/test/PickingRaycasterTest.ts
+++ b/@here/harp-mapview/test/PickingRaycasterTest.ts
@@ -9,7 +9,6 @@
 // tslint:disable:no-unused-expression
 //    Chai uses properties instead of functions for some expect checks.
 
-import { GeometryKind } from "@here/harp-datasource-protocol";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
@@ -59,41 +58,30 @@ describe("PickingRaycaster", function() {
             }
         });
 
-        it("skips background objects", function() {
+        it("skips non-pickable objects", function() {
             const object = createFakeObject(THREE.Object3D);
-            object.userData.kind = [GeometryKind.Background];
+            object.userData.pickable = false;
             {
                 const intersections = raycaster.intersectObject(object);
                 expect(intersections).to.be.empty;
             }
             {
                 const intersections = raycaster.intersectObjects([object, object]);
-                expect(intersections).to.be.empty;
-            }
-        });
-
-        it("skips depth prepass meshes", function() {
-            const mesh = createFakeObject(THREE.Mesh);
-            mesh.material = new THREE.Material();
-            (mesh.material as any).isDepthPrepassMaterial = true;
-            {
-                const intersections = raycaster.intersectObject(mesh);
-                expect(intersections).to.be.empty;
-            }
-            {
-                const intersections = raycaster.intersectObjects([mesh, mesh]);
                 expect(intersections).to.be.empty;
             }
         });
 
         it("tests pickable objects", function() {
-            const object = createFakeObject(THREE.Object3D);
+            const object1 = createFakeObject(THREE.Object3D);
+            const object2 = createFakeObject(THREE.Object3D);
+            object2.userData.pickable = true;
+
             {
-                const intersections = raycaster.intersectObject(object);
+                const intersections = raycaster.intersectObject(object1);
                 expect(intersections).to.have.length(1);
             }
             {
-                const intersections = raycaster.intersectObjects([object, object]);
+                const intersections = raycaster.intersectObjects([object1, object2]);
                 expect(intersections).to.have.length(2);
             }
         });

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -28,6 +28,7 @@ import { DataSource } from "../lib/DataSource";
 import { isDepthPrePassMesh } from "../lib/DepthPrePass";
 import { DisplacementMap } from "../lib/DisplacementMap";
 import { TileGeometryCreator } from "../lib/geometry/TileGeometryCreator";
+import { MapObjectAdapter } from "../lib/MapObjectAdapter";
 import { Tile } from "../lib/Tile";
 
 class FakeMapView {
@@ -140,8 +141,9 @@ describe("TileGeometryCreator", () => {
     it("background geometry is registered as non-pickable", () => {
         tgc.addGroundPlane(newTile, 0);
         assert.equal(newTile.objects.length, 1);
-        const userData = newTile.objects[0].userData;
-        expect(userData.pickable).to.equal(false);
+        const adapter = MapObjectAdapter.get(newTile.objects[0]);
+        expect(adapter).not.equals(undefined);
+        expect(adapter!.isPickable(new MapEnv({}))).to.equal(false);
     });
 
     it("extruded polygon depth prepass and edges geometries are registered as non-pickable", () => {
@@ -180,11 +182,13 @@ describe("TileGeometryCreator", () => {
         tgc.createObjects(newTile, decodedTile);
         assert.equal(newTile.objects.length, 3);
 
-        newTile.objects.forEach(object =>
-            expect(object.userData.pickable).to.equal(
+        newTile.objects.forEach(object => {
+            const adapter = MapObjectAdapter.get(object);
+            expect(adapter).not.equals(undefined);
+            expect(adapter!.isPickable(new MapEnv({}))).to.equal(
                 !isDepthPrePassMesh(object) && !(object as any).isLine
-            )
-        );
+            );
+        });
     });
 
     it("fill outline geometry is registered as non-pickable", () => {
@@ -220,8 +224,13 @@ describe("TileGeometryCreator", () => {
         };
         tgc.createObjects(newTile, decodedTile);
         assert.equal(newTile.objects.length, 2);
-        expect(newTile.objects[0].userData.pickable).equals(true);
-        expect(newTile.objects[1].userData.pickable).equals(false);
+        const adapter0 = MapObjectAdapter.get(newTile.objects[0]);
+        expect(adapter0).not.equals(undefined);
+        expect(adapter0!.isPickable(new MapEnv({}))).to.equal(true);
+
+        const adapter1 = MapObjectAdapter.get(newTile.objects[1]);
+        expect(adapter1).not.equals(undefined);
+        expect(adapter1!.isPickable(new MapEnv({}))).to.equal(false);
     });
 
     it("solid line without outline is registered as pickable", () => {
@@ -246,7 +255,9 @@ describe("TileGeometryCreator", () => {
         };
         tgc.createObjects(newTile, decodedTile);
         assert.equal(newTile.objects.length, 1);
-        expect(newTile.objects[0].userData.pickable).equals(true);
+        const adapter = MapObjectAdapter.get(newTile.objects[0]);
+        expect(adapter).not.equals(undefined);
+        expect(adapter!.isPickable(new MapEnv({}))).to.equal(true);
     });
 
     it("only outline geometry from solid line with outline is registered as pickable", () => {
@@ -272,8 +283,13 @@ describe("TileGeometryCreator", () => {
         };
         tgc.createObjects(newTile, decodedTile);
         assert.equal(newTile.objects.length, 2);
-        expect(newTile.objects[0].userData.pickable).equals(false);
-        expect(newTile.objects[1].userData.pickable).equals(true);
+        const adapter0 = MapObjectAdapter.get(newTile.objects[0]);
+        expect(adapter0).not.equals(undefined);
+        expect(adapter0!.isPickable(new MapEnv({}))).to.equal(false);
+
+        const adapter1 = MapObjectAdapter.get(newTile.objects[1]);
+        expect(adapter1).not.equals(undefined);
+        expect(adapter1!.isPickable(new MapEnv({}))).to.equal(true);
     });
 
     it("categories", () => {

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -25,6 +25,7 @@ import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
 import { DataSource } from "../lib/DataSource";
+import { isDepthPrePassMesh } from "../lib/DepthPrePass";
 import { DisplacementMap } from "../lib/DisplacementMap";
 import { TileGeometryCreator } from "../lib/geometry/TileGeometryCreator";
 import { Tile } from "../lib/Tile";
@@ -83,6 +84,9 @@ describe("TileGeometryCreator", () => {
         mockDatasource.getTilingScheme.callsFake(() => webMercatorTilingScheme);
         sinon.stub(mockDatasource, "projection").get(() => mercatorProjection);
         sinon.stub(mockDatasource, "mapView").get(() => mapView);
+    });
+
+    beforeEach(function() {
         newTile = new Tile(
             (mockDatasource as unknown) as DataSource,
             TileKey.fromRowColumnLevel(0, 0, 0)
@@ -131,6 +135,145 @@ describe("TileGeometryCreator", () => {
         const imageData: ImageData = (userData.texture as THREE.DataTexture).image;
         assert.equal(imageData.width, decodedDisplacementMap.xCountVertices);
         assert.equal(imageData.height, decodedDisplacementMap.yCountVertices);
+    });
+
+    it("background geometry is registered as non-pickable", () => {
+        tgc.addGroundPlane(newTile, 0);
+        assert.equal(newTile.objects.length, 1);
+        const userData = newTile.objects[0].userData;
+        expect(userData.pickable).to.equal(false);
+    });
+
+    it("extruded polygon depth prepass and edges geometries are registered as non-pickable", () => {
+        const decodedTile: DecodedTile = {
+            geometries: [
+                {
+                    type: GeometryType.Polygon,
+                    vertexAttributes: [
+                        {
+                            name: "position",
+                            buffer: new Float32Array([1.0, 2.0, 3.0]),
+                            type: "float",
+                            itemCount: 3
+                        }
+                    ],
+                    groups: [{ start: 0, count: 1, technique: 0, createdOffsets: [] }],
+                    edgeIndex: {
+                        name: "index",
+                        buffer: new Uint16Array([0]),
+                        type: "float",
+                        itemCount: 1
+                    }
+                }
+            ],
+            techniques: [
+                {
+                    name: "extruded-polygon",
+                    lineWidth: 0,
+                    opacity: 0.1,
+                    renderOrder: 0,
+                    _index: 0,
+                    _styleSetIndex: 0
+                }
+            ]
+        };
+        tgc.createObjects(newTile, decodedTile);
+        assert.equal(newTile.objects.length, 3);
+
+        newTile.objects.forEach(object =>
+            expect(object.userData.pickable).to.equal(
+                !isDepthPrePassMesh(object) && !(object as any).isLine
+            )
+        );
+    });
+
+    it("fill outline geometry is registered as non-pickable", () => {
+        const decodedTile: DecodedTile = {
+            geometries: [
+                {
+                    type: GeometryType.Polygon,
+                    vertexAttributes: [
+                        {
+                            name: "position",
+                            buffer: new Float32Array([1.0, 2.0, 3.0]),
+                            type: "float",
+                            itemCount: 3
+                        }
+                    ],
+                    groups: [{ start: 0, count: 1, technique: 0, createdOffsets: [] }],
+                    edgeIndex: {
+                        name: "index",
+                        buffer: new Uint16Array([0]),
+                        type: "float",
+                        itemCount: 1
+                    }
+                }
+            ],
+            techniques: [
+                {
+                    name: "fill",
+                    renderOrder: 0,
+                    _index: 0,
+                    _styleSetIndex: 0
+                }
+            ]
+        };
+        tgc.createObjects(newTile, decodedTile);
+        assert.equal(newTile.objects.length, 2);
+        expect(newTile.objects[0].userData.pickable).equals(true);
+        expect(newTile.objects[1].userData.pickable).equals(false);
+    });
+
+    it("solid line without outline is registered as pickable", () => {
+        const decodedTile: DecodedTile = {
+            geometries: [
+                {
+                    type: GeometryType.Polygon,
+                    vertexAttributes: [],
+                    groups: [{ start: 0, count: 1, technique: 0, createdOffsets: [] }]
+                }
+            ],
+            techniques: [
+                {
+                    name: "solid-line",
+                    color: "red",
+                    lineWidth: 1,
+                    renderOrder: 0,
+                    _index: 0,
+                    _styleSetIndex: 0
+                }
+            ]
+        };
+        tgc.createObjects(newTile, decodedTile);
+        assert.equal(newTile.objects.length, 1);
+        expect(newTile.objects[0].userData.pickable).equals(true);
+    });
+
+    it("only outline geometry from solid line with outline is registered as pickable", () => {
+        const decodedTile: DecodedTile = {
+            geometries: [
+                {
+                    type: GeometryType.Polygon,
+                    vertexAttributes: [],
+                    groups: [{ start: 0, count: 1, technique: 0, createdOffsets: [] }]
+                }
+            ],
+            techniques: [
+                {
+                    name: "solid-line",
+                    color: "red",
+                    lineWidth: 1,
+                    secondaryWidth: 2,
+                    renderOrder: 0,
+                    _index: 0,
+                    _styleSetIndex: 0
+                }
+            ]
+        };
+        tgc.createObjects(newTile, decodedTile);
+        assert.equal(newTile.objects.length, 2);
+        expect(newTile.objects[0].userData.pickable).equals(false);
+        expect(newTile.objects[1].userData.pickable).equals(true);
     });
 
     it("categories", () => {
@@ -187,9 +330,9 @@ describe("TileGeometryCreator", () => {
         tgc.processTechniques(newTile, undefined, undefined);
         tgc.createObjects(newTile, decodedTile as DecodedTile);
 
-        assert.strictEqual(newTile.objects.length, 3);
-        assert.strictEqual(newTile.objects[1].renderOrder, 20);
-        assert.strictEqual(newTile.objects[2].renderOrder, 10);
+        assert.strictEqual(newTile.objects.length, 2);
+        assert.strictEqual(newTile.objects[0].renderOrder, 20);
+        assert.strictEqual(newTile.objects[1].renderOrder, 10);
 
         newTile.mapView.theme = savedTheme;
     });


### PR DESCRIPTION
Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

The flag may be set to false to disable picking for particular objects. Picking is disabled for depth prepass, background, edges and center line of solid lines with outline (knowing whether the outline is picked is enough).