### PR TITLE
HARP-12145: Fix gaps along the antimeridian.

### DIFF
--- a/@here/harp-vectortile-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvDecoderDefs.ts
@@ -206,6 +206,8 @@ export interface OmvDecoderOptions {
     politicalView?: string;
 
     enableElevationOverlay?: boolean;
+
+    roundUpCoordinatesIfNeeded?: boolean;
 }
 
 /**

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataSource.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataSource.ts
@@ -159,6 +159,16 @@ export interface VectorTileDataSourceParameters extends DataSourceOptions {
      * Default is true (i.e. if not defined it is taken to be true)
      */
     addGroundPlane?: boolean;
+
+    /**
+     * Indicates whether the decoder is allowed to adjust the coordinates to
+     * avoid possible glitches at the 180th meridian.
+     *
+     * @defaultValue `true` if the data service is
+     *               `https://vector.hereapi.com/v2/vectortiles/base/mc`,
+     *               `false` otherwise.
+     */
+    roundUpCoordinatesIfNeeded?: boolean;
 }
 
 /**
@@ -287,6 +297,15 @@ export class VectorTileDataSource extends TileDataSource {
         this.addGroundPlane =
             m_params.addGroundPlane === undefined || m_params.addGroundPlane === true;
 
+        let roundUpCoordinatesIfNeeded = m_params.roundUpCoordinatesIfNeeded;
+
+        if (
+            roundUpCoordinatesIfNeeded === undefined &&
+            (m_params as Partial<OmvWithRestClientParams>)?.baseUrl === hereVectorTileBaseUrl
+        ) {
+            roundUpCoordinatesIfNeeded = true;
+        }
+
         this.m_decoderOptions = {
             showMissingTechniques: this.m_params.showMissingTechniques === true,
             filterDescription: this.m_params.filterDescr,
@@ -297,7 +316,8 @@ export class VectorTileDataSource extends TileDataSource {
             politicalView: this.m_params.politicalView,
             skipShortLabels: this.m_params.skipShortLabels,
             storageLevelOffset: m_params.storageLevelOffset ?? -1,
-            enableElevationOverlay: this.m_params.enableElevationOverlay === true
+            enableElevationOverlay: this.m_params.enableElevationOverlay === true,
+            roundUpCoordinatesIfNeeded
         };
 
         this.maxGeometryHeight = getOptionValue(

--- a/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
@@ -64,14 +64,20 @@ export class VectorTileDataProcessor implements IGeometryProcessor {
         private readonly m_skipShortLabels = true,
         private readonly m_storageLevelOffset = 0,
         private readonly m_enableElevationOverlay = false,
+        private readonly m_roundUpCoordinatesIfNeeded = false,
         private readonly m_languages?: string[]
     ) {
         const styleSetDataFilter = new StyleSetDataFilter(m_styleSetEvaluator);
         const dataPreFilter = m_dataFilter
             ? new ComposedDataFilter([styleSetDataFilter, m_dataFilter])
             : styleSetDataFilter;
+
         // Register the default adapters.
-        this.m_dataAdapters.push(new OmvDataAdapter(this, dataPreFilter, logger));
+
+        const omvDataAdapter = new OmvDataAdapter(this, dataPreFilter, logger);
+        omvDataAdapter.roundUpCoordinatesIfNeeded = m_roundUpCoordinatesIfNeeded;
+        this.m_dataAdapters.push(omvDataAdapter);
+
         this.m_dataAdapters.push(new GeoJsonVtDataAdapter(this, dataPreFilter, logger));
         this.m_dataAdapters.push(new GeoJsonDataAdapter(this, dataPreFilter, logger));
     }
@@ -301,6 +307,7 @@ export class VectorTileDecoder extends ThemedTileDecoder {
     private m_gatherFeatureAttributes: boolean = false;
     private m_skipShortLabels: boolean = true;
     private m_enableElevationOverlay: boolean = false;
+    private m_roundUpCoordinatesIfNeeded: boolean = false;
 
     /** @override */
     connect(): Promise<void> {
@@ -326,6 +333,7 @@ export class VectorTileDecoder extends ThemedTileDecoder {
             this.m_skipShortLabels,
             this.m_storageLevelOffset,
             this.m_enableElevationOverlay,
+            this.m_roundUpCoordinatesIfNeeded,
             this.languages
         );
 
@@ -419,6 +427,9 @@ export class VectorTileDecoder extends ThemedTileDecoder {
             }
             if (omvOptions.enableElevationOverlay !== undefined) {
                 this.m_enableElevationOverlay = omvOptions.enableElevationOverlay;
+            }
+            if (omvOptions.roundUpCoordinatesIfNeeded !== undefined) {
+                this.m_roundUpCoordinatesIfNeeded = omvOptions.roundUpCoordinatesIfNeeded;
             }
         }
         if (languages !== undefined) {


### PR DESCRIPTION
This change introduces the flag `roundUpCoordinatesIfNeeded` to
the `VectorTileDataSource`. When the flag is enabled the decoder
is allowed to adjust the coordinates of liens and polygons close
to the antimeridian to avoid gaps.
