### PR TITLE
HARP-10758: Save the API metadata and markdown artifacts.

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,3 +21,13 @@ jobs:
           run: yarn --frozen-lockfile
         - name: Generate docs
           run: yarn docs
+        - name: Save API metadata
+          uses: actions/upload-artifact@master
+          with:
+            name: harp-api-metadata
+            path: input
+        - name: Save API reference
+          uses: actions/upload-artifact@master
+          with:
+            name: harp-api-reference
+            path: markdown


### PR DESCRIPTION
This PR saves the API metadata produced by api-extractor
and the markdown docs created by api-documenter
as github artifacts.