### PR TITLE
HARP-10881: Added image regression test to reproduce the issue

### DIFF
--- a/test/rendering/StylingTest.ts
+++ b/test/rendering/StylingTest.ts
@@ -971,11 +971,22 @@ describe("MapView Styling Test", function() {
                         "extruded-polygon-3d-rgba": {
                             color: "#0b97c480"
                         },
+                        "extruded-polygon-3d-rgba-disabled": {
+                            color: "#0b97c480",
+                            enabled: false
+                        },
                         "extruded-polygon-3d-rgba-outline": {
                             color: "#0b97c480",
                             lineWidth: 1,
                             lineColorMix: 0,
                             lineColor: "#7f7"
+                        },
+                        "extruded-polygon-3d-rgba-outline-disabled": {
+                            color: "#0b97c480",
+                            lineWidth: 1,
+                            lineColorMix: 0,
+                            lineColor: "#7f7",
+                            enabled: false
                         }
                     },
                     viewOptions


### PR DESCRIPTION
Building edges are still rendered even though the buildings are disabled.