### PR TITLE
Made wireframe an automatic property

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptors.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptors.ts
@@ -229,6 +229,7 @@ const fillTechniqueDescriptor = mergeTechniqueDescriptor<FillTechnique>(
     polygonalTechniqueDescriptor,
     {
         attrDescriptors: {
+            wireframe: { scope: AttrScope.TechniqueRendering, automatic: true },
             color: { scope: AttrScope.TechniqueRendering, automatic: true },
             opacity: { scope: AttrScope.TechniqueRendering, automatic: true },
             transparent: { scope: AttrScope.TechniqueRendering, automatic: true },


### PR DESCRIPTION
This change adds ensures that updates to dynamic changes to the property `wireframe` are automatically applied to the underlying technique.