### PR TITLE
HARP-11509: Update the harp.gl yo templates.

### DIFF
--- a/@here/generator-harp.gl/README.md
+++ b/@here/generator-harp.gl/README.md
@@ -4,10 +4,10 @@ Yeoman generator for [harp.gl](https://github.com/heremaps/harp.gl) based projec
 
 ## Pre-requirements
 
-* [node.js](https://nodejs.org/)
-* [yeoman](https://yeoman.io/) - Install globally with `npm install -g yo` or use without
-  installation with `npx` like this `npx yo`.
-* By default, generated app retrieves map data from HERE Vector Tiles Service. You need an `apikey` that you can generate yourself. Please see our [Getting Started Guide](../../docs/GettingStartedGuide.md).
+-   [node.js](https://nodejs.org/)
+-   [yeoman](https://yeoman.io/) - Install globally with `npm install -g yo` or use without
+    installation with `npx` like this `npx yo`.
+-   By default, generated app retrieves map data from HERE Vector Tiles Service. You need an `apikey` that you can generate yourself. Please see our [Getting Started Guide](../../docs/GettingStartedGuide.md).
 
 ## Usage
 
@@ -17,15 +17,17 @@ cd 3dmap-example
 npx -p yo -p @here/generator-harp.gl yo @here/harp.gl
 > package name 3dmap-example name:
 ```
+
 This command will generate complete, clean project based on Node.js, Webpack, Typescript.
 Set you access token in `View.ts`:
 
 ```typescript
-const omvDataSource = new OmvDataSource({
+const dataSource = new VectorTileDataSource({
     baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
     authenticationCode: "YOUR-APIKEY"
 });
 ```
+
 Then start it using `webpack-dev-server`:
 
 ```sh

--- a/@here/generator-harp.gl/generators/app/index.js
+++ b/@here/generator-harp.gl/generators/app/index.js
@@ -52,7 +52,7 @@ module.exports = class extends Generator {
             "@here/harp-geoutils",
             "@here/harp-map-controls",
             "@here/harp-map-theme",
-            "@here/harp-omv-datasource",
+            "@here/harp-vectortile-datasource",
             "@here/harp-webpack-utils"
         ];
         // for CI testing support installing from local packages

--- a/@here/generator-harp.gl/generators/app/templates/javascript/View.js
+++ b/@here/generator-harp.gl/generators/app/templates/javascript/View.js
@@ -6,7 +6,7 @@
 
 import { MapControls } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 
 const defaultTheme = "resources/berlin_tilezen_base.json";
 
@@ -23,10 +23,10 @@ export class View {
             theme: this.theme,
             decoderUrl: "decoder.bundle.js"
         });
-        const omvDataSource = new OmvDataSource({
+        const dataSource = new VectorTileDataSource({
             authenticationCode: "<%= apikey %>"
         });
-        mapView.addDataSource(omvDataSource);
+        mapView.addDataSource(dataSource);
         MapControls.create(mapView);
         return mapView;
     }

--- a/@here/generator-harp.gl/generators/app/templates/javascript/decoder.js
+++ b/@here/generator-harp.gl/generators/app/templates/javascript/decoder.js
@@ -6,7 +6,10 @@
 
 self.importScripts("three.min.js");
 
-import { OmvTileDecoderService, OmvTilerService } from "@here/harp-omv-datasource/index-worker";
+import {
+    GeoJsonTilerService,
+    VectorTileDecoderService
+} from "@here/harp-vectortile-datasource/index-worker";
 
-OmvTileDecoderService.start();
-OmvTilerService.start();
+VectorTileDecoderService.start();
+GeoJsonTilerService.start();

--- a/@here/generator-harp.gl/generators/app/templates/typescript/View.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/View.ts
@@ -7,7 +7,7 @@
 import { Theme } from "@here/harp-datasource-protocol";
 import { MapControls } from "@here/harp-map-controls";
 import { MapView } from "@here/harp-mapview";
-import { OmvDataSource } from "@here/harp-omv-datasource";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 
 const defaultTheme = "resources/berlin_tilezen_base.json";
 
@@ -35,10 +35,10 @@ export class View {
             decoderUrl: "decoder.bundle.js"
         });
 
-        const omvDataSource = new OmvDataSource({
+        const dataSource = new VectorTileDataSource({
             authenticationCode: "<%= apikey %>"
         });
-        mapView.addDataSource(omvDataSource);
+        mapView.addDataSource(dataSource);
 
         MapControls.create(mapView);
 

--- a/@here/generator-harp.gl/generators/app/templates/typescript/decoder.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/decoder.ts
@@ -10,7 +10,10 @@ declare let self: Worker & {
 
 self.importScripts("three.min.js");
 
-import { OmvTileDecoderService, OmvTilerService } from "@here/harp-omv-datasource/index-worker";
+import {
+    GeoJsonTilerService,
+    VectorTileDecoderService
+} from "@here/harp-vectortile-datasource/index-worker";
 
-OmvTileDecoderService.start();
-OmvTilerService.start();
+VectorTileDecoderService.start();
+GeoJsonTilerService.start();


### PR DESCRIPTION
This change remove usages of the deprecated @here/harp-omv-datasource
from the harp.gl yo templates.
