### PR TITLE
HARP-11151: Force ring winding to follow Mapbox Vector Tile spec.

### DIFF
--- a/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-omv-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -167,16 +167,16 @@ describe("OmvDecodedTileEmitter", function() {
 
         const eps = 1e-15;
         assert.closeTo(texCoords[0], 0, eps);
-        assert.closeTo(texCoords[1], 0, eps);
+        assert.closeTo(texCoords[1], 1, eps);
 
         assert.closeTo(texCoords[2], 1, eps);
-        assert.closeTo(texCoords[3], 0, eps);
+        assert.closeTo(texCoords[3], 1, eps);
 
         assert.closeTo(texCoords[4], 1, eps);
-        assert.closeTo(texCoords[5], 1, eps);
+        assert.closeTo(texCoords[5], 0, eps);
 
         assert.closeTo(texCoords[6], 0, eps);
-        assert.closeTo(texCoords[7], 1, eps);
+        assert.closeTo(texCoords[7], 0, eps);
     });
 
     it("Test splitJaggyLines for short paths", function() {


### PR DESCRIPTION
Outer rings are clockwise, inner rings counter-clockwise.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
