### PR TITLE
HARP-11152: Fix extruded polygon outlines when style has no minZoomLe…

### DIFF
--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -112,7 +112,7 @@ export class AnimatedExtrusionHandler {
 
         const animateExtrusionValue = getPropertyValue(technique.animateExtrusion, env);
 
-        if (animateExtrusionValue === null) {
+        if (animateExtrusionValue === null && "minZoomLevel" in technique) {
             return this.enabled;
         }
 

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -98,7 +98,8 @@ export class AnimatedExtrusionHandler {
             return false;
         }
 
-        if ("minZoomLevel" in technique) {
+        const techniqueHasMinZl = technique.hasOwnProperty("minZoomLevel");
+        if (techniqueHasMinZl) {
             this.m_minZoomLevel = (technique as any).minZoomLevel;
         }
 
@@ -112,7 +113,7 @@ export class AnimatedExtrusionHandler {
 
         const animateExtrusionValue = getPropertyValue(technique.animateExtrusion, env);
 
-        if (animateExtrusionValue === null && "minZoomLevel" in technique) {
+        if (animateExtrusionValue === null && techniqueHasMinZl) {
             return this.enabled;
         }
 

--- a/@here/harp-mapview/test/AnimatedExtrusionHandlerTest.ts
+++ b/@here/harp-mapview/test/AnimatedExtrusionHandlerTest.ts
@@ -83,13 +83,36 @@ describe("AnimatedExtrusionHandler", function() {
             expect(enabled).to.be.false;
         });
 
-        it("returns forced enable value if technique does not define animateExtrusion", function() {
+        // tslint:disable-next-line: max-line-length
+        it("returns forced enabled if technique has minZoomLevel but not animateExtrusion", function() {
+            {
+                const enabled = handler.setAnimationProperties(
+                    {
+                        name: "extruded-polygon",
+                        minZoomLevel: 5
+                    } as any,
+                    env
+                );
+                expect(enabled).to.be.true;
+            }
+
+            {
+                handler.enabled = false;
+                const enabled = handler.setAnimationProperties(
+                    { name: "extruded-polygon", minZoomLevel: 5 } as any,
+                    env
+                );
+                expect(enabled).to.be.false;
+            }
+        });
+
+        it("returns false if technique has neither minZoomLevel nor animateExtrusion", function() {
             {
                 const enabled = handler.setAnimationProperties(
                     { name: "extruded-polygon" } as any,
                     env
                 );
-                expect(enabled).to.be.true;
+                expect(enabled).to.be.false;
             }
 
             {


### PR DESCRIPTION
…vel.

Extrusion animation is enabled by default, when a extruded polygon style
does not define a value "animateExtrusion" value. In this case, if no
minZoomLevel is specified, extrusion does not start until zoom level 16
by default, and therefore outlines are not rendered.

To fix it, extrusion animation is disabled if neither "animateExtrusion"
nor "minZoomLevel" are defined in the style.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
