### PR TITLE
HARP-11784: Fix typo when parsing interpolate operators.

### DIFF
--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -962,7 +962,7 @@ function parseInterpolateExpr(
     if (mode[0] === "exponential" && typeof mode[1] !== "number") {
         throw new Error("expected the base of the exponential interpolation");
     }
-    const input = node[2] ? parseNode(node[2], referenceResolverState) : undefined;
+    const input = node[2] !== undefined ? parseNode(node[2], referenceResolverState) : undefined;
     if (!Expr.isExpr(input)) {
         throw new Error(`expected the input of the interpolation`);
     }

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -871,6 +871,8 @@ describe("ExprEvaluator", function() {
                 evaluate(["interpolate", ["exponential", 2], ["zoom"], 0, 0, 1, 1, 2, 2])
             );
 
+            assert.isNotNull(evaluate(["interpolate", ["linear"], 0, 0, 100, 20, 200]));
+
             assert.throws(() => evaluate(["interpolate"]), "expected an interpolation type");
 
             assert.throws(


### PR DESCRIPTION
A typo in the parser prevents creating interpolations with input
parameter equal to 0.
