### PR TITLE
HARP-11468 Empty payloads are set with an empty decodedTile so that the background plane is still set

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileLoader.ts
+++ b/@here/harp-mapview-decoder/lib/TileLoader.ts
@@ -217,7 +217,10 @@ export class TileLoader implements ITileLoader {
             (payload.constructor === Object && Object.keys(payload).length === 0)
         ) {
             // Object is empty
-            this.onDone(TileLoaderState.Ready);
+            this.onDecoded({
+                geometries: [],
+                techniques: []
+            });
             return;
         }
 

--- a/@here/harp-mapview-decoder/test/TileLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileLoaderTest.ts
@@ -163,6 +163,8 @@ describe("TileLoader", function() {
                 getTileStub.resolves({});
                 loadPromise = tileLoader.loadAndDecode();
                 expect(loadPromise).to.not.be.undefined;
+                expect(tileLoader.decodedTile!.geometries.length).eq(0);
+                expect(tileLoader.decodedTile?.techniques.length).eq(0);
 
                 return expect(loadPromise).to.eventually.be.fulfilled.then(() => {
                     expect(decodeTileSpy.notCalled).to.be.true;


### PR DESCRIPTION
Empty payload from the data provider now sets the decodedTile to be empty, this ensures that the
ground plane is properly created which is needed because otherwise, if the DataSource
isFullyCovering, it will remove the BackgroundDataSource's tiles and there will be holes in the
map.