### PR TITLE
MINOR: Fix race condition with CameraKeyTrackAnimation

### DIFF
--- a/@here/harp-map-controls/lib/CameraKeyTrackAnimation.ts
+++ b/@here/harp-map-controls/lib/CameraKeyTrackAnimation.ts
@@ -297,6 +297,8 @@ export class CameraKeyTrackAnimation {
         const deltaTime = (Date.now() - this.m_lastFrameTime) / 1000;
         this.m_animationMixer.update(deltaTime);
         this.m_lastFrameTime = Date.now();
-        this.updateCameraFromDummy();
+        if (this.m_running) {
+            this.updateCameraFromDummy();
+        }
     }
 }


### PR DESCRIPTION
Changing look-at from within `onFinish` handler was not applied due to race condition with already stopped animation.