### PR TITLE
HARP-11466: Fix animation example.

### DIFF
--- a/@here/harp-examples/src/threejs_animation.ts
+++ b/@here/harp-examples/src/threejs_animation.ts
@@ -7,12 +7,8 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapAnchor, MapViewEventNames, RenderEvent } from "@here/harp-mapview";
 import * as THREE from "three";
+import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
 import { HelloWorldExample } from "./getting-started_hello-world_npm";
-
-// tslint:disable-next-line:no-var-requires
-(window as any).Zlib = require("three/examples/js/libs/inflate.min.js").Zlib;
-
-import "three/examples/js/loaders/FBXLoader";
 
 /**
  * This example builds on top of the [[ThreejsAddSimpleObject]].
@@ -82,7 +78,7 @@ export namespace ThreejsAddAnimatedObject {
     };
 
     // snippet:harp_gl_threejs_add_animated-object_load.ts
-    const loader = new (THREE as any).FBXLoader();
+    const loader = new FBXLoader();
     loader.load("resources/dancing.fbx", onLoad);
     // end:harp_gl_threejs_add_animated-object_load.ts
 


### PR DESCRIPTION
It got broken due to changes in inflate.min.js dependency in latest
THREE.js release. Fixed by importing module version of FBXLoader.
inflate is imported directly in that module.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
