### PR TITLE
MINOR: Add safe version for screen to geo conversion

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2706,7 +2706,12 @@ export class MapView extends EventDispatcher {
      */
     getGeoCoordinatesAtSafe(x: number, y: number): GeoCoordinates {
         const worldPosition = this.getWorldPositionAtSafe(x, y);
-        return this.projection.unprojectPoint(worldPosition).normalized();
+        const geoPos = this.projection.unprojectPoint(worldPosition);
+        if (!this.tileWrappingEnabled && this.projection.type === ProjectionType.Planar) {
+            // When the map is not wrapped we clamp the longitude
+            geoPos.longitude = THREE.MathUtils.clamp(geoPos.longitude, -180, 180);
+        }
+        return geoPos.normalized();
     }
 
     /**
@@ -2727,7 +2732,13 @@ export class MapView extends EventDispatcher {
         if (!worldPosition) {
             return null;
         }
-        return this.projection.unprojectPoint(worldPosition).normalized();
+
+        const geoPos = this.projection.unprojectPoint(worldPosition);
+        if (!this.tileWrappingEnabled && this.projection.type === ProjectionType.Planar) {
+            // When the map is not wrapped we clamp the longitude
+            geoPos.longitude = THREE.MathUtils.clamp(geoPos.longitude, -180, 180);
+        }
+        return geoPos.normalized();
     }
 
     /**

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2642,25 +2642,30 @@ export class MapView extends EventDispatcher {
         return this.m_raycaster;
     }
 
+    getWorldPositionAt(x: number, y: number, fallback: true): THREE.Vector3;
+    getWorldPositionAt(x: number, y: number, fallback?: boolean): THREE.Vector3 | null;
+
     /**
      * Returns the world space position from the given screen position.
      *
      * @remarks
-     * This method will always return a point. if the given `(x, y)` value is not intersecting
-     * the ground plane a fallback point on the far plane will be computed.
-     * Therfore the returned point might not be on the earth surface.
+     * If `fallback !== true` the return value can be `null`, in case the camera has a high tilt
+     * and the given `(x, y)` value is not intersecting the ground plane.
+     * If `fallback === true` the return value will always exist but it might not be on the earth
+     * surface.
      *
      * @param x - The X position in css/client coordinates (without applied display ratio).
      * @param y - The Y position in css/client coordinates (without applied display ratio).
+     * @param fallback - Whether to compute a fallback position if the earth surface is not hit.
      */
-    getWorldPositionAtSafe(x: number, y: number): THREE.Vector3 {
+    getWorldPositionAt(x: number, y: number, fallback?: boolean): THREE.Vector3 | null {
         this.m_raycaster.setFromCamera(this.getNormalizedScreenCoordinates(x, y), this.m_camera);
         const worldPos =
             this.projection.type === ProjectionType.Spherical
                 ? this.m_raycaster.ray.intersectSphere(this.m_sphere, cache.vector3[0])
                 : this.m_raycaster.ray.intersectPlane(this.m_plane, cache.vector3[0]);
 
-        if (worldPos === null) {
+        if (worldPos === null && fallback === true) {
             // Fall back to the far plane
             const cosAlpha = this.m_camera
                 .getWorldDirection(cache.vector3[0])
@@ -2674,61 +2679,25 @@ export class MapView extends EventDispatcher {
         return worldPos;
     }
 
+    getGeoCoordinatesAt(x: number, y: number, fallback: true): GeoCoordinates;
+    getGeoCoordinatesAt(x: number, y: number, fallback?: boolean): GeoCoordinates | null;
+
     /**
-     * Returns the world space position from the given screen position.
+     * Returns the {@link @here/harp-geoutils#GeoCoordinates} from the
+     * given screen position.
      *
      * @remarks
-     * The return value can be `null`, in case the camera is facing the horizon
+     * If `fallback !== true` the return value can be `null`, in case the camera has a high tilt
      * and the given `(x, y)` value is not intersecting the ground plane.
+     * If `fallback === true` the return value will always exist but it might not be on the earth
+     * surface.
      *
      * @param x - The X position in css/client coordinates (without applied display ratio).
      * @param y - The Y position in css/client coordinates (without applied display ratio).
+     * @param fallback - Whether to compute a fallback position if the earth surface is not hit.
      */
-    getWorldPositionAt(x: number, y: number): THREE.Vector3 | null {
-        this.m_raycaster.setFromCamera(this.getNormalizedScreenCoordinates(x, y), this.m_camera);
-        return this.projection.type === ProjectionType.Spherical
-            ? this.m_raycaster.ray.intersectSphere(this.m_sphere, cache.vector3[0])
-            : this.m_raycaster.ray.intersectPlane(this.m_plane, cache.vector3[0]);
-    }
-
-    /**
-     * Returns the {@link @here/harp-geoutils#GeoCoordinates} from the
-     * given screen position.
-     *
-     * @remarks
-     * This method will always return a point. if the given `(x, y)` value is not intersecting
-     * the ground plane a fallback point on the far plane will be computed.
-     * Therfore the returned point might not be on the earth surface (i.e. altitude > 0)
-     *
-     * @param x - The X position in css/client coordinates (without applied display ratio).
-     * @param y - The Y position in css/client coordinates (without applied display ratio).
-     * @param fallback - Fallback to
-     */
-    getGeoCoordinatesAtSafe(x: number, y: number): GeoCoordinates {
-        const worldPosition = this.getWorldPositionAtSafe(x, y);
-        const geoPos = this.projection.unprojectPoint(worldPosition);
-        if (!this.tileWrappingEnabled && this.projection.type === ProjectionType.Planar) {
-            // When the map is not wrapped we clamp the longitude
-            geoPos.longitude = THREE.MathUtils.clamp(geoPos.longitude, -180, 180);
-        }
-        return geoPos.normalized();
-    }
-
-    /**
-     * Returns the {@link @here/harp-geoutils#GeoCoordinates} from the
-     * given screen position.
-     *
-     * @remarks
-     * The return value can be
-     * `null`, in case the camera is facing the horizon and
-     * the given `(x, y)` value is not
-     * intersecting the ground plane.
-     *
-     * @param x - The X position in css/client coordinates (without applied display ratio).
-     * @param y - The Y position in css/client coordinates (without applied display ratio).
-     */
-    getGeoCoordinatesAt(x: number, y: number): GeoCoordinates | null {
-        const worldPosition = this.getWorldPositionAt(x, y);
+    getGeoCoordinatesAt(x: number, y: number, fallback?: boolean): GeoCoordinates | null {
+        const worldPosition = this.getWorldPositionAt(x, y, fallback);
         if (!worldPosition) {
             return null;
         }

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -23,8 +23,10 @@ const URL = typeof window !== "undefined" ? window.URL : nodeUrl.URL;
 import {
     GeoBox,
     GeoCoordinates,
+    MAX_LONGITUDE,
     MercatorConstants,
     mercatorProjection,
+    MIN_LONGITUDE,
     sphereProjection,
     webMercatorTilingScheme
 } from "@here/harp-geoutils";
@@ -990,7 +992,7 @@ describe("MapView", function() {
         assert.closeTo(top!.altitude!, 0, eps);
     });
 
-    it("convert screen to geo anti meridian east mercator", async function() {
+    it("convert screen to geo anti meridian east mercator wrapped", async function() {
         const target = new GeoCoordinates(0, 180);
         const eps = 1e-10;
 
@@ -1012,7 +1014,7 @@ describe("MapView", function() {
         assert.closeTo(top!.altitude!, 0, eps);
     });
 
-    it("convert screen to geo anti meridian west mercator", async function() {
+    it("convert screen to geo anti meridian west mercator wrapped", async function() {
         const target = new GeoCoordinates(0, -180);
         const eps = 1e-10;
 
@@ -1030,6 +1032,64 @@ describe("MapView", function() {
         assert.isNotNull(top);
         assert.closeTo(top!.latitude, target.latitude, eps);
         assert.closeTo(top!.longitude, 179.5419726676294, eps);
+        assert.isDefined(top!.altitude);
+        assert.closeTo(top!.altitude!, 0, eps);
+    });
+
+    it("convert screen to geo anti meridian east mercator not-wrapped", async function() {
+        const target = new GeoCoordinates(0, 180);
+        const eps = 1e-10;
+
+        mapView = new MapView({
+            canvas,
+            target,
+            tilt: 45,
+            zoomLevel: 10,
+            heading: 90,
+            tileWrappingEnabled: false
+        });
+        const center = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        assert.isNotNull(center);
+        assert.closeTo(center!.latitude, target.latitude, eps);
+        assert.closeTo(center!.longitude, target.longitude, eps);
+        assert.isDefined(center!.altitude);
+        assert.closeTo(center!.altitude!, 0, eps);
+
+        // Clicking "behind" the anti-meridian should wrap around
+        const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+
+        assert.isNotNull(top);
+        assert.closeTo(top!.latitude, target.latitude, eps);
+        assert.closeTo(top!.longitude, MAX_LONGITUDE, eps);
+        assert.isDefined(top!.altitude);
+        assert.closeTo(top!.altitude!, 0, eps);
+    });
+
+    it("convert screen to geo anti meridian west mercator not-wrapped", async function() {
+        const target = new GeoCoordinates(0, -180);
+        const eps = 1e-10;
+
+        mapView = new MapView({
+            canvas,
+            target,
+            tilt: 45,
+            zoomLevel: 10,
+            heading: -90,
+            tileWrappingEnabled: false
+        });
+        const center = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        assert.isNotNull(center);
+        assert.closeTo(center!.latitude, target.latitude, eps);
+        assert.closeTo(center!.longitude, target.longitude, eps);
+        assert.isDefined(center!.altitude);
+        assert.closeTo(center!.altitude!, 0, eps);
+
+        // Clicking "behind" the anti-meridian should wrap around
+        const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+
+        assert.isNotNull(top);
+        assert.closeTo(top!.latitude, target.latitude, eps);
+        assert.closeTo(top!.longitude, MIN_LONGITUDE, eps);
         assert.isDefined(top!.altitude);
         assert.closeTo(top!.altitude!, 0, eps);
     });

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -886,7 +886,7 @@ describe("MapView", function() {
                 assert.closeTo(top!.altitude!, 0, eps);
             } else {
                 assert.isNull(top);
-                top = mapView.getGeoCoordinatesAtSafe(canvas.clientWidth / 2, 0);
+                top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0, true);
                 assert.isAbove(top.altitude!, 0);
             }
             assert.isAbove(top!.latitude, target.latitude);

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -23,6 +23,7 @@ const URL = typeof window !== "undefined" ? window.URL : nodeUrl.URL;
 import {
     GeoBox,
     GeoCoordinates,
+    MercatorConstants,
     mercatorProjection,
     sphereProjection,
     webMercatorTilingScheme
@@ -782,7 +783,7 @@ describe("MapView", function() {
         expect(mapView.fog instanceof MapViewFog).to.equal(true);
     });
 
-    it("converts screen coords to geo to screen", function() {
+    it("converts screen coords to geo to screen w/ different pixel ratio", function() {
         const customCanvas = {
             clientWidth: 1920,
             clientHeight: 1080,
@@ -810,7 +811,7 @@ describe("MapView", function() {
             }
         }
     });
-    it("converts screen coords to world to screen", function() {
+    it("converts screen coords to world to screen w/ different pixel ratio", function() {
         const customCanvas = {
             clientWidth: 1920,
             clientHeight: 1080,
@@ -837,6 +838,200 @@ describe("MapView", function() {
                 mapView = undefined;
             }
         }
+    });
+
+    it("convert screen to geo different tilt mercator", async function() {
+        const eps = 1e-10;
+        const target = new GeoCoordinates(52.5145, 13.3501);
+        mapView = new MapView({ canvas, target, tilt: 0, zoomLevel: 10 });
+        for (let tilt = 0; tilt < 90; ++tilt) {
+            mapView.tilt = tilt;
+            const center = mapView.getGeoCoordinatesAt(
+                canvas.clientWidth / 2,
+                canvas.clientHeight / 2
+            );
+            assert.isNotNull(center);
+            assert.closeTo(center!.latitude, target.latitude, eps);
+            assert.closeTo(center!.longitude, target.longitude, eps);
+            assert.isDefined(center!.altitude);
+            assert.closeTo(center!.altitude!, 0, eps);
+
+            const left = mapView.getGeoCoordinatesAt(0, canvas.clientHeight / 2);
+            assert.isNotNull(left);
+            assert.closeTo(left!.latitude, target.latitude, eps);
+            assert.isBelow(left!.longitude, target.longitude);
+            assert.isDefined(left!.altitude);
+            assert.closeTo(left!.altitude!, 0, eps);
+
+            const right = mapView.getGeoCoordinatesAt(canvas.clientWidth, canvas.clientHeight / 2);
+            assert.isNotNull(right);
+            assert.closeTo(right!.latitude, target.latitude, eps);
+            assert.isAbove(right!.longitude, target.longitude);
+            assert.isDefined(right!.altitude);
+            assert.closeTo(right!.altitude!, 0, eps);
+
+            const bottom = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight);
+            assert.isNotNull(bottom);
+            assert.isBelow(bottom!.latitude, target.latitude);
+            assert.closeTo(bottom!.longitude, target.longitude, eps);
+            assert.isDefined(bottom!.altitude);
+            assert.closeTo(bottom!.altitude!, 0, eps);
+
+            let top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+            if (tilt <= 70) {
+                assert.isNotNull(top);
+                assert.isDefined(top!.altitude);
+                assert.closeTo(top!.altitude!, 0, eps);
+            } else {
+                assert.isNull(top);
+                top = mapView.getGeoCoordinatesAtSafe(canvas.clientWidth / 2, 0);
+                assert.isAbove(top.altitude!, 0);
+            }
+            assert.isAbove(top!.latitude, target.latitude);
+            assert.closeTo(top!.longitude, target.longitude, eps);
+        }
+    });
+
+    it("convert screen to geo different zoom mercator", async function() {
+        const eps = 1e-10;
+        const target = new GeoCoordinates(52.5145, 13.3501);
+        mapView = new MapView({ canvas, target, tilt: 45, zoomLevel: 1 });
+        for (let zoom = 1; zoom < 20; ++zoom) {
+            mapView.zoomLevel = zoom;
+            const center = mapView.getGeoCoordinatesAt(
+                canvas.clientWidth / 2,
+                canvas.clientHeight / 2
+            );
+            assert.isNotNull(center);
+            assert.closeTo(center!.latitude, target.latitude, eps);
+            assert.closeTo(center!.longitude, target.longitude, eps);
+            assert.isDefined(center!.altitude);
+            assert.closeTo(center!.altitude!, 0, eps);
+
+            const left = mapView.getGeoCoordinatesAt(0, canvas.clientHeight / 2);
+            assert.isNotNull(left);
+            assert.closeTo(left!.latitude, target.latitude, eps);
+            assert.isBelow(left!.longitude, target.longitude);
+            assert.isDefined(left!.altitude);
+            assert.closeTo(left!.altitude!, 0, eps);
+
+            const right = mapView.getGeoCoordinatesAt(canvas.clientWidth, canvas.clientHeight / 2);
+            assert.isNotNull(right);
+            assert.closeTo(right!.latitude, target.latitude, eps);
+            assert.isAbove(right!.longitude, target.longitude);
+            assert.isDefined(right!.altitude);
+            assert.closeTo(right!.altitude!, 0, eps);
+
+            const bottom = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight);
+            assert.isNotNull(bottom);
+            assert.isBelow(bottom!.latitude, target.latitude);
+            assert.closeTo(bottom!.longitude, target.longitude, eps);
+            assert.isDefined(bottom!.altitude);
+            assert.closeTo(bottom!.altitude!, 0, eps);
+
+            const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+            assert.isNotNull(top);
+            assert.isAbove(top!.latitude, target.latitude);
+            assert.closeTo(top!.longitude, target.longitude, eps);
+            assert.isDefined(top!.altitude);
+            assert.closeTo(top!.altitude!, 0, eps);
+        }
+    });
+
+    it("convert screen to geo north pole mercator", async function() {
+        const target = new GeoCoordinates(
+            THREE.MathUtils.radToDeg(MercatorConstants.MAXIMUM_LATITUDE),
+            0
+        );
+        const eps = 1e-10;
+
+        mapView = new MapView({ canvas, target, tilt: 45, zoomLevel: 10 });
+        const center = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        assert.isNotNull(center);
+        assert.closeTo(center!.latitude, target.latitude, eps);
+        assert.closeTo(center!.longitude, target.longitude, eps);
+        assert.isDefined(center!.altitude);
+        assert.closeTo(center!.altitude!, 0, eps);
+
+        // Clicking "behind" the north pole should return the north pole.
+        const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+
+        assert.isNotNull(top);
+        // FIXME: Latitude returned is bigger than MAXIMUM_LATITUDE
+        assert.closeTo(top!.latitude, target.latitude, 0.05);
+        assert.closeTo(top!.longitude, target.longitude, eps);
+        assert.isDefined(top!.altitude);
+        assert.closeTo(top!.altitude!, 0, eps);
+    });
+
+    it("convert screen to geo south pole mercator", async function() {
+        const target = new GeoCoordinates(
+            -THREE.MathUtils.radToDeg(MercatorConstants.MAXIMUM_LATITUDE),
+            0
+        );
+        const eps = 1e-10;
+
+        mapView = new MapView({ canvas, target, tilt: 45, zoomLevel: 10, heading: 180 });
+        const center = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        assert.isNotNull(center);
+        assert.closeTo(center!.latitude, target.latitude, eps);
+        assert.closeTo(center!.longitude, target.longitude, eps);
+        assert.isDefined(center!.altitude);
+        assert.closeTo(center!.altitude!, 0, eps);
+
+        // Clicking "behind" the south pole should return the south pole.
+        const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+
+        assert.isNotNull(top);
+        // FIXME: Latitude returned is smaller than -MAXIMUM_LATITUDE
+        assert.closeTo(top!.latitude, target.latitude, 0.05);
+        assert.closeTo(top!.longitude, target.longitude, eps);
+        assert.isDefined(top!.altitude);
+        assert.closeTo(top!.altitude!, 0, eps);
+    });
+
+    it("convert screen to geo anti meridian east mercator", async function() {
+        const target = new GeoCoordinates(0, 180);
+        const eps = 1e-10;
+
+        mapView = new MapView({ canvas, target, tilt: 45, zoomLevel: 10, heading: 90 });
+        const center = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        assert.isNotNull(center);
+        assert.closeTo(center!.latitude, target.latitude, eps);
+        assert.closeTo(center!.longitude, target.longitude, eps);
+        assert.isDefined(center!.altitude);
+        assert.closeTo(center!.altitude!, 0, eps);
+
+        // Clicking "behind" the anti-meridian should wrap around
+        const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+
+        assert.isNotNull(top);
+        assert.closeTo(top!.latitude, target.latitude, eps);
+        assert.closeTo(top!.longitude, -179.5419726676294, eps);
+        assert.isDefined(top!.altitude);
+        assert.closeTo(top!.altitude!, 0, eps);
+    });
+
+    it("convert screen to geo anti meridian west mercator", async function() {
+        const target = new GeoCoordinates(0, -180);
+        const eps = 1e-10;
+
+        mapView = new MapView({ canvas, target, tilt: 45, zoomLevel: 10, heading: -90 });
+        const center = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        assert.isNotNull(center);
+        assert.closeTo(center!.latitude, target.latitude, eps);
+        assert.closeTo(center!.longitude, target.longitude, eps);
+        assert.isDefined(center!.altitude);
+        assert.closeTo(center!.altitude!, 0, eps);
+
+        // Clicking "behind" the anti-meridian should wrap around
+        const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
+
+        assert.isNotNull(top);
+        assert.closeTo(top!.latitude, target.latitude, eps);
+        assert.closeTo(top!.longitude, 179.5419726676294, eps);
+        assert.isDefined(top!.altitude);
+        assert.closeTo(top!.altitude!, 0, eps);
     });
 
     it("updates scene materials, objects & skips transparent ones", async function() {

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -1055,7 +1055,7 @@ describe("MapView", function() {
         assert.isDefined(center!.altitude);
         assert.closeTo(center!.altitude!, 0, eps);
 
-        // Clicking "behind" the anti-meridian should wrap around
+        // Clicking "behind" the anti-meridian should clamp
         const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
 
         assert.isNotNull(top);
@@ -1084,7 +1084,7 @@ describe("MapView", function() {
         assert.isDefined(center!.altitude);
         assert.closeTo(center!.altitude!, 0, eps);
 
-        // Clicking "behind" the anti-meridian should wrap around
+        // Clicking "behind" the anti-meridian should clamp
         const top = mapView.getGeoCoordinatesAt(canvas.clientWidth / 2, 0);
 
         assert.isNotNull(top);


### PR DESCRIPTION
In case the ray-casting of the screen coordinate is not hitting the earth surface a fallback to the far plane will be computed
