### PR TITLE
HARP-11487: Ensure DataProvider's connect and disposed are called once.

### DIFF
--- a/@here/harp-examples/src/datasource_custom.ts
+++ b/@here/harp-examples/src/datasource_custom.ts
@@ -97,7 +97,7 @@ import { CUSTOM_DECODER_SERVICE_TYPE } from "../decoder/custom_decoder_defs";
 
 export namespace CustomDatasourceExample {
     // snippet:custom_datasource_example_custom_data_provider.ts
-    class CustomDataProvider implements DataProvider
+    class CustomDataProvider extends DataProvider
     // end:custom_datasource_example_custom_data_provider.ts
     {
         connect() {

--- a/@here/harp-examples/src/tile_dependencies.ts
+++ b/@here/harp-examples/src/tile_dependencies.ts
@@ -73,7 +73,7 @@ export namespace TileDependenciesExample {
         </p>
         <pre id="mouse-picked-result"></pre>
     `;
-    class CustomDataProvider implements DataProvider {
+    class CustomDataProvider extends DataProvider {
         enableTileDependencies: boolean = false;
         connect() {
             // Here you could connect to the service.

--- a/@here/harp-mapview-decoder/lib/TestDataProviders.ts
+++ b/@here/harp-mapview-decoder/lib/TestDataProviders.ts
@@ -14,13 +14,15 @@ import { DataProvider } from "../lib/DataProvider";
 /**
  * Data provider that loads test tile using [[loadTestResource]].
  */
-export class TestSingleFileDataProvider implements DataProvider {
+export class TestSingleFileDataProvider extends DataProvider {
     /**
      * TestDataProvider constructor
      * @param moduleName - name of the module's directory
      * @param basePath - base path to the test resources
      */
-    constructor(private readonly moduleName: string, private readonly basePath: string) {}
+    constructor(private readonly moduleName: string, private readonly basePath: string) {
+        super();
+    }
 
     ready(): boolean {
         return true;
@@ -46,13 +48,15 @@ export class TestSingleFileDataProvider implements DataProvider {
  * The URL is constructed using the following formula:
  * `${this.basePath}/${tileKey.mortonCode()}.bin`
  */
-export class TestTilesDataProvider implements DataProvider {
+export class TestTilesDataProvider extends DataProvider {
     /**
      * Constructs `TestFilesDataProvider` using the provided base path.
      *
      * @param basePath - base path to be used to construct the url to the resource.
      */
-    constructor(private readonly basePath: string) {}
+    constructor(private readonly basePath: string) {
+        super();
+    }
 
     ready(): boolean {
         return true;

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -163,7 +163,7 @@ export class TileDataSource<TileType extends Tile = Tile> extends DataSource {
     dispose() {
         this.m_unregisterClearTileCache?.();
         this.decoder.dispose();
-        this.dataProvider().dispose();
+        this.dataProvider().unregister(this);
     }
 
     /** @override */
@@ -181,7 +181,7 @@ export class TileDataSource<TileType extends Tile = Tile> extends DataSource {
 
     /** @override */
     async connect() {
-        await Promise.all([this.m_options.dataProvider.connect(), this.m_decoder.connect()]);
+        await Promise.all([this.m_options.dataProvider.register(this), this.m_decoder.connect()]);
         this.m_isReady = true;
 
         this.m_decoder.configure(undefined, undefined, undefined, {

--- a/@here/harp-mapview-decoder/test/DataProviderTest.ts
+++ b/@here/harp-mapview-decoder/test/DataProviderTest.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { DataProvider } from "../index";
+
+class FakeDataProvider extends DataProvider {
+    /** @override */ async connect() {
+        // empty implementation
+    }
+
+    ready(): boolean {
+        return true;
+    }
+
+    async getTile(): Promise<ArrayBufferLike | {}> {
+        return await Promise.resolve({});
+    }
+
+    /** @override */ dispose() {
+        // Nothing to be done here.
+    }
+}
+
+describe("DataProvider", function() {
+    const clients = [{}, {}];
+
+    it("calls connect only on first registered client", function() {
+        const dataProvider = new FakeDataProvider();
+        const connectSpy = sinon.spy(dataProvider, "connect");
+
+        dataProvider.register(clients[0]);
+        expect(connectSpy.calledOnce).is.true;
+
+        dataProvider.register(clients[0]);
+        dataProvider.register(clients[1]);
+        expect(connectSpy.calledOnce).is.true;
+    });
+
+    it("calls dispose only on last unregistered client", function() {
+        const dataProvider = new FakeDataProvider();
+        const disposeSpy = sinon.spy(dataProvider, "dispose");
+
+        dataProvider.register(clients[0]);
+        dataProvider.register(clients[1]);
+
+        dataProvider.unregister(clients[0]);
+        dataProvider.unregister(clients[0]);
+        expect(disposeSpy.called).is.false;
+
+        dataProvider.unregister(clients[1]);
+        expect(disposeSpy.calledOnce).is.true;
+        dataProvider.unregister(clients[1]);
+        expect(disposeSpy.calledOnce).is.true;
+    });
+});

--- a/@here/harp-mapview-decoder/test/TileLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileLoaderTest.ts
@@ -37,11 +37,7 @@ class MockDataSource extends DataSource {
     }
 }
 
-class MockDataProvider implements DataProvider {
-    constructor() {
-        // empty implementation
-    }
-
+class MockDataProvider extends DataProvider {
     async connect() {
         // empty implementation
     }

--- a/@here/harp-olp-utils/lib/OlpDataProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpDataProvider.ts
@@ -41,11 +41,13 @@ export interface OlpDataProviderParams {
 /**
  * [[DataProvider]] implementation for OLP catalogs.
  */
-export class OlpDataProvider implements DataProvider {
+export class OlpDataProvider extends DataProvider {
     private m_versionLayerClient: VersionedLayerClient | undefined;
     private m_catalogVersion: number = -1;
 
-    constructor(readonly params: OlpDataProviderParams) {}
+    constructor(readonly params: OlpDataProviderParams) {
+        super();
+    }
 
     /**
      * Connect to the data source. Returns a promise to wait for successful (or failed) connection.

--- a/@here/harp-vectortile-datasource/lib/GeoJsonDataProvider.ts
+++ b/@here/harp-vectortile-datasource/lib/GeoJsonDataProvider.ts
@@ -11,7 +11,6 @@ import { TileKey } from "@here/harp-geoutils";
 import { ConcurrentTilerFacade } from "@here/harp-mapview";
 import { DataProvider } from "@here/harp-mapview-decoder";
 import { LoggerManager } from "@here/harp-utils";
-import { EventDispatcher } from "three";
 
 import { GEOJSON_TILER_SERVICE_TYPE } from "./OmvDecoderDefs";
 
@@ -44,7 +43,7 @@ let missingTilerServiceInfoEmitted: boolean = false;
  * @remarks
  * Automatically handles tiling and simplification of static GeoJson.
  */
-export class GeoJsonDataProvider extends EventDispatcher implements DataProvider {
+export class GeoJsonDataProvider extends DataProvider {
     private readonly m_tiler: ITiler;
     private m_registered = false;
 

--- a/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
@@ -283,11 +283,12 @@ export interface OmvRestClientParameters {
 /**
  * REST client supporting getting protobuf OMV Tile from REST-based servers.
  */
-export class OmvRestClient implements DataProvider {
+export class OmvRestClient extends DataProvider {
     private readonly downloadManager: ITransferManager;
     private readonly urlParams: { [key: string]: string };
 
     constructor(readonly params: OmvRestClientParameters) {
+        super();
         this.downloadManager =
             params.downloadManager === undefined
                 ? TransferManager.instance()

--- a/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
@@ -24,7 +24,7 @@ import {
 import { VectorTileDecoder } from "../index-worker";
 import { GeoJsonDataProvider } from "../lib/GeoJsonDataProvider";
 
-class MockDataProvider implements DataProvider {
+class MockDataProvider extends DataProvider {
     /** Overriding abstract method, in this case doing nothing. */
     async connect(): Promise<void> {
         //do nothing


### PR DESCRIPTION
Both methods are now protected. Clients call instead register/unregister,
and new DataProvider abstract class ensures connect is called on first
registered client and dispose called on last unregistered client.

Breaking API change:
- Classes derived from DataProvider must use "extends" instead of "implements",
 and must call super() on constructor.
- Custom Data sources using DataProvider must call register/unregister instead
of connect/dispose.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
