### PR TITLE
HARP-11672: Make TileGeometryLoader protected.

### DIFF
--- a/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
@@ -127,22 +127,6 @@ describe("TileGeometryLoader", function() {
             expect(geometryLoader.isFinished).to.be.false;
         });
 
-        it("should not load geometry before tile is decoded", function() {
-            //TODO: Review what this was supposed to do
-            geometryLoader.update();
-            geometryLoader.update();
-
-            expect(geometryLoader.hasDecodedTile).to.be.false;
-
-            expect(mapView.taskQueue.numItemsLeft(TileTaskGroups.CREATE)).to.equal(0);
-
-            expect(geometryLoader.tile.hasGeometry).to.be.false;
-
-            expect(geometryLoader.tile.allGeometryLoaded).to.be.false;
-
-            return expect(geometryLoader.isFinished).to.be.false;
-        });
-
         it("should start load geometry for decoded tile", async function() {
             // Mimic the tile is being decoded.
             tile.decodedTile = createFakeDecodedTile();
@@ -161,36 +145,6 @@ describe("TileGeometryLoader", function() {
             });
         });
 
-        it("should not start geometry loading for invisible tile", async function() {
-            // Mimic the tile is being decoded.
-            tile.decodedTile = createFakeDecodedTile();
-            tile.isVisible = false;
-
-            geometryLoader!.update();
-
-            expect(geometryLoader.hasDecodedTile).to.be.false;
-            expect(mapView.taskQueue.numItemsLeft(TileTaskGroups.CREATE)).to.equal(0);
-
-            geometryLoader.waitFinished().should.be.rejected.then(() => {
-                expect(geometryLoader.isFinished).to.be.false;
-            });
-        });
-
-        it("should not start geometry loading for disposed tile", async function() {
-            // Mimic the tile is being decoded.
-            tile.decodedTile = createFakeDecodedTile();
-            tile.dispose();
-
-            geometryLoader!.update();
-
-            expect(geometryLoader.hasDecodedTile).to.be.false;
-            expect(mapView.taskQueue.numItemsLeft(TileTaskGroups.CREATE)).to.equal(0);
-
-            geometryLoader.waitFinished().should.be.rejected.then(() => {
-                expect(geometryLoader.isFinished).to.be.false;
-            });
-        });
-
         it("should not start geometry loading for empty tile", async function() {
             tile.tileLoader!.isFinished = true;
             geometryLoader!.update();
@@ -205,46 +159,6 @@ describe("TileGeometryLoader", function() {
     });
 
     describe("tile geometry creation", function() {
-        it("should not start geometry creation for invisible tile", function() {
-            tile.decodedTile = createFakeDecodedTile();
-            tile.isVisible = false;
-
-            const geometryCreator = TileGeometryCreator.instance;
-            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
-            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
-
-            expect(spyProcessTechniques.callCount).equal(0);
-            expect(spyCreateGeometries.callCount).equal(0);
-
-            geometryLoader!.update();
-
-            expect(spyProcessTechniques.callCount).equal(0);
-            expect(spyCreateGeometries.callCount).equal(0);
-
-            expect(geometryLoader.hasDecodedTile).to.be.false;
-            expect(geometryLoader.isFinished).to.be.false;
-        });
-
-        it("should not start geometry creation for disposed tile", function() {
-            tile.decodedTile = createFakeDecodedTile();
-            tile.dispose();
-
-            const geometryCreator = TileGeometryCreator.instance;
-            const spyProcessTechniques = sandbox.spy(geometryCreator, "processTechniques") as any;
-            const spyCreateGeometries = sandbox.spy(geometryCreator, "createAllGeometries") as any;
-
-            expect(spyProcessTechniques.callCount).equal(0);
-            expect(spyCreateGeometries.callCount).equal(0);
-
-            geometryLoader!.update();
-
-            expect(spyProcessTechniques.callCount).equal(0);
-            expect(spyCreateGeometries.callCount).equal(0);
-
-            expect(geometryLoader.hasDecodedTile).to.be.false;
-            expect(geometryLoader.isFinished).to.be.false;
-        });
-
         it("should start processing geometry for decoded tile only once", async function() {
             tile.decodedTile = createFakeDecodedTile();
 

--- a/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
@@ -103,6 +103,7 @@ describe("TileGeometryLoader", function() {
         tileKey = TileKey.fromRowColumnLevel(0, 0, 0);
         mapView = createFakeMapView();
         dataSource = new MockDataSource();
+        dataSource.useGeometryLoader = true;
         dataSource.attach(mapView);
     });
 
@@ -111,8 +112,7 @@ describe("TileGeometryLoader", function() {
             dataSource.attach(mapView);
         }
         tile = dataSource.getTile(tileKey)!;
-        geometryLoader = new TileGeometryLoader(tile, mapView.taskQueue);
-        tile.tileGeometryLoader = geometryLoader;
+        geometryLoader = (tile as any).m_tileGeometryLoader!;
         sandbox = sinon.createSandbox();
     });
 

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -391,8 +391,16 @@ export class Tile implements CachedResource {
         }
     }
 
+    /**
+     * Sets the tile visibility status.
+     * @param visible - `True` to mark the tile as visible, `False` otherwise.
+     */
     set isVisible(visible: boolean) {
         this.frameNumLastRequested = visible ? this.dataSource.mapView.frameNumber : -1;
+
+        if (!visible && this.m_tileGeometryLoader && !this.m_tileGeometryLoader.isSettled) {
+            this.m_tileGeometryLoader.cancel();
+        }
     }
 
     /**
@@ -1088,6 +1096,11 @@ export class Tile implements CachedResource {
             return true;
         }
 
+        if (this.dataSource.isDetached()) {
+            this.m_tileGeometryLoader.cancel();
+            return true;
+        }
+
         if (this.tileLoader) {
             if (!this.tileLoader.isFinished) {
                 return true;
@@ -1098,10 +1111,6 @@ export class Tile implements CachedResource {
             }
         }
 
-        if (!this.isVisible) {
-            this.m_tileGeometryLoader.cancel();
-            return true;
-        }
         if (priority !== undefined) {
             this.m_tileGeometryLoader.priority = priority;
         }

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -1628,9 +1628,6 @@ export namespace MapViewUtils {
             numTilesLoading += tileList.numTilesLoading;
 
             for (const tile of tileList.visibleTiles) {
-                if (tile.tileLoader !== undefined && !tile.tileLoader.isFinished) {
-                    numTilesLoading++;
-                }
                 if (!tile.allGeometryLoaded) {
                     numTilesLoading++;
                 }

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -1631,7 +1631,7 @@ export namespace MapViewUtils {
                 if (tile.tileLoader !== undefined && !tile.tileLoader.isFinished) {
                     numTilesLoading++;
                 }
-                if (tile.tileGeometryLoader !== undefined && !tile.tileGeometryLoader.isFinished) {
+                if (!tile.allGeometryLoaded) {
                     numTilesLoading++;
                 }
             }

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -659,7 +659,7 @@ export class VisibleTileSet {
             // Remove all tiles that are still being loaded, but are no longer visible. They have to
             // be reloaded when they become visible again. Hopefully, they are still in the browser
             // cache by then.
-            if (!tile.isVisible && tile.tileLoader !== undefined && !tile.tileLoader.isFinished) {
+            if (!tile.isVisible && !tile.allGeometryLoaded) {
                 // The internal TileLoader is cancelled automatically when the Tile is disposed.
                 this.disposeTile(tile);
             }

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -1213,7 +1213,6 @@ export class VisibleTileSet {
             tile.offset = offset;
             touchTile(tile);
             tileCache.set(tileKey.mortonCode(), offset, dataSource, tile);
-            this.m_tileGeometryManager.initTile(tile);
         }
         return tile;
     }
@@ -1241,30 +1240,25 @@ export class VisibleTileSet {
         const dataSourceCache = this.m_dataSourceCache;
         const retainedTiles: Set<TileCacheId> = new Set();
 
-        function markTileDirty(tile: Tile, tileGeometryManager: TileGeometryManager) {
+        function markTileDirty(tile: Tile) {
             const tileKey = DataSourceCache.getKeyForTile(tile);
             if (!retainedTiles.has(tileKey)) {
                 retainedTiles.add(tileKey);
-                if (tile.tileGeometryLoader !== undefined) {
-                    tile.tileGeometryLoader.reset();
-                }
-
                 // Prevent label rendering issues when the style set is changing. Prevent Text
                 // element rendering that depends on cleaned font catalog data.
                 tile.clearTextElements();
-
                 tile.load();
             }
         }
 
         renderListEntry.visibleTiles.forEach(tile => {
             if (filter === undefined || filter(tile)) {
-                markTileDirty(tile, this.m_tileGeometryManager);
+                markTileDirty(tile);
             }
         });
         renderListEntry.renderedTiles.forEach(tile => {
             if (filter === undefined || filter(tile)) {
-                markTileDirty(tile, this.m_tileGeometryManager);
+                markTileDirty(tile);
             }
         });
 

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -39,6 +39,7 @@ export enum TileGeometryLoaderState {
 
 /**
  * Loads the geometry for its {@link Tile}. Loads all geometry in a single step.
+ * @internal
  */
 export class TileGeometryLoader {
     /**
@@ -155,6 +156,13 @@ export class TileGeometryLoader {
     }
 
     /**
+     * `True` if loader is finished, canceled or disposed.
+     */
+    get isSettled(): boolean {
+        return this.isFinished || this.isCanceled || this.isDisposed;
+    }
+
+    /**
      * Returns a promise resolved when this `TileGeometryLoader` is in
      * `TileGeometryLoaderState.Finished` state, or rejected when it's in
      * `TileGeometryLoaderState.Cancelled` or `TileGeometryLoaderState.Disposed` states.
@@ -257,11 +265,7 @@ export class TileGeometryLoader {
     reset(): void {
         this.clear();
 
-        if (
-            this.m_state === TileGeometryLoaderState.Finished ||
-            this.m_state === TileGeometryLoaderState.Canceled ||
-            this.m_state === TileGeometryLoaderState.Disposed
-        ) {
+        if (this.isSettled) {
             this.m_finishedPromise = new Promise((resolve, reject) => {
                 this.m_resolveFinishedPromise = resolve;
                 this.m_rejectFinishedPromise = reject;
@@ -511,6 +515,13 @@ export class TileGeometryLoader {
         }
         // No difference found.
         return true;
+    }
+
+    /**
+     * `True` if TileGeometryLoader was canceled
+     */
+    private get isCanceled(): boolean {
+        return this.m_state === TileGeometryLoaderState.Canceled;
     }
 
     /**

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -254,6 +254,7 @@ export class TileGeometryLoader {
      * Dispose of any resources.
      */
     dispose(): void {
+        addDiscardedTileToStats(this.tile);
         this.clear();
         this.m_state = TileGeometryLoaderState.Disposed;
         this.m_rejectFinishedPromise?.();
@@ -307,14 +308,7 @@ export class TileGeometryLoader {
             group: TileTaskGroups.CREATE,
             getPriority: this.getPriority.bind(this),
             isExpired: () => {
-                if (this.m_state !== TileGeometryLoaderState.CreationQueued) {
-                    return true;
-                }
-                if (!this.tile.isVisible || this.tile.disposed) {
-                    this.cancel();
-                    return true;
-                }
-                return false;
+                return this.m_state !== TileGeometryLoaderState.CreationQueued;
             },
             estimatedProcessTime: () => {
                 //TODO: this seems to be close in many cases, but take some measures to confirm

--- a/@here/harp-mapview/test/TileTest.ts
+++ b/@here/harp-mapview/test/TileTest.ts
@@ -13,18 +13,44 @@ import {
     TileKey,
     webMercatorTilingScheme
 } from "@here/harp-geoutils";
+import { TaskQueue } from "@here/harp-utils";
 import { assert, expect } from "chai";
+import * as sinon from "sinon";
 import * as THREE from "three";
 
 import { DataSource } from "../lib/DataSource";
-import { MapView } from "../lib/MapView";
+import { TileGeometryLoader } from "../lib/geometry/TileGeometryLoader";
+import { MapView, TileTaskGroups } from "../lib/MapView";
 import { TextElement } from "../lib/text/TextElement";
-import { Tile } from "../lib/Tile";
+import { ITileLoader, Tile, TileLoaderState } from "../lib/Tile";
 
+class FakeTileLoader implements ITileLoader {
+    state: TileLoaderState = TileLoaderState.Ready;
+    isFinished: boolean = false;
+    priority: number = 0;
+
+    loadAndDecode(): Promise<TileLoaderState> {
+        return new Promise(() => this.state);
+    }
+
+    waitSettled(): Promise<TileLoaderState> {
+        return new Promise(() => this.state);
+    }
+
+    updatePriority(area: number): void {
+        // do nothing.
+    }
+
+    cancel(): void {
+        // do nothing.
+    }
+}
 class TileTestStubDataSource extends DataSource {
     /** @override */
-    getTile(tileKey: TileKey) {
-        return undefined;
+    getTile(tileKey: TileKey): Tile {
+        const tile = new Tile(this, tileKey);
+        tile.tileLoader = new FakeTileLoader();
+        return tile;
     }
 
     /** @override */
@@ -39,12 +65,29 @@ function createFakeTextElement(): TextElement {
 }
 describe("Tile", function() {
     const tileKey = TileKey.fromRowColumnLevel(0, 0, 0);
-    const stubDataSource = new TileTestStubDataSource({ name: "test-data-source" });
-    const mapView = {
-        projection: mercatorProjection,
-        frameNumber: 0
-    };
-    stubDataSource.attach(mapView as MapView);
+    let stubDataSource: any;
+    let mapView: any;
+    let sandbox: any;
+
+    before(function() {
+        sandbox = sinon.createSandbox();
+    });
+
+    beforeEach(function() {
+        stubDataSource = new TileTestStubDataSource({ name: "test-data-source" });
+        mapView = {
+            taskQueue: new TaskQueue({
+                groups: [TileTaskGroups.CREATE, TileTaskGroups.FETCH_AND_DECODE]
+            }),
+            projection: mercatorProjection,
+            frameNumber: 1
+        } as MapView;
+        stubDataSource.attach(mapView);
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
 
     it("set empty decoded tile forces hasGeometry to be true", function() {
         const tile = new Tile(stubDataSource, tileKey);
@@ -77,92 +120,96 @@ describe("Tile", function() {
         assert(tile.hasGeometry);
         expect(tile.decodedTile).to.be.equal(decodedTile);
     });
-    it("addTextElement to changed tile does not recreate text group", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        tile.addTextElement(createFakeTextElement());
 
-        const oldGroup = tile.textElementGroups.groups.values().next().value;
-        expect(oldGroup.elements).to.have.lengthOf(1);
+    describe("Text elements", function() {
+        it("addTextElement to changed tile does not recreate text group", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            tile.addTextElement(createFakeTextElement());
 
-        tile.addTextElement(createFakeTextElement());
-        const newGroup = tile.textElementGroups.groups.values().next().value;
-        expect(newGroup.elements).to.have.lengthOf(2);
-        expect(newGroup).to.equal(oldGroup);
+            const oldGroup = tile.textElementGroups.groups.values().next().value;
+            expect(oldGroup.elements).to.have.lengthOf(1);
+
+            tile.addTextElement(createFakeTextElement());
+            const newGroup = tile.textElementGroups.groups.values().next().value;
+            expect(newGroup.elements).to.have.lengthOf(2);
+            expect(newGroup).to.equal(oldGroup);
+        });
+
+        it("addTextElement to unchanged tile recreates text group", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            tile.addTextElement(createFakeTextElement());
+            tile.textElementsChanged = false;
+
+            const oldGroup = tile.textElementGroups.groups.values().next().value;
+            expect(oldGroup.elements).to.have.lengthOf(1);
+
+            tile.addTextElement(createFakeTextElement());
+            const newGroup = tile.textElementGroups.groups.values().next().value;
+            expect(newGroup.elements).to.have.lengthOf(2);
+            expect(newGroup).to.not.equal(oldGroup);
+            assert.isTrue(tile.textElementsChanged);
+        });
+
+        it("removeTextElement from changed tile does not recreate text group", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            tile.addTextElement(createFakeTextElement());
+            const textElement = createFakeTextElement();
+            tile.addTextElement(textElement);
+
+            const oldGroup = tile.textElementGroups.groups.values().next().value;
+            expect(oldGroup.elements).to.have.lengthOf(2);
+
+            const result = tile.removeTextElement(textElement);
+            assert.isTrue(result);
+
+            const newGroup = tile.textElementGroups.groups.values().next().value;
+            expect(newGroup.elements).to.have.lengthOf(1);
+            expect(newGroup).to.equal(oldGroup);
+        });
+
+        it("removeTextElement from unchanged tile recreates text group", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            tile.addTextElement(createFakeTextElement());
+            const textElement = createFakeTextElement();
+            tile.addTextElement(textElement);
+            tile.textElementsChanged = false;
+
+            const oldGroup = tile.textElementGroups.groups.values().next().value;
+            const result = tile.removeTextElement(textElement);
+            assert.isTrue(result);
+
+            const newGroup = tile.textElementGroups.groups.values().next().value;
+            expect(newGroup.elements).to.have.lengthOf(1);
+            expect(newGroup).to.not.equal(oldGroup);
+            assert.isTrue(tile.textElementsChanged);
+        });
+
+        it("clearTextElements from empty tile does nothing", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            assert.isFalse(tile.textElementsChanged);
+
+            tile.clearTextElements();
+            assert.isFalse(tile.textElementsChanged);
+
+            const textElement = createFakeTextElement();
+            tile.addTextElement(textElement);
+            tile.removeTextElement(textElement);
+            tile.clearTextElements();
+            assert.isTrue(tile.textElementsChanged);
+        });
+
+        it("clearTextElements from non-empty tile marks it as changed", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            tile.addTextElement(createFakeTextElement());
+            expect(tile.textElementGroups.count()).to.equal(1);
+            tile.textElementsChanged = false;
+
+            tile.clearTextElements();
+            expect(tile.textElementGroups.count()).to.equal(0);
+            assert.isTrue(tile.textElementsChanged);
+        });
     });
 
-    it("addTextElement to unchanged tile recreates text group", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        tile.addTextElement(createFakeTextElement());
-        tile.textElementsChanged = false;
-
-        const oldGroup = tile.textElementGroups.groups.values().next().value;
-        expect(oldGroup.elements).to.have.lengthOf(1);
-
-        tile.addTextElement(createFakeTextElement());
-        const newGroup = tile.textElementGroups.groups.values().next().value;
-        expect(newGroup.elements).to.have.lengthOf(2);
-        expect(newGroup).to.not.equal(oldGroup);
-        assert.isTrue(tile.textElementsChanged);
-    });
-
-    it("removeTextElement from changed tile does not recreate text group", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        tile.addTextElement(createFakeTextElement());
-        const textElement = createFakeTextElement();
-        tile.addTextElement(textElement);
-
-        const oldGroup = tile.textElementGroups.groups.values().next().value;
-        expect(oldGroup.elements).to.have.lengthOf(2);
-
-        const result = tile.removeTextElement(textElement);
-        assert.isTrue(result);
-
-        const newGroup = tile.textElementGroups.groups.values().next().value;
-        expect(newGroup.elements).to.have.lengthOf(1);
-        expect(newGroup).to.equal(oldGroup);
-    });
-
-    it("removeTextElement from unchanged tile recreates text group", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        tile.addTextElement(createFakeTextElement());
-        const textElement = createFakeTextElement();
-        tile.addTextElement(textElement);
-        tile.textElementsChanged = false;
-
-        const oldGroup = tile.textElementGroups.groups.values().next().value;
-        const result = tile.removeTextElement(textElement);
-        assert.isTrue(result);
-
-        const newGroup = tile.textElementGroups.groups.values().next().value;
-        expect(newGroup.elements).to.have.lengthOf(1);
-        expect(newGroup).to.not.equal(oldGroup);
-        assert.isTrue(tile.textElementsChanged);
-    });
-
-    it("clearTextElements from empty tile does nothing", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        assert.isFalse(tile.textElementsChanged);
-
-        tile.clearTextElements();
-        assert.isFalse(tile.textElementsChanged);
-
-        const textElement = createFakeTextElement();
-        tile.addTextElement(textElement);
-        tile.removeTextElement(textElement);
-        tile.clearTextElements();
-        assert.isTrue(tile.textElementsChanged);
-    });
-
-    it("clearTextElements from non-empty tile marks it as changed", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        tile.addTextElement(createFakeTextElement());
-        expect(tile.textElementGroups.count()).to.equal(1);
-        tile.textElementsChanged = false;
-
-        tile.clearTextElements();
-        expect(tile.textElementGroups.count()).to.equal(0);
-        assert.isTrue(tile.textElementsChanged);
-    });
     it("setting skipping will cause willRender to return false", function() {
         const tile = new Tile(stubDataSource, tileKey);
         tile.skipRendering = true;
@@ -171,109 +218,111 @@ describe("Tile", function() {
         expect(tile.willRender(0)).is.true;
     });
 
-    it("default tile min/max elevation and max geometry height are 0", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        const oldGeoBox = tile.geoBox.clone();
-        const oldBBox = tile.boundingBox.clone();
+    describe("Elevation", function() {
+        it("default tile min/max elevation and max geometry height are 0", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            const oldGeoBox = tile.geoBox.clone();
+            const oldBBox = tile.boundingBox.clone();
 
-        tile.decodedTile = { techniques: [], geometries: [] };
+            tile.decodedTile = { techniques: [], geometries: [] };
 
-        expect(tile.geoBox).deep.equals(oldGeoBox);
-        expect(tile.boundingBox).deep.equals(oldBBox);
-    });
+            expect(tile.geoBox).deep.equals(oldGeoBox);
+            expect(tile.boundingBox).deep.equals(oldBBox);
+        });
 
-    it("elevationRange setter does not elevate bbox if maxGeometryHeight is not set", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        const oldBBox = tile.boundingBox.clone();
+        it("elevationRange setter does not elevate bbox if maxGeometryHeight is not set", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            const oldBBox = tile.boundingBox.clone();
 
-        tile.elevationRange = { minElevation: 5, maxElevation: 10 };
+            tile.elevationRange = { minElevation: 5, maxElevation: 10 };
 
-        expect(tile.geoBox.minAltitude).equals(tile.elevationRange.minElevation);
-        expect(tile.geoBox.maxAltitude).equals(tile.elevationRange.maxElevation);
-        expect(tile.boundingBox).deep.equals(oldBBox);
+            expect(tile.geoBox.minAltitude).equals(tile.elevationRange.minElevation);
+            expect(tile.geoBox.maxAltitude).equals(tile.elevationRange.maxElevation);
+            expect(tile.boundingBox).deep.equals(oldBBox);
 
-        tile.decodedTile = { techniques: [], geometries: [], boundingBox: new OrientedBox3() };
+            tile.decodedTile = { techniques: [], geometries: [], boundingBox: new OrientedBox3() };
 
-        tile.elevationRange = { minElevation: 100, maxElevation: 500 };
-        expect(tile.boundingBox).deep.equals(tile.decodedTile.boundingBox);
-    });
+            tile.elevationRange = { minElevation: 100, maxElevation: 500 };
+            expect(tile.boundingBox).deep.equals(tile.decodedTile.boundingBox);
+        });
 
-    it("elevationRange setter elevates bbox if maxGeometryHeight is set", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        const minElevation = 30;
-        const maxElevation = 50;
-        const maxGeometryHeight = 100;
-        const expectedGeoBox = tile.geoBox.clone();
-        expectedGeoBox.southWest.altitude = minElevation;
-        expectedGeoBox.northEast.altitude = maxElevation + maxGeometryHeight;
-        const expectedBBox = new OrientedBox3();
-        stubDataSource.mapView.projection.projectBox(expectedGeoBox, expectedBBox);
+        it("elevationRange setter elevates bbox if maxGeometryHeight is set", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            const minElevation = 30;
+            const maxElevation = 50;
+            const maxGeometryHeight = 100;
+            const expectedGeoBox = tile.geoBox.clone();
+            expectedGeoBox.southWest.altitude = minElevation;
+            expectedGeoBox.northEast.altitude = maxElevation + maxGeometryHeight;
+            const expectedBBox = new OrientedBox3();
+            stubDataSource.mapView.projection.projectBox(expectedGeoBox, expectedBBox);
 
-        tile.decodedTile = { techniques: [], geometries: [], maxGeometryHeight };
-        tile.elevationRange = { minElevation, maxElevation };
+            tile.decodedTile = { techniques: [], geometries: [], maxGeometryHeight };
+            tile.elevationRange = { minElevation, maxElevation };
 
-        expect(tile.geoBox).deep.equals(expectedGeoBox);
-        expect(tile.boundingBox).deep.equals(expectedBBox);
-    });
+            expect(tile.geoBox).deep.equals(expectedGeoBox);
+            expect(tile.boundingBox).deep.equals(expectedBBox);
+        });
 
-    it("elevationRange setter elevates bbox if minGeometryHeight is set", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        const minElevation = 30;
-        const maxElevation = 50;
-        const minGeometryHeight = -100;
-        const expectedGeoBox = tile.geoBox.clone();
-        expectedGeoBox.southWest.altitude = minElevation + minGeometryHeight;
-        expectedGeoBox.northEast.altitude = maxElevation;
-        const expectedBBox = new OrientedBox3();
-        stubDataSource.mapView.projection.projectBox(expectedGeoBox, expectedBBox);
+        it("elevationRange setter elevates bbox if minGeometryHeight is set", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            const minElevation = 30;
+            const maxElevation = 50;
+            const minGeometryHeight = -100;
+            const expectedGeoBox = tile.geoBox.clone();
+            expectedGeoBox.southWest.altitude = minElevation + minGeometryHeight;
+            expectedGeoBox.northEast.altitude = maxElevation;
+            const expectedBBox = new OrientedBox3();
+            stubDataSource.mapView.projection.projectBox(expectedGeoBox, expectedBBox);
 
-        tile.decodedTile = { techniques: [], geometries: [], minGeometryHeight };
-        tile.elevationRange = { minElevation, maxElevation };
+            tile.decodedTile = { techniques: [], geometries: [], minGeometryHeight };
+            tile.elevationRange = { minElevation, maxElevation };
 
-        expect(tile.geoBox).deep.equals(expectedGeoBox);
-        expect(tile.boundingBox).deep.equals(expectedBBox);
-    });
+            expect(tile.geoBox).deep.equals(expectedGeoBox);
+            expect(tile.boundingBox).deep.equals(expectedBBox);
+        });
 
-    it("decodedTile setter sets decoded tile bbox if defined but does not elevate it", function() {
-        const key = new TileKey(5, 5, 5);
-        const tile = new Tile(stubDataSource, key);
-        const expectedGeoBox = tile.dataSource.getTilingScheme().getGeoBox(key);
-        expectedGeoBox.southWest.altitude = 500;
-        expectedGeoBox.northEast.altitude = 1000;
-        const expectedBBox = new OrientedBox3(
-            new THREE.Vector3(1, 2, 3),
-            new THREE.Matrix4(),
-            new THREE.Vector3(1, 1, 1)
-        );
+        it("decodedTile setter sets decoded tile bbox if defined but does not elevate it", function() {
+            const key = new TileKey(5, 5, 5);
+            const tile = new Tile(stubDataSource, key);
+            const expectedGeoBox = tile.dataSource.getTilingScheme().getGeoBox(key);
+            expectedGeoBox.southWest.altitude = 500;
+            expectedGeoBox.northEast.altitude = 1000;
+            const expectedBBox = new OrientedBox3(
+                new THREE.Vector3(1, 2, 3),
+                new THREE.Matrix4(),
+                new THREE.Vector3(1, 1, 1)
+            );
 
-        tile.elevationRange = { minElevation: 500, maxElevation: 1000 };
-        tile.decodedTile = {
-            techniques: [],
-            geometries: [],
-            boundingBox: expectedBBox,
-            maxGeometryHeight: 10
-        };
+            tile.elevationRange = { minElevation: 500, maxElevation: 1000 };
+            tile.decodedTile = {
+                techniques: [],
+                geometries: [],
+                boundingBox: expectedBBox,
+                maxGeometryHeight: 10
+            };
 
-        expect(tile.geoBox).deep.equals(expectedGeoBox);
-        expect(tile.boundingBox).deep.equals(expectedBBox);
-    });
+            expect(tile.geoBox).deep.equals(expectedGeoBox);
+            expect(tile.boundingBox).deep.equals(expectedBBox);
+        });
 
-    it("decodedTile setter elevates bbox with decoded maxGeometryHeight if defined", function() {
-        const tile = new Tile(stubDataSource, tileKey);
-        const minElevation = 500;
-        const maxElevation = 1000;
-        const maxGeometryHeight = 10;
-        const expectedGeoBox = tile.geoBox.clone();
-        expectedGeoBox.southWest.altitude = minElevation;
-        expectedGeoBox.northEast.altitude = maxElevation + maxGeometryHeight;
-        const expectedBBox = new OrientedBox3();
-        stubDataSource.mapView.projection.projectBox(expectedGeoBox, expectedBBox);
+        it("decodedTile setter elevates bbox with decoded maxGeometryHeight if defined", function() {
+            const tile = new Tile(stubDataSource, tileKey);
+            const minElevation = 500;
+            const maxElevation = 1000;
+            const maxGeometryHeight = 10;
+            const expectedGeoBox = tile.geoBox.clone();
+            expectedGeoBox.southWest.altitude = minElevation;
+            expectedGeoBox.northEast.altitude = maxElevation + maxGeometryHeight;
+            const expectedBBox = new OrientedBox3();
+            stubDataSource.mapView.projection.projectBox(expectedGeoBox, expectedBBox);
 
-        tile.elevationRange = { minElevation, maxElevation };
-        tile.decodedTile = { techniques: [], geometries: [], maxGeometryHeight };
+            tile.elevationRange = { minElevation, maxElevation };
+            tile.decodedTile = { techniques: [], geometries: [], maxGeometryHeight };
 
-        expect(tile.geoBox).deep.equals(expectedGeoBox);
-        expect(tile.boundingBox).deep.equals(expectedBBox);
+            expect(tile.geoBox).deep.equals(expectedGeoBox);
+            expect(tile.boundingBox).deep.equals(expectedBBox);
+        });
     });
 
     it("doesnt throw on isVisble if not attached to a MapView", function() {
@@ -285,5 +334,63 @@ describe("Tile", function() {
         stubDataSource.detach(mapView as MapView);
         expect(tile.isVisible).not.throw;
         expect(tile.isVisible).is.false;
+    });
+
+    describe("updateGeometry", function() {
+        it("returns false immediately if tile does not use geometry loader", function() {
+            stubDataSource.useGeometryLoader = false;
+            const tile = stubDataSource.getTile(tileKey);
+            expect(tile.updateGeometry()).be.false;
+        });
+
+        it("does not update geometry loader if tile loader is not done", function() {
+            stubDataSource.useGeometryLoader = true;
+            const tile = stubDataSource.getTile(tileKey);
+            const geometryLoader = (tile as any).m_tileGeometryLoader;
+            (tile.tileLoader as FakeTileLoader).isFinished = false;
+            const updateSpy: sinon.SinonSpy = sandbox.spy(geometryLoader, "update");
+
+            expect(tile.updateGeometry()).be.true;
+            expect(updateSpy.called).be.false;
+        });
+
+        it("finishes geometry loader if decoded tile is empty", function() {
+            stubDataSource.useGeometryLoader = true;
+            const tile = stubDataSource.getTile(tileKey);
+            const geometryLoader: TileGeometryLoader = (tile as any).m_tileGeometryLoader;
+            (tile.tileLoader as FakeTileLoader).isFinished = true;
+            const updateSpy: sinon.SinonSpy = sandbox.spy(geometryLoader, "update");
+
+            expect(tile.updateGeometry()).be.true;
+            expect(updateSpy.called).be.false;
+            expect(geometryLoader.isFinished).be.true;
+        });
+
+        it("cancels geometry loader for invisible tile", function() {
+            stubDataSource.useGeometryLoader = true;
+            const tile = stubDataSource.getTile(tileKey);
+            const geometryLoader = (tile as any).m_tileGeometryLoader;
+            (tile.tileLoader as FakeTileLoader).isFinished = true;
+            tile.decodedTile = { techniques: [], geometries: [] };
+            tile.isVisible = false;
+            const updateSpy: sinon.SinonSpy = sandbox.spy(geometryLoader, "update");
+            const cancelSpy: sinon.SinonSpy = sandbox.spy(geometryLoader, "cancel");
+
+            expect(tile.updateGeometry()).be.true;
+            expect(cancelSpy.called).be.true;
+            expect(updateSpy.called).be.false;
+        });
+
+        it("does not update geometry loader for disposed tile", function() {
+            stubDataSource.useGeometryLoader = true;
+            const tile = stubDataSource.getTile(tileKey);
+            const geometryLoader = (tile as any).m_tileGeometryLoader;
+            (tile.tileLoader as FakeTileLoader).isFinished = true;
+            tile.dispose();
+            const updateSpy: sinon.SinonSpy = sandbox.spy(geometryLoader, "update");
+
+            expect(tile.updateGeometry()).be.true;
+            expect(updateSpy.called).be.false;
+        });
     });
 });


### PR DESCRIPTION
A Tile subclass may still need access (e.g. to attach callbacks to the finished promise).

Also, fix uncaught promised exception when a tile is disposed
before it waits on the TileGeometryDecoder promise.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
