### PR TITLE
Support for WebGL2 and GLSL 3.0 shaders.

### DIFF
--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -86,7 +86,7 @@ export interface MaterialOptions {
     /**
      * Version of GLSL to use for materials
      */
-    glslVersion: Number;
+    glslVersion?: Number;
 }
 
 /**

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -82,6 +82,11 @@ export interface MaterialOptions {
      * Whether shadows are enabled or not, this is required because we change the material used.
      */
     shadowsEnabled?: boolean;
+
+    /**
+     * Version of GLSL to use for materials
+     */
+    glslVersion: Number;
 }
 
 /**
@@ -108,11 +113,11 @@ export function createMaterial(
         return undefined;
     }
 
-    if (
-        Constructor.prototype instanceof THREE.RawShaderMaterial &&
-        Constructor !== HighPrecisionLineMaterial
-    ) {
-        settings.fog = options.fog;
+    if (Constructor.prototype instanceof THREE.RawShaderMaterial) {
+        settings.glslVersion = options.glslVersion;
+        if (Constructor !== HighPrecisionLineMaterial) {
+            settings.fog = options.fog;
+        }
     }
     if (options.shadowsEnabled === true && technique.name === "fill") {
         settings.removeDiffuseLight = true;

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -2146,6 +2146,13 @@ export class MapView extends EventDispatcher {
     }
 
     /**
+     * Returns the glsl version compatible with the MapView's renderer
+     */
+    get glslVersion(): number {
+        return this.m_renderer.capabilities.isWebGL2 ? 3.0 : 1.0;
+    }
+
+    /**
      * Set's the way in which the fov is calculated on the map view.
      *
      * @remarks

--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -116,7 +116,11 @@ export class PolarTileDataSource extends DataSource {
             return undefined;
         }
         const technique = techniques[0];
-        const material = createMaterial({ technique, env: this.mapView.env });
+        const material = createMaterial({
+            technique,
+            env: this.mapView.env,
+            glslVersion: this.mapView.glslVersion
+        });
         if (!material) {
             return undefined;
         }

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -757,7 +757,8 @@ export class TileGeometryCreator {
                             technique,
                             env: mapView.env,
                             fog: mapView.scene.fog !== null,
-                            shadowsEnabled: mapView.shadowsEnabled
+                            shadowsEnabled: mapView.shadowsEnabled,
+                            glslVersion: mapView.glslVersion
                         },
                         onMaterialUpdated
                     );
@@ -1010,7 +1011,8 @@ export class TileGeometryCreator {
                         fadeNear: fadingParams.lineFadeNear,
                         fadeFar: fadingParams.lineFadeFar,
                         extrusionRatio: extrusionAnimationEnabled ? 0 : undefined,
-                        vertexColors: bufferGeometry.getAttribute("color") ? true : false
+                        vertexColors: bufferGeometry.getAttribute("color") ? true : false,
+                        glslVersion: mapView.glslVersion
                     };
                     const edgeMaterial = new EdgeMaterial(materialParams);
                     const edgeObj = new THREE.LineSegments(
@@ -1094,7 +1096,8 @@ export class TileGeometryCreator {
                         colorMix: fadingParams.colorMix,
                         fadeNear: fadingParams.lineFadeNear,
                         fadeFar: fadingParams.lineFadeFar,
-                        vertexColors: bufferGeometry.getAttribute("color") ? true : false
+                        vertexColors: bufferGeometry.getAttribute("color") ? true : false,
+                        glslVersion: mapView.glslVersion
                     };
                     const outlineMaterial = new EdgeMaterial(materialParams);
                     const outlineObj = new THREE.LineSegments(

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -131,6 +131,11 @@ export interface EdgeMaterialParameters
      * @defaultValue false
      */
     vertexColors?: boolean;
