### PR TITLE
HARP-11509: Remove usages of @here/harp-omv-datasource from the examples

### DIFF
--- a/@here/harp-examples/decoder/decoder.ts
+++ b/@here/harp-examples/decoder/decoder.ts
@@ -10,11 +10,14 @@ declare let self: Worker & {
 
 self.importScripts("three.min.js");
 
-import { OmvTileDecoderService, OmvTilerService } from "@here/harp-omv-datasource/index-worker";
+import {
+    GeoJsonTilerService,
+    VectorTileDecoderService
+} from "@here/harp-vectortile-datasource/index-worker";
 import { CustomDecoderService } from "./custom_decoder";
 
-OmvTileDecoderService.start();
-OmvTilerService.start();
+VectorTileDecoderService.start();
+GeoJsonTilerService.start();
 
 //Following code is only needed for datasource_custom example.
 // snippet:custom_datasource_example_custom_decoder_service_start.ts

--- a/@here/harp-examples/lib/PerformanceUtils.ts
+++ b/@here/harp-examples/lib/PerformanceUtils.ts
@@ -18,8 +18,12 @@ import {
     SimpleFrameStatistics
 } from "@here/harp-mapview";
 import { debugContext } from "@here/harp-mapview/lib/DebugContext";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
 import { assert, LoggerManager, PerformanceTimer } from "@here/harp-utils";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
 import { apikey, copyrightInfo } from "../config";
 import { PerformanceTestData } from "./PerformanceConfig";
@@ -31,7 +35,7 @@ export namespace PerformanceUtils {
         mapView: MapView;
         mapControls: MapControls;
         omvDataSourceConnected: boolean;
-        mainDataSource: OmvDataSource | undefined;
+        mainDataSource: VectorTileDataSource | undefined;
     }
 
     export interface ThemeDef {
@@ -175,11 +179,11 @@ export namespace PerformanceUtils {
         dataSourceTypes: string[],
         storageLevelOffsetModifier: number
     ): Promise<DataSource[]> {
-        const createDataSource = (dataSourceType: string): OmvDataSource => {
-            let dataSource: OmvDataSource | undefined;
+        const createDataSource = (dataSourceType: string): VectorTileDataSource => {
+            let dataSource: VectorTileDataSource | undefined;
             switch (dataSourceType) {
                 case "OMV":
-                    dataSource = new OmvDataSource({
+                    dataSource = new VectorTileDataSource({
                         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                         apiFormat: APIFormat.XYZOMV,
                         styleSetName: "tilezen",
@@ -207,7 +211,7 @@ export namespace PerformanceUtils {
                 }
 
                 return mapViewApp.mapView.addDataSource(dataSource).then(() => {
-                    if (dataSource instanceof OmvDataSource) {
+                    if (dataSource instanceof VectorTileDataSource) {
                         mapViewApp.omvDataSourceConnected = true;
                     }
                     return dataSource;
@@ -678,7 +682,7 @@ export namespace PerformanceUtils {
 
     function applyDataFilter(mapView: MapView, showLabels: boolean) {
         for (const dataSource of mapView.dataSources) {
-            if (dataSource instanceof OmvDataSource) {
+            if (dataSource instanceof VectorTileDataSource) {
                 applyDataFilterToDataSource(mapView, dataSource, showLabels);
             }
         }
@@ -686,7 +690,7 @@ export namespace PerformanceUtils {
 
     function applyDataFilterToDataSource(
         mapView: MapView,
-        dataSource: OmvDataSource,
+        dataSource: VectorTileDataSource,
         showLabels: boolean
     ) {
         const tileGeometryManager = mapView.tileGeometryManager;

--- a/@here/harp-examples/package.json
+++ b/@here/harp-examples/package.json
@@ -37,7 +37,7 @@
         "@here/harp-mapview": "^0.18.0",
         "@here/harp-mapview-decoder": "^0.18.0",
         "@here/harp-materials": "^0.18.0",
-        "@here/harp-omv-datasource": "^0.18.0",
+        "@here/harp-vectortile-datasource": "^0.18.0",
         "@here/harp-text-canvas": "^0.18.0",
         "@here/harp-utils": "^0.18.0",
         "@here/harp-webtile-datasource": "^0.18.0",

--- a/@here/harp-examples/src/bounds-generation.ts
+++ b/@here/harp-examples/src/bounds-generation.ts
@@ -12,7 +12,7 @@ import {
 import { GeoCoordinates, mercatorProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { BoundsGenerator, CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 
 import { apikey } from "../config";
 
@@ -85,7 +85,7 @@ export namespace BoundsExample {
             map.resize(window.innerWidth, window.innerHeight);
         });
 
-        addOmvDataSource(map);
+        addVectorTileDataSource(map);
         const featureList: MapViewFeature[] = []; //createFeatureList();
         let featuresDataSource: FeaturesDataSource | undefined;
         //@ts-ignore
@@ -169,8 +169,8 @@ export namespace BoundsExample {
         return map;
     }
 
-    function addOmvDataSource(map: MapView) {
-        const omvDataSource = new OmvDataSource({
+    function addVectorTileDataSource(map: MapView) {
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/camera-animations_key-track.ts
+++ b/@here/harp-examples/src/camera-animations_key-track.ts
@@ -10,7 +10,7 @@ import {
     ControlPoint
 } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import THREE = require("three");
 
@@ -243,7 +243,7 @@ export namespace CameraAnimationExample {
             mapView.resize(window.innerWidth, window.innerHeight);
         });
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/datasource_features_lines-and-points.ts
+++ b/@here/harp-examples/src/datasource_features_lines-and-points.ts
@@ -13,7 +13,7 @@ import {
 import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 
 import { apikey } from "../config";
 import { faults, hotspots } from "../resources/geology";
@@ -225,7 +225,7 @@ export namespace LinesPointsFeaturesExample {
 
         CopyrightElementHandler.install("copyrightNotice", mapView);
 
-        const baseMap = new OmvDataSource({
+        const baseMap = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -12,7 +12,7 @@ import {
 import { GeoCoordinates, sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
 
 import { apikey } from "../config";
@@ -334,7 +334,7 @@ export namespace PolygonsFeaturesExample {
 
         CopyrightElementHandler.install("copyrightNotice", mapView);
 
-        const baseMap = new OmvDataSource({
+        const baseMap = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/datasource_geojson_choropleth.ts
+++ b/@here/harp-examples/src/datasource_geojson_choropleth.ts
@@ -7,7 +7,7 @@ import { Style, StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { GeoJsonDataProvider, OmvDataSource } from "@here/harp-omv-datasource";
+import { GeoJsonDataProvider, VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
 
 import { apikey } from "../config";
@@ -88,7 +88,7 @@ export namespace GeoJsonHeatmapExample {
 
         CopyrightElementHandler.install("copyrightNotice", mapView);
 
-        const baseMapDataSource = new OmvDataSource({
+        const baseMapDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });
@@ -166,7 +166,7 @@ export namespace GeoJsonHeatmapExample {
         "italy",
         new URL("resources/italy.json", window.location.href)
     );
-    const geoJsonDataSource = new OmvDataSource({
+    const geoJsonDataSource = new VectorTileDataSource({
         dataProvider: geoJsonDataProvider,
         styleSetName: "geojson"
     });

--- a/@here/harp-examples/src/datasource_geojson_custom-shader.ts
+++ b/@here/harp-examples/src/datasource_geojson_custom-shader.ts
@@ -7,7 +7,7 @@
 import { GeoBox, GeoCoordinates, GeoPointLike } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { GeoJsonDataProvider, OmvDataSource } from "@here/harp-omv-datasource";
+import { GeoJsonDataProvider, VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { apikey } from "../config";
 
 import * as geojson from "../resources/polygon.json";
@@ -118,7 +118,7 @@ export namespace GeoJsonCustomShaderExample {
         start() {}
 
         private addBaseMap() {
-            const dataSource = new OmvDataSource({
+            const dataSource = new VectorTileDataSource({
                 baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                 authenticationCode: apikey
             });
@@ -127,7 +127,7 @@ export namespace GeoJsonCustomShaderExample {
         }
 
         private addEvRange() {
-            const datasource = new OmvDataSource({
+            const datasource = new VectorTileDataSource({
                 dataProvider: new GeoJsonDataProvider("geojson", geojson as any),
                 styleSetName: "geojson"
             });

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -11,21 +11,21 @@ import {
     APIFormat,
     AuthenticationMethod,
     GeoJsonDataProvider,
-    OmvDataSource
-} from "@here/harp-omv-datasource";
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { apikey, copyrightInfo } from "../config";
 import * as geojson from "../resources/italy.json";
 
 /**
- * In this example showcases how to use the styling of a [[OmvDataSource]] that using a
+ * In this example showcases how to use the styling of a [[VectorTileDataSource]] that using a
  * [[GeoJsonDataProvider]] with a dynamic [[StyleSet]] to generate a quiz game. First, we generate a
  * [[MapView]], without [[MapControls]] this time, and then we also attach an additional base map
- * from an [[OmvDataSource]].
+ * from an [[VectorTileDataSource]].
  * ```typescript
  * [[include:harp_gl_initmapview.ts]]
  * ```
  *
- * We then create the map of Italy via a [[OmvDataSource]] that only serves one GeoJson.
+ * We then create the map of Italy via a [[VectorTileDataSource]] that only serves one GeoJson.
  * This is performed via a custom class, `GeoJsonDataProvider`. When the datasource is linked we
  * then set its [[StyleSet]] and add the click listener on the canvas to handle the quiz logic.
  * ```typescript
@@ -34,7 +34,7 @@ import * as geojson from "../resources/italy.json";
  *
  * The quiz logic is performed when a region is picked. The name of the picked
  * region is compared to the expected name, and if they match, an update to the
- * [[OmvDataSource]]'s [[StyleSet]] is performed.
+ * [[VectorTileDataSource]]'s [[StyleSet]] is performed.
  * ```typescript
  * [[include:harp_gl_gamelogic.ts]]
  * ```
@@ -94,7 +94,7 @@ export namespace GeoJsonStylingGame {
             mapView.resize(window.innerWidth, window.innerHeight);
         });
         mapView.canvas.addEventListener("contextmenu", e => e.preventDefault());
-        const baseMap = new OmvDataSource({
+        const baseMap = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",
@@ -114,7 +114,7 @@ export namespace GeoJsonStylingGame {
             new URL("resources/italy.json", window.location.href)
         );
 
-        const geoJsonDataSource = new OmvDataSource({
+        const geoJsonDataSource = new VectorTileDataSource({
             dataProvider: geoJsonDataProvider,
             name: "geojson",
             styleSetName: "geojson",

--- a/@here/harp-examples/src/datasource_here_vector_tile.ts
+++ b/@here/harp-examples/src/datasource_here_vector_tile.ts
@@ -5,7 +5,11 @@
  */
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 
 import { apikey, copyrightInfo } from "../config";
 
@@ -43,7 +47,7 @@ import { apikey, copyrightInfo } from "../config";
  * [[include:harp_gl_datasource_here_vector_tile_example_3.ts]]
  * ```
  * At the end of the initialization a [[MapView]] object is returned. To show vector tiles the HERE
- * Vector Tile datasource is used, [[OmvDataSource]]:
+ * Vector Tile datasource is used, [[VectorTileDataSource]]:
  *
  * ```typescript
  * [[include:harp_gl_datasource_here_vector_tile_example_4.ts]]
@@ -97,7 +101,7 @@ export namespace DatasourceHEREVectorTileExample {
         const mapView = initializeMapView("mapCanvas");
 
         // snippet:harp_gl_datasource_here_vector_tile_example_4.ts
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",

--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -8,7 +8,7 @@ import { StyleSet, Theme } from "@here/harp-datasource-protocol";
 import { FeaturesDataSource } from "@here/harp-features-datasource";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { apikey } from "../config";
 
 /**
@@ -169,7 +169,7 @@ export namespace GeoJsonExample {
             mapView.resize(innerWidth - _width, innerHeight);
         });
 
-        const baseMap = new OmvDataSource({
+        const baseMap = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/getting-started_free-camera.ts
+++ b/@here/harp-examples/src/getting-started_free-camera.ts
@@ -14,7 +14,7 @@ import {
     MapViewOptions,
     MapViewUtils
 } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
 import { apikey } from "../config";
 
@@ -94,13 +94,13 @@ export namespace FreeCameraAppDebuggingToolExample {
         }
 
         /**
-         * Attaches the [[OmvDataSource]] and [[DebugTileDataSource]] to the map as well as
+         * Attaches the [[VectorTileDataSource]] and [[DebugTileDataSource]] to the map as well as
          * initializes the debug view (making the: `R`, `T` and `V` keys modify the camera's current
          * rotation (`R`), translation/postion (`T`) and changing the camera view to the one the
          * user is seeing (`V`).
          */
         start() {
-            const omvDataSource = new OmvDataSource({
+            const omvDataSource = new VectorTileDataSource({
                 baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                 authenticationCode: apikey
             });

--- a/@here/harp-examples/src/getting-started_globe-projection.ts
+++ b/@here/harp-examples/src/getting-started_globe-projection.ts
@@ -7,7 +7,7 @@
 import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { apikey } from "../config";
 
 export namespace GlobeExample {
@@ -35,7 +35,7 @@ export namespace GlobeExample {
     function main() {
         const map = initializeMapView("mapCanvas");
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
+++ b/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
@@ -98,7 +98,7 @@
             };
             const copyrights = [hereCopyrightInfo];
 
-            const omvDataSource = new harp.OmvDataSource({
+            const omvDataSource = new harp.VectorTileDataSource({
                 baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
                 apiFormat: harp.APIFormat.XYZOMV,
                 styleSetName: "tilezen",

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -7,7 +7,7 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { apikey } from "../config";
 
 /**
@@ -50,7 +50,7 @@ import { apikey } from "../config";
  * [[include:harp_gl_hello_world_example_3.ts]]
  * ```
  * At the end of the initialization a [[MapView]] object is returned. To show map tiles an exemplary
- * datasource is used, [[OmvDataSource]]:
+ * datasource is used, [[VectorTileDataSource]]:
  *
  * ```typescript
  * [[include:harp_gl_hello_world_example_4.ts]]
@@ -105,14 +105,14 @@ export namespace HelloWorldExample {
         });
         // end:harp_gl_hello_world_example_3.ts
 
-        addOmvDataSource(map);
+        addVectorTileDataSource(map);
 
         return map;
     }
 
-    function addOmvDataSource(map: MapView) {
+    function addVectorTileDataSource(map: MapView) {
         // snippet:harp_gl_hello_world_example_4.ts
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -7,7 +7,7 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, ThemeLoader } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import { apikey } from "../config";
 
@@ -46,7 +46,7 @@ export namespace ThemesExample {
 
     const mapView = initializeMapView();
 
-    const omvDataSource = new OmvDataSource({
+    const omvDataSource = new VectorTileDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         authenticationCode: apikey
     });

--- a/@here/harp-examples/src/getting-started_orbiting-view.ts
+++ b/@here/harp-examples/src/getting-started_orbiting-view.ts
@@ -6,7 +6,7 @@
 
 import { GeoCoordinates, mercatorProjection, sphereProjection } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import { apikey } from "../config";
 
@@ -67,7 +67,7 @@ export namespace CameraOrbitExample {
             mapView.resize(window.innerWidth, window.innerHeight);
         });
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -7,7 +7,7 @@
 import { Theme } from "@here/harp-datasource-protocol";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, PickResult } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { apikey } from "../config";
 
 /**
@@ -217,7 +217,7 @@ export namespace PickingExample {
 
         // end:datasource_object_picking_1.ts
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey,
             gatherFeatureAttributes: true

--- a/@here/harp-examples/src/real-time-shadows.ts
+++ b/@here/harp-examples/src/real-time-shadows.ts
@@ -8,7 +8,7 @@ import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import * as THREE from "three";
 import "three/examples/js/controls/TrackballControls";
@@ -228,7 +228,7 @@ function initializeMapView(id: string, theme: Theme): MapView {
         map.resize(window.innerWidth, window.innerHeight);
     });
 
-    addOmvDataSource().then(() => {
+    addVectorTileDataSource().then(() => {
         const light = map.lights.find(item => item instanceof THREE.DirectionalLight) as
             | THREE.DirectionalLight
             | undefined;
@@ -249,8 +249,8 @@ function initializeMapView(id: string, theme: Theme): MapView {
     return map;
 }
 
-const addOmvDataSource = (): Promise<void> => {
-    const omvDataSource = new OmvDataSource({
+const addVectorTileDataSource = (): Promise<void> => {
+    const omvDataSource = new VectorTileDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         authenticationCode: apikey
     });

--- a/@here/harp-examples/src/rendering_globe-atmosphere.ts
+++ b/@here/harp-examples/src/rendering_globe-atmosphere.ts
@@ -11,7 +11,11 @@ import {
     MapView,
     MapViewAtmosphere
 } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { HereTileProvider, HereWebTileDataSource } from "@here/harp-webtile-datasource";
 
 import { apikey, copyrightInfo } from "../config";
@@ -49,7 +53,7 @@ export namespace GlobeAtmosphereExample {
 
         let dataSource;
         if (dataSourceVariant === DataSourceVariant.Omv) {
-            dataSource = new OmvDataSource({
+            dataSource = new VectorTileDataSource({
                 baseUrl: "https://xyz.api.here.com/tiles/herebase.02",
                 apiFormat: APIFormat.XYZOMV,
                 styleSetName: "tilezen",

--- a/@here/harp-examples/src/rendering_post-effects_all.ts
+++ b/@here/harp-examples/src/rendering_post-effects_all.ts
@@ -7,7 +7,11 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import { apikey, copyrightInfo } from "../config";
 
@@ -57,7 +61,7 @@ export namespace EffectsAllExample {
 
     const map = initializeMapView("mapCanvas");
 
-    const omvDataSource = new OmvDataSource({
+    const omvDataSource = new VectorTileDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",

--- a/@here/harp-examples/src/rendering_post-effects_themes.ts
+++ b/@here/harp-examples/src/rendering_post-effects_themes.ts
@@ -7,7 +7,11 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import { apikey, copyrightInfo } from "../config";
 
@@ -46,7 +50,7 @@ export namespace EffectsExample {
 
     const map = initializeMapView("mapCanvas");
 
-    const omvDataSource = new OmvDataSource({
+    const omvDataSource = new VectorTileDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",

--- a/@here/harp-examples/src/rendering_synchronous.ts
+++ b/@here/harp-examples/src/rendering_synchronous.ts
@@ -5,7 +5,11 @@
  */
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import THREE = require("three");
 import { apikey, copyrightInfo } from "../config";
 
@@ -63,7 +67,7 @@ export namespace SynchronousRendering {
             map.resize(window.innerWidth, window.innerHeight);
         });
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",

--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -7,7 +7,11 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { apikey, copyrightInfo } from "../config";
 
 export namespace DataDrivenThemeExample {
@@ -116,7 +120,7 @@ export namespace DataDrivenThemeExample {
     function main() {
         const map = initializeMapView("mapCanvas");
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "population",

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -7,7 +7,11 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { apikey, copyrightInfo } from "../config";
 
 /**
@@ -128,13 +132,13 @@ export namespace HelloCustomThemeExample {
             map.resize(window.innerWidth, window.innerHeight);
         });
 
-        addOmvDataSource(map);
+        addVectorTileDataSource(map);
 
         return map;
     }
 
-    function addOmvDataSource(map: MapView) {
-        const omvDataSource = new OmvDataSource({
+    function addVectorTileDataSource(map: MapView) {
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -5,11 +5,15 @@
  */
 
 import { Theme } from "@here/harp-datasource-protocol";
-// import { GeoJsonDataProvider } from "@here/harp-omv-datasource";
+// import { GeoJsonDataProvider } from "@here/harp-vectortile-datasource";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { apikey, copyrightInfo } from "../config";
 
 /**
@@ -461,7 +465,7 @@ export namespace TiledGeoJsonTechniquesExample {
             }
         });
 
-        const baseMapDataSource = new OmvDataSource({
+        const baseMapDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",

--- a/@here/harp-examples/src/styling_square-technique.ts
+++ b/@here/harp-examples/src/styling_square-technique.ts
@@ -6,7 +6,7 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 
 import { apikey } from "../config";
 
@@ -65,13 +65,13 @@ export namespace SquaresTechniqueExample {
             map.resize(window.innerWidth, window.innerHeight);
         });
 
-        addOmvDataSource(map);
+        addVectorTileDataSource(map);
 
         return map;
     }
 
-    function addOmvDataSource(map: MapView) {
-        const omvDataSource = new OmvDataSource({
+    function addVectorTileDataSource(map: MapView) {
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             authenticationCode: apikey
         });

--- a/@here/harp-examples/src/styling_textured-areas.ts
+++ b/@here/harp-examples/src/styling_textured-areas.ts
@@ -9,7 +9,11 @@ import { isJsonExpr } from "@here/harp-datasource-protocol/lib/Expr";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, ThemeLoader } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { apikey, copyrightInfo } from "../config";
 
 export namespace HelloWorldTexturedExample {
@@ -18,7 +22,7 @@ export namespace HelloWorldTexturedExample {
 
         const mapView = initializeMapView("mapCanvas");
 
-        const omvDataSource = new OmvDataSource({
+        const omvDataSource = new VectorTileDataSource({
             baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
             apiFormat: APIFormat.XYZOMV,
             styleSetName: "tilezen",

--- a/@here/harp-examples/src/synchronized-views.ts
+++ b/@here/harp-examples/src/synchronized-views.ts
@@ -7,7 +7,11 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, MapViewUtils } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import { apikey, copyrightInfo } from "../config";
 
 /**
@@ -144,9 +148,9 @@ export namespace TripleViewExample {
         copyrightInfo
     };
     const dataSources = {
-        omvDataSource1: new OmvDataSource(xyzDataSourceParams),
-        omvDataSource2: new OmvDataSource(xyzDataSourceParams),
-        omvDataSource3: new OmvDataSource(xyzDataSourceParams)
+        omvDataSource1: new VectorTileDataSource(xyzDataSourceParams),
+        omvDataSource2: new VectorTileDataSource(xyzDataSourceParams),
+        omvDataSource3: new VectorTileDataSource(xyzDataSourceParams)
     };
 
     mapViews.view1.mapView.addDataSource(dataSources.omvDataSource1);

--- a/@here/harp-examples/src/threejs_raycast.ts
+++ b/@here/harp-examples/src/threejs_raycast.ts
@@ -7,7 +7,11 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { LongPressHandler, MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
-import { APIFormat, AuthenticationMethod, OmvDataSource } from "@here/harp-omv-datasource";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
 import { apikey, copyrightInfo } from "../config";
 
@@ -139,7 +143,7 @@ export namespace ThreejsRaycast {
 
     const mapView = initializeMapView("mapCanvas");
 
-    const omvDataSource = new OmvDataSource({
+    const omvDataSource = new VectorTileDataSource({
         baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
         apiFormat: APIFormat.XYZOMV,
         styleSetName: "tilezen",


### PR DESCRIPTION
This change replaces the usages of the deprecate module
@here/harp-omv-datasource with @here/harp-vectortile-datasource.
