### PR TITLE
HARP-12342: Fix rendering strings with control characters

### DIFF
--- a/@here/harp-text-canvas/lib/rendering/FontCatalog.ts
+++ b/@here/harp-text-canvas/lib/rendering/FontCatalog.ts
@@ -3,10 +3,10 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as THREE from "three";
 
 import { MemoryUsage } from "../TextCanvas";
+import { UnicodeUtils } from "../utils/UnicodeUtils";
 import { GlyphData } from "./GlyphData";
 import { GlyphTextureCache } from "./GlyphTextureCache";
 import { FontStyle, FontVariant, TextRenderStyle } from "./TextStyle";
@@ -544,6 +544,8 @@ export class FontCatalog {
         (replacementGlyph as any).codePoint = codePoint;
         (replacementGlyph as any).character = char;
         (replacementGlyph as any).font = font;
+        // Glyphs for ASCII control characters and such are not really replacement glyphs.
+        (replacementGlyph as any).isReplacement = UnicodeUtils.isPrintable(codePoint);
         return replacementGlyph;
     }
 

--- a/@here/harp-text-canvas/test/rendering/TextCanvasRenderingTest.ts
+++ b/@here/harp-text-canvas/test/rendering/TextCanvasRenderingTest.ts
@@ -119,7 +119,6 @@ describe("TextCanvas", function() {
                     }
                 });
                 await fontCatalog.loadCharset("ß\n", renderingStyle);
-                fontCatalog.showReplacementGlyphs = true;
                 textCanvas.textRenderStyle = renderingStyle;
                 textCanvas.textLayoutStyle = new TextLayoutStyle({
                     horizontalAlignment: HorizontalAlignment.Center
@@ -153,7 +152,6 @@ describe("TextCanvas", function() {
                     }
                 });
                 await fontCatalog.loadCharset("ß-\n", renderingStyle);
-                fontCatalog.showReplacementGlyphs = true;
                 textCanvas.textRenderStyle = renderingStyle;
                 textCanvas.textLayoutStyle = new TextLayoutStyle({
                     horizontalAlignment: HorizontalAlignment.Center


### PR DESCRIPTION
* non-rendered control characters are not replacement glyphs

Signed-off-by: StefanDachwitz <stefan.dachwitz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
