### PR TITLE
HARP-8067: Renamed OmvTileDecoder to VectorTileDecoder

### DIFF
--- a/@here/harp-omv-datasource/index-worker.ts
+++ b/@here/harp-omv-datasource/index-worker.ts
@@ -5,3 +5,9 @@
  */
 
 export * from "@here/harp-vectortile-datasource/index-worker";
+
+export {
+    VectorTileDataProcessor as OmvDecoder,
+    VectorTileDecoderService as OmvTileDecoderService,
+    VectorTileDecoder as OmvTileDecoder
+} from "@here/harp-vectortile-datasource/index-worker";

--- a/@here/harp-vectortile-datasource/index-worker.ts
+++ b/@here/harp-vectortile-datasource/index-worker.ts
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from "./lib/OmvDecoder";
+export * from "./lib/VectorTileDecoder";
 export * from "./lib/OmvTiler";
 export * from "./lib/OmvDecoderDefs";

--- a/@here/harp-vectortile-datasource/lib/OmvDecoder.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvDecoder.ts
@@ -36,7 +36,6 @@ import {
     OmvGenericFeatureFilter,
     OmvGenericFeatureModifier
 } from "./OmvDataFilter";
-import { OmvDecodedTileEmitter } from "./OmvDecodedTileEmitter";
 import {
     FeatureModifierId,
     OmvDecoderOptions,
@@ -46,41 +45,14 @@ import {
 import { OmvPoliticalViewFeatureModifier } from "./OmvPoliticalViewFeatureModifier";
 import { OmvTomTomFeatureModifier } from "./OmvTomTomFeatureModifier";
 import { StyleSetDataFilter } from "./StyleSetDataFilter";
+import { VectorTileDataEmitter } from "./VectorTileDataEmitter";
 
 const logger = LoggerManager.instance.create("OmvDecoder", { enabled: false });
-
-export interface IOmvEmitter {
-    processPointFeature(
-        layer: string,
-        extents: number,
-        geometry: THREE.Vector2[],
-        context: AttrEvaluationContext,
-        techniques: IndexedTechnique[]
-    ): void;
-
-    processLineFeature(
-        layer: string,
-        extents: number,
-        feature: ILineGeometry[],
-        context: AttrEvaluationContext,
-        techniques: IndexedTechnique[],
-        featureId: number | undefined
-    ): void;
-
-    processPolygonFeature(
-        layer: string,
-        extents: number,
-        feature: IPolygonGeometry[],
-        context: AttrEvaluationContext,
-        techniques: IndexedTechnique[],
-        featureId: number | undefined
-    ): void;
-}
 
 export class OmvDecoder implements IGeometryProcessor {
     // The emitter is optional now.
     // TODO: Add option to control emitter generation.
-    private m_decodedTileEmitter: OmvDecodedTileEmitter | undefined;
+    private m_decodedTileEmitter: VectorTileDataEmitter | undefined;
     private readonly m_dataAdapters: DataAdapter[] = [];
 
     constructor(
@@ -141,7 +113,7 @@ export class OmvDecoder implements IGeometryProcessor {
             this.m_storageLevelOffset
         );
 
-        this.m_decodedTileEmitter = new OmvDecodedTileEmitter(
+        this.m_decodedTileEmitter = new VectorTileDataEmitter(
             decodeInfo,
             this.m_styleSetEvaluator,
             this.m_gatherFeatureAttributes,

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
@@ -64,7 +64,6 @@ import {
 } from "@here/harp-geoutils";
 
 import { ILineGeometry, IPolygonGeometry } from "./IGeometryProcessor";
-import { IOmvEmitter } from "./OmvDecoder";
 import {
     tile2world,
     webMercatorTile2TargetTile,
@@ -223,7 +222,7 @@ class MeshBuffers implements IMeshBuffers {
     }
 }
 
-export enum LineType {
+enum LineType {
     Simple,
     Complex
 }
@@ -231,7 +230,7 @@ export enum LineType {
 type TexCoordsFunction = (tilePos: THREE.Vector2, tileExtents: number) => THREE.Vector2;
 const tmpColor = new THREE.Color();
 
-export class OmvDecodedTileEmitter implements IOmvEmitter {
+export class VectorTileDataEmitter {
     // mapping from style index to mesh buffers
     private readonly m_meshBuffers = new Map<number, MeshBuffers>();
 

--- a/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
@@ -47,9 +47,9 @@ import { OmvTomTomFeatureModifier } from "./OmvTomTomFeatureModifier";
 import { StyleSetDataFilter } from "./StyleSetDataFilter";
 import { VectorTileDataEmitter } from "./VectorTileDataEmitter";
 
-const logger = LoggerManager.instance.create("OmvDecoder", { enabled: false });
+const logger = LoggerManager.instance.create("VectorTileDecoder", { enabled: false });
 
-export class OmvDecoder implements IGeometryProcessor {
+export class VectorTileDataProcessor implements IGeometryProcessor {
     // The emitter is optional now.
     // TODO: Add option to control emitter generation.
     private m_decodedTileEmitter: VectorTileDataEmitter | undefined;
@@ -292,7 +292,11 @@ export class OmvDecoder implements IGeometryProcessor {
         return techniques;
     }
 }
-export class OmvTileDecoder extends ThemedTileDecoder {
+
+/**
+ * The vector tile decoder.
+ */
+export class VectorTileDecoder extends ThemedTileDecoder {
     private m_showMissingTechniques: boolean = false;
     private m_featureFilter?: OmvFeatureFilter;
     private m_featureModifiers?: OmvFeatureModifier[];
@@ -314,7 +318,7 @@ export class OmvTileDecoder extends ThemedTileDecoder {
     ): Promise<DecodedTile> {
         const startTime = PerformanceTimer.now();
 
-        const decoder = new OmvDecoder(
+        const decoder = new VectorTileDataProcessor(
             projection,
             styleSetEvaluator,
             this.m_showMissingTechniques,
@@ -441,32 +445,20 @@ export class OmvTileDecoder extends ThemedTileDecoder {
 }
 
 /**
- * OMV tile decoder service.
+ * Vector Tile Decoder Service.
  */
-export class OmvTileDecoderService {
+export class VectorTileDecoderService {
     /**
-     * Register[[OmvTileDecoder]] service class in [[WorkerServiceManager]].
+     * Register a vector tile decoder service.
      *
+     * @remarks
      * Has to be called during initialization of decoder bundle.
      */
     static start() {
         WorkerServiceManager.getInstance().register({
             serviceType: OMV_TILE_DECODER_SERVICE_TYPE,
             factory: (serviceId: string) =>
-                TileDecoderService.start(serviceId, new OmvTileDecoder())
+                TileDecoderService.start(serviceId, new VectorTileDecoder())
         });
-    }
-}
-
-/**
- * Starts an OMV decoder service.
- *
- * @deprecated Please use [[OmvTileDecoderService.start]].
- */
-export default class OmvWorkerClient {
-    // TODO(HARP-3651): remove this class when clients are ready
-    constructor() {
-        logger.warn("OmvWorkerClient class is deprecated, please use OmvTileDecoderService.start");
-        OmvTileDecoderService.start();
     }
 }

--- a/@here/harp-vectortile-datasource/test/MapViewPickingTest.ts
+++ b/@here/harp-vectortile-datasource/test/MapViewPickingTest.ts
@@ -39,7 +39,7 @@ import { getAppBaseUrl } from "@here/harp-utils";
 import { assert } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
-import { OmvTileDecoder } from "../index-worker";
+import { VectorTileDecoder } from "../index-worker";
 import { GeoJsonDataProvider } from "../lib/GeoJsonDataProvider";
 import { VectorTileDataSource } from "../lib/VectorTileDataSource";
 import { GEOJSON_DATA, THEME } from "./resources/geoJsonData";
@@ -192,7 +192,7 @@ describe("MapView Picking", async function() {
         });
 
         geoJsonDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             dataProvider: geoJsonDataProvider,
             name: "geojson",
             styleSetName: "geojson",

--- a/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
@@ -19,7 +19,7 @@ import {
     OmvRestClient,
     VectorTileDataSource
 } from "../index";
-import { OmvTileDecoder } from "../index-worker";
+import { VectorTileDecoder } from "../index-worker";
 import { GeoJsonDataProvider } from "../lib/GeoJsonDataProvider";
 
 import * as sinon from "sinon";
@@ -51,7 +51,7 @@ describe("DataProviders", function() {
     it("Creates a OmvDataSource with a custom DataProvider", function() {
         const mockDataProvider = new MockDataProvider();
         const omvDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             dataProvider: mockDataProvider
         });
         assert.equal(omvDataSource.dataProvider(), mockDataProvider);
@@ -60,7 +60,7 @@ describe("DataProviders", function() {
 
     it("Creates a OmvDataSource with a REST based DataProvider with proper params", function() {
         const omvDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
             apiFormat: APIFormat.MapboxV4,
             authenticationCode: "123",
@@ -85,7 +85,7 @@ describe("DataProviders", function() {
     it("Creates OmvDataSource with custom DataProvider, ignoring other attributes", function() {
         const mockDataProvider = new MockDataProvider();
         const omvDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
             apiFormat: APIFormat.MapboxV4,
             authenticationCode: "123",
@@ -97,7 +97,7 @@ describe("DataProviders", function() {
     it("supports deprecated minZoomLevel and maxZoomLevel in constructor", function() {
         const mockDataProvider = new MockDataProvider();
         const omvDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
             apiFormat: APIFormat.MapboxV4,
             authenticationCode: "123",
@@ -117,7 +117,7 @@ describe("DataProviders", function() {
     it("supports minDataLevel and maxDataLevel in constructor", function() {
         const mockDataProvider = new MockDataProvider();
         const omvDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
             apiFormat: APIFormat.MapboxV4,
             authenticationCode: "123",
@@ -143,7 +143,7 @@ describe("DataProviders", function() {
             } as any;
             const mockDataProvider = new MockDataProvider();
             const omvDataSource = new VectorTileDataSource({
-                decoder: new OmvTileDecoder(),
+                decoder: new VectorTileDecoder(),
                 baseUrl: "https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7",
                 apiFormat: APIFormat.MapboxV4,
                 authenticationCode: "123",
@@ -175,7 +175,7 @@ describe("DataProviders", function() {
             tiler
         });
 
-        const decoder = new OmvTileDecoder();
+        const decoder = new VectorTileDecoder();
 
         const omvDataSource = new VectorTileDataSource({ dataProvider, decoder });
 

--- a/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -25,10 +25,10 @@ import { assert } from "chai";
 import { Vector2, Vector3 } from "three";
 import { DecodeInfo } from "../lib/DecodeInfo";
 import { IPolygonGeometry } from "../lib/IGeometryProcessor";
-import { OmvDecodedTileEmitter } from "../lib/OmvDecodedTileEmitter";
 import { world2tile } from "../lib/OmvUtils";
+import { VectorTileDataEmitter } from "../lib/VectorTileDataEmitter";
 
-class OmvDecodedTileEmitterTest extends OmvDecodedTileEmitter {
+class OmvDecodedTileEmitterTest extends VectorTileDataEmitter {
     splitJaggyLinesTest(
         lines: number[][],
         minEstimatedLabelLengthSqr: number,

--- a/@here/harp.gl/lib/DecoderBundleMain.ts
+++ b/@here/harp.gl/lib/DecoderBundleMain.ts
@@ -13,9 +13,9 @@ if (!(self as any).THREE) {
 }
 
 import {
-    OmvTileDecoderService,
-    OmvTilerService
+    OmvTilerService,
+    VectorTileDecoderService
 } from "@here/harp-vectortile-datasource/index-worker";
 
 OmvTilerService.start();
-OmvTileDecoderService.start();
+VectorTileDecoderService.start();

--- a/@here/harp.gl/lib/index.ts
+++ b/@here/harp.gl/lib/index.ts
@@ -16,6 +16,7 @@ if (!(window as any).THREE) {
 
 export * from "@here/harp-mapview";
 export * from "@here/harp-vectortile-datasource";
+export * from "@here/harp-omv-datasource";
 export * from "@here/harp-debug-datasource";
 export * from "@here/harp-geojson-datasource";
 export * from "@here/harp-features-datasource";

--- a/@here/harp.gl/package.json
+++ b/@here/harp.gl/package.json
@@ -47,6 +47,7 @@
         "@here/harp-materials": "^0.18.0",
         "@here/harp-olp-utils": "^0.18.0",
         "@here/harp-vectortile-datasource": "^0.18.0",
+        "@here/harp-omv-datasource": "^0.18.0",
         "@here/harp-test-utils": "^0.18.0",
         "@here/harp-text-canvas": "^0.18.0",
         "@here/harp-utils": "^0.18.0",

--- a/test/performance/OmvDecoderPerformanceTest.ts
+++ b/test/performance/OmvDecoderPerformanceTest.ts
@@ -33,7 +33,7 @@ import {
     ILineGeometry,
     IPolygonGeometry
 } from "@here/harp-vectortile-datasource/lib/IGeometryProcessor";
-import { OmvDecoder } from "@here/harp-vectortile-datasource/lib/OmvDecoder";
+import { VectorTileDataProcessor } from "@here/harp-vectortile-datasource/lib/VectorTileDecoder";
 
 export interface OMVDecoderPerformanceTestOptions {
     /**
@@ -161,7 +161,11 @@ export function createOMVDecoderPerformanceTest(
 
             await measurePerformanceSync(counterName, repeats, function() {
                 for (const [tileKey, tileData] of omvTiles) {
-                    const decoder = new OmvDecoder(projection, styleSetEvaluator, false);
+                    const decoder = new VectorTileDataProcessor(
+                        projection,
+                        styleSetEvaluator,
+                        false
+                    );
                     decoder.getDecodedTile(tileKey, tileData);
                 }
             });
@@ -181,7 +185,11 @@ export function createOMVDecoderPerformanceTest(
 
             await measurePerformanceSync(counterName, repeats, function() {
                 for (const [tileKey, tileData] of omvTiles) {
-                    const decoder = new OmvDecoder(projection, styleSetEvaluator, false);
+                    const decoder = new VectorTileDataProcessor(
+                        projection,
+                        styleSetEvaluator,
+                        false
+                    );
                     decoder.getDecodedTile(tileKey, tileData);
                 }
             });

--- a/test/rendering/GeoJsonDataRendering.ts
+++ b/test/rendering/GeoJsonDataRendering.ts
@@ -13,7 +13,7 @@ import { LookAtParams, MapView, MapViewEventNames } from "@here/harp-mapview";
 import { GeoJsonTiler } from "@here/harp-mapview-decoder/index-worker";
 import { RenderingTestHelper, waitForEvent } from "@here/harp-test-utils";
 import { GeoJsonDataProvider, VectorTileDataSource } from "@here/harp-vectortile-datasource";
-import { OmvTileDecoder } from "@here/harp-vectortile-datasource/lib/OmvDecoder";
+import { VectorTileDecoder } from "@here/harp-vectortile-datasource/lib/VectorTileDecoder";
 
 describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", function() {
     let mapView: MapView;
@@ -82,7 +82,7 @@ describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", functio
         };
 
         const geoJsonDataSource = new VectorTileDataSource({
-            decoder: new OmvTileDecoder(),
+            decoder: new VectorTileDecoder(),
             dataProvider: new GeoJsonDataProvider(
                 "geojson",
                 typeof options.geoJson === "string"

--- a/test/rendering/StylingTest.ts
+++ b/test/rendering/StylingTest.ts
@@ -32,7 +32,7 @@ import { GeoJsonTiler } from "@here/harp-mapview-decoder/index-worker";
 import { getPlatform, RenderingTestHelper, TestOptions, waitForEvent } from "@here/harp-test-utils";
 import { getReferenceImageUrl } from "@here/harp-test-utils/lib/rendering/ReferenceImageLocator";
 import { getOptionValue, mergeWithOptions } from "@here/harp-utils";
-import { OmvTileDecoder } from "@here/harp-vectortile-datasource/index-worker";
+import { VectorTileDecoder } from "@here/harp-vectortile-datasource/index-worker";
 
 interface RenderingTestOptions extends TestOptions {
     /**
@@ -150,7 +150,7 @@ function mapViewFeaturesRenderingTest(
             const dataSource = new FeaturesDataSource({
                 styleSetName: "geojson",
                 geojson: options.geoJson,
-                decoder: new OmvTileDecoder(),
+                decoder: new VectorTileDecoder(),
                 tiler: new GeoJsonTiler(),
                 gatherFeatureAttributes: true
             });

--- a/www/src/decoder.ts
+++ b/www/src/decoder.ts
@@ -10,6 +10,6 @@ declare let self: Worker & {
 
 self.importScripts("three.min.js");
 
-import { OmvTileDecoderService } from "@here/harp-vectortile-datasource/index-worker";
+import { VectorTileDecoderService } from "@here/harp-vectortile-datasource/index-worker";
 
-OmvTileDecoderService.start();
+VectorTileDecoderService.start();


### PR DESCRIPTION
This change renames
 - OmvTileDecoder to VectorTileDecoder
 - OmvDecoder to VectorTileDataProcessor
 - OmvTileDecoderService to VectorTileDecoderService 
 - OmvDecodedTileEmitter to VectorTileDataEmitter