### PR TITLE
HARP-11250: Add support for style extensions.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -13,7 +13,7 @@ import {
     interpolatedPropertyDefinitionToJsonExpr,
     isInterpolatedPropertyDefinition
 } from "./InterpolatedPropertyDefs";
-import { Definitions, isBoxedDefinition, isLiteralDefinition } from "./Theme";
+import { Definitions } from "./Theme";
 
 import * as THREE from "three";
 import { Pixels } from "./Pixels";
@@ -1038,18 +1038,14 @@ function resolveReference(node: JsonArray, referenceResolverState?: ReferenceRes
     }
     let definitionEntry = referenceResolverState.definitions[name] as any;
     let result: Expr;
-    if (isLiteralDefinition(definitionEntry)) {
-        return Expr.fromJSON(definitionEntry);
-    } else if (isBoxedDefinition(definitionEntry)) {
-        if (isInterpolatedPropertyDefinition(definitionEntry.value)) {
-            // found a reference to an interpolation using
-            // the deprecated object-like syntax.
-            return Expr.fromJSON(interpolatedPropertyDefinitionToJsonExpr(definitionEntry.value));
-        } else if (isJsonExpr(definitionEntry.value)) {
-            definitionEntry = definitionEntry.value;
-        } else {
-            return Expr.fromJSON(definitionEntry.value);
-        }
+    if (isInterpolatedPropertyDefinition(definitionEntry.value)) {
+        // found a reference to an interpolation using
+        // the deprecated object-like syntax.
+        return Expr.fromJSON(interpolatedPropertyDefinitionToJsonExpr(definitionEntry.value));
+    } else if (isJsonExpr(definitionEntry.value)) {
+        definitionEntry = definitionEntry.value;
+    } else {
+        return Expr.fromJSON(definitionEntry.value);
     }
 
     if (isJsonExpr(definitionEntry)) {

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -35,15 +35,7 @@ import {
 } from "./InterpolatedPropertyDefs";
 import { AttrScope, mergeTechniqueDescriptor } from "./TechniqueDescriptor";
 import { IndexedTechnique, Technique, techniqueDescriptors } from "./Techniques";
-import {
-    Definitions,
-    isActualSelectorDefinition,
-    isJsonExprReference,
-    Style,
-    StyleDeclaration,
-    StyleSelector,
-    StyleSet
-} from "./Theme";
+import { Definitions, Style, StyleSet } from "./Theme";
 
 const logger = LoggerManager.instance.create("StyleSetEvaluator");
 
@@ -139,7 +131,7 @@ interface StyleInternalParams {
     _usesFeatureState?: boolean;
 }
 
-type InternalStyle = Style & StyleSelector & StyleInternalParams;
+type InternalStyle = Style & StyleInternalParams;
 
 /**
  * [[StyleConditionClassifier]] searches for usages of `$layer` in `when` conditions
@@ -941,31 +933,11 @@ function computeDefaultRenderOrder(styleSet: InternalStyle[]) {
     }
 }
 
-function resolveReferences(styleSet: StyleDeclaration[], definitions: Definitions | undefined) {
+function resolveReferences(styleSet: Style[], definitions: Definitions | undefined) {
     return styleSet.map(style => resolveStyleReferences(style, definitions));
 }
 
-function resolveStyleReferences(
-    style: StyleDeclaration,
-    definitions: Definitions | undefined
-): InternalStyle {
-    if (isJsonExpr(style)) {
-        if (!isJsonExprReference(style)) {
-            throw new Error("invalid expression in this context, only 'ref's are supported");
-        }
-        // expand and instantiate references to style definitions.
-        const definitionName = style[1];
-        const def = definitions && definitions[definitionName];
-        if (!def) {
-            throw new Error(`invalid reference '${definitionName}' - not found`);
-        }
-        if (!isActualSelectorDefinition(def)) {
-            throw new Error(`invalid reference '${definitionName}' - expected style definition`);
-        }
-        // instantiate the style
-        return resolveStyleReferences(def, definitions);
-    }
-
+function resolveStyleReferences(style: Style, definitions: Definitions | undefined): InternalStyle {
     return { ...style };
 }
 

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -134,7 +134,7 @@ interface StyleInternalParams {
 type InternalStyle = Style & StyleInternalParams;
 
 /**
- * [[StyleConditionClassifier]] searches for usages of `$layer` in `when` conditions
+ * `StyleConditionClassifier` searches for usages of `$layer` in `when` conditions
  * associated with styling rules.
  *
  * @hidden

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -8,14 +8,12 @@ import { JsonExpr } from "./Expr";
 import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 
 /**
- * Available line caps types(`"None"`, `"Round"`, `"Square"`, `"TriangleOut"`, `"TriangleIn"`).
- * Default is `"Round"`.
+ * The style type of the line caps.
  */
 export type LineCaps = "Square" | "Round" | "None" | "TriangleOut" | "TriangleIn";
 
 /**
- * Available line dash types(`"Round"`, `"Square"`, `"Diamond"`).
- * Default is `"Square"`.
+ * The style type of the line dashes.
  */
 export type LineDashes = "Square" | "Round" | "Diamond";
 
@@ -85,12 +83,10 @@ export enum StandardGeometryKind {
 }
 
 /**
- * Geometry kind used for use by [[BaseTechniqueParams.kind]].
- *
- * @remarks
  * The kind of geometry is used to group objects together,
  * allowing the group to be hidden or displayed.
  *
+ * @remarks
  * Any string can be used to specify the kind of the technique in a style in the theme file. Is is
  * suggested to specify multiple kinds for specific types of data. For a highway, the following list
  * of kinds is suggested:
@@ -132,7 +128,7 @@ export type StyleLength = string | number;
 export type StyleColor = string | number;
 
 /**
- * A set of [[GeometryKind]]s.
+ * A set of {@link GeometryKind}s.
  */
 export class GeometryKindSet extends Set {
     /**
@@ -195,7 +191,8 @@ export interface BaseTechniqueParams {
     /**
      * The render order of the objects created using this technique.
      *
-     * If not specified in style file, [[StyleSetEvaluator]] will assign monotonically increasing
+     * @remarks
+     * If not specified in style file monotonically increasing
      * values according to style position in file.
      */
     renderOrder?: DynamicProperty<number>;
@@ -203,8 +200,9 @@ export interface BaseTechniqueParams {
     /**
      * The category of this technique.
      *
-     * The category is used in conjunction with [[Theme.priorities]]
-     * to assign render orders to the objects created by this [[Style]].
+     * @remarks
+     * The category is used in conjunction with {@link Theme.priorities}
+     * to assign render orders to the objects created by this {@link Style}.
      */
     category?: DynamicProperty<string>;
 
@@ -214,7 +212,7 @@ export interface BaseTechniqueParams {
     transient?: boolean;
 
     /**
-     * Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the object start
+     * Distance to the camera `(0.0 = camera position, 1.0 = farPlane) at which the object start
      * fading out (opacity decreases).
      */
     fadeNear?: DynamicProperty<number>;
@@ -226,10 +224,12 @@ export interface BaseTechniqueParams {
     fadeFar?: DynamicProperty<number>;
 
     /**
-     * Specified kind of geometry. One kind is set as default in the technique, and can be
-     * overridden in the style.
+     * Specified kind of geometry.
      *
-     * @deprecated Use [[enabled]] with expressions based on `['dynamic-properties']` operator.
+     * @remarks
+     * One kind is set as default in the technique, and can be overridden in the style.
+     *
+     * @deprecated Use {@link enabled} with expressions based on `['dynamic-properties']` operator.
      */
     kind?: GeometryKind | GeometryKindSet;
 
@@ -238,7 +238,7 @@ export interface BaseTechniqueParams {
      *
      * Use with `['dynamic-properties']` operator for dynamic feature highlight, highlighig etc.
      *
-     * @see Picking example - [[PickingExample]]
+     * @see Picking example
      */
     enabled?: DynamicProperty<boolean>;
 }
@@ -246,12 +246,16 @@ export interface BaseTechniqueParams {
 export enum TextureCoordinateType {
     /**
      * Texture coordinates are in tile space.
+     *
+     * @remarks
      * SW of the tile will have (0,0) and NE will have (1,1).
      */
     TileSpace = "tile-space",
 
     /**
      * Texture coordinates are in equirectangular space.
+     *
+     * @remarks
      * (u, v) = ( (longitude+180) / 360, (latitude+90) / 180).
      */
     EquirectangularSpace = "equirectangular-space",
@@ -259,6 +263,7 @@ export enum TextureCoordinateType {
     /**
      * Texture coordinates in feature space.
      *
+     * @remarks
      * To compute texture coordinates in feature space,
      * the feature must have a property named `bbox` with value
      * the tuple `[west, south, east, north]`.
@@ -502,6 +507,7 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Text to be displayed for feature.
      *
+     * @remarks
      * Defaults to first defined:
      *  - feature property `label` if present in technique (deprecated)
      *  - `["get", "name:short"]` is `useAbbreviation` is true
@@ -556,8 +562,8 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Icon color.
      *
+     * @remarks
      * If specified, combined using multiplication with color value read from icon texture.
-     *
      * Works best for grayscale or monochromatic textures.
      */
     iconColor?: StyleColor;
@@ -565,10 +571,11 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Icon brightness.
      *
+     * @remarks
      * Factor that multiplies a color on top of the icon texture (and `iconColor`) with `0` being
      * fully black as final output, `1` being the original rgb colors of the texture.
      *
-     * @default `1`
+     * @defaultValue `1`
      */
     iconBrightness?: number;
 
@@ -578,24 +585,29 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     distanceScale?: number;
     /**
      * If `false`, text may overlap markers.
-     * @default `false`
+     * @defaultValue `false`
      */
     textMayOverlap?: boolean;
     /**
-     * If `false`, the icon may overlap text and other icons of lower priority. If not defined, the
+     * If `false`, the icon may overlap text and other icons of lower priority.
+     *
+     * @remarks
+     * If not defined, the
      * property value from `textMayOverlap` will be used.
-     * @default `false`
+     * @defaultValue `false`
      */
     iconMayOverlap?: boolean;
     /**
      * If `false`, text will not reserve screen space, other markers will be able to overlap.
-     * @default `true`
+     * @defaultValue `true`
      */
     textReserveSpace?: boolean;
     /**
-     * If `false`, icon will not reserve screen space, other markers will be able to overlap. If not
-     * defined, the property value from `iconReserveSpace` will be used.
-     * @default `true`
+     * If `false`, icon will not reserve screen space, other markers will be able to overlap.
+     *
+     * @remarks
+     * If not defined, the property value from `iconReserveSpace` will be used.
+     * @defaultValue `true`
      */
     iconReserveSpace?: boolean;
     /**
@@ -603,14 +615,19 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
      */
     renderTextDuringMovements?: boolean;
     /**
-     * If `true`, the label will always be rendered on top. If overlapping with other labels with
+     * If `true`, the label will always be rendered on top.
+     *
+     * @remarks
+     * If overlapping with other labels with
      * this flag set, the render order is undefined.
-     * @default `false`
+     * @defaultValue `false`
      */
     alwaysOnTop?: boolean;
     /**
-     * If `true`, icon will appear even if the text part is blocked by other labels. Defaults to
-     * `false`.
+     * If `true`, icon will appear even if the text part is blocked by other labels.
+     *
+     * @remarks
+     * @defaultValue `false`
      */
     textIsOptional?: boolean;
     /**
@@ -627,7 +644,9 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     minDistance?: number;
     /**
      * If true, the text will appear even if the icon cannot be rendered because of missing icon
-     * graphics. Defaults to `true`.
+     * graphics.
+     *
+     * @defaultValue `true`
      */
     iconIsOptional?: boolean;
     /**
@@ -671,7 +690,10 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
      */
     poiTable?: string;
     /**
-     * Fixed name to identify POI options in the POI table. If `poiName` has a value, this value
+     * Fixed name to identify POI options in the POI table.
+     *
+     * @remarks
+     * If `poiName` has a value, this value
      * supersedes any value read from the field referenced in `poiNameField`.
      */
     poiName?: string;
@@ -787,6 +809,7 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     /**
      * Text label positions relative to the label central position (anchor point).
      *
+     * @remarks
      * This attribute defines a comma separated tokens of possible text placements
      * relative to label central position (anchor), for example: "TL, TR, C".
      * Keep in mind that horizontal placement defines text position in opposite way to
@@ -799,7 +822,10 @@ export interface MarkerTechniqueParams extends BaseTechniqueParams {
     placements?: string;
 
     /**
-     * World space offset in meters applied to the icon. Valid only for icons which have the
+     * World space offset in meters applied to the icon.
+     *
+     * @remarks
+     * Valid only for icons which have the
      * "offset_direction" property as an attribute of the data.
      */
     worldOffset?: DynamicProperty<number>;
@@ -813,7 +839,10 @@ export interface LineTechniqueParams extends BaseTechniqueParams {
      */
     color: DynamicProperty<StyleColor>;
     /**
-     * Set to true if line should appear transparent. Rendering transparent lines may come with a
+     * Set to true if line should appear transparent.
+     *
+     * @remarks
+     * Rendering transparent lines may come with a
      * slight performance impact.
      */
     transparent?: boolean;
@@ -859,7 +888,10 @@ export interface SegmentsTechniqueParams extends BaseTechniqueParams {
  */
 export interface PolygonalTechniqueParams {
     /**
-     * Whether to use polygon offset. Default is false. This corresponds to the
+     * Whether to use polygon offset. Default is false.
+     *
+     * @remarks
+     * This corresponds to the
      * GL_POLYGON_OFFSET_FILL WebGL feature.
      *
      * PolygonOffset is used to raise the geometry towards the geometry (for depth calculation
@@ -915,8 +947,10 @@ export interface BasicExtrudedLineTechniqueParams
     extends BaseTechniqueParams,
         PolygonalTechniqueParams {
     /**
-     * A value determining the shading technique. Valid values are "Basic" and "Standard". Default
-     * is "Basic".
+     * A value determining the shading technique.
+     *
+     * @remarks
+     * Valid values are "Basic" and "Standard". Default is "basic".
      *
      * `"basic"`   : Simple shading, faster to render. Only simple color and opacity are effective.
      * `"standard"`: Elaborate shading, with metalness, and roughness.
@@ -929,7 +963,10 @@ export interface BasicExtrudedLineTechniqueParams
      */
     color: DynamicProperty<StyleColor>;
     /**
-     * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
+     * Set to `true` if line should appear transparent.\
+     *
+     * @remarks
+     * Rendering transparent lines may come with a
      * slight performance impact.
      */
     transparent?: boolean;
@@ -963,6 +1000,7 @@ export interface StandardExtrudedLineTechniqueParams
      * A value determining the shading technique. Valid values are `"basic"` and `"standard"`.
      * Default is `"basic"`.
      *
+     * @remarks
      * `"basic"` : Simple shading, faster to render. Only simple color and opacity are effective.
      * `"standard"` : Elaborate shading, with metalness, and roughness.
      */
@@ -972,7 +1010,10 @@ export interface StandardExtrudedLineTechniqueParams
      */
     lineWidth: DynamicProperty<number>;
     /**
-     * Style of both end caps. Possible values: `"None"`, `"Circle"`. A value of undefined maps to
+     * Style of both end caps. Possible values: `"None"`, `"Circle"`.
+     *
+     * @remarks
+     * A value of undefined maps to
      * `"Circle"`.
      */
     caps?: DynamicProperty<"None" | "Circle">;
@@ -1019,12 +1060,12 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
     outlineWidth?: DynamicProperty<StyleLength>;
     /**
      * Clip the line outside the tile if `true`.
-     * @default false
+     * @defaultValue false
      */
     clipping?: DynamicProperty<boolean>;
     /**
-     * Describes line caps type (`"None"`, `"Round"`, `"Square"`, `"TriangleOut"`, `"TriangleIn"`).
-     * Default is `"Round"`.
+     * Describes the style of the line caps.
+     * @defaultValue `"Round"`.
      */
     caps?: DynamicProperty<LineCaps>;
     /**
@@ -1042,9 +1083,8 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      */
     secondaryRenderOrder?: DynamicProperty<number>;
     /**
-     * Describes secondary line caps type (`"None"`, `"Round"`, `"Square"`, `"TriangleOut"`,
-     * `"TriangleIn"`).
-     * Default is `"Round"`.
+     * Describes the style of the secondary line caps
+     * @defaultValue `"Round"`.
      */
     secondaryCaps?: DynamicProperty<LineCaps>;
     /**
@@ -1062,8 +1102,8 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      */
     drawRangeEnd?: number;
     /**
-     * Describes line dash type (`"Round"`, `"Square"`, `"Diamond"`).
-     * Default is `"Square"`.
+     * Describes the style of the line dashes.
+     * @defaultValue `"Square"`.
      */
     dashes?: DynamicProperty<LineDashes>;
     /**
@@ -1087,7 +1127,7 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
     /**
      * Skip rendering clobbered pixels.
      * See https://threejs.org/docs/#api/en/materials/Material.depthTest.
-     * @default `false`
+     * @defaultValue `false`
      */
     depthTest?: boolean;
 }
@@ -1103,7 +1143,10 @@ export interface FillTechniqueParams extends BaseTechniqueParams, PolygonalTechn
      */
     color?: DynamicProperty<StyleColor>;
     /**
-     * Set to `true` if line should appear transparent. Rendering transparent lines may come with a
+     * Set to `true` if line should appear transparent.
+     *
+     * @renarks
+     * Rendering transparent lines may come with a
      * slight performance impact.
      */
     transparent?: boolean;
@@ -1194,14 +1237,17 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
      * If `true`, the height of the extruded buildings will not be modified by the mercator
      * projection distortion that happens around the poles.
      *
-     * @default `false`
+     * @defaultValue `false`
      */
     constantHeight?: boolean;
 
     /**
-     * If `true`, wall geometry will is added along the tile boundaries. Note, this causes artifacts
-     * when used with shadows, so it should be known in advance that shadows won't be enabled.
-     * @default `false`
+     * If `true`, wall geometry will is added along the tile boundaries.
+     *
+     * @remarks
+     * this causes artifacts when used with shadows,
+     * so it should be known in advance that shadows won't be enabled.
+     * @defaultValue `false`
      */
     boundaryWalls?: boolean;
 
@@ -1218,6 +1264,7 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
     /**
      * Control rendering of depth prepass before the actual geometry.
      *
+     * @remarks
      * Depth prepass is a method to render translucent meshes, hence only the visible front faces of
      * a mesh are actually rendered, removing artifacts caused by blending with internal faces of
      * the mesh. This method is used for drawing translucent buildings over map background.
@@ -1243,13 +1290,15 @@ export interface ShaderTechniqueParams extends BaseTechniqueParams {
     params: ShaderTechniqueMaterialParameters;
 
     /**
-     * Type of primitive for the shader technique. Valid values are "point" | "line" | "segments" |
-     * "mesh"
+     * Type of primitive for the shader technique.
      */
     primitive: "point" | "line" | "segments" | "mesh";
 
     /**
-     * Set to 'true' if line should appear transparent. Rendering transparent lines may come with a
+     * Set to 'true' if line should appear transparent.
+     *
+     * @remarks
+     * Rendering transparent lines may come with a
      * slight performance impact.
      * See https://threejs.org/docs/#api/en/materials/Material.transparent.
      */
@@ -1260,6 +1309,8 @@ export interface ShaderTechniqueParams extends BaseTechniqueParams {
 
 /**
  * Technique used to render a terrain geometry with a texture.
+ *
+ * @remarks
  * When using this technique, the datasource will produce texture coordinates in
  * local tile space (i.e. [0,0] at south-west and [1,1] at north-east tile corner).
  */
@@ -1272,12 +1323,15 @@ export interface TerrainTechniqueParams extends StandardTechniqueParams {
     /**
      * If `heightBasedColors` is defined, this value defines the interpolation method used to
      * generate the height-based gradient texture (defaults to `Discrete`).
+     * @defaultValue `"Discrete"`
      */
     heightGradientInterpolation?: "Discrete" | "Linear" | "Cubic";
 
     /**
      * If `heightBasedColors` is defined, this value defines the width (in pixels) of the generated
-     * gradient texture (defaults to `128`).
+     * gradient texture.
+     *
+     * @defaultValue `128`
      */
     heightGradientWidth?: number;
 }
@@ -1289,14 +1343,13 @@ export interface TextTechniqueParams extends BaseTechniqueParams {
     /**
      * Text to be displayed for feature.
      *
+     * @remarks
      * Defaults to first defined:
      *  - feature property `label` if present in technique (depreacted);
      *  - `["get", "name:short"]` is `useAbbreviation` is true;
      *  - `["get", "iso_code"]` is `useIsoCode` is true;
      *  - `["get", "name:$LANGUAGE"]` for each specified language;
      *  - `["get", "name"]`.
-     *
-     * See [[ExtendedTileInfo.getFeatureText]].
      */
     text?: DynamicProperty<string>;
 
@@ -1314,6 +1367,7 @@ export interface TextTechniqueParams extends BaseTechniqueParams {
     useAbbreviation?: boolean;
     /**
      * If `true`, the iso code (field 'iso_code') of the elements is used as text.
+     * @remarks
      * The `iso_code` field contains the ISO 3166-1 2-letter country code.
      *
      * @deprecated Use proper expression with [`get`, `iso_code`] for this purpose.
@@ -1337,13 +1391,13 @@ export interface TextTechniqueParams extends BaseTechniqueParams {
     distanceScale?: number;
     /**
      * If `true`, icon is allowed to overlap other labels or icons of lower priority.
-     * @default `false`
+     * @defaultValue `false`
      */
     mayOverlap?: boolean;
     /**
      * If `true`, element will reserve screen space, other markers of lower priority will not be
      * able to overlap.
-     * @default `true`
+     * @defaultValue `true`
      */
     reserveSpace?: boolean;
     /**

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -20,6 +20,11 @@ export type LineCaps = "Square" | "Round" | "None" | "TriangleOut" | "TriangleIn
 export type LineDashes = "Square" | "Round" | "Diamond";
 
 /**
+ * Defines how to interpret the units.
+ */
+export type MetricUnit = "Meter" | "Pixel";
+
+/**
  * Standard kinds of geometry.
  */
 export enum StandardGeometryKind {
@@ -915,8 +920,6 @@ export interface BasicExtrudedLineTechniqueParams
      *
      * `"basic"`   : Simple shading, faster to render. Only simple color and opacity are effective.
      * `"standard"`: Elaborate shading, with metalness, and roughness.
-     *
-     * TODO: is this TechniqueParams or Style prop ?
      */
     shading?: "basic";
     /**
@@ -1001,12 +1004,11 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      * opaque.
      */
     opacity?: DynamicProperty<number>;
-    // TODO: Make pixel units default.
     /**
      * @deprecated Specify metrics units as part of the value instead.
      * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
      */
-    metricUnit?: string;
+    metricUnit?: MetricUnit;
     /**
      * Width of a line in `metricUnit` for different zoom levels.
      */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -361,19 +361,6 @@ export interface StyleAttributes<Technique, Params> {
      */
     debug?: boolean;
 
-    // TODO: Make pixel units default.
-    /**
-     * Units in which different size properties are specified. Either `Meter` (default) or `Pixel`.
-     *
-     * @deprecated use "string encoded numerals" as documented in TODO, wher eis the doc ?
-     */
-    metricUnit?: "Meter" | "Pixel";
-
-    /**
-     * XYZ defines the property to display as text label of a feature in the styles.
-     */
-    labelProperty?: string;
-
     attr?: Partial<Params>;
 }
 
@@ -747,14 +734,13 @@ export interface PoiTableDef {
     /** Name of the `PoiTable`. Must be unique. */
     name?: string;
     /**
-     * Stores the list of [[PoiTableEntry]]s.
+     * Stores the list of {@link PoiTableEntryDef}s.
      */
     poiList?: PoiTableEntryDef[];
 }
 
 /**
- * Interface for the JSON description of the [[PoiTableEntry]]. The interface is being implemented
- * as [[PoiTableEntry]].
+ * Interface descrining POI entries.
  */
 export interface PoiTableEntryDef {
     /** Default name of the POI as the key for looking it up. */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -5,12 +5,11 @@
  */
 
 import { Vector3Like } from "@here/harp-geoutils/lib/math/Vector3Like";
-import { isJsonExpr, JsonExpr } from "./Expr";
-import { isInterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
+import { JsonExpr, JsonValue } from "./Expr";
+import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 import {
     BaseTechniqueParams,
     BasicExtrudedLineTechniqueParams,
-    DynamicProperty,
     ExtrudedPolygonTechniqueParams,
     FillTechniqueParams,
     LineTechniqueParams,
@@ -134,6 +133,7 @@ export interface Theme {
      * are used together with [[Theme.priorities]] to sort
      * the objects created using this {@link Theme}, for example:
      *
+     * @example
      * ```json
      * {
      *      "priorities": [
@@ -160,6 +160,7 @@ export interface Theme {
      * technique (e.g. `"text"`) must match on the strings
      * defined by this [[Theme.labelPriorities]], for example:
      *
+     * @example
      * ```json
      * {
      *      "labelPriorities": [
@@ -184,19 +185,19 @@ export interface Theme {
  */
 export interface StylePriority {
     /**
-     * The group of this [[StylePriority]].
+     * The group of this `StylePriority`.
      */
     group: string;
 
     /**
-     * The category of this [[StylePriority]].
+     * The category of this `StylePriority`.
      */
     category?: string;
 }
 
 /**
  * A type representing HARP themes with all the styleset declarations
- * grouped in one [[Array]].
+ * grouped in one `Array`.
  *
  * @internal This type will merge with {@link Theme}.
  */
@@ -208,34 +209,18 @@ export type FlatTheme = Omit<Theme, "styles"> & {
 };
 
 /**
- * Checks if the given definition implements the [[BoxedDefinition]] interface.
- */
-export function isBoxedDefinition(def: Definition): def is BoxedDefinition {
-    const bdef = def as BoxedDefinition;
-    return (
-        typeof bdef === "object" &&
-        bdef !== null &&
-        (typeof bdef.type === "string" || typeof bdef.type === "undefined") &&
-        (typeof bdef.value === "string" ||
-            typeof bdef.value === "number" ||
-            typeof bdef.value === "boolean" ||
-            isInterpolatedPropertyDefinition(bdef.value) ||
-            isJsonExpr(bdef.value))
-    );
-}
-
-export function isLiteralDefinition(def: Definition): def is LiteralValue {
-    return typeof def === "string" || typeof def === "number" || typeof def === "boolean";
-}
-
-/**
  * Value definition commons.
  */
-export interface BaseValueDefinition {
+export interface Definition {
     /**
      * The type of the definition.
      */
-    type?: string;
+    type?: "selector" | "boolean" | "number" | "string" | "color";
+
+    /**
+     * The value of the definition.
+     */
+    value: JsonValue | InterpolatedPropertyDefinition<JsonValue>;
 
     /**
      * The description of the definition.
@@ -244,144 +229,10 @@ export interface BaseValueDefinition {
 }
 
 /**
- * Possible types of unboxed literal values carried by [[Definition]].
- */
-export type LiteralValue = string | number | boolean;
-
-/**
- * Boxed definition without type.
- */
-export interface BoxedAnyDefinition extends BaseValueDefinition {
-    /**
-     * The value of the definition.
-     */
-    value: LiteralValue | JsonExpr;
-}
-
-/**
- * A boxed boolean value definition.
- */
-export interface BoxedBooleanDefinition extends BaseValueDefinition {
-    /**
-     * The type of the definition.
-     */
-    type: "boolean";
-
-    /**
-     * The value of the definition.
-     */
-    value: DynamicProperty<boolean>;
-}
-
-/**
- * A boxed numerical value definition.
- */
-export interface BoxedNumericDefinition extends BaseValueDefinition {
-    /**
-     * The type of the definition.
-     */
-    type: "number";
-
-    /**
-     * The value of the definition.
-     */
-    value: DynamicProperty<number>;
-}
-
-/**
- * A boxed string value definition.
- */
-export interface BoxedStringDefinition extends BaseValueDefinition {
-    /**
-     * The type of the definition.
-     */
-    type: "string";
-
-    /**
-     * The value of the definition.
-     */
-    value: DynamicProperty<string>;
-}
-
-/**
- * A boxed color value definition.
- */
-export interface BoxedColorDefinition extends BaseValueDefinition {
-    /**
-     * The type of the definition.
-     */
-    type: "color";
-
-    /**
-     * The value of the definition.
-     */
-    value: DynamicProperty<string>;
-}
-
-/**
- * A boxed selector value definition.
- */
-export interface BoxedSelectorDefinition extends BaseValueDefinition {
-    /**
-     * The type of the definition.
-     */
-    type: "selector";
-
-    /**
-     * The value of the definition.
-     *
-     * See [[BaseStyle.when]].
-     */
-    value: string | JsonExpr;
-}
-
-/**
- * A boxed value definition.
- */
-export type BoxedDefinition =
-    | BoxedAnyDefinition
-    | BoxedBooleanDefinition
-    | BoxedNumericDefinition
-    | BoxedStringDefinition
-    | BoxedColorDefinition
-    | BoxedSelectorDefinition;
-
-/**
- * Possible values for `definitions` element of [Theme].
- */
-export type Definition = LiteralValue | JsonExpr | BoxedDefinition | StyleDeclaration;
-
-/**
- * An array of [[Definition]]s.
+ * An set of {@link Definition}s.
  */
 export interface Definitions {
     [name: string]: Definition;
-}
-
-/**
- * Base [StyleSelector] attributes required to match [Style] object against given feature.
- *
- * Contains [Style]'s members related to feature matching in [[StyleSetEvaluator]].
- */
-export interface StyleSelector {
-    /**
-     * Condition when this style rule applies.
-     *
-     * @remarks
-     * Condition that is applied to feature properties to check if given [[Style]] this feature
-     * should emit geometry of this style.
-     */
-    when: string | JsonExpr;
-
-    /**
-     * The layer containing the carto features processed by this style rule.
-     */
-    layer?: string;
-
-    /**
-     * Optional. If `true`, no more matching styles will be evaluated.
-     */
-    final?: boolean;
 }
 
 export type JsonExprReference = ["ref", string];
@@ -401,45 +252,59 @@ export function isJsonExprReference(value: any): value is JsonExprReference {
 }
 
 /**
- * Like [[StyleDeclaration]], but without [[Reference]] type.
+ * An array of {@link Style}s that are used together to define how a
+ * {@link @here/harp-mapview#DataSource} should be rendered.
+ *
+ * @remarks
+ * `StyleSet`s are applied to sources providing vector tiles via their method
+ * `setStyleSet`. This is also handle internally when a whole theme is passed to a
+ * {@link @here/harp-mapview#MapView} via {@link @here/harp-mapview#MapViewtheme}.
  */
-export type ResolvedStyleDeclaration = Style & StyleSelector;
+export type StyleSet = Style[];
 
 /**
- * Like [[StyleSet]], but without [[Reference]] type.
- */
-export type ResolvedStyleSet = ResolvedStyleDeclaration[];
-
-/**
- * Compound type that merges all raw [Style] with selector arguments from [BaseSelector], optionally
- * a [[Reference]].
- */
-export type StyleDeclaration = (Style & StyleSelector) | JsonExpr;
-
-export function isActualSelectorDefinition(def: Definition): def is Style & StyleSelector {
-    const styleDef = def as StyleDeclaration;
-    return (
-        typeof styleDef === "object" &&
-        styleDef !== null &&
-        !Array.isArray(styleDef) &&
-        typeof styleDef.technique === "string"
-    );
-}
-
-/**
- * An array of [[StyleSelector]]s that are used together to define how a [[DataSource]] should be
- * rendered. `StyleSet`s are applied to sources providing vector tiles via their method
- * `setStyleSet`. This is also handle internally when a whole theme is passed to a [[MapView]] via
- * `mapview.theme`.
- */
-export type StyleSet = StyleDeclaration[];
-
-/**
- * The object that defines what way an item of a [[DataSource]] should be decoded to assemble a
- * tile. [[Style]] is describing which features are shown on a map and in what way they are being
+ * The object that defines what way an item of a {@link @here/harp-mapview#DataSource}
+ * should be decoded to assemble a tile.
+ *
+ * @remarks
+ * {@link Style} is describing which features are shown on a map and in what way they are being
  * shown.
  */
-export type BaseStyle<Technique, Params> = Partial<Params> & {
+export type BaseStyle<Technique, Params> = StyleAttributes<Technique, Params> & Partial<Params>;
+
+/**
+ * The common attributes of a {@link Style}.
+ */
+export interface StyleAttributes<Technique, Params> {
+    /**
+     * Unique identifier associated with this `Style`.
+     */
+    id?: string;
+
+    /**
+     * Reference to the identifier of an existing `Style` to extend.
+     */
+    extends?: string;
+
+    /**
+     * Condition when this style rule applies.
+     *
+     * @remarks
+     * Condition that is applied to feature properties to check if given {@link Style} this feature
+     * should emit geometry of this style.
+     */
+    when: string | JsonExpr;
+
+    /**
+     * The layer containing the carto features processed by this style rule.
+     */
+    layer?: string;
+
+    /**
+     * Optional. If `true`, no more matching styles will be evaluated.
+     */
+    final?: boolean;
+
     /**
      * Human readable description.
      */
@@ -510,7 +375,7 @@ export type BaseStyle<Technique, Params> = Partial<Params> & {
     labelProperty?: string;
 
     attr?: Partial<Params>;
-};
+}
 
 export type Style =
     | SquaresStyle
@@ -532,7 +397,7 @@ export type Style =
     | NoneStyle;
 
 /**
- * A dictionary of [[StyleSet]]s.
+ * A dictionary of {@link StyleSet}s.
  */
 export interface Styles {
     [styleSetName: string]: StyleSet;
@@ -541,6 +406,7 @@ export interface Styles {
 /**
  * A reference to a style definition.
  *
+ * @remarks
  * Use as value `attrs` to reference value from `definitions`.
  *
  * Example of usage:
@@ -570,14 +436,14 @@ export type Attr<T> = { [P in keyof T]?: T[P] | JsonExpr };
 /**
  * Render feature as set of squares rendered in screen space.
  *
- * @see [[PointTechniqueParams]].
+ * @see {@link PointTechniqueParams}.
  */
 export type SquaresStyle = BaseStyle<"squares", PointTechniqueParams>;
 
 /**
  * Render feature as set of circles rendered in screen space.
  *
- * @see [[PointTechniqueParams]].
+ * @see {@link PointTechniqueParams}.
  */
 export type CirclesStyle = BaseStyle<"circles", PointTechniqueParams>;
 

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -505,63 +505,54 @@ export interface BaseLight {
 }
 
 /**
- * Light type: ambient.
- *
- * @remarks
- *
- * @defaultSnippets [
- *     {
- *         "label": "New Ambient Light",
- *         "description": "Adds a new Ambient Light",
- *         "body": {
- *             "type": "ambient",
- *             "name": "${1:ambient light}",
- *             "color": "#${2:fff}",
- *             "intensity": "^${3:1}"
- *         }
- *     }
- * ]
+ * Ambient light
  */
 export interface AmbientLight extends BaseLight {
-    type: "ambient";
     /**
-     * @format color-hex
+     * The type of the light.
+     */
+    type: "ambient";
+
+    /**
+     * The color of this ambient light.
      */
     color: string;
+
+    /**
+     * The intensity of this ambient light.
+     */
     intensity?: number;
 }
 
 /**
- * Light type: directional.
- *
- * @remarks
- *
- * @defaultSnippets [
- *     {
- *         "label": "New Directional Light",
- *         "description": "Adds a new Directional Light",
- *         "body": {
- *             "type": "directional",
- *             "name": "${1:directional-light$:1}",
- *             "color": "#${2:fff}",
- *             "intensity": "^${3:1}",
- *             "direction": {
- *                 "x": "^${4:1}",
- *                 "y": "^${5:0}",
- *                 "z": "^${6:0}"
- *             }
- *         }
- *     }
- * ]
+ * Directional light.
  */
 export interface DirectionalLight extends BaseLight {
-    type: "directional";
     /**
-     * @format color-hex
+     * The type of the light.
+     */
+    type: "directional";
+
+    /**
+     * The color of this directional light.
      */
     color: string;
+
+    /**
+     * The intensity of this directional light.
+     */
     intensity: number;
+
+    /**
+     * The direction of this directional light.
+     */
     direction: Vector3Like;
+
+    /**
+     * Determine if this light casts dynamic shadows.
+     *
+     * @defaultValue false
+     */
     castShadow?: boolean;
 }
 

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -293,7 +293,7 @@ export interface StyleAttributes<Technique, Params> {
      * Condition that is applied to feature properties to check if given {@link Style} this feature
      * should emit geometry of this style.
      */
-    when: string | JsonExpr;
+    when?: string | JsonExpr;
 
     /**
      * The layer containing the carto features processed by this style rule.

--- a/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
+++ b/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
@@ -5,7 +5,7 @@
  */
 
 import { isJsonExpr } from "./Expr";
-import { StyleDeclaration, Theme } from "./Theme";
+import { Style, Theme } from "./Theme";
 
 /**
  * The ThemeVisitor visits every style in the theme in a depth-first fashion.
@@ -19,8 +19,8 @@ export class ThemeVisitor {
      *                  `true` to cancel visitation.
      * @returns `true` if function has finished prematurely.
      */
-    visitStyles(visitFunc: (style: StyleDeclaration) => boolean): boolean {
-        const visit = (style: StyleDeclaration): boolean => {
+    visitStyles(visitFunc: (style: Style) => boolean): boolean {
+        const visit = (style: Style): boolean => {
             if (isJsonExpr(style)) {
                 return false;
             }

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -57,11 +57,11 @@ describe("Expr", function() {
     describe("#fromJson", function() {
         describe("ref operator support", function() {
             const baseDefinitions: Definitions = {
-                color: "#ff0",
+                color: { value: "#ff0" },
                 string: { value: "abc" },
                 number: { type: "number", value: 123 },
                 number2: { value: 234 },
-                boolean: true
+                boolean: { value: true }
             };
             it("supports literal references", function() {
                 assert.equal(evaluate(Expr.fromJSON(["ref", "color"], baseDefinitions)), "#ff0");
@@ -77,7 +77,7 @@ describe("Expr", function() {
             });
             it("supports basic expression references", function() {
                 const definitions: Definitions = {
-                    literalExpr: ["+", 2, 3],
+                    literalExpr: { value: ["+", 2, 3] },
                     boxedTypedExpr: { type: "selector", value: ["+", 3, 4] },
                     boxedUntypedExpr: { value: ["+", 4, 5] }
                 };
@@ -94,10 +94,14 @@ describe("Expr", function() {
             });
             it("supports complex embedded references", function() {
                 const definitions: Definitions = {
-                    number: 1,
-                    refConstantExpr: ["+", 1, ["ref", "number"]],
-                    refExpr1: ["+", ["ref", "number"], ["ref", "number"], ["ref", "refExpr2"]],
-                    refExpr2: ["*", ["ref", "refConstantExpr"], ["ref", "refConstantExpr"]],
+                    number: { value: 1 },
+                    refConstantExpr: { value: ["+", 1, ["ref", "number"]] },
+                    refExpr1: {
+                        value: ["+", ["ref", "number"], ["ref", "number"], ["ref", "refExpr2"]]
+                    },
+                    refExpr2: {
+                        value: ["*", ["ref", "refConstantExpr"], ["ref", "refConstantExpr"]]
+                    },
                     refTopExpr: {
                         // 6 - 4 -> 2, old syntax
                         type: "selector",

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -15,7 +15,7 @@ import {
 } from "../lib/InterpolatedPropertyDefs";
 import { StyleSetEvaluator } from "../lib/StyleSetEvaluator";
 import { FillTechnique, isSolidLineTechnique, SolidLineTechnique } from "../lib/Techniques";
-import { Definitions, StyleDeclaration, StyleSet } from "../lib/Theme";
+import { Definitions, Style, StyleSet } from "../lib/Theme";
 
 import * as THREE from "three";
 
@@ -220,7 +220,7 @@ describe("StyleSetEvaluator", function() {
         });
     });
     describe('definitions / "ref" operator support', function() {
-        const sampleStyleDeclaration: StyleDeclaration = {
+        const sampleStyleDeclaration: Style = {
             technique: "fill",
             when: ["ref", "expr"],
             attr: { lineWidth: ["ref", "number"], color: ["ref", "interpolator"] }
@@ -257,22 +257,8 @@ describe("StyleSetEvaluator", function() {
                 renderOrder: 0
             });
         });
-        it("resolves style declaration references", function() {
-            const sse = new StyleSetEvaluator([["ref", "style"]], {
-                ...sampleDefinitions,
-                style: sampleStyleDeclaration
-            });
-            const techniques = sse.getMatchingTechniques(new MapEnv({ kind: "park" }));
-
-            assert.equal(techniques.length, 1);
-            assert.deepNestedInclude(techniques[0], {
-                name: "fill",
-                lineWidth: 123,
-                renderOrder: 0
-            });
-        });
         it("reuses very same instances of objects from definition table", function() {
-            const styleReferencingObject: StyleDeclaration = {
+            const styleReferencingObject: Style = {
                 technique: "fill",
                 when: ["ref", "expr"],
                 attr: { lineWidth: ["ref", "number"], color: ["ref", "bigObject"] }
@@ -280,7 +266,7 @@ describe("StyleSetEvaluator", function() {
             const bigObject = {};
             const definitions: Definitions = {
                 ...sampleDefinitions,
-                bigObject: ["literal", bigObject]
+                bigObject: { value: ["literal", bigObject] }
             };
             const sse = new StyleSetEvaluator([styleReferencingObject], definitions);
 
@@ -523,7 +509,7 @@ describe("StyleSetEvaluator", function() {
     });
 
     it("Filter techniques by zoom level", function() {
-        function getMatchingTechniques(props: ValueMap, styleSet: StyleDeclaration[]) {
+        function getMatchingTechniques(props: ValueMap, styleSet: Style[]) {
             return new StyleSetEvaluator(styleSet).getMatchingTechniques(new MapEnv(props));
         }
 

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -3,7 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { StyleDeclaration, StyleSet } from "@here/harp-datasource-protocol";
+import { Style, StyleSet } from "@here/harp-datasource-protocol";
 import {
     FeaturesDataSource,
     MapViewFeature,
@@ -247,7 +247,7 @@ export namespace PolygonsFeaturesExample {
             const max = options.thresholds[i];
             const min = i - 1 < 0 ? 0 : options.thresholds[i - 1];
             const propertyName = options.property;
-            const style: StyleDeclaration = {
+            const style: Style = {
                 description: "geoJson property-based style",
                 technique: "extruded-polygon",
                 when: [

--- a/@here/harp-examples/src/datasource_geojson_choropleth.ts
+++ b/@here/harp-examples/src/datasource_geojson_choropleth.ts
@@ -3,7 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { StyleDeclaration, StyleSet, Theme } from "@here/harp-datasource-protocol";
+import { Style, StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
@@ -117,7 +117,7 @@ export namespace GeoJsonHeatmapExample {
             const min = i - 1 < 0 ? 0 : options.thresholds[i - 1];
             // snippet:geojson_heatmap1.ts
             const propertyName = options.property;
-            const style: StyleDeclaration = {
+            const style: Style = {
                 description: "geoJson property-based style",
                 technique: "extruded-polygon",
                 when:

--- a/@here/harp-examples/src/real-time-shadows.ts
+++ b/@here/harp-examples/src/real-time-shadows.ts
@@ -310,7 +310,7 @@ export namespace RealTimeShadows {
         ],
         definitions: {
             // Opaque buildings
-            defaultBuildingColor: "#EDE7E1FF"
+            defaultBuildingColor: { value: "#EDE7E1FF" }
         }
     };
     initializeMapView("mapCanvas", theme);

--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -48,8 +48,29 @@ export namespace DataDrivenThemeExample {
                 },
                 styles: {
                     population: [
-                        ["ref", "countryBorderOutline"],
-                        ["ref", "waterPolygons"],
+                        {
+                            id: "countryBorderOutline",
+                            description: "country border - outline",
+                            when: [
+                                "all",
+                                ["==", ["get", "$layer"], "boundaries"],
+                                ["==", ["geometry-type"], "LineString"],
+                                ["==", ["get", "kind"], "country"]
+                            ],
+                            technique: "solid-line",
+                            renderOrder: 4,
+                            color: "#52676E",
+                            lineWidth: ["ref", "countryBorderOutlineWidth"]
+                        },
+                        {
+                            id: "waterPolygons",
+                            layer: "water",
+                            description: "water",
+                            when: ["==", ["geometry-type"], "Polygon"],
+                            technique: "fill",
+                            renderOrder: 5,
+                            color: ["ref", "waterColor"]
+                        },
                         {
                             when: [
                                 "all",

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -88,6 +88,19 @@ export namespace HelloCustomThemeExample {
                         type: "color",
                         value: "#00aa33"
                     }
+                },
+                styles: {
+                    tilezen: [
+                        {
+                            // overrides the `extrudedBuildings` style
+                            // to use the fill technique instead of
+                            // extruded polygons.
+                            id: "extrudedBuildings",
+                            technique: "fill",
+                            when: ["ref", "extrudedBuildingsCondition"],
+                            color: ["ref", "defaultBuildingColor"]
+                        }
+                    ]
                 }
             }
         });

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -87,13 +87,6 @@ export namespace HelloCustomThemeExample {
                     parkColor: {
                         type: "color",
                         value: "#00aa33"
-                    },
-                    extrudedBuildings: {
-                        technique: "fill",
-                        when: ["ref", "extrudedBuildingsCondition"],
-                        attr: {
-                            color: "#774400"
-                        }
                     }
                 }
             }

--- a/@here/harp-map-theme/resources/berlin_derived.json
+++ b/@here/harp-map-theme/resources/berlin_derived.json
@@ -1,42 +1,39 @@
 {
     "extends": "berlin_tilezen_base.json",
     "definitions": {
-        "parkColor": "#f00",
-        "extrudedBuildings": {
-            "technique": "fill",
-            "when": ["ref", "extrudedBuildingsCondition"],
-            "color": "#00f"
-        },
-        "countryBorderLineWidth": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            2,
-            2000,
-            3,
-            1400,
-            4,
-            1000,
-            5,
-            500,
-            6,
-            220,
-            7,
-            90,
-            8,
-            50,
-            9,
-            30,
-            10,
-            20,
-            11,
-            15,
-            12,
-            10,
-            13,
-            5,
-            14,
-            2
-        ]
+        "parkColor": { "value": "#f00" },
+        "countryBorderLineWidth": {
+            "value": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                2,
+                2000,
+                3,
+                1400,
+                4,
+                1000,
+                5,
+                500,
+                6,
+                220,
+                7,
+                90,
+                8,
+                50,
+                9,
+                30,
+                10,
+                20,
+                11,
+                15,
+                12,
+                10,
+                13,
+                5,
+                14,
+                2
+            ]
+        }
     }
 }

--- a/@here/harp-map-theme/resources/berlin_derived.json
+++ b/@here/harp-map-theme/resources/berlin_derived.json
@@ -35,5 +35,14 @@
                 2
             ]
         }
+    },
+    "styles": {
+        "tilezen": [
+            {
+                "extends": "extrudedBuildings",
+                "technique": "extruded-polygon",
+                "color": "yellow"
+            }
+        ]
     }
 }

--- a/@here/harp-map-theme/resources/berlin_tilezen_base.json
+++ b/@here/harp-map-theme/resources/berlin_tilezen_base.json
@@ -1,137 +1,84 @@
 {
     "definitions": {
-        "parkColor": "#6C9478",
-        "extrudedBuildingsCondition": [
-            "all",
-            ["==", ["get", "$layer"], "buildings"],
-            ["==", ["geometry-type"], "Polygon"]
-        ],
-        "defaultBuildingColor": "#EDE7E1E6",
-        "waterColor": "#436981",
-        "waterPolygons": {
-            "description": "water",
-            "when": [
+        "parkColor": { "value": "#6C9478" },
+        "extrudedBuildingsCondition": {
+            "value": [
                 "all",
-                ["==", ["get", "$layer"], "water"],
+                ["==", ["get", "$layer"], "buildings"],
                 ["==", ["geometry-type"], "Polygon"]
-            ],
-            "technique": "fill",
-            "renderOrder": 5,
-            "color": ["ref", "waterColor"]
+            ]
         },
-        "extrudedBuildings": {
-            "description": "extruded buildings",
-            "technique": "extruded-polygon",
-            "when": ["ref", "extrudedBuildingsCondition"],
-            "minZoomLevel": 16,
-            "renderOrder": 2000,
-            "height": ["get", "height"],
-            "color": ["ref", "defaultBuildingColor"],
-            "roughness": 1,
-            "metalness": 0.8,
-            "emissive": "#78858C",
-            "emissiveIntensity": 0.85,
-            "footprint": true,
-            "maxSlope": 0.8799999999999999,
-            "lineWidth": 1,
-            "lineColor": "#172023",
-            "lineColorMix": 0.6,
-            "fadeNear": 0.9,
-            "fadeFar": 1,
-            "lineFadeNear": -0.75,
-            "lineFadeFar": 1
+        "defaultBuildingColor": { "value": "#EDE7E1E6" },
+        "waterColor": { "value": "#436981" },
+        "countryBorderLineWidth": {
+            "value": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                2,
+                2000,
+                3,
+                1400,
+                4,
+                1000,
+                5,
+                500,
+                6,
+                220,
+                7,
+                90,
+                8,
+                50,
+                9,
+                30,
+                10,
+                20,
+                11,
+                15,
+                12,
+                10,
+                13,
+                5,
+                14,
+                2
+            ]
         },
-        "countryBorderLineWidth": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            2,
-            2000,
-            3,
-            1400,
-            4,
-            1000,
-            5,
-            500,
-            6,
-            220,
-            7,
-            90,
-            8,
-            50,
-            9,
-            30,
-            10,
-            20,
-            11,
-            15,
-            12,
-            10,
-            13,
-            5,
-            14,
-            2
-        ],
-        "roadsFadeNear": 0.9,
-        "roadsFadeFar": 0.95,
-        "countryBorderOutlineWidth": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            1,
-            10000,
-            2,
-            8000,
-            3,
-            7000,
-            4,
-            5000,
-            5,
-            3000,
-            6,
-            2000,
-            7,
-            1000,
-            8,
-            500,
-            9,
-            250,
-            10,
-            120,
-            11,
-            80,
-            12,
-            40,
-            13,
-            20,
-            14,
-            10
-        ],
-        "countryBorderLine": {
-            "description": "country border",
-            "when": [
-                "all",
-                ["==", ["get", "$layer"], "boundaries"],
-                ["==", ["geometry-type"], "LineString"],
-                ["==", ["get", "kind"], "country"]
-            ],
-            "technique": "solid-line",
-            "renderOrder": 4.1,
-            "color": "#2F444B",
-            "lineWidth": ["ref", "countryBorderLineWidth"]
-        },
-        "countryBorderOutline": {
-            "description": "country border - outline",
-            "when": [
-                "all",
-                ["==", ["get", "$layer"], "boundaries"],
-                ["==", ["geometry-type"], "LineString"],
-                ["==", ["get", "kind"], "country"]
-            ],
-            "technique": "solid-line",
-            "renderOrder": 4,
-            "color": "#52676E",
-            "lineWidth": ["ref", "countryBorderOutlineWidth"]
+        "roadsFadeNear": { "value": 0.9 },
+        "roadsFadeFar": { "value": 0.95 },
+        "countryBorderOutlineWidth": {
+            "value": [
+                "interpolate",
+                ["linear"],
+                ["zoom"],
+                1,
+                10000,
+                2,
+                8000,
+                3,
+                7000,
+                4,
+                5000,
+                5,
+                3000,
+                6,
+                2000,
+                7,
+                1000,
+                8,
+                500,
+                9,
+                250,
+                10,
+                120,
+                11,
+                80,
+                12,
+                40,
+                13,
+                20,
+                14,
+                10
+            ]
         }
     },
     "sky": {
@@ -1296,7 +1243,15 @@
                 "gapSize": ["step", ["zoom"], 100, 11, 40, 12, 24, 13, 30, 14, 25, 15, 15, 16, 8],
                 "lineWidth": ["interpolate", ["linear"], ["zoom"], 13, 2.75, 14, 1.75]
             },
-            ["ref", "waterPolygons"],
+            {
+                "id": "waterPolygons",
+                "layer": "water",
+                "description": "water",
+                "when": ["==", ["geometry-type"], "Polygon"],
+                "technique": "fill",
+                "renderOrder": 5,
+                "color": ["ref", "waterColor"]
+            },
             {
                 "description": "water",
                 "when": ["all", ["==", ["get", "$layer"], "water"]],
@@ -1307,8 +1262,34 @@
                 "opacity": 0.5,
                 "size": 12.8
             },
-            ["ref", "countryBorderOutline"],
-            ["ref", "countryBorderLine"],
+            {
+                "id": "countryBorderOutline",
+                "description": "country border - outline",
+                "when": [
+                    "all",
+                    ["==", ["get", "$layer"], "boundaries"],
+                    ["==", ["geometry-type"], "LineString"],
+                    ["==", ["get", "kind"], "country"]
+                ],
+                "technique": "solid-line",
+                "renderOrder": 4,
+                "color": "#52676E",
+                "lineWidth": ["ref", "countryBorderOutlineWidth"]
+            },
+            {
+                "id": "countryBorderLine",
+                "description": "country border",
+                "layer": "boundaries",
+                "when": [
+                    "all",
+                    ["==", ["geometry-type"], "LineString"],
+                    ["==", ["get", "kind"], "country"]
+                ],
+                "technique": "solid-line",
+                "renderOrder": 4.1,
+                "color": "#2F444B",
+                "lineWidth": ["ref", "countryBorderLineWidth"]
+            },
             {
                 "description": "country border - labels",
                 "when": [
@@ -2250,7 +2231,29 @@
                 "fadeNear": 0.8,
                 "fadeFar": 0.9
             },
-            ["ref", "extrudedBuildings"],
+            {
+                "id": "extrudedBuildings",
+                "description": "extruded buildings",
+                "technique": "extruded-polygon",
+                "when": ["ref", "extrudedBuildingsCondition"],
+                "minZoomLevel": 16,
+                "renderOrder": 2000,
+                "height": ["get", "height"],
+                "color": ["ref", "defaultBuildingColor"],
+                "roughness": 1,
+                "metalness": 0.8,
+                "emissive": "#78858C",
+                "emissiveIntensity": 0.85,
+                "footprint": true,
+                "maxSlope": 0.8799999999999999,
+                "lineWidth": 1,
+                "lineColor": "#172023",
+                "lineColorMix": 0.6,
+                "fadeNear": 0.9,
+                "fadeFar": 1,
+                "lineFadeNear": -0.75,
+                "lineFadeFar": 1
+            },
             {
                 "description": "building_address",
                 "when": [

--- a/@here/harp-map-theme/test/DefaultThemeTest.ts
+++ b/@here/harp-map-theme/test/DefaultThemeTest.ts
@@ -17,13 +17,7 @@ import {
 } from "@here/harp-datasource-protocol/index-decoder";
 import { loadTestResource } from "@here/harp-test-utils";
 
-import {
-    Definitions,
-    isJsonExprReference,
-    Style,
-    StyleSelector,
-    Theme
-} from "@here/harp-datasource-protocol";
+import { Definitions, Theme } from "@here/harp-datasource-protocol";
 import * as Ajv from "ajv";
 import * as path from "path";
 
@@ -105,19 +99,12 @@ describe("Berlin Theme", function() {
                 for (const styleSetName in theme.styles) {
                     const styleSet = theme.styles[styleSetName];
                     for (let i = 0; i < styleSet.length; ++i) {
-                        let style = styleSet[i];
-                        if (isJsonExpr(style)) {
-                            assert(isJsonExprReference(style));
-                            assert.isDefined(theme.definitions);
-                            const refName = style[1] as string;
-                            style = theme.definitions![refName] as Style & StyleSelector;
-                            assert.isDefined(style, `invalid reference: ${style}`);
-                        }
+                        const style = styleSet[i];
                         const location = `${styleSetName}[${i}]`;
                         if (typeof style.when === "string") {
                             assert.doesNotThrow(() =>
                                 // tslint:disable-next-line: deprecation
-                                Expr.parse((style as Style & StyleSelector).when as string)
+                                Expr.parse(style.when as string)
                             );
                         } else {
                             assertExprValid(style.when, theme.definitions, `${location}.when`);

--- a/@here/harp-map-theme/test/DefaultThemeTest.ts
+++ b/@here/harp-map-theme/test/DefaultThemeTest.ts
@@ -106,7 +106,7 @@ describe("Berlin Theme", function() {
                                 // tslint:disable-next-line: deprecation
                                 Expr.parse(style.when as string)
                             );
-                        } else {
+                        } else if (style.when !== undefined) {
                             assertExprValid(style.when, theme.definitions, `${location}.when`);
                         }
 

--- a/@here/harp-mapview/test/PolarTileDataSourceTest.ts
+++ b/@here/harp-mapview/test/PolarTileDataSourceTest.ts
@@ -7,7 +7,7 @@
 // tslint:disable:only-arrow-functions
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import { StyleDeclaration } from "@here/harp-datasource-protocol";
+import { Style } from "@here/harp-datasource-protocol";
 import {
     GeoCoordinates,
     MercatorConstants,
@@ -28,19 +28,19 @@ describe("PolarTileDataSource", function() {
     let dataSource: PolarTileDataSource;
     let mapViewStub: sinon.SinonStubbedInstance<MapView>;
 
-    const north_style: StyleDeclaration = {
+    const north_style: Style = {
         when: ["==", ["get", "kind"], "north_pole"],
         technique: "fill",
         attr: { color: "#dac0de" }
     };
-    const south_style: StyleDeclaration = {
+    const south_style: Style = {
         when: ["==", ["get", "kind"], "south_pole"],
         technique: "fill",
         attr: { color: "#bada55" }
     };
 
-    const theme_both: StyleDeclaration[] = [north_style, south_style];
-    const theme_south: StyleDeclaration[] = [south_style];
+    const theme_both: Style[] = [north_style, south_style];
+    const theme_south: Style[] = [south_style];
 
     describe("should", function() {
         it("#canGetTile()", function() {

--- a/@here/harp-mapview/test/resources/baseTheme.json
+++ b/@here/harp-mapview/test/resources/baseTheme.json
@@ -9,15 +9,6 @@
                 "zoomLevels": [8, 9, 10, 11, 12, 13, 14, 16, 18],
                 "values": [650, 400, 220, 120, 65, 35, 27, 9, 7]
             }
-        },
-        "primaryRoadFillStyle": {
-            "description": "roads",
-            "when": "kind == 'road",
-            "technique": "solid-line",
-            "attr": {
-                "lineWidth": ["ref", "primaryRoadFillLineWidth"],
-                "lineColor": ["ref", "roadColor"]
-            }
         }
     },
     "fontCatalogs": [
@@ -27,6 +18,16 @@
         }
     ],
     "styles": {
-        "tilezen": [["ref", "primaryRoadFillStyle"]]
+        "tilezen": [
+            {
+                "description": "roads",
+                "when": "kind == 'road",
+                "technique": "solid-line",
+                "attr": {
+                    "lineWidth": ["ref", "primaryRoadFillLineWidth"],
+                    "lineColor": ["ref", "roadColor"]
+                }
+            }
+        ]
     }
 }

--- a/@here/harp-omv-datasource/test/resources/geoJsonData.ts
+++ b/@here/harp-omv-datasource/test/resources/geoJsonData.ts
@@ -104,7 +104,6 @@ export const THEME: Theme = {
                     size: 8,
                     priority: 100
                 },
-                labelProperty: "name",
                 renderOrder: 10.3
             }
         ]

--- a/test/rendering/StylingTest.ts
+++ b/test/rendering/StylingTest.ts
@@ -20,7 +20,7 @@ import {
     Light,
     PoiStyle,
     SolidLineStyle,
-    StyleDeclaration,
+    Style,
     TextTechniqueStyle,
     TextureCoordinateType,
     Theme
@@ -221,7 +221,7 @@ describe("MapView Styling Test", function() {
             kind: "background"
         }
     };
-    const referenceBackroundStyle: StyleDeclaration = {
+    const referenceBackroundStyle: Style = {
         when: "$geometryType == 'polygon' && kind == 'background'",
         technique: "fill",
         final: true,


### PR DESCRIPTION
Add support for extending and overriding existing style rules.

An existing style can be extended by referencing its `id` in
an `extends` property, for example:

base.json
```json
{
   "styles": [
     {
        "styleSet": "tilezen",
        "id": "extruded-building-rule",
        "layer": "buildings",
        "when": ["==", ["geometry-type"], "Polygon"],
        "technique": "extruded-building",
        "color": "red"
     }
  ]
}
```

can be extended by `derived.json` using

```json
{
   "extends": [
       "./base.json",
   ],
   "styles": [
     {
        "styleSet": "tilezen",
        "id": "extruded-building-rule",
        "color": "yellow",
        "minZoomLevel": 16
     }
  ]
}
```

Alternatively, the rule `extruded-building-rule` can be replaced by simply reusing its id in a derived theme, e.g.
```jsonc
{
   "extends": [
       "./base.json",
   ],
   "styles": [
     {
        "styleSet": "tilezen",
        "id": "extruded-building-rule",
        "layer": "buildings",
        "when": ["==", ["geometry-type"], "Polygon"],
        "technique": "fill", // use `fill` instead of `extruded-polygon`
        "color": "yellow"
     }
  ]
}
```



Also, this PR removes references to style and inline literal definitions.
