### PR TITLE
HARP-11261: Fix zoomOnTargetPosition

### DIFF
--- a/@here/harp-map-controls/test/MapControlsTest.ts
+++ b/@here/harp-map-controls/test/MapControlsTest.ts
@@ -359,6 +359,31 @@ describe("MapControls", function() {
                         expect(initWorldDir.dot(endWorldDir)).closeTo(1, 1e-5);
                     });
 
+                    it(`camera target is recomputed (pitch ${pitch})`, function() {
+                        resetCamera(pitch, 5);
+                        mapControls.maxTiltAngle = 90;
+
+                        mapControls.zoomOnTargetPosition(0, 0.1, 6);
+                        // tslint:disable-next-line: deprecation
+                        const oldTarget = MapViewUtils.getTargetAndDistance(projection, camera)
+                            .target;
+                        const expAzimuth = MapViewUtils.extractSphericalCoordinatesFromLocation(
+                            mapView,
+                            camera,
+                            projection.unprojectPoint(oldTarget)
+                        ).azimuth;
+                        mapControls.zoomOnTargetPosition(0, 0.2, 7);
+                        // tslint:disable-next-line: deprecation
+                        const newTarget = MapViewUtils.getTargetAndDistance(projection, camera)
+                            .target;
+                        const actualAzimuth = MapViewUtils.extractSphericalCoordinatesFromLocation(
+                            mapView,
+                            camera,
+                            projection.unprojectPoint(newTarget)
+                        ).azimuth;
+                        expect(actualAzimuth).to.be.closeTo(expAzimuth, 1e-5);
+                    });
+
                     it(`zoom target stays at the same screen coords (pitch ${pitch})`, function() {
                         resetCamera(pitch);
 

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -163,7 +163,15 @@ export namespace MapViewUtils {
 
         // Get current target position in world space before we zoom.
         const zoomTarget = rayCastWorldCoordinates(mapView, targetNDCx, targetNDCy, elevation);
-        const cameraTarget = mapView.worldTarget;
+
+        // Compute current camera target, it may not be the one set in MapView, e.g. when this
+        // function is called multiple times between frames.
+        // tslint:disable-next-line: deprecation
+        const cameraTarget = MapViewUtils.getTargetAndDistance(
+            projection,
+            camera,
+            elevationProvider
+        ).target;
         const newCameraDistance = calculateDistanceFromZoomLevel(mapView, zoomLevel);
 
         if (mapView.geoMaxBounds) {


### PR DESCRIPTION
Camera target must be computed, since mapView.targetWorld might be
outdated, .e.g., during a zoom animation.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
