### PR TITLE
HARP-11835: Fix typo preventing the detection of typescript react apps.

### DIFF
--- a/@here/harp-webpack-utils/scripts/HarpWebpackConfig.ts
+++ b/@here/harp-webpack-utils/scripts/HarpWebpackConfig.ts
@@ -43,10 +43,9 @@ export function addHarpWebpackConfig(config?: Configuration, harpConfig?: HarpWe
             rules: [{ test: /\.tsx?$/, loader: "ts-loader" }]
         }
     };
-    const mainConfig =
-        mainEntry !== undefined && mainEntry.endsWith(".ts")
-            ? WebpackMerge.smart(baseConfig, typescriptConfig)
-            : baseConfig;
+    const mainConfig = mainEntry?.match(/\.tsx?$/)
+        ? WebpackMerge.smart(baseConfig, typescriptConfig)
+        : baseConfig;
     const bundles = [
         WebpackMerge.smart(
             {


### PR DESCRIPTION
The code was not handling the case when the entry point is a tsx
file.