+
+    /**
+     * GLSL version
+     */
+    glslVersion?: number;
 }
 
 /**
@@ -164,7 +169,8 @@ export class EdgeMaterial extends RawShaderMaterial
         if (params?.vertexColors === true) {
             setShaderDefine(defines, "USE_COLOR", true);
         }
-        const shaderParams = {
+
+        const shaderParams: THREE.ShaderMaterialParameters = {
             name: "EdgeMaterial",
             vertexShader: vertexSource,
             fragmentShader: fragmentSource,
@@ -182,6 +188,9 @@ export class EdgeMaterial extends RawShaderMaterial
             depthWrite: false,
             defines
         };
+        if (params?.glslVersion === 3.0) {
+            shaderParams.glslVersion = THREE.GLSL3;
+        }
         super(shaderParams);
         enforceBlending(this);
 

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -400,6 +400,11 @@ export interface SolidLineMaterialParameters
      * How much to offset in world units.
      */
     offset?: number;
+
+    /**
+     * GLSL version
+     */
+    glslVersion?: number;
 }
 
 /**
@@ -502,6 +507,9 @@ export class SolidLineMaterial extends RawShaderMaterial
             fog: fogParam,
             opacity: opacityParam
         };
+        if (params?.glslVersion === 3.0) {
+            shaderParams.glslVersion = THREE.GLSL3;
+        }
         super(shaderParams);
         // Required to satisfy compiler error if fields has no initializer or are not definitely
         // assigned in the constructor, this also mimics ShaderMaterial set of defaults

--- a/@here/harp-text-canvas/lib/TextCanvas.ts
+++ b/@here/harp-text-canvas/lib/TextCanvas.ts
@@ -255,7 +255,10 @@ export class TextCanvas {
 
         if (params.material === undefined) {
             this.m_ownsMaterial = true;
-            this.m_material = createSdfTextMaterial({ fontCatalog: params.fontCatalog });
+            this.m_material = createSdfTextMaterial({
+                fontCatalog: params.fontCatalog,
+                glslVersion: this.m_renderer.capabilities.isWebGL2 ? 3.0 : undefined
+            });
         } else {
             this.m_ownsMaterial = false;
             this.m_material = params.material;
@@ -264,7 +267,8 @@ export class TextCanvas {
             this.m_ownsBgMaterial = true;
             this.m_bgMaterial = createSdfTextMaterial({
                 fontCatalog: params.fontCatalog,
-                isBackground: true
+                isBackground: true,
+                glslVersion: this.m_renderer.capabilities.isWebGL2 ? 3.0 : undefined
             });
         } else {
             this.m_ownsBgMaterial = false;

--- a/@here/harp-text-canvas/lib/rendering/TextMaterials.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextMaterials.ts
@@ -244,6 +244,7 @@ export interface SdfTextMaterialParameters {
     isBackground: boolean;
     vertexSource?: string;
     fragmentSource?: string;
+    glslVersion?: number;
 }
 
 /**
@@ -284,6 +285,9 @@ export class SdfTextMaterial extends THREE.RawShaderMaterial {
             side: THREE.DoubleSide,
             transparent: true
         };
+        if (params?.glslVersion === 3.0) {
+            shaderParams.glslVersion = THREE.GLSL3;
+        }
         super(shaderParams);
         this.extensions.derivatives = true;
     }

--- a/@here/harp-text-canvas/lib/utils/MaterialUtils.ts
+++ b/@here/harp-text-canvas/lib/utils/MaterialUtils.ts
@@ -16,6 +16,7 @@ export interface SdfTextMaterialParameters {
     isBackground?: boolean;
     vertexSource?: string;
     fragmentSource?: string;
+    glslVersion?: number;
 }
 
 /**
@@ -35,6 +36,7 @@ export function createSdfTextMaterial(params: SdfTextMaterialParameters): SdfTex
         isMsdf: params.fontCatalog.type === "msdf",
         isBackground: params.isBackground === true,
         vertexSource: params.vertexSource,
-        fragmentSource: params.fragmentSource
+        fragmentSource: params.fragmentSource,
+        glslVersion: params.glslVersion
     });
 }


### PR DESCRIPTION
Commit to close #1575 

Determine WebGL2 support via canvas capabilities via MapView
Use new glslVersion setting (as of Three@0.120) in ShaderMaterials to support GLSL 3.0 features.

Signed-off-by: Jose Rojas <jrojas@redlinesolutions.co>

