### PR TITLE
MINOR: Add optional filter to markTilesDirty method

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2950,9 +2950,10 @@ export class MapView extends EventDispatcher {
      *
      * @param dataSource - If passed, only the tiles from this {@link DataSource} instance
      * are processed. If `undefined`, tiles from all {@link DataSource}s are processed.
+     * @param filter Optional tile filter
      */
-    markTilesDirty(dataSource?: DataSource) {
-        this.m_visibleTiles.markTilesDirty(dataSource);
+    markTilesDirty(dataSource?: DataSource, filter?: (tile: Tile) => boolean) {
+        this.m_visibleTiles.markTilesDirty(dataSource, filter);
     }
 
     /**

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -886,18 +886,19 @@ export class VisibleTileSet {
      *
      * @param dataSource - If passed, only the tiles from this {@link DataSource} instance
      *      are processed. If `undefined`, tiles from all {@link DataSource}s are processed.
+     * @param filter Optional tile filter
      */
-    markTilesDirty(dataSource?: DataSource) {
+    markTilesDirty(dataSource?: DataSource, filter?: (tile: Tile) => boolean) {
         if (dataSource === undefined) {
             this.dataSourceTileList.forEach(renderListEntry => {
-                this.markDataSourceTilesDirty(renderListEntry);
+                this.markDataSourceTilesDirty(renderListEntry, filter);
             });
         } else {
             const renderListEntry = this.dataSourceTileList.find(e => e.dataSource === dataSource);
             if (renderListEntry === undefined) {
                 return;
             }
-            this.markDataSourceTilesDirty(renderListEntry);
+            this.markDataSourceTilesDirty(renderListEntry, filter);
         }
     }
 
@@ -1233,7 +1234,10 @@ export class VisibleTileSet {
         });
     }
 
-    private markDataSourceTilesDirty(renderListEntry: DataSourceTileList) {
+    private markDataSourceTilesDirty(
+        renderListEntry: DataSourceTileList,
+        filter?: (tile: Tile) => boolean
+    ) {
         const dataSourceCache = this.m_dataSourceCache;
         const retainedTiles: Set<TileCacheId> = new Set();
 
@@ -1254,14 +1258,18 @@ export class VisibleTileSet {
         }
 
         renderListEntry.visibleTiles.forEach(tile => {
-            markTileDirty(tile, this.m_tileGeometryManager);
+            if (filter === undefined || filter(tile)) {
+                markTileDirty(tile, this.m_tileGeometryManager);
+            }
         });
         renderListEntry.renderedTiles.forEach(tile => {
-            markTileDirty(tile, this.m_tileGeometryManager);
+            if (filter === undefined || filter(tile)) {
+                markTileDirty(tile, this.m_tileGeometryManager);
+            }
         });
 
         dataSourceCache.forEach((tile, key) => {
-            if (!retainedTiles.has(key)) {
+            if ((filter === undefined || filter(tile)) && !retainedTiles.has(key)) {
                 dataSourceCache.deleteByKey(key);
                 tile.dispose();
             }

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -36,6 +36,7 @@ import { MapObjectAdapter } from "../lib/MapObjectAdapter";
 import { MapView, MapViewEventNames } from "../lib/MapView";
 import { MapViewFog } from "../lib/MapViewFog";
 import { MapViewUtils } from "../lib/Utils";
+import { VisibleTileSet } from "../lib/VisibleTileSet";
 import { FakeOmvDataSource } from "./FakeOmvDataSource";
 
 //    expect-type assertions are unused expressions and are perfectly valid
@@ -1715,5 +1716,15 @@ describe("MapView", function() {
             mapView.update();
             return await waitForEvent(mapView, MapViewEventNames.FrameComplete);
         });
+    });
+
+    it("markTilesDirty proxies call to VisibleTileSet", () => {
+        const markTilesDirtySpy = sinon.spy(VisibleTileSet.prototype, "markTilesDirty");
+        mapView = new MapView({ canvas });
+        const dataSource = new FakeOmvDataSource({ name: "omv" });
+        const tileFilter = () => true;
+        mapView.markTilesDirty(dataSource, tileFilter);
+
+        expect(markTilesDirtySpy.calledWith(dataSource, tileFilter)).to.be.true;
     });
 });


### PR DESCRIPTION
Adds a simple optional filter function to mark only subset of tiles as dirty.