### PR TITLE
HARP-11228: Call WebGlRenderer.forceLooseCont

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1265,6 +1265,9 @@ export class MapView extends EventDispatcher {
      * Disposes this `MapView`.
      * @override
      *
+     * @param freeContext - `true` to force ThreeJS to loose the context. Supply `false` to keep
+     * the context for further use.
+     *
      * @remarks
      * This function cleans the resources that are managed manually including those that exist in
      * shared caches.
@@ -1273,7 +1276,7 @@ export class MapView extends EventDispatcher {
      * TypeScript's garbage collecting mechanism. Consequently, if you need to perform a full
      * cleanup, you must ensure that all references to this `MapView` are removed.
      */
-    dispose() {
+    dispose(freeContext = true) {
         // Enforce listeners that we are about to dispose.
         DISPOSE_EVENT.time = Date.now();
         this.dispatchEvent(DISPOSE_EVENT);
@@ -1299,6 +1302,16 @@ export class MapView extends EventDispatcher {
         this.m_visibleTiles.clearTileCache();
         this.m_textElementsRenderer.clearRenderStates();
         this.m_renderer.dispose();
+
+        if (freeContext) {
+            // See for a discussion of using this call to force freeing the context:
+            //   https://github.com/mrdoob/three.js/pull/17588
+            // The patch to call forceContextLoss() upon WebGLRenderer.dispose() had been merged,
+            // but has been reverted later:
+            //   https://github.com/mrdoob/three.js/pull/19022
+            this.m_renderer.forceContextLoss();
+        }
+
         this.m_imageCache.clear();
         this.m_tileGeometryManager.clear();
 

--- a/@here/harp-test-utils/lib/WebGLStub.ts
+++ b/@here/harp-test-utils/lib/WebGLStub.ts
@@ -35,6 +35,7 @@ export function getWebGLRendererStub(sandbox: sinon.SinonSandbox, clearColorStub
         clear: () => undefined,
         render: () => undefined,
         dispose: () => undefined,
+        forceContextLoss: () => undefined,
         info: { autoReset: true, reset: () => undefined },
         debug: { checkShaderErrors: true }
     };


### PR DESCRIPTION
ext() upon MapView.dispose

Signed-off-by: StefanDachwitz <stefan.dachwitz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
