### PR TITLE
Use eslint simple-import-sort plugin instead of import/order.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "plugins": ["@typescript-eslint", "prettier"],
+    "plugins": ["@typescript-eslint", "prettier", "simple-import-sort"],
     "extends": ["standard-with-typescript", "prettier/@typescript-eslint"],
     "parserOptions": {
         "project": "./tsconfig.json"
@@ -41,7 +41,9 @@
         "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
 
-        "import/order": ["error", { "alphabetize": { "order": "asc", "caseInsensitive": true } }],
+        "simple-import-sort/sort": "error",
+        "sort-imports": "off",
+        "import/order": "off",
 
         "max-len": [
             "error",

--- a/@here/generator-harp.gl/generators/app/templates/typescript/index.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { GeoCoordinates } from "@here/harp-geoutils";
+
 import { View } from "./View";
 
 const app = new View({

--- a/@here/harp-atlas-tools/src/AtlasGenerator.ts
+++ b/@here/harp-atlas-tools/src/AtlasGenerator.ts
@@ -5,6 +5,7 @@
  */
 
 import * as path from "path";
+
 import {
     BlendAlpha,
     BlendAlphaPremultiplied,

--- a/@here/harp-atlas-tools/src/FileSystem.ts
+++ b/@here/harp-atlas-tools/src/FileSystem.ts
@@ -5,8 +5,8 @@
  */
 
 import * as fileSystem from "fs";
-import * as path from "path";
 import * as mkpath from "mkpath";
+import * as path from "path";
 
 /**
  * Describes possible image formats.

--- a/@here/harp-atlas-tools/src/ImageBitmapCoders.ts
+++ b/@here/harp-atlas-tools/src/ImageBitmapCoders.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Jimp from "jimp";
+
 import { ColorUtils } from "./ColorUtils";
 import { FileSystem, ImageFormat } from "./FileSystem";
 import {

--- a/@here/harp-atlas-tools/src/ImageVectorCoders.ts
+++ b/@here/harp-atlas-tools/src/ImageVectorCoders.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Jimp from "jimp";
+
 import { ColorUtils } from "./ColorUtils";
 import { FileSystem, ImageFormat } from "./FileSystem";
 import { ImageBitmapEncoderConstructor } from "./ImageBitmapCoders";

--- a/@here/harp-atlas-tools/src/cli-atlas-generator.ts
+++ b/@here/harp-atlas-tools/src/cli-atlas-generator.ts
@@ -5,10 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as program from "commander";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import * as program from "commander";
+
 import { AtlasOptions, generateSpritesAtlas } from "./AtlasGenerator";
 import { getLogger, Logger, LogLevel } from "./Logger";
 

--- a/@here/harp-atlas-tools/src/cli-sprites-generator.ts
+++ b/@here/harp-atlas-tools/src/cli-sprites-generator.ts
@@ -5,10 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as program from "commander";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import * as program from "commander";
+
 import { generateSprites, ProcessingOptions } from "./AtlasGenerator";
 import { getLogger, Logger, LogLevel } from "./Logger";
 

--- a/@here/harp-datasource-protocol/lib/ColorUtils.ts
+++ b/@here/harp-datasource-protocol/lib/ColorUtils.ts
@@ -6,6 +6,7 @@
 
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { RGBA } from "./RGBA";
 
 const SHIFT_TRANSPARENCY: number = 24;

--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -14,6 +14,7 @@ import {
     Vector3Like,
     webMercatorProjection
 } from "@here/harp-geoutils";
+
 import { Env } from "./Expr";
 import { AttrEvaluationContext, evaluateTechniqueAttr } from "./TechniqueAttr";
 import {

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { Env, Value } from "./Env";
 import { ExprEvaluator, ExprEvaluatorContext, OperatorDescriptor } from "./ExprEvaluator";
 import { ExprInstantiator, InstantiationContext } from "./ExprInstantiator";
@@ -14,7 +15,6 @@ import {
     interpolatedPropertyDefinitionToJsonExpr,
     isInterpolatedPropertyDefinition
 } from "./InterpolatedPropertyDefs";
-
 import { Pixels } from "./Pixels";
 import { RGBA } from "./RGBA";
 import { Definitions } from "./Theme";

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import {
     BooleanLiteralExpr,
     CallExpr,
@@ -25,7 +26,6 @@ import {
     Value,
     VarExpr
 } from "./Expr";
-
 import { ArrayOperators } from "./operators/ArrayOperators";
 import { CastOperators } from "./operators/CastOperators";
 import { ColorOperators } from "./operators/ColorOperators";

--- a/@here/harp-datasource-protocol/lib/ITiler.ts
+++ b/@here/harp-datasource-protocol/lib/ITiler.ts
@@ -5,6 +5,7 @@
  */
 
 import { TileKey } from "@here/harp-geoutils";
+
 import { GeoJson } from "../lib/GeoJsonDataType";
 
 /**

--- a/@here/harp-datasource-protocol/lib/PropertyValue.ts
+++ b/@here/harp-datasource-protocol/lib/PropertyValue.ts
@@ -5,6 +5,7 @@
  */
 
 import { LoggerManager } from "@here/harp-utils";
+
 import { Env } from "./Env";
 import { Expr, ExprScope, Value } from "./Expr";
 import { Pixels } from "./Pixels";

--- a/@here/harp-datasource-protocol/lib/RGBA.ts
+++ b/@here/harp-datasource-protocol/lib/RGBA.ts
@@ -5,6 +5,7 @@
  */
 
 import { MathUtils } from "three";
+
 import { ColorUtils } from "./ColorUtils";
 import { parseStringEncodedColor } from "./StringEncodedNumeral";
 

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -6,6 +6,7 @@
 import { assert } from "@here/harp-utils";
 //@ts-ignore
 import { parseCSSColor } from "csscolorparser";
+
 import { ColorUtils } from "./ColorUtils";
 
 /**

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -5,6 +5,7 @@
  */
 
 import { Vector3Like } from "@here/harp-geoutils/lib/math/Vector3Like";
+
 import { JsonExpr, JsonValue } from "./Expr";
 import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 import {

--- a/@here/harp-datasource-protocol/lib/ThreeBufferUtils.ts
+++ b/@here/harp-datasource-protocol/lib/ThreeBufferUtils.ts
@@ -10,6 +10,7 @@ import {
     InterleavedBufferAttribute as ThreeInterleavedBufferAttribute,
     TypedArray
 } from "three";
+
 import {
     BufferAttribute,
     BufferElementType,

--- a/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
@@ -6,7 +6,6 @@
 
 import { Env } from "../Env";
 import { CallExpr, ExprScope } from "../Expr";
-
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const operators = {

--- a/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { CallExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 

--- a/@here/harp-datasource-protocol/lib/operators/ObjectOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ObjectOperators.ts
@@ -6,7 +6,6 @@
 
 import { Env } from "../Env";
 import { CallExpr, Expr, ExprScope } from "../Expr";
-
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/@here/harp-datasource-protocol/lib/operators/VectorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/VectorOperators.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { Value } from "../Env";
 import { CallExpr, NumberLiteralExpr } from "../Expr";
 import { ExprEvaluatorContext, OperatorDescriptorMap } from "../ExprEvaluator";

--- a/@here/harp-datasource-protocol/test/ColorUtilsTest.ts
+++ b/@here/harp-datasource-protocol/test/ColorUtilsTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { assert } from "chai";
+
 import { ColorUtils } from "../lib/ColorUtils";
 
 describe("ColorUtils", function() {

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -8,6 +8,7 @@
 
 import { assert } from "chai";
 import * as THREE from "three";
+
 import {
     Env,
     Expr,

--- a/@here/harp-datasource-protocol/test/ExprPoolTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprPoolTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { Expr } from "../lib/Expr";
 import { ExprPool } from "../lib/ExprPool";
 

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { CallExpr, Env, Expr, JsonExpr, MapEnv, Value, ValueMap } from "../lib/Expr";
 import { Definitions } from "../lib/Theme";
 

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { MapEnv } from "../lib/Env";
 import { Expr, JsonArray } from "../lib/Expr";
 import { getPropertyValue } from "../lib/PropertyValue";

--- a/@here/harp-datasource-protocol/test/OutlinesTest.ts
+++ b/@here/harp-datasource-protocol/test/OutlinesTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { addPolygonEdges } from "../lib/Outliner";
 
 describe("Outlines", function() {

--- a/@here/harp-datasource-protocol/test/StringDecodersTest.ts
+++ b/@here/harp-datasource-protocol/test/StringDecodersTest.ts
@@ -9,6 +9,7 @@
 //    Allow bitwise operations for colors decoding tests
 
 import { assert } from "chai";
+
 import { ColorUtils } from "../lib/ColorUtils";
 import { parseStringEncodedNumeral } from "../lib/StringEncodedNumeral";
 

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -8,6 +8,7 @@
 
 import { assert } from "chai";
 import * as THREE from "three";
+
 import { Env, Expr, MapEnv, ValueMap } from "../lib/Expr";
 import {
     InterpolatedPropertyDefinition,

--- a/@here/harp-datasource-protocol/test/ThreeBufferUtilsTest.ts
+++ b/@here/harp-datasource-protocol/test/ThreeBufferUtilsTest.ts
@@ -8,6 +8,7 @@
 
 import { assert, expect } from "chai";
 import * as THREE from "three";
+
 import { BufferAttribute, Geometry } from "../lib/DecodedTile";
 import { ThreeBufferUtils } from "../lib/ThreeBufferUtils";
 

--- a/@here/harp-debug-datasource/lib/DebugTileDataSource.ts
+++ b/@here/harp-debug-datasource/lib/DebugTileDataSource.ts
@@ -13,7 +13,6 @@ import {
     TextRenderStyle,
     VerticalAlignment
 } from "@here/harp-text-canvas";
-
 import * as THREE from "three";
 
 const debugMaterial = new THREE.LineBasicMaterial({

--- a/@here/harp-examples/codebrowser.ts
+++ b/@here/harp-examples/codebrowser.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as hljs from "highlight.js";
-
 import "style-loader!css-loader!highlight.js/styles/default.css";
+
+import * as hljs from "highlight.js";
 
 (() => {
     if (location.search === undefined || location.search.length === 0) {

--- a/@here/harp-examples/decoder/custom_decoder.ts
+++ b/@here/harp-examples/decoder/custom_decoder.ts
@@ -23,6 +23,7 @@ import {
     WorkerServiceManager
 } from "@here/harp-mapview-decoder/index-worker";
 import { BoxBufferGeometry, Matrix4, Vector3 } from "three";
+
 import { CUSTOM_DECODER_SERVICE_TYPE } from "./custom_decoder_defs";
 
 export // snippet:custom_datasource_example_custom_decoder.ts

--- a/@here/harp-examples/decoder/decoder.ts
+++ b/@here/harp-examples/decoder/decoder.ts
@@ -14,6 +14,7 @@ import {
     GeoJsonTilerService,
     VectorTileDecoderService
 } from "@here/harp-vectortile-datasource/index-worker";
+
 import { CustomDecoderService } from "./custom_decoder";
 
 VectorTileDecoderService.start();

--- a/@here/harp-examples/lib/PerformanceUtils.ts
+++ b/@here/harp-examples/lib/PerformanceUtils.ts
@@ -25,6 +25,7 @@ import {
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
+
 import { apikey, copyrightInfo } from "../config";
 import { PerformanceTestData } from "./PerformanceConfig";
 

--- a/@here/harp-examples/src/camera-animations_quaternion-slerp.ts
+++ b/@here/harp-examples/src/camera-animations_quaternion-slerp.ts
@@ -7,6 +7,7 @@
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapView, MapViewEventNames, MapViewUtils } from "@here/harp-mapview";
 import * as THREE from "three";
+
 import { HelloWorldExample } from "./getting-started_hello-world_npm";
 
 /**

--- a/@here/harp-examples/src/datasource_geojson_custom-shader.ts
+++ b/@here/harp-examples/src/datasource_geojson_custom-shader.ts
@@ -8,8 +8,8 @@ import { GeoBox, GeoCoordinates, GeoPointLike } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { GeoJsonDataProvider, VectorTileDataSource } from "@here/harp-vectortile-datasource";
-import { apikey } from "../config";
 
+import { apikey } from "../config";
 import * as geojson from "../resources/polygon.json";
 
 export namespace GeoJsonCustomShaderExample {

--- a/@here/harp-examples/src/datasource_geojson_points.ts
+++ b/@here/harp-examples/src/datasource_geojson_points.ts
@@ -13,6 +13,7 @@ import {
     GeoJsonDataProvider,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -13,6 +13,7 @@ import {
     GeoJsonDataProvider,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 import * as geojson from "../resources/italy.json";
 

--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -9,6 +9,7 @@ import { FeaturesDataSource } from "@here/harp-features-datasource";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
+
 import { apikey } from "../config";
 
 /**

--- a/@here/harp-examples/src/getting-started_free-camera.ts
+++ b/@here/harp-examples/src/getting-started_free-camera.ts
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Import the gesture handlers from the three.js additional libraries.
+// The controls are not in common.js they explicitly require a
+// global instance of THREE and they must be imported only for their
+// side effect.
+import "three/examples/js/controls/TrackballControls";
+import "three/examples/js/controls/TransformControls";
+
 import { DebugTileDataSource } from "@here/harp-debug-datasource";
 import { GeoCoordinates, webMercatorTilingScheme } from "@here/harp-geoutils";
 import { MapControls } from "@here/harp-map-controls";
@@ -16,14 +23,8 @@ import {
 } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
-import { apikey } from "../config";
 
-// Import the gesture handlers from the three.js additional libraries.
-// The controls are not in common.js they explicitly require a
-// global instance of THREE and they must be imported only for their
-// side effect.
-import "three/examples/js/controls/TrackballControls";
-import "three/examples/js/controls/TransformControls";
+import { apikey } from "../config";
 
 /**
  * This app adds another freely moveable camera into the map view scene.

--- a/@here/harp-examples/src/getting-started_globe-projection.ts
+++ b/@here/harp-examples/src/getting-started_globe-projection.ts
@@ -8,6 +8,7 @@ import { sphereProjection } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
+
 import { apikey } from "../config";
 
 export namespace GlobeExample {

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -8,6 +8,7 @@ import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
+
 import { apikey } from "../config";
 
 /**

--- a/@here/harp-examples/src/getting-started_look-at.ts
+++ b/@here/harp-examples/src/getting-started_look-at.ts
@@ -6,6 +6,7 @@
 
 import { GeoBox, GeoCoordinates, mercatorProjection, sphereProjection } from "@here/harp-geoutils";
 import { GUI } from "dat.gui";
+
 import { HelloWorldExample } from "./getting-started_hello-world_npm";
 
 /**

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -9,6 +9,7 @@ import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, ThemeLoader } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
+
 import { apikey } from "../config";
 
 /**

--- a/@here/harp-examples/src/getting-started_orbiting-view.ts
+++ b/@here/harp-examples/src/getting-started_orbiting-view.ts
@@ -8,6 +8,7 @@ import { GeoCoordinates, mercatorProjection, sphereProjection } from "@here/harp
 import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
+
 import { apikey } from "../config";
 
 /**

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -8,6 +8,7 @@ import { Theme } from "@here/harp-datasource-protocol";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
 import { CopyrightElementHandler, MapView, PickResult } from "@here/harp-mapview";
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
+
 import { apikey } from "../config";
 
 /**

--- a/@here/harp-examples/src/real-time-shadows.ts
+++ b/@here/harp-examples/src/real-time-shadows.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import "three/examples/js/controls/TrackballControls";
+
 import { Theme } from "@here/harp-datasource-protocol";
 import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapControls, MapControlsUI } from "@here/harp-map-controls";
@@ -11,7 +13,7 @@ import { CopyrightElementHandler, MapView, MapViewEventNames } from "@here/harp-
 import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
 import * as THREE from "three";
-import "three/examples/js/controls/TrackballControls";
+
 import { apikey } from "../config";
 
 const SunCalc = require("suncalc");

--- a/@here/harp-examples/src/rendering_post-effects_all.ts
+++ b/@here/harp-examples/src/rendering_post-effects_all.ts
@@ -13,6 +13,7 @@ import {
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/rendering_post-effects_themes.ts
+++ b/@here/harp-examples/src/rendering_post-effects_themes.ts
@@ -13,6 +13,7 @@ import {
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
 import { GUI } from "dat.gui";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -12,6 +12,7 @@ import {
     AuthenticationMethod,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 
 export namespace DataDrivenThemeExample {

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -12,6 +12,7 @@ import {
     AuthenticationMethod,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -14,6 +14,7 @@ import {
     AuthenticationMethod,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/styling_textured-areas.ts
+++ b/@here/harp-examples/src/styling_textured-areas.ts
@@ -14,6 +14,7 @@ import {
     AuthenticationMethod,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 
 export namespace HelloWorldTexturedExample {

--- a/@here/harp-examples/src/synchronized-views.ts
+++ b/@here/harp-examples/src/synchronized-views.ts
@@ -12,6 +12,7 @@ import {
     AuthenticationMethod,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/threejs_add-object.ts
+++ b/@here/harp-examples/src/threejs_add-object.ts
@@ -7,6 +7,7 @@
 import { LongPressHandler } from "@here/harp-map-controls";
 import { MapAnchor, MapView } from "@here/harp-mapview";
 import * as THREE from "three";
+
 import { HelloWorldExample } from "./getting-started_hello-world_npm";
 
 /**

--- a/@here/harp-examples/src/threejs_animation.ts
+++ b/@here/harp-examples/src/threejs_animation.ts
@@ -8,6 +8,7 @@ import { GeoCoordinates } from "@here/harp-geoutils";
 import { MapAnchor, MapViewEventNames, RenderEvent } from "@here/harp-mapview";
 import * as THREE from "three";
 import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
+
 import { HelloWorldExample } from "./getting-started_hello-world_npm";
 
 /**

--- a/@here/harp-examples/src/threejs_raycast.ts
+++ b/@here/harp-examples/src/threejs_raycast.ts
@@ -13,6 +13,7 @@ import {
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
 import * as THREE from "three";
+
 import { apikey, copyrightInfo } from "../config";
 
 /**

--- a/@here/harp-examples/src/tile_dependencies.ts
+++ b/@here/harp-examples/src/tile_dependencies.ts
@@ -16,6 +16,7 @@ import {
     TileFactory
 } from "@here/harp-mapview-decoder";
 import { GUI } from "dat.gui";
+
 import { CUSTOM_DECODER_SERVICE_TYPE } from "../decoder/custom_decoder_defs";
 
 /**

--- a/@here/harp-features-datasource/lib/FeaturesDataSource.ts
+++ b/@here/harp-features-datasource/lib/FeaturesDataSource.ts
@@ -19,6 +19,7 @@ import {
     VectorTileDataSource,
     VectorTileDataSourceParameters
 } from "@here/harp-vectortile-datasource";
+
 import { MapViewFeature } from "./Features";
 
 const logger = LoggerManager.instance.create("FeaturesDataSource");

--- a/@here/harp-fetch/test/FetchTest.ts
+++ b/@here/harp-fetch/test/FetchTest.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from "path";
-import { assert } from "chai";
 import "../index";
+
+import { assert } from "chai";
+import * as path from "path";
 
 const isNode = typeof window === "undefined";
 const describeOnlyNode = isNode ? describe : xdescribe;

--- a/@here/harp-geometry/lib/EdgeLengthGeometrySubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/EdgeLengthGeometrySubdivisionModifier.ts
@@ -7,6 +7,7 @@
 import { Box3Like, GeoBox, Projection, ProjectionType } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 import { Vector3 } from "three";
+
 import { SubdivisionModifier } from "./SubdivisionModifier";
 
 const VERTEX_POSITION_CACHE = [new Vector3(), new Vector3()];

--- a/@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier.ts
@@ -6,6 +6,7 @@
 
 import { Projection, sphereProjection } from "@here/harp-geoutils";
 import { Vector3 } from "three";
+
 import { SubdivisionModifier } from "./SubdivisionModifier";
 
 const VERTEX_POSITION_CACHE = [new Vector3(), new Vector3(), new Vector3()];

--- a/@here/harp-geometry/test/ClipPolygonTest.ts
+++ b/@here/harp-geometry/test/ClipPolygonTest.ts
@@ -7,6 +7,7 @@
 import { assert } from "chai";
 import earcut from "earcut";
 import { ShapeUtils, Vector2 } from "three";
+
 import { clipPolygon } from "../lib/ClipPolygon";
 
 describe("ClipPolygon", () => {

--- a/@here/harp-geometry/test/SphericalGeometrySubdivisionModifierTest.ts
+++ b/@here/harp-geometry/test/SphericalGeometrySubdivisionModifierTest.ts
@@ -8,8 +8,8 @@
 
 import * as geo from "@here/harp-geoutils";
 import { assert } from "chai";
-
 import * as THREE from "three";
+
 import { SphericalGeometrySubdivisionModifier } from "../lib/SphericalGeometrySubdivisionModifier";
 
 describe("SphericalGeometrySubdivisionModifier", function() {

--- a/@here/harp-geoutils/lib/coordinates/GeoBox.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoBox.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBoxExtentLike } from "./GeoBoxExtentLike";
 import { GeoCoordinates } from "./GeoCoordinates";
 

--- a/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoCoordinatesLike, isGeoCoordinatesLike } from "./GeoCoordinatesLike";
 import { GeoPointLike, isGeoPointLike } from "./GeoPointLike";
 import { isLatLngLike, LatLngLike } from "./LatLngLike";

--- a/@here/harp-geoutils/lib/math/MathUtils.ts
+++ b/@here/harp-geoutils/lib/math/MathUtils.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { Box3Like } from "./Box3Like";
 import { Vector3Like } from "./Vector3Like";
 

--- a/@here/harp-geoutils/lib/math/OrientedBox3.ts
+++ b/@here/harp-geoutils/lib/math/OrientedBox3.ts
@@ -5,6 +5,7 @@
  */
 
 import { Frustum, Matrix4, Plane, Ray, Vector3 } from "three";
+
 import { OrientedBox3Like } from "./OrientedBox3Like";
 
 function intersectsSlab(

--- a/@here/harp-geoutils/lib/projection/EquirectangularProjection.ts
+++ b/@here/harp-geoutils/lib/projection/EquirectangularProjection.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBox } from "../coordinates/GeoBox";
 import { GeoCoordinates } from "../coordinates/GeoCoordinates";
 import { GeoCoordinatesLike } from "../coordinates/GeoCoordinatesLike";

--- a/@here/harp-geoutils/lib/projection/IdentityProjection.ts
+++ b/@here/harp-geoutils/lib/projection/IdentityProjection.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBox } from "../coordinates/GeoBox";
 import { GeoCoordinates } from "../coordinates/GeoCoordinates";
 import { GeoCoordinatesLike } from "../coordinates/GeoCoordinatesLike";

--- a/@here/harp-geoutils/lib/projection/MercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/MercatorProjection.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBox } from "../coordinates/GeoBox";
 import { GeoCoordinates } from "../coordinates/GeoCoordinates";
 import { GeoCoordinatesLike, isGeoCoordinatesLike } from "../coordinates/GeoCoordinatesLike";

--- a/@here/harp-geoutils/lib/projection/SphereProjection.ts
+++ b/@here/harp-geoutils/lib/projection/SphereProjection.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBox } from "../coordinates/GeoBox";
 import { GeoCoordinates } from "../coordinates/GeoCoordinates";
 import { GeoCoordinatesLike, isGeoCoordinatesLike } from "../coordinates/GeoCoordinatesLike";

--- a/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBox } from "../coordinates/GeoBox";
 import { GeoCoordinates } from "../coordinates/GeoCoordinates";
 import { GeoCoordinatesLike } from "../coordinates/GeoCoordinatesLike";

--- a/@here/harp-geoutils/lib/tiling/FlatTileBoundingBoxGenerator.ts
+++ b/@here/harp-geoutils/lib/tiling/FlatTileBoundingBoxGenerator.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GeoBox } from "../coordinates/GeoBox";
 import { Box3Like } from "../math/Box3Like";
 import { Vector3Like } from "../math/Vector3Like";

--- a/@here/harp-geoutils/test/GeoBoxTest.ts
+++ b/@here/harp-geoutils/test/GeoBoxTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert, expect } from "chai";
+
 import { GeoBox } from "../lib/coordinates/GeoBox";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { MathUtils } from "../lib/math/MathUtils";

--- a/@here/harp-geoutils/test/GeoCoordinatesTest.ts
+++ b/@here/harp-geoutils/test/GeoCoordinatesTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { GeoPointLike, isGeoPointLike } from "../lib/coordinates/GeoPointLike";
 

--- a/@here/harp-geoutils/test/OrientedBox3Test.ts
+++ b/@here/harp-geoutils/test/OrientedBox3Test.ts
@@ -7,7 +7,6 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert, expect } from "chai";
-
 import * as THREE from "three";
 
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";

--- a/@here/harp-geoutils/test/ProjectionTest.ts
+++ b/@here/harp-geoutils/test/ProjectionTest.ts
@@ -6,6 +6,7 @@
 
 import { assert } from "chai";
 import * as THREE from "three";
+
 import { GeoBox } from "../lib/coordinates/GeoBox";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { Box3Like } from "../lib/math/Box3Like";

--- a/@here/harp-geoutils/test/SphereProjectionTest.ts
+++ b/@here/harp-geoutils/test/SphereProjectionTest.ts
@@ -8,6 +8,7 @@
 
 import { assert } from "chai";
 import { Vector3 } from "three";
+
 import { GeoBox } from "../lib/coordinates/GeoBox";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { GeoCoordinatesLike } from "../lib/coordinates/GeoCoordinatesLike";

--- a/@here/harp-geoutils/test/SubTilesTest.ts
+++ b/@here/harp-geoutils/test/SubTilesTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { SubTiles } from "../lib/tiling/SubTiles";
 import { TileKey } from "../lib/tiling/TileKey";
 

--- a/@here/harp-geoutils/test/TileKeyTest.ts
+++ b/@here/harp-geoutils/test/TileKeyTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { GeoBox } from "../lib/coordinates/GeoBox";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { hereTilingScheme } from "../lib/tiling/HereTilingScheme";

--- a/@here/harp-geoutils/test/TransverseMercatorProjectionTest.ts
+++ b/@here/harp-geoutils/test/TransverseMercatorProjectionTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { GeoBox } from "../lib/coordinates/GeoBox";
 import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { GeoCoordinatesLike } from "../lib/coordinates/GeoCoordinatesLike";

--- a/@here/harp-lines/lib/HighPrecisionLines.ts
+++ b/@here/harp-lines/lib/HighPrecisionLines.ts
@@ -5,8 +5,8 @@
  */
 
 import { HighPrecisionLineMaterial } from "@here/harp-materials";
-
 import * as THREE from "three";
+
 import { HighPrecisionUtils } from "./HighPrecisionUtils";
 
 /**

--- a/@here/harp-lines/test/rendering/RenderLines.ts
+++ b/@here/harp-lines/test/rendering/RenderLines.ts
@@ -8,6 +8,7 @@ import { mercatorProjection } from "@here/harp-geoutils";
 import { SolidLineMaterial, SolidLineMaterialParameters } from "@here/harp-materials";
 import { RenderingTestHelper } from "@here/harp-test-utils";
 import * as THREE from "three";
+
 import { createLineGeometry, LineGroup } from "../../lib/Lines";
 
 function createFakeDisplacementMap(sideSize: number): THREE.DataTexture {

--- a/@here/harp-lrucache/test/LRUCacheTest.ts
+++ b/@here/harp-lrucache/test/LRUCacheTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { assert } from "chai";
+
 import { Entry, LRUCache } from "../lib/LRUCache";
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions

--- a/@here/harp-map-controls/lib/MapAnimations.ts
+++ b/@here/harp-map-controls/lib/MapAnimations.ts
@@ -5,12 +5,11 @@
  */
 
 import { GeoCoordinates, GeoCoordinatesLike } from "@here/harp-geoutils";
-
 import { MapView } from "@here/harp-mapview";
 import { PerformanceTimer } from "@here/harp-utils";
-
 import * as TWEEN from "@tweenjs/tween.js";
 import * as THREE from "three";
+
 import { EventNames, MapControls } from "./MapControls";
 
 /**

--- a/@here/harp-map-controls/lib/MapControls.ts
+++ b/@here/harp-map-controls/lib/MapControls.ts
@@ -7,6 +7,7 @@
 import * as geoUtils from "@here/harp-geoutils";
 import { EventDispatcher, MapView, MapViewEventNames, MapViewUtils } from "@here/harp-mapview";
 import * as THREE from "three";
+
 import * as utils from "./Utils";
 
 enum State {

--- a/@here/harp-map-controls/lib/MapControlsUI.ts
+++ b/@here/harp-map-controls/lib/MapControlsUI.ts
@@ -7,6 +7,7 @@
 import { mercatorProjection, ProjectionType, sphereProjection } from "@here/harp-geoutils";
 import { MapViewEventNames, MapViewUtils } from "@here/harp-mapview";
 import * as THREE from "three";
+
 import { MapControls } from "./MapControls";
 
 /**

--- a/@here/harp-map-controls/test/MapControlsTest.ts
+++ b/@here/harp-map-controls/test/MapControlsTest.ts
@@ -11,6 +11,7 @@ import { MapView, MapViewUtils } from "@here/harp-mapview";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { MapControls } from "../lib/MapControls";
 
 declare const global: any;

--- a/@here/harp-map-controls/test/UtilsTest.ts
+++ b/@here/harp-map-controls/test/UtilsTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { safeParseDecimalInt } from "../lib/Utils";
 
 describe("MapControls", function() {

--- a/@here/harp-map-theme/scripts/prepack.ts
+++ b/@here/harp-map-theme/scripts/prepack.ts
@@ -6,8 +6,8 @@
 
 /* eslint-disable no-console */
 
-import * as path from "path";
 import { ncp } from "ncp";
+import * as path from "path";
 
 function onCopyError(err: Error[] | null) {
     if (err === null) {

--- a/@here/harp-map-theme/scripts/prepareIcons.ts
+++ b/@here/harp-map-theme/scripts/prepareIcons.ts
@@ -6,14 +6,14 @@
 
 /* eslint-disable no-console */
 
-import * as os from "os";
-import * as path from "path";
 import {
     AtlasOptions,
     generateSprites,
     generateSpritesAtlas,
     ProcessingOptions
 } from "@here/harp-atlas-tools/src";
+import * as os from "os";
+import * as path from "path";
 
 // Allow to use console output, script runs in a shell (node), not in the browser.
 

--- a/@here/harp-map-theme/test/DefaultThemeTest.ts
+++ b/@here/harp-map-theme/test/DefaultThemeTest.ts
@@ -8,7 +8,6 @@
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import * as path from "path";
 import { Definitions, Theme } from "@here/harp-datasource-protocol";
 import {
     Expr,
@@ -16,11 +15,10 @@ import {
     JsonExpr,
     StyleSetEvaluator
 } from "@here/harp-datasource-protocol/index-decoder";
-
 import { loadTestResource } from "@here/harp-test-utils";
-
 import * as Ajv from "ajv";
 import { assert } from "chai";
+import * as path from "path";
 
 function assertExprValid(
     expr: JsonExpr,

--- a/@here/harp-mapview-decoder/lib/DataProvider.ts
+++ b/@here/harp-mapview-decoder/lib/DataProvider.ts
@@ -5,6 +5,7 @@
  */
 
 import "@here/harp-fetch";
+
 import { TileKey } from "@here/harp-geoutils";
 
 /**

--- a/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
+++ b/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
@@ -6,7 +6,6 @@
 
 import { GeoJson, ITiler } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils";
-
 // @ts-ignore
 import * as geojsonvtExport from "geojson-vt";
 

--- a/@here/harp-mapview-decoder/lib/TestDataProviders.ts
+++ b/@here/harp-mapview-decoder/lib/TestDataProviders.ts
@@ -5,8 +5,10 @@
  */
 
 import "@here/harp-fetch";
+
 import { TileKey } from "@here/harp-geoutils";
 import { loadTestResource } from "@here/harp-test-utils";
+
 import { DataProvider } from "../lib/DataProvider";
 
 /**

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -22,6 +22,7 @@ import {
     TileLoaderState
 } from "@here/harp-mapview";
 import { ILogger, LoggerManager } from "@here/harp-utils";
+
 import { DataProvider } from "./DataProvider";
 import { TileInfoLoader, TileLoader } from "./TileLoader";
 

--- a/@here/harp-mapview-decoder/lib/TilerService.ts
+++ b/@here/harp-mapview-decoder/lib/TilerService.ts
@@ -6,6 +6,7 @@
 
 import { ITiler, WorkerTilerProtocol } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils";
+
 import { GeoJsonTiler } from "./GeoJsonTiler";
 import { WorkerService, WorkerServiceResponse } from "./WorkerService";
 

--- a/@here/harp-mapview-decoder/lib/WorkerServiceManager.ts
+++ b/@here/harp-mapview-decoder/lib/WorkerServiceManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { WorkerServiceProtocol } from "@here/harp-datasource-protocol";
+
 import { WorkerService, WorkerServiceResponse } from "./WorkerService";
 
 /**

--- a/@here/harp-mapview-decoder/test/TileDataSourceTest.ts
+++ b/@here/harp-mapview-decoder/test/TileDataSourceTest.ts
@@ -6,8 +6,9 @@
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import { DecodedTile, Geometry, ITileDecoder, TileInfo } from "@here/harp-datasource-protocol";
 import "@here/harp-fetch";
+
+import { DecodedTile, Geometry, ITileDecoder, TileInfo } from "@here/harp-datasource-protocol";
 import {
     Projection,
     TileKey,
@@ -17,6 +18,7 @@ import {
 import { DataSource, MapView, Statistics, Tile, TileLoaderState } from "@here/harp-mapview";
 import { assert } from "chai";
 import * as sinon from "sinon";
+
 import { DataProvider, TileDataSource, TileFactory } from "../index";
 
 function createMockDataProvider() {

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -13,6 +13,7 @@ import {
 import { TileKey } from "@here/harp-geoutils";
 import { ExtrusionFeature, ExtrusionFeatureDefs } from "@here/harp-materials";
 import { MathUtils } from "@here/harp-utils";
+
 import { DataSource } from "./DataSource";
 import { MapView } from "./MapView";
 import { Tile } from "./Tile";

--- a/@here/harp-mapview/lib/BackgroundDataSource.ts
+++ b/@here/harp-mapview/lib/BackgroundDataSource.ts
@@ -6,6 +6,7 @@
 
 import { Theme } from "@here/harp-datasource-protocol";
 import { TileKey, TilingScheme, webMercatorTilingScheme } from "@here/harp-geoutils";
+
 import { DataSource } from "./DataSource";
 import { TileGeometryCreator } from "./geometry/TileGeometryCreator";
 import { Tile } from "./Tile";

--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -8,6 +8,7 @@ import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import { EarthConstants, Projection, ProjectionType } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { ElevationProvider } from "./ElevationProvider";
 import { MapViewUtils } from "./Utils";
 

--- a/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
@@ -5,6 +5,7 @@
  */
 
 import { ITileDecoder } from "@here/harp-datasource-protocol";
+
 import { ConcurrentWorkerSet } from "./ConcurrentWorkerSet";
 import { WorkerBasedDecoder } from "./WorkerBasedDecoder";
 

--- a/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
@@ -5,6 +5,7 @@
  */
 
 import { ITiler } from "@here/harp-datasource-protocol";
+
 import { ConcurrentWorkerSet } from "./ConcurrentWorkerSet";
 import { WorkerBasedTiler } from "./WorkerBasedTiler";
 

--- a/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
+++ b/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
@@ -11,8 +11,8 @@ import {
     LogLevel,
     WORKERCHANNEL_MSG_TYPE
 } from "@here/harp-utils";
-
 import * as THREE from "three";
+
 import { WorkerLoader } from "./workers/WorkerLoader";
 
 const logger = LoggerManager.instance.create("ConcurrentWorkerSet");

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -8,6 +8,7 @@ import { ExprPool } from "@here/harp-datasource-protocol/lib/ExprPool";
 import { Projection, TileKey, TilingScheme } from "@here/harp-geoutils";
 import { assert, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { MapView } from "./MapView";
 import { Tile } from "./Tile";
 

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -19,8 +19,8 @@ import {
     parseStringEncodedColor,
     ShaderTechnique,
     Technique,
-    TextureProperties,
     TEXTURE_PROPERTY_KEYS,
+    TextureProperties,
     TRANSPARENCY_PROPERTY_KEYS,
     Value
 } from "@here/harp-datasource-protocol";
@@ -36,6 +36,7 @@ import {
 } from "@here/harp-materials";
 import { assert, LoggerManager, pick } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { DisplacedMesh } from "./geometry/DisplacedMesh";
 import { SolidLineMesh } from "./geometry/SolidLineMesh";
 import { MapAdapterUpdateEnv, MapMaterialAdapter, StyledProperties } from "./MapMaterialAdapter";

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -8,6 +8,7 @@ import { Env, ExtrudedPolygonTechnique } from "@here/harp-datasource-protocol";
 import { ColorUtils } from "@here/harp-datasource-protocol/lib/ColorUtils";
 import { enforceBlending, MapMeshStandardMaterial } from "@here/harp-materials";
 import * as THREE from "three";
+
 import { evaluateBaseColorProperty } from "./DecodedTileHelpers";
 
 /**

--- a/@here/harp-mapview/lib/ElevationProvider.ts
+++ b/@here/harp-mapview/lib/ElevationProvider.ts
@@ -5,6 +5,7 @@
  */
 
 import { GeoCoordinates, TileKey, TilingScheme } from "@here/harp-geoutils";
+
 import { TileDisplacementMap } from "./DisplacementMap";
 
 export interface ElevationProvider {

--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -13,6 +13,7 @@ import {
 } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { DataSource } from "./DataSource";
 import { CalculationStatus, ElevationRangeSource } from "./ElevationRangeSource";
 import { MapTileCuller } from "./MapTileCuller";

--- a/@here/harp-mapview/lib/MapAnchors.ts
+++ b/@here/harp-mapview/lib/MapAnchors.ts
@@ -13,7 +13,6 @@ import {
     Projection,
     Vector3Like
 } from "@here/harp-geoutils";
-
 import * as THREE from "three";
 
 /**

--- a/@here/harp-mapview/lib/MapMaterialAdapter.ts
+++ b/@here/harp-mapview/lib/MapMaterialAdapter.ts
@@ -7,6 +7,7 @@
 import { ColorUtils, Expr, getPropertyValue, Value } from "@here/harp-datasource-protocol";
 import { disableBlending, enableBlending } from "@here/harp-materials";
 import * as THREE from "three";
+
 import { evaluateColorProperty } from "./DecodedTileHelpers";
 import { MapView } from "./MapView";
 

--- a/@here/harp-mapview/lib/MapViewAtmosphere.ts
+++ b/@here/harp-mapview/lib/MapViewAtmosphere.ts
@@ -6,11 +6,10 @@
 
 import { Theme } from "@here/harp-datasource-protocol";
 import { EarthConstants, Projection, ProjectionType } from "@here/harp-geoutils";
-
 import { GroundAtmosphereMaterial, SkyAtmosphereMaterial } from "@here/harp-materials";
-
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { TiltViewClipPlanesEvaluator } from "./ClipPlanesEvaluator";
 import { MapAnchor, MapAnchors } from "./MapAnchors";
 

--- a/@here/harp-mapview/lib/MapViewFog.ts
+++ b/@here/harp-mapview/lib/MapViewFog.ts
@@ -8,6 +8,7 @@ import { Theme } from "@here/harp-datasource-protocol";
 import { HighPrecisionLineMaterial } from "@here/harp-materials";
 import { assert, MathUtils } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { MapView } from "./MapView";
 
 /**

--- a/@here/harp-mapview/lib/MapViewPoints.ts
+++ b/@here/harp-mapview/lib/MapViewPoints.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { PickingRaycaster } from "./PickingRaycaster";
 
 /**

--- a/@here/harp-mapview/lib/PickListener.ts
+++ b/@here/harp-mapview/lib/PickListener.ts
@@ -5,6 +5,7 @@
  */
 
 import { assert } from "@here/harp-utils";
+
 import { IntersectParams } from "./IntersectParams";
 import { PickResult } from "./PickHandler";
 

--- a/@here/harp-mapview/lib/PickingRaycaster.ts
+++ b/@here/harp-mapview/lib/PickingRaycaster.ts
@@ -6,6 +6,7 @@
 
 import { MapEnv } from "@here/harp-datasource-protocol";
 import * as THREE from "three";
+
 import { MapObjectAdapter } from "./MapObjectAdapter";
 
 function intersectObject(

--- a/@here/harp-mapview/lib/ScreenCollisions.ts
+++ b/@here/harp-mapview/lib/ScreenCollisions.ts
@@ -6,6 +6,7 @@
 
 import { LoggerManager, Math2D } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { debugContext } from "./DebugContext";
 
 declare const require: any;

--- a/@here/harp-mapview/lib/SkyBackground.ts
+++ b/@here/harp-mapview/lib/SkyBackground.ts
@@ -7,6 +7,7 @@
 import { CubemapSky, GradientSky } from "@here/harp-datasource-protocol";
 import { ProjectionType } from "@here/harp-geoutils";
 import * as THREE from "three";
+
 import { SkyCubemapTexture } from "./SkyCubemapTexture";
 import { SkyGradientTexture } from "./SkyGradientTexture";
 

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import "@here/harp-fetch";
+
 import { isJsonExpr } from "@here/harp-datasource-protocol";
 import {
     Definitions,
@@ -25,9 +27,8 @@ import {
     resolveReferenceUri,
     UriResolver
 } from "@here/harp-utils";
-import { SkyCubemapFaceId, SKY_CUBEMAP_FACE_COUNT } from "./SkyCubemapTexture";
 
-import "@here/harp-fetch";
+import { SKY_CUBEMAP_FACE_COUNT, SkyCubemapFaceId } from "./SkyCubemapTexture";
 
 /**
  * @internal

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -7,6 +7,7 @@ import { DecodedTile, GeometryType, TextPathGeometry } from "@here/harp-datasour
 import { GeoBox, OrientedBox3, Projection, TileKey } from "@here/harp-geoutils";
 import { assert, CachedResource, chainCallbacks, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { CopyrightInfo } from "./copyrights/CopyrightInfo";
 import { DataSource } from "./DataSource";
 import { ElevationRange } from "./ElevationRangeSource";

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -18,6 +18,7 @@ import { EarthConstants } from "@here/harp-geoutils/lib/projection/EarthConstant
 import { MapMeshBasicMaterial, MapMeshStandardMaterial } from "@here/harp-materials";
 import { assert, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { ElevationProvider } from "./ElevationProvider";
 import { LodMesh } from "./geometry/LodMesh";
 import { MapView } from "./MapView";

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -15,6 +15,7 @@ import {
 import { LRUCache } from "@here/harp-lrucache";
 import { assert, MathUtils, TaskQueue } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { BackgroundDataSource } from "./BackgroundDataSource";
 import { ClipPlanesEvaluator } from "./ClipPlanesEvaluator";
 import { DataSource } from "./DataSource";

--- a/@here/harp-mapview/lib/WorkerBasedTiler.ts
+++ b/@here/harp-mapview/lib/WorkerBasedTiler.ts
@@ -11,6 +11,7 @@ import {
     WorkerTilerProtocol
 } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils";
+
 import { ConcurrentWorkerSet } from "./ConcurrentWorkerSet";
 
 /**

--- a/@here/harp-mapview/lib/composing/MapRenderingManager.ts
+++ b/@here/harp-mapview/lib/composing/MapRenderingManager.ts
@@ -12,6 +12,7 @@ import {
 } from "@here/harp-datasource-protocol";
 import { SepiaShader, VignetteShader } from "@here/harp-materials";
 import * as THREE from "three";
+
 import { IPassManager } from "./IPassManager";
 import { LowResRenderPass } from "./LowResRenderPass";
 import { MSAARenderPass, MSAASampling } from "./MSAARenderPass";

--- a/@here/harp-mapview/lib/composing/UnrealBloomPass.ts
+++ b/@here/harp-mapview/lib/composing/UnrealBloomPass.ts
@@ -6,6 +6,7 @@
 
 import { CopyShader, LuminosityHighPassShader } from "@here/harp-materials";
 import * as THREE from "three";
+
 import { Pass } from "./Pass";
 
 const BlurDirectionX = new THREE.Vector2(1.0, 0.0);

--- a/@here/harp-mapview/lib/copyrights/CopyrightCoverageProvider.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightCoverageProvider.ts
@@ -6,6 +6,7 @@
 
 import { GeoBox } from "@here/harp-geoutils";
 import { getOptionValue, ILogger, LoggerManager } from "@here/harp-utils";
+
 import { CopyrightInfo } from "./CopyrightInfo";
 import { CopyrightProvider } from "./CopyrightProvider";
 

--- a/@here/harp-mapview/lib/copyrights/CopyrightElementHandler.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightElementHandler.ts
@@ -5,6 +5,7 @@
  */
 
 import { getOptionValue } from "@here/harp-utils";
+
 import { MapView, MapViewEventNames } from "../MapView";
 import { CopyrightInfo } from "./CopyrightInfo";
 

--- a/@here/harp-mapview/lib/copyrights/CopyrightProvider.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightProvider.ts
@@ -5,6 +5,7 @@
  */
 
 import { GeoBox } from "@here/harp-geoutils";
+
 import { CopyrightInfo } from "./CopyrightInfo";
 
 /**

--- a/@here/harp-mapview/lib/copyrights/UrlCopyrightProvider.ts
+++ b/@here/harp-mapview/lib/copyrights/UrlCopyrightProvider.ts
@@ -5,6 +5,7 @@
  */
 
 import { ITransferManager, TransferManager } from "@here/harp-transfer-manager";
+
 import {
     AreaCopyrightInfo,
     CopyrightCoverageProvider,

--- a/@here/harp-mapview/lib/geometry/DisplacedBufferAttribute.ts
+++ b/@here/harp-mapview/lib/geometry/DisplacedBufferAttribute.ts
@@ -7,6 +7,7 @@
 import { Vector3Like } from "@here/harp-geoutils";
 import { sampleBilinear } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { VertexCache } from "./VertexCache";
 
 /**

--- a/@here/harp-mapview/lib/geometry/DisplacedBufferGeometry.ts
+++ b/@here/harp-mapview/lib/geometry/DisplacedBufferGeometry.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { DisplacedBufferAttribute } from "./DisplacedBufferAttribute";
 
 const tmpV1 = new THREE.Vector3();

--- a/@here/harp-mapview/lib/geometry/DisplacedMesh.ts
+++ b/@here/harp-mapview/lib/geometry/DisplacedMesh.ts
@@ -7,6 +7,7 @@
 import { DisplacementFeature, hasDisplacementFeature } from "@here/harp-materials";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { DisplacedBufferAttribute } from "./DisplacedBufferAttribute";
 import { DisplacedBufferGeometry, DisplacementRange } from "./DisplacedBufferGeometry";
 

--- a/@here/harp-mapview/lib/geometry/SolidLineMesh.ts
+++ b/@here/harp-mapview/lib/geometry/SolidLineMesh.ts
@@ -8,6 +8,7 @@ import { OrientedBox3 } from "@here/harp-geoutils";
 import { SolidLineMaterial } from "@here/harp-materials";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { displaceBox, DisplacedBufferGeometry, DisplacementRange } from "./DisplacedBufferGeometry";
 
 const tmpSphere = new THREE.Sphere();

--- a/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
+++ b/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
@@ -7,6 +7,7 @@
 import { GeometryType, getFeatureId } from "@here/harp-datasource-protocol";
 import { assert, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { Tile, TileFeatureData } from "../Tile";
 import {
     BufferedGeometryLineAccessor,

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -77,6 +77,7 @@ import {
 import { ContextualArabicConverter } from "@here/harp-text-canvas";
 import { assert, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import {
     applyBaseColorToMaterial,
     buildMetricValueEvaluator,

--- a/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { GeometryKind, GeometryKindSet } from "@here/harp-datasource-protocol";
+
 import { MapObjectAdapter } from "../MapObjectAdapter";
 import { MapView } from "../MapView";
 import { Tile } from "../Tile";

--- a/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
+++ b/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
@@ -9,6 +9,7 @@ import { Projection } from "@here/harp-geoutils";
 import { hasDisplacementFeature } from "@here/harp-materials";
 import { assert } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { TileDisplacementMap } from "../DisplacementMap";
 import { ElevationProvider } from "../ElevationProvider";
 import { TextElement } from "../text/TextElement";

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -22,6 +22,7 @@ import {
 import { ContextualArabicConverter } from "@here/harp-text-canvas";
 import { assert, assertExists, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { ColorCache } from "../ColorCache";
 import { MapView } from "../MapView";
 import { TextElement } from "../text/TextElement";

--- a/@here/harp-mapview/lib/poi/PoiRendererFactory.ts
+++ b/@here/harp-mapview/lib/poi/PoiRendererFactory.ts
@@ -5,6 +5,7 @@
  */
 
 import { TextCanvas } from "@here/harp-text-canvas";
+
 import { MapView } from "../MapView";
 import { PoiRenderer } from "./PoiRenderer";
 

--- a/@here/harp-mapview/lib/text/MapViewState.ts
+++ b/@here/harp-mapview/lib/text/MapViewState.ts
@@ -7,6 +7,7 @@
 import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { Projection } from "@here/harp-geoutils";
 import * as THREE from "three";
+
 import { ElevationProvider } from "../ElevationProvider";
 import { MapView } from "../MapView";
 import { ViewState } from "./ViewState";

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -19,6 +19,7 @@ import {
 } from "@here/harp-text-canvas";
 import { assert, Math2D, MathUtils } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { PoiManager } from "../poi/PoiManager";
 import { PoiRenderer } from "../poi/PoiRenderer";
 import { CollisionBox, DetailedCollisionBox, IBox, ScreenCollisions } from "../ScreenCollisions";

--- a/@here/harp-mapview/lib/text/TextCanvasRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextCanvasRenderer.ts
@@ -5,6 +5,7 @@
  */
 
 import { TextCanvas } from "@here/harp-text-canvas";
+
 import { PoiRenderer } from "../poi/PoiRenderer";
 
 export interface TextCanvasRenderer {

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -21,7 +21,6 @@ import {
     TextRenderStyle
 } from "@here/harp-text-canvas";
 import { Math2D, MathUtils } from "@here/harp-utils";
-
 import * as THREE from "three";
 
 import { ImageItem } from "../image/Image";

--- a/@here/harp-mapview/lib/text/TextElementGroup.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroup.ts
@@ -5,6 +5,7 @@
  */
 
 import { PriorityListGroup } from "@here/harp-utils";
+
 import { TextElement } from "./TextElement";
 
 /**

--- a/@here/harp-mapview/lib/text/TextElementGroupPriorityList.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupPriorityList.ts
@@ -5,6 +5,7 @@
  */
 
 import { GroupedPriorityList } from "@here/harp-utils";
+
 import { TextElement } from "./TextElement";
 
 /**

--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -6,6 +6,7 @@
 
 import { TileKey } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
+
 import { TextElementGroup } from "./TextElementGroup";
 import { TextElementState } from "./TextElementState";
 

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -12,6 +12,7 @@ import {
     vPlacementFromAlignment
 } from "@here/harp-text-canvas";
 import { assert } from "@here/harp-utils";
+
 import { LayoutState } from "./LayoutState";
 import { RenderState } from "./RenderState";
 import { TextElement } from "./TextElement";

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -6,6 +6,7 @@
 
 import { TileKey } from "@here/harp-geoutils";
 import { assert, LoggerManager, LogLevel } from "@here/harp-utils";
+
 import { TextElement } from "./TextElement";
 import { TextElementGroup } from "./TextElementGroup";
 import { TextElementFilter, TextElementGroupState } from "./TextElementGroupState";

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -36,6 +36,7 @@ import {
     WrappingMode
 } from "@here/harp-text-canvas";
 import { getOptionValue, LoggerManager } from "@here/harp-utils";
+
 import { ColorCache } from "../ColorCache";
 import { evaluateColorProperty } from "../DecodedTileHelpers";
 import { PoiRenderer } from "../poi/PoiRenderer";

--- a/@here/harp-mapview/lib/text/TileTextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TileTextStyleCache.ts
@@ -11,6 +11,7 @@ import {
     TextTechnique
 } from "@here/harp-datasource-protocol";
 import { TextLayoutStyle, TextRenderStyle } from "@here/harp-text-canvas";
+
 import { Tile } from "../Tile";
 
 export class TileTextStyleCache {

--- a/@here/harp-mapview/lib/text/UpdateStats.ts
+++ b/@here/harp-mapview/lib/text/UpdateStats.ts
@@ -5,6 +5,7 @@
  */
 
 import { IChannel } from "@here/harp-utils";
+
 import { PrePlacementResult } from "./Placement";
 
 export class UpdateStats {

--- a/@here/harp-mapview/lib/text/ViewState.ts
+++ b/@here/harp-mapview/lib/text/ViewState.ts
@@ -6,6 +6,7 @@
 
 import { Env, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { Projection } from "@here/harp-geoutils";
+
 import { ElevationProvider } from "../ElevationProvider";
 
 /**

--- a/@here/harp-mapview/lib/workers/WorkerLoader.ts
+++ b/@here/harp-mapview/lib/workers/WorkerLoader.ts
@@ -7,6 +7,7 @@
 import "@here/harp-fetch";
 
 import { getUrlOrigin, LoggerManager } from "@here/harp-utils";
+
 import { isWorkerBootstrapRequest, WorkerBootstrapResponse } from "./WorkerBootstrapDefs";
 
 const logger = LoggerManager.instance.create("WorkerLoader");

--- a/@here/harp-mapview/test/AnimatedExtrusionHandlerTest.ts
+++ b/@here/harp-mapview/test/AnimatedExtrusionHandlerTest.ts
@@ -12,6 +12,7 @@ import { TileKey, webMercatorTilingScheme } from "@here/harp-geoutils";
 import { ExtrusionFeature } from "@here/harp-materials";
 import { expect } from "chai";
 import * as sinon from "sinon";
+
 import { AnimatedExtrusionHandler } from "../lib/AnimatedExtrusionHandler";
 import { DataSource } from "../lib/DataSource";
 import { MapView } from "../lib/MapView";

--- a/@here/harp-mapview/test/BackgroundDataSourceTest.ts
+++ b/@here/harp-mapview/test/BackgroundDataSourceTest.ts
@@ -9,6 +9,7 @@
 import { hereTilingScheme, mercatorTilingScheme } from "@here/harp-geoutils";
 import { expect } from "chai";
 import * as sinon from "sinon";
+
 import { BackgroundDataSource } from "../lib/BackgroundDataSource";
 import { MapView } from "../lib/MapView";
 import { FakeOmvDataSource } from "./FakeOmvDataSource";

--- a/@here/harp-mapview/test/CopyrightProvidersTest.ts
+++ b/@here/harp-mapview/test/CopyrightProvidersTest.ts
@@ -12,6 +12,7 @@ import { TransferManager } from "@here/harp-transfer-manager";
 import { LoggerManager } from "@here/harp-utils";
 import { expect } from "chai";
 import * as sinon from "sinon";
+
 import { CopyrightInfo } from "../lib/copyrights/CopyrightInfo";
 import { UrlCopyrightProvider } from "../lib/copyrights/UrlCopyrightProvider";
 

--- a/@here/harp-mapview/test/DebugContextTest.ts
+++ b/@here/harp-mapview/test/DebugContextTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { debugContext } from "../lib/DebugContext";
 
 describe("debug-context", function() {

--- a/@here/harp-mapview/test/DecodedTileHelpersTest.ts
+++ b/@here/harp-mapview/test/DecodedTileHelpersTest.ts
@@ -10,6 +10,7 @@ import { assertLogsSync } from "@here/harp-test-utils";
 import { LoggerManager } from "@here/harp-utils";
 import { assert } from "chai";
 import * as THREE from "three";
+
 import {
     applyBaseColorToMaterial,
     createMaterial,

--- a/@here/harp-mapview/test/DisplacedBufferAttributeTest.ts
+++ b/@here/harp-mapview/test/DisplacedBufferAttributeTest.ts
@@ -8,6 +8,7 @@
 
 import { expect } from "chai";
 import * as THREE from "three";
+
 import { DisplacedBufferAttribute } from "../lib/geometry/DisplacedBufferAttribute";
 
 function createBuffer(array: number[], itemSize: number) {

--- a/@here/harp-mapview/test/DisplacedBufferGeometryTest.ts
+++ b/@here/harp-mapview/test/DisplacedBufferGeometryTest.ts
@@ -9,6 +9,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import {
     DisplacedBufferGeometry,
     DisplacementRange

--- a/@here/harp-mapview/test/FakeOmvDataSource.ts
+++ b/@here/harp-mapview/test/FakeOmvDataSource.ts
@@ -12,6 +12,7 @@ import {
     TilingScheme,
     webMercatorTilingScheme
 } from "@here/harp-geoutils";
+
 import { DataSource, DataSourceOptions } from "../lib/DataSource";
 import { ITileLoader, Tile, TileLoaderState } from "../lib/Tile";
 

--- a/@here/harp-mapview/test/MapViewFogTest.ts
+++ b/@here/harp-mapview/test/MapViewFogTest.ts
@@ -10,6 +10,7 @@ import { Theme } from "@here/harp-datasource-protocol";
 import { SolidLineMaterial } from "@here/harp-materials";
 import { assert } from "chai";
 import { BoxGeometry, Fog, Mesh, Scene } from "three";
+
 import { MapViewFog } from "../lib/MapViewFog";
 
 describe("MapViewFog", function() {

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -32,6 +32,7 @@ import { getAppBaseUrl } from "@here/harp-utils";
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { BackgroundDataSource } from "../lib/BackgroundDataSource";
 import { DataSource } from "../lib/DataSource";
 import { ElevationProvider } from "../lib/ElevationProvider";

--- a/@here/harp-mapview/test/PickListenerTest.ts
+++ b/@here/harp-mapview/test/PickListenerTest.ts
@@ -9,6 +9,7 @@
 
 import { expect } from "chai";
 import * as THREE from "three";
+
 import { PickObjectType, PickResult } from "../lib/PickHandler";
 import { PickListener } from "../lib/PickListener";
 

--- a/@here/harp-mapview/test/PickingRaycasterTest.ts
+++ b/@here/harp-mapview/test/PickingRaycasterTest.ts
@@ -11,6 +11,7 @@ import { MapEnv } from "@here/harp-datasource-protocol";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { MapObjectAdapter } from "../lib/MapObjectAdapter";
 import { PickingRaycaster } from "../lib/PickingRaycaster";
 

--- a/@here/harp-mapview/test/PlacementTest.ts
+++ b/@here/harp-mapview/test/PlacementTest.ts
@@ -10,10 +10,9 @@
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import * as path from "path";
+import "@here/harp-fetch";
 
 import { Env } from "@here/harp-datasource-protocol";
-import "@here/harp-fetch";
 import { getTestResourceUrl } from "@here/harp-test-utils";
 import {
     FontCatalog,
@@ -34,8 +33,10 @@ import {
 } from "@here/harp-text-canvas";
 import { getAppBaseUrl } from "@here/harp-utils";
 import { expect } from "chai";
+import * as path from "path";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { ScreenCollisions } from "../lib/ScreenCollisions";
 import {
     persistentPointLabelTextMargin,

--- a/@here/harp-mapview/test/PoiInfoBuilder.ts
+++ b/@here/harp-mapview/test/PoiInfoBuilder.ts
@@ -5,6 +5,7 @@
  */
 
 import { LineMarkerTechnique, PoiTechnique } from "@here/harp-datasource-protocol";
+
 import { PoiInfo, TextElement } from "../lib/text/TextElement";
 
 export class PoiInfoBuilder {

--- a/@here/harp-mapview/test/PolarTileDataSourceTest.ts
+++ b/@here/harp-mapview/test/PolarTileDataSourceTest.ts
@@ -17,6 +17,7 @@ import {
 import { assert } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { MapView } from "../lib/MapView";
 import { PolarTileDataSource } from "../lib/PolarTileDataSource";
 import { Tile } from "../lib/Tile";

--- a/@here/harp-mapview/test/ScreenCollisionsTest.ts
+++ b/@here/harp-mapview/test/ScreenCollisionsTest.ts
@@ -7,9 +7,9 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { Math2D } from "@here/harp-utils";
-
 import { assert } from "chai";
 import * as THREE from "three";
+
 import {
     CollisionBox,
     DetailedCollisionBox,

--- a/@here/harp-mapview/test/ScreenProjectorTest.ts
+++ b/@here/harp-mapview/test/ScreenProjectorTest.ts
@@ -6,6 +6,7 @@
 
 import { assert, expect } from "chai";
 import * as THREE from "three";
+
 import { ScreenProjector } from "../lib/ScreenProjector";
 
 describe("ScreenProjector", () => {

--- a/@here/harp-mapview/test/SolidLineMeshTest.ts
+++ b/@here/harp-mapview/test/SolidLineMeshTest.ts
@@ -10,6 +10,7 @@
 import { SolidLineMaterial } from "@here/harp-materials";
 import { expect } from "chai";
 import * as THREE from "three";
+
 import { DisplacedBufferGeometry } from "../lib/geometry/DisplacedBufferGeometry";
 import { SolidLineMesh } from "../lib/geometry/SolidLineMesh";
 

--- a/@here/harp-mapview/test/TextElementBuilder.ts
+++ b/@here/harp-mapview/test/TextElementBuilder.ts
@@ -6,6 +6,7 @@
 
 import { TextLayoutParameters, TextRenderParameters } from "@here/harp-text-canvas";
 import * as THREE from "three";
+
 import { TextElement } from "../lib/text/TextElement";
 import { PoiInfoBuilder } from "./PoiInfoBuilder";
 

--- a/@here/harp-mapview/test/TextElementStateTest.ts
+++ b/@here/harp-mapview/test/TextElementStateTest.ts
@@ -14,6 +14,7 @@ import {
     VerticalPlacement
 } from "@here/harp-text-canvas/lib/rendering/TextStyle";
 import { expect } from "chai";
+
 import { TextElementState } from "../lib/text/TextElementState";
 import { TextElementType } from "../lib/text/TextElementType";
 

--- a/@here/harp-mapview/test/TextElementsRendererTest.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTest.ts
@@ -9,6 +9,7 @@
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { TextElement } from "../lib/text/TextElement";
 import { PoiInfoBuilder } from "./PoiInfoBuilder";
 import {
@@ -27,16 +28,16 @@ import {
 } from "./TextElementsRendererTestFixture";
 import {
     builder,
-    fadedIn,
-    fadedOut,
-    fadeIn,
-    fadeInAndFadedOut,
-    FadeState,
     FADE_2_CYCLES,
     FADE_CYCLE,
     FADE_IN,
     FADE_IN_OUT,
     FADE_OUT,
+    fadedIn,
+    fadedOut,
+    fadeIn,
+    fadeInAndFadedOut,
+    FadeState,
     firstNFrames,
     framesEnabled,
     frameStates,

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -10,6 +10,7 @@ import { TextCanvas } from "@here/harp-text-canvas";
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { PoiRenderer } from "../lib/poi/PoiRenderer";
 import { ScreenCollisions } from "../lib/ScreenCollisions";
 import { ScreenProjector } from "../lib/ScreenProjector";

--- a/@here/harp-mapview/test/TextureLoaderTest.ts
+++ b/@here/harp-mapview/test/TextureLoaderTest.ts
@@ -11,9 +11,9 @@ import * as chai from "chai";
 import * as chai_as_promised from "chai-as-promised";
 chai.use(chai_as_promised);
 const { expect } = chai;
-import * as THREE from "three";
-
 import "@here/harp-fetch";
+
+import * as THREE from "three";
 
 import { TextureLoader } from "../lib/TextureLoader";
 

--- a/@here/harp-mapview/test/ThemeLoaderTest.ts
+++ b/@here/harp-mapview/test/ThemeLoaderTest.ts
@@ -21,6 +21,7 @@ import {
     UriResolver
 } from "@here/harp-utils";
 import { assert } from "chai";
+
 import { ThemeLoader } from "../lib/ThemeLoader";
 
 function makeUrlRelative(baseUrl: string, url: string) {

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -10,6 +10,7 @@ import { TileKey } from "@here/harp-geoutils";
 import { MapMeshStandardMaterial } from "@here/harp-materials";
 import { assert, expect } from "chai";
 import * as THREE from "three";
+
 import { DisplacedMesh } from "../lib/geometry/DisplacedMesh";
 import { buildObject, createMaterial, usesObject3D } from "./../lib/DecodedTileHelpers";
 import { Tile } from "./../lib/Tile";

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -26,6 +26,7 @@ import { MapMeshBasicMaterial } from "@here/harp-materials";
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { DataSource } from "../lib/DataSource";
 import { isDepthPrePassMesh } from "../lib/DepthPrePass";
 import { DisplacementMap } from "../lib/DisplacementMap";

--- a/@here/harp-mapview/test/TileTest.ts
+++ b/@here/harp-mapview/test/TileTest.ts
@@ -15,6 +15,7 @@ import {
 } from "@here/harp-geoutils";
 import { assert, expect } from "chai";
 import * as THREE from "three";
+
 import { DataSource } from "../lib/DataSource";
 import { MapView } from "../lib/MapView";
 import { TextElement } from "../lib/text/TextElement";

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -20,6 +20,7 @@ import {
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { ElevationProvider } from "../lib/ElevationProvider";
 import { MapView } from "../lib/MapView";
 import { MapViewUtils, TileOffsetUtils } from "../lib/Utils";

--- a/@here/harp-mapview/test/VertexCacheTest.ts
+++ b/@here/harp-mapview/test/VertexCacheTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { expect } from "chai";
+
 import { VertexCache } from "../lib/geometry/VertexCache";
 
 describe("VertexCache", function() {

--- a/@here/harp-mapview/test/stubElevationProvider.ts
+++ b/@here/harp-mapview/test/stubElevationProvider.ts
@@ -6,6 +6,7 @@
 
 import { GeoCoordinates, mercatorTilingScheme, TileKey, TilingScheme } from "@here/harp-geoutils";
 import * as THREE from "three";
+
 import { DisplacementMap, TileDisplacementMap } from "../lib/DisplacementMap";
 import { ElevationProvider } from "../lib/ElevationProvider";
 

--- a/@here/harp-mapview/test/stubFontCatalogLoader.ts
+++ b/@here/harp-mapview/test/stubFontCatalogLoader.ts
@@ -6,6 +6,7 @@
 
 import { FontCatalog } from "@here/harp-text-canvas";
 import * as sinon from "sinon";
+
 import { DEFAULT_FONT_CATALOG_NAME, FontCatalogLoader } from "../lib/text/FontCatalogLoader";
 
 /**

--- a/@here/harp-mapview/test/stubPoiManager.ts
+++ b/@here/harp-mapview/test/stubPoiManager.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import * as sinon from "sinon";
+
 import { PoiManager } from "../lib/poi/PoiManager";
 
 /**

--- a/@here/harp-mapview/test/stubPoiRenderer.ts
+++ b/@here/harp-mapview/test/stubPoiRenderer.ts
@@ -8,6 +8,7 @@ import { Env } from "@here/harp-datasource-protocol";
 import { Math2D } from "@here/harp-utils";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { PoiRenderer } from "../lib/poi/PoiRenderer";
 import { PoiRendererFactory } from "../lib/poi/PoiRendererFactory";
 import { ScreenCollisions } from "../lib/ScreenCollisions";

--- a/@here/harp-mapview/test/stubTextCanvas.ts
+++ b/@here/harp-mapview/test/stubTextCanvas.ts
@@ -15,6 +15,7 @@ import {
 } from "@here/harp-text-canvas";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { TextCanvasFactory } from "../lib/text/TextCanvasFactory";
 
 /**

--- a/@here/harp-materials/lib/CirclePointsMaterial.ts
+++ b/@here/harp-materials/lib/CirclePointsMaterial.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { enforceBlending } from "./Utils";
 
 const vertexShader: string = `

--- a/@here/harp-materials/lib/GroundAtmosphereMaterial.ts
+++ b/@here/harp-materials/lib/GroundAtmosphereMaterial.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as THREE from "three";
+
 import { RawShaderMaterial } from "./RawShaderMaterial";
 import AtmosphereShaderChunks from "./ShaderChunks/AtmosphereChunks";
 import { setShaderDefine, setShaderMaterialDefine } from "./Utils";

--- a/@here/harp-materials/lib/HighPrecisionLineMaterial.ts
+++ b/@here/harp-materials/lib/HighPrecisionLineMaterial.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { RawShaderMaterial } from "./RawShaderMaterial";
 import linesShaderChunk from "./ShaderChunks/LinesChunks";
 

--- a/@here/harp-materials/lib/HighPrecisionPointMaterial.ts
+++ b/@here/harp-materials/lib/HighPrecisionPointMaterial.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import linesShaderChunk from "./ShaderChunks/LinesChunks";
 
 const vertexSource: string = `

--- a/@here/harp-materials/lib/IconMaterial.ts
+++ b/@here/harp-materials/lib/IconMaterial.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { RawShaderMaterial } from "./RawShaderMaterial";
 
 const vertexSource: string = `

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -6,7 +6,6 @@
 
 import { ViewRanges } from "@here/harp-datasource-protocol/lib/ViewRanges";
 import { applyMixinsWithoutProperties, assert, chainCallbacks } from "@here/harp-utils";
-
 import * as THREE from "three";
 
 import { DisplacementFeature, DisplacementFeatureParameters } from "./DisplacementFeature";

--- a/@here/harp-materials/lib/SkyAtmosphereMaterial.ts
+++ b/@here/harp-materials/lib/SkyAtmosphereMaterial.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as THREE from "three";
+
 import { RawShaderMaterial } from "./RawShaderMaterial";
 import AtmosphereShaderChunks from "./ShaderChunks/AtmosphereChunks";
 import { setShaderDefine, setShaderMaterialDefine } from "./Utils";

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -6,6 +6,7 @@
 
 import { LineCaps, LineDashes } from "@here/harp-datasource-protocol";
 import * as THREE from "three";
+
 import { DisplacementFeature, DisplacementFeatureParameters } from "./DisplacementFeature";
 import { FadingFeature, FadingFeatureParameters } from "./MapMeshMaterials";
 import { RawShaderMaterial } from "./RawShaderMaterial";

--- a/@here/harp-olp-utils/test/OlpDataProviderTest.ts
+++ b/@here/harp-olp-utils/test/OlpDataProviderTest.ts
@@ -7,10 +7,12 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import "@here/harp-fetch";
+
 import { TileKey } from "@here/harp-geoutils";
 import { assertRejected } from "@here/harp-test-utils";
 import { VersionedLayerClient } from "@here/olp-sdk-dataservice-read";
 import * as sinon from "sinon";
+
 import { OlpDataProvider } from "../lib/OlpDataProvider";
 
 describe("OlpDataProvider", function() {

--- a/@here/harp-test-utils/lib/rendering/DomImageUtils.ts
+++ b/@here/harp-test-utils/lib/rendering/DomImageUtils.ts
@@ -6,6 +6,7 @@
 
 import { LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
+
 import { TestOptions } from "./RenderingTestHelper";
 
 declare const require: any;

--- a/@here/harp-test-utils/lib/rendering/ReferenceImageLocator.ts
+++ b/@here/harp-test-utils/lib/rendering/ReferenceImageLocator.ts
@@ -5,6 +5,7 @@
  */
 
 import * as querystring from "querystring";
+
 import { TestImageProps } from "./Interface";
 
 let referenceImageResovler: (imageProps: TestImageProps) => string = defaultReferenceImageResolver;

--- a/@here/harp-test-utils/lib/rendering/RenderingTestHelper.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestHelper.ts
@@ -4,15 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as querystring from "querystring";
 import { LoggerManager } from "@here/harp-utils";
 import { assert } from "chai";
+import * as querystring from "querystring";
 import * as THREE from "three";
 import { UAParser } from "ua-parser-js";
 
 import { canvasToImageData, compareImages, loadImageData } from "./DomImageUtils";
 import { DomReporter } from "./DomReporter";
-
 import { Reporter, TestImageProps } from "./Interface";
 import { getReferenceImageUrl } from "./ReferenceImageLocator";
 import { RenderingTestResultReporter } from "./RenderingTestResultReporter";

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultCli.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultCli.ts
@@ -6,10 +6,10 @@
 
 // @here:check-imports:environment:node
 
-import * as fs from "fs";
-
 import { LoggerManager } from "@here/harp-utils";
 import * as program from "commander";
+import * as fs from "fs";
+
 import { genHtmlReport } from "./HtmlReport";
 import { ImageTestResultLocal } from "./Interface";
 import { getOutputImagePath, loadSavedResults } from "./RenderingTestResultCommon";

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultCommon.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultCommon.ts
@@ -7,8 +7,9 @@
 // @here:check-imports:environment:node
 
 import * as fs from "fs";
-import * as util from "util";
 import * as glob from "glob";
+import * as util from "util";
+
 import { ImageTestResultLocal, TestImageProps } from "./Interface";
 
 const promisedGlob = util.promisify(glob);

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultServer.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultServer.ts
@@ -6,14 +6,14 @@
 
 // @here:check-imports:environment:node
 
-import * as fs from "fs";
-import * as path from "path";
-import * as util from "util";
 import { LoggerManager } from "@here/harp-utils";
 import * as bodyParser from "body-parser";
 import * as express from "express";
+import * as fs from "fs";
 import * as mkpath from "mkpath";
+import * as path from "path";
 import * as serveStatic from "serve-static";
+import * as util from "util";
 
 import { genHtmlReport } from "./HtmlReport";
 import { ImageTestResultLocal, ImageTestResultRequest } from "./Interface";

--- a/@here/harp-test-utils/test/TestDataUtilsTest.ts
+++ b/@here/harp-test-utils/test/TestDataUtilsTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { loadTestResource } from "../index";
 
 describe("@here/harp-test-utils", function() {

--- a/@here/harp-test-utils/test/TestUtilsTest.ts
+++ b/@here/harp-test-utils/test/TestUtilsTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { inBrowserContext, inNodeContext, inWebWorkerContext } from "../lib/TestUtils";
 
 describe("@here/harp-test-utils", function() {

--- a/@here/harp-text-canvas/lib/rendering/TextBufferObject.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextBufferObject.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { GlyphData } from "./GlyphData";
 import { TextLayoutStyle, TextRenderStyle } from "./TextStyle";
 

--- a/@here/harp-text-canvas/lib/typesetting/Typesetter.ts
+++ b/@here/harp-text-canvas/lib/typesetting/Typesetter.ts
@@ -5,6 +5,7 @@
  */
 
 import * as THREE from "three";
+
 import { FontCatalog } from "../rendering/FontCatalog";
 import { GlyphData } from "../rendering/GlyphData";
 import { TextGeometry } from "../rendering/TextGeometry";

--- a/@here/harp-text-canvas/test/TextStyleTest.ts
+++ b/@here/harp-text-canvas/test/TextStyleTest.ts
@@ -7,8 +7,8 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
-
 import * as THREE from "three";
+
 import {
     DefaultTextStyle,
     FontStyle,

--- a/@here/harp-theme-tools/src/cli-build-theme.ts
+++ b/@here/harp-theme-tools/src/cli-build-theme.ts
@@ -7,11 +7,11 @@
 
 /* eslint-disable no-console */
 
-import * as fs from "fs";
-import * as path from "path";
 import { ThemeLoader } from "@here/harp-mapview";
 import * as program from "commander";
+import * as fs from "fs";
 import * as glob from "glob";
+import * as path from "path";
 
 const version = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"))
     .version;

--- a/@here/harp-transfer-manager/src/TransferManager.ts
+++ b/@here/harp-transfer-manager/src/TransferManager.ts
@@ -11,6 +11,7 @@
  */
 
 import "@here/harp-fetch";
+
 import { DeferredPromise } from "./DeferredPromise";
 
 /**

--- a/@here/harp-transfer-manager/test/TransferManagerTest.ts
+++ b/@here/harp-transfer-manager/test/TransferManagerTest.ts
@@ -7,8 +7,10 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import "@here/harp-fetch";
+
 import { assert } from "chai";
 import * as sinon from "sinon";
+
 import { TransferManager } from "../index";
 
 describe("TransferManager", function() {

--- a/@here/harp-utils/test/GroupedPriorityListTest.ts
+++ b/@here/harp-utils/test/GroupedPriorityListTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { GroupedPriorityList } from "../lib/GroupedPriorityList";
 
 interface Item {

--- a/@here/harp-utils/test/MathUtilsTest.ts
+++ b/@here/harp-utils/test/MathUtilsTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { assert } from "chai";
+
 import { MathUtils } from "../lib/MathUtils";
 
 describe("MathUtils", () => {

--- a/@here/harp-utils/test/PerformanceTimerTest.ts
+++ b/@here/harp-utils/test/PerformanceTimerTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { PerformanceTimer } from "../lib/PerformanceTimer";
 
 describe("PerformanceTimer", function() {

--- a/@here/harp-utils/test/SampleBilinearTest.ts
+++ b/@here/harp-utils/test/SampleBilinearTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { expect } from "chai";
+
 import { sampleBilinear } from "../lib/SampleBilinear";
 
 describe("sampleBilinearTest", () => {

--- a/@here/harp-utils/test/TaskQueueTest.ts
+++ b/@here/harp-utils/test/TaskQueueTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { Task, TaskQueue } from "../lib/TaskQueue";
 
 describe("TaskQueue", function() {

--- a/@here/harp-utils/test/UriResolverTest.ts
+++ b/@here/harp-utils/test/UriResolverTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { assert } from "chai";
+
 import { PrefixMapUriResolver, RelativeUriResolver } from "../lib/UriResolver";
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions

--- a/@here/harp-utils/test/UrlUtilsTest.ts
+++ b/@here/harp-utils/test/UrlUtilsTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { baseUrl, getUrlOrigin, resolveReferenceUri } from "../lib/UrlUtils";
 
 describe("UrlUtils", function() {

--- a/@here/harp-utils/test/WorkerChannelTest.ts
+++ b/@here/harp-utils/test/WorkerChannelTest.ts
@@ -8,6 +8,7 @@
 
 import { assert } from "chai";
 import * as sinon from "sinon";
+
 import { LogLevel } from "../lib/Logger/ILogger";
 import { LoggerManager } from "../lib/Logger/LoggerManager";
 import {

--- a/@here/harp-vectortile-datasource/lib/DecodeInfo.ts
+++ b/@here/harp-vectortile-datasource/lib/DecodeInfo.ts
@@ -12,8 +12,8 @@ import {
     TilingScheme,
     webMercatorTilingScheme
 } from "@here/harp-geoutils";
-
 import * as THREE from "three";
+
 import { WorldTileProjectionCookie } from "./OmvUtils";
 
 export class DecodeInfo {

--- a/@here/harp-vectortile-datasource/lib/GeoJsonDataProvider.ts
+++ b/@here/harp-vectortile-datasource/lib/GeoJsonDataProvider.ts
@@ -4,14 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GeoJson, ITiler, WorkerServiceProtocol } from "@here/harp-datasource-protocol";
 import "@here/harp-fetch";
+
+import { GeoJson, ITiler, WorkerServiceProtocol } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils";
 import { ConcurrentTilerFacade } from "@here/harp-mapview";
 import { DataProvider } from "@here/harp-mapview-decoder";
 import { LoggerManager } from "@here/harp-utils";
-
 import { EventDispatcher } from "three";
+
 import { GEOJSON_TILER_SERVICE_TYPE } from "./OmvDecoderDefs";
 
 const logger = LoggerManager.instance.create("GeoJsonDataProvider");

--- a/@here/harp-vectortile-datasource/lib/GeoJsonTilerService.ts
+++ b/@here/harp-vectortile-datasource/lib/GeoJsonTilerService.ts
@@ -5,6 +5,7 @@
  */
 
 import { TilerService, WorkerServiceManager } from "@here/harp-mapview-decoder/index-worker";
+
 import { GEOJSON_TILER_SERVICE_TYPE } from "./OmvDecoderDefs";
 
 /**

--- a/@here/harp-vectortile-datasource/lib/OmvDataFilter.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvDataFilter.ts
@@ -5,6 +5,7 @@
  */
 import { GeometryKind, GeometryKindSet } from "@here/harp-datasource-protocol";
 import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
+
 import {
     OmvFeatureFilterDescription,
     OmvFilterDescription,

--- a/@here/harp-vectortile-datasource/lib/OmvPoliticalViewFeatureModifier.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvPoliticalViewFeatureModifier.ts
@@ -6,6 +6,7 @@
 
 import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
 import { LoggerManager } from "@here/harp-utils";
+
 import { OmvFeatureModifier } from "./OmvDataFilter";
 
 const logger = LoggerManager.instance.create("OmvPoliticalViewFeatureModifier");

--- a/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
@@ -5,6 +5,7 @@
  */
 
 import "@here/harp-fetch";
+
 import { TileKey, TilingScheme } from "@here/harp-geoutils";
 import { DataProvider } from "@here/harp-mapview-decoder";
 import { ITransferManager, TransferManager } from "@here/harp-transfer-manager";

--- a/@here/harp-vectortile-datasource/lib/OmvTomTomFeatureModifier.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvTomTomFeatureModifier.ts
@@ -6,6 +6,7 @@
 
 import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
 import { LoggerManager } from "@here/harp-utils";
+
 import { OmvGenericFeatureModifier } from "./OmvDataFilter";
 import { OmvFeatureFilterDescription, OmvFilterDescription } from "./OmvDecoderDefs";
 

--- a/@here/harp-vectortile-datasource/lib/StyleSetDataFilter.ts
+++ b/@here/harp-vectortile-datasource/lib/StyleSetDataFilter.ts
@@ -5,6 +5,7 @@
  */
 
 import { StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
+
 import { OmvFeatureFilter } from "./OmvDataFilter";
 
 /**

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
@@ -39,8 +39,8 @@ import {
     TextGeometry,
     TextPathGeometry,
     TextTechnique,
-    textureCoordinateType,
-    TextureCoordinateType
+    TextureCoordinateType,
+    textureCoordinateType
 } from "@here/harp-datasource-protocol";
 import {
     Env,

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataSource.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataSource.ts
@@ -20,6 +20,7 @@ import {
     TileFactory
 } from "@here/harp-mapview-decoder";
 import { getOptionValue, LoggerManager } from "@here/harp-utils";
+
 import {
     FeatureModifierId,
     OmvDecoderOptions,

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
@@ -13,6 +13,7 @@ import {
 import { webMercatorProjection } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
 import { Vector2, Vector3 } from "three";
+
 import { DataAdapter } from "../../DataAdapter";
 import { DecodeInfo } from "../../DecodeInfo";
 import { IGeometryProcessor, ILineGeometry, IPolygonGeometry } from "../../IGeometryProcessor";

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
@@ -8,6 +8,7 @@ import { MapEnv, ValueMap } from "@here/harp-datasource-protocol/lib/Env";
 import { GeoCoordinates, GeoPointLike, webMercatorProjection } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
 import { Vector2, Vector3 } from "three";
+
 import { DataAdapter } from "../../DataAdapter";
 import { DecodeInfo } from "../../DecodeInfo";
 import { IGeometryProcessor, ILineGeometry, IPolygonGeometry } from "../../IGeometryProcessor";

--- a/@here/harp-vectortile-datasource/lib/adapters/omv/OmvData.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/omv/OmvData.ts
@@ -5,6 +5,7 @@
  */
 
 import { Vector2 } from "three";
+
 import { com } from "./proto/vector_tile";
 
 /**

--- a/@here/harp-vectortile-datasource/lib/adapters/omv/OmvDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/omv/OmvDataAdapter.ts
@@ -9,6 +9,7 @@ import { TileKey } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
 import * as Long from "long";
 import { ShapeUtils, Vector2 } from "three";
+
 import { DataAdapter } from "../../DataAdapter";
 import { DecodeInfo } from "../../DecodeInfo";
 import { IGeometryProcessor, ILineGeometry, IPolygonGeometry } from "../../IGeometryProcessor";

--- a/@here/harp-vectortile-datasource/test/MapViewPickingTest.ts
+++ b/@here/harp-vectortile-datasource/test/MapViewPickingTest.ts
@@ -36,6 +36,7 @@ import { getAppBaseUrl } from "@here/harp-utils";
 import { assert } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
+
 import { VectorTileDecoder } from "../index-worker";
 import { GeoJsonDataProvider } from "../lib/GeoJsonDataProvider";
 import { VectorTileDataSource } from "../lib/VectorTileDataSource";

--- a/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
@@ -6,13 +6,15 @@
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
-import { FeatureCollection } from "@here/harp-datasource-protocol";
 import "@here/harp-fetch";
+
+import { FeatureCollection } from "@here/harp-datasource-protocol";
 import { TileKey } from "@here/harp-geoutils";
 import { DataProvider } from "@here/harp-mapview-decoder";
 import { GeoJsonTiler } from "@here/harp-mapview-decoder/index-worker";
 import { assert } from "chai";
 import * as sinon from "sinon";
+
 import {
     APIFormat,
     AuthenticationTypeAccessToken,

--- a/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -22,6 +22,7 @@ import {
 } from "@here/harp-geoutils";
 import { assert } from "chai";
 import { Vector2, Vector3 } from "three";
+
 import { DecodeInfo } from "../lib/DecodeInfo";
 import { IPolygonGeometry } from "../lib/IGeometryProcessor";
 import { world2tile } from "../lib/OmvUtils";

--- a/@here/harp-vectortile-datasource/test/OmvRestClientTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvRestClientTest.ts
@@ -7,10 +7,12 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import "@here/harp-fetch";
+
 import { TileKey } from "@here/harp-geoutils";
 import { TransferManager } from "@here/harp-transfer-manager";
 import { assert } from "chai";
 import * as sinon from "sinon";
+
 import { APIFormat, AuthenticationMethod, AuthenticationTypeBearer, OmvRestClient } from "../index";
 
 function createMockDownloadResponse(tileUrl: string) {

--- a/@here/harp-vectortile-datasource/test/OmvTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvTest.ts
@@ -8,6 +8,7 @@
 
 import { MapEnv, Value } from "@here/harp-datasource-protocol/index-decoder";
 import { assert } from "chai";
+
 import {
     OmvFeatureFilter,
     OmvFeatureFilterDescriptionBuilder,

--- a/@here/harp-vectortile-datasource/test/OmvTomTomFeatureModifierTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvTomTomFeatureModifierTest.ts
@@ -8,6 +8,7 @@
 
 import { MapEnv } from "@here/harp-datasource-protocol/index-decoder";
 import { assert } from "chai";
+
 import { OmvFeatureFilterDescriptionBuilder } from "../lib/OmvDataFilter";
 import { OmvFeatureFilterDescription } from "../lib/OmvDecoderDefs";
 import { OmvTomTomFeatureModifier } from "../lib/OmvTomTomFeatureModifier";

--- a/@here/harp-vectortile-datasource/test/RingTest.ts
+++ b/@here/harp-vectortile-datasource/test/RingTest.ts
@@ -13,6 +13,7 @@
 import { clipPolygon } from "@here/harp-geometry/lib/ClipPolygon";
 import { assert } from "chai";
 import { Vector2 } from "three";
+
 import { Ring } from "../lib/Ring";
 
 const DEFAULT_EXTENTS = 4 * 1024;

--- a/@here/harp-webtile-datasource/test/WebTileTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileTest.ts
@@ -7,6 +7,7 @@
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
 import { assert } from "chai";
+
 import { HereTileProvider, HereWebTileDataSource, WebTileDataSource } from "../index";
 
 describe("WebTileDataSource", function() {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-promise": "^4.2.1",
+        "eslint-plugin-simple-import-sort": "^5.0.3",
         "eslint-plugin-standard": "^4.0.1",
         "express": "^4.17.1",
         "fs-extra": "^9.0.0",

--- a/scripts/apidocs.ts
+++ b/scripts/apidocs.ts
@@ -6,10 +6,10 @@
 
 /* eslint-disable no-console */
 
+import { Extractor, ExtractorConfig } from "@microsoft/api-extractor";
 import { execSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
-import { Extractor, ExtractorConfig } from "@microsoft/api-extractor";
 
 async function main() {
     const reportFolder = path.resolve("input");

--- a/scripts/credentials.ts
+++ b/scripts/credentials.ts
@@ -7,6 +7,7 @@
 /* eslint-disable no-console */
 
 import * as fs from "fs";
+
 import { apikey } from "../@here/harp-examples/config";
 
 function usage() {

--- a/scripts/setup-docs.ts
+++ b/scripts/setup-docs.ts
@@ -8,9 +8,9 @@
 
 import { execSync } from "child_process";
 import * as fs from "fs";
-import * as path from "path";
 import * as fse from "fs-extra";
 import * as glob from "glob";
+import * as path from "path";
 
 /**
  * Script to extract all code snippets from examples, render Mermaid diagrams and

--- a/scripts/with-http-server.ts
+++ b/scripts/with-http-server.ts
@@ -10,10 +10,10 @@
 declare const require: any;
 
 import * as child_process from "child_process";
-import * as http from "http";
-import * as path from "path";
 import * as commander from "commander";
 import * as express from "express";
+import * as http from "http";
+import * as path from "path";
 
 const modulesToLoad: string[] = [];
 function addLoadedModule(val: string) {

--- a/test/ImportTest.ts
+++ b/test/ImportTest.ts
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from "fs";
-import * as path from "path";
-
 import { assert } from "chai";
+import * as fs from "fs";
 import * as glob from "glob";
+import * as path from "path";
 
 // these dependencies are ok to include in files using node.js
 const nodeDependencyWhitelist: { [moduleName: string]: boolean } = {

--- a/test/LicenseHeaderTest.ts
+++ b/test/LicenseHeaderTest.ts
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from "fs";
-import * as path from "path";
-
 import { assert } from "chai";
+import * as fs from "fs";
 import * as glob from "glob";
+import * as path from "path";
 
 const licenseRegEx = /\/\*\n \* Copyright \(C\) (\d\d\d\d)-?(\d\d\d\d)? HERE Europe.B\.V\.\n \* Licensed under Apache 2\.0\, see full license in LICENSE\n \* SPDX\-License\-Identifier\: Apache\-2\.0\n \*\//;
 

--- a/test/YarnLockTest.ts
+++ b/test/YarnLockTest.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { assert } from "chai";
 import * as fs from "fs";
 import * as path from "path";
-
-import { assert } from "chai";
 
 describe("YarnLockFile", function() {
     it("Contains only public paths", function() {

--- a/www/src/index.ts
+++ b/www/src/index.ts
@@ -12,6 +12,7 @@ import {
     AuthenticationMethod,
     VectorTileDataSource
 } from "@here/harp-vectortile-datasource";
+
 import { apikey, copyrightInfo } from "../../@here/harp-examples/config";
 
 const theme = require("../resources/theme.json");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,6 +3023,11 @@ eslint-plugin-promise@^4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
   integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
+eslint-plugin-simple-import-sort@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-5.0.3.tgz#9ae258ddada6efffc55e47a134afbd279eb31fc6"
+  integrity sha512-1rf3AWiHeWNCQdAq0iXNnlccnH1UDnelGgrPbjBBHE8d2hXVtOudcmy0vTF4hri3iJ0MKz8jBhmH6lJ0ZWZLHQ==
+
 eslint-plugin-standard@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"


### PR DESCRIPTION
The major difference is that the simple-import-sort plugin allows
auto fix in vscode. Also, please note that the default
simple-import-sort separates import groups with a newline (relative,
external, side-effect, ..).
