### PR TITLE
HARP-11899: Cull only labels that are completely off screen

### DIFF
--- a/@here/harp-mapview/lib/ScreenProjector.ts
+++ b/@here/harp-mapview/lib/ScreenProjector.ts
@@ -16,6 +16,15 @@ function isOnScreen(ndc: THREE.Vector3) {
 }
 
 /**
+ * Determines whether a position in NDC (Normalized Device Coordinates) is between the near
+ * and far plane.
+ * @param ndc - The position to check.
+ */
+function isInRange(ndc: THREE.Vector3) {
+    return ndc.z > -1 && ndc.z < 1;
+}
+
+/**
  * @hidden
  * Handles the projection of world coordinates to screen coordinates.
  */
@@ -70,14 +79,14 @@ export class ScreenProjector {
      * @param {(Vector3Like)} source The source vector to project.
      * @param {THREE.Vector2} target The target vector.
      * @returns {THREE.Vector2} The projected vector (the parameter 'target') or undefined if
-     * outside the screen.
+     * outside of the near/far plane. The point may be outside the screen.
      */
-    projectOnScreen(
+    projectToScreen(
         source: Vector3Like,
         target: THREE.Vector2 = new THREE.Vector2()
     ): THREE.Vector2 | undefined {
         const p = this.projectVector(source, ScreenProjector.tempV3);
-        if (isOnScreen(p)) {
+        if (isInRange(p)) {
             return this.ndcToScreen(p, target);
         }
         return undefined;

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -442,7 +442,8 @@ export class PoiRenderer {
     }
 
     /**
-     * Render the icon.
+     * Render the icon. Icon will only be rendered if opacity > 0, otherwise only its space will be
+     * allocated.
      *
      * @param poiInfo - PoiInfo containing information for rendering the POI icon.
      * @param screenPosition - Position on screen (2D):
@@ -451,6 +452,7 @@ export class PoiRenderer {
      * @param scale - Scaling factor to apply to text and icon.
      * @param allocateScreenSpace - If `true` screen space will be allocated for the icon.
      * @param opacity - Opacity of icon to allow fade in/out.
+     * @returns - `true` if icon has been actually rendered, `false` otherwise.
      */
     renderPoi(
         poiInfo: PoiInfo,
@@ -461,7 +463,7 @@ export class PoiRenderer {
         allocateScreenSpace: boolean,
         opacity: number,
         env: Env
-    ): void {
+    ): boolean {
         assert(poiInfo.poiRenderBatch !== undefined);
 
         PoiRenderer.computeIconScreenBox(poiInfo, screenPosition, scale, env, this.m_tempScreenBox);
@@ -470,7 +472,11 @@ export class PoiRenderer {
             screenCollisions.allocate(this.m_tempScreenBox);
         }
 
-        this.m_renderBuffer.addPoi(poiInfo, this.m_tempScreenBox, viewDistance, opacity);
+        if (opacity > 0) {
+            this.m_renderBuffer.addPoi(poiInfo, this.m_tempScreenBox, viewDistance, opacity);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -454,7 +454,6 @@ export function placePointLabel(
             textCanvas,
             env,
             screenCollisions,
-            isRejected,
             outScreenPosition
         );
     }
@@ -536,7 +535,6 @@ function placePointLabelChoosingAnchor(
             textCanvas,
             env,
             screenCollisions,
-            false,
             !isLastPlacement,
             outScreenPosition
         );
@@ -609,7 +607,6 @@ function placePointLabelAtCurrentAnchor(
     textCanvas: TextCanvas,
     env: Env,
     screenCollisions: ScreenCollisions,
-    isRejected: boolean,
     outScreenPosition: THREE.Vector3
 ): PlacementResult {
     assert(labelState.element.layoutStyle !== undefined);
@@ -624,7 +621,6 @@ function placePointLabelAtCurrentAnchor(
         textCanvas,
         env,
         screenCollisions,
-        isRejected,
         !labelState.visible,
         outScreenPosition
     );
@@ -663,7 +659,6 @@ function placePointLabelAtAnchor(
     textCanvas: TextCanvas,
     env: Env,
     screenCollisions: ScreenCollisions,
-    isRejected: boolean,
     forceInvalidation: boolean,
     outScreenPosition: THREE.Vector3
 ): PlacementResult {
@@ -696,11 +691,6 @@ function placePointLabelAtAnchor(
     // Update output screen position.
     outScreenPosition.set(textOffset.x, textOffset.y, labelState.renderDistance);
 
-    // Check if icon's label was already rejected.
-    if (isRejected) {
-        return PlacementResult.Rejected;
-    }
-
     tmpBox.copy(label.bounds!);
     // Apply additional persistent margin, keep in mind that text bounds just calculated
     // are not (0, 0, w, h) based, so their coords usually are also non-zero.
@@ -713,6 +703,12 @@ function placePointLabelAtAnchor(
 
     tmpSize.multiplyScalar(scale);
     tmp2DBox.set(tmpCenter.x - tmpSize.x / 2, tmpCenter.y - tmpSize.y / 2, tmpSize.x, tmpSize.y);
+
+    // Check the text visibility if invisible finish immediately
+    // regardless of the persistence state - no fading required.
+    if (!screenCollisions.isVisible(tmp2DBox)) {
+        return PlacementResult.Invisible;
+    }
 
     // Save original bounds for visibility check
     tmp2DBox2.copy(tmp2DBox);

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -428,7 +428,6 @@ export function placePointLabel(
     textCanvas: TextCanvas,
     env: Env,
     screenCollisions: ScreenCollisions,
-    isRejected: boolean,
     outScreenPosition: THREE.Vector3,
     multiAnchor: boolean = false
 ): PlacementResult {
@@ -436,16 +435,11 @@ export function placePointLabel(
 
     const layoutStyle = labelState.element.layoutStyle!;
 
-    // For the new labels with rejected icons we don't need to go further.
-    const newLabel = !labelState.visible;
-    if (isRejected && newLabel) {
-        return PlacementResult.Rejected;
-    }
     // Check if alternative placements have been provided.
     multiAnchor =
         multiAnchor && layoutStyle.placements !== undefined && layoutStyle.placements.length > 1;
     // For single placement labels or labels with icon rejected, do only current anchor testing.
-    if (!multiAnchor || isRejected) {
+    if (!multiAnchor) {
         return placePointLabelAtCurrentAnchor(
             labelState,
             screenPosition,

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -348,7 +348,6 @@ const tmpCollisionBox = new CollisionBox();
 const tmpScreenPosition = new THREE.Vector2();
 const tmpTextOffset = new THREE.Vector2();
 const tmp2DBox = new Math2D.Box();
-const tmp2DBox2 = new Math2D.Box();
 const tmpCenter = new THREE.Vector2();
 const tmpSize = new THREE.Vector2();
 
@@ -710,9 +709,6 @@ function placePointLabelAtAnchor(
         return PlacementResult.Invisible;
     }
 
-    // Save original bounds for visibility check
-    tmp2DBox2.copy(tmp2DBox);
-
     if (measureText) {
         // Up-scaled label bounds are used only for new labels and only for collision check, this
         // is intentional to avoid processing labels out of the screen due to increased bounds,
@@ -734,32 +730,27 @@ function placePointLabelAtAnchor(
         return PlacementResult.Rejected;
     }
 
-    // Visibility check with non-enlarged bounds
-    if (screenCollisions.isVisible(tmp2DBox2)) {
-        // Don't allocate space for rejected text. When zooming, this allows placement of a
-        // lower priority text element that was displaced by a higher priority one (not
-        // present in the new zoom level) before an even lower priority one takes the space.
-        // Otherwise the lowest priority text will fade in and back out.
-        // TODO: Add a unit test for this scenario.
-        if (label.textReservesSpace) {
-            screenCollisions.allocate(tmp2DBox);
-        }
-
-        // Glyphs arrangement have been changed remove text buffer object which needs to be
-        // re-created.
-        if (measureText) {
-            label.textBufferObject = undefined;
-        }
-
-        // Save current placement in label state.
-        // TextElementState creates layout snapshot solely for alternative placements which saves
-        // memory that could be wasted on unnecessary objects construction.
-        labelState.textPlacement = placement;
-
-        return PlacementResult.Ok;
+    // Don't allocate space for rejected text. When zooming, this allows placement of a
+    // lower priority text element that was displaced by a higher priority one (not
+    // present in the new zoom level) before an even lower priority one takes the space.
+    // Otherwise the lowest priority text will fade in and back out.
+    // TODO: Add a unit test for this scenario.
+    if (label.textReservesSpace) {
+        screenCollisions.allocate(tmp2DBox);
     }
 
-    return PlacementResult.Invisible;
+    // Glyphs arrangement have been changed remove text buffer object which needs to be
+    // re-created.
+    if (measureText) {
+        label.textBufferObject = undefined;
+    }
+
+    // Save current placement in label state.
+    // TextElementState creates layout snapshot solely for alternative placements which saves
+    // memory that could be wasted on unnecessary objects construction.
+    labelState.textPlacement = placement;
+
+    return PlacementResult.Ok;
 }
 
 /**

--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -113,10 +113,15 @@ export class RenderState {
     }
 
     /**
-     * @returns `true` if state is neither faded out nor undefined.
+     * @returns `true` if state is neither faded out nor undefined and the opacity is larger
+     * than 0.
      */
     isVisible(): boolean {
-        return this.m_state !== FadingState.FadedOut && this.m_state !== FadingState.Undefined;
+        return (
+            this.m_state !== FadingState.FadedOut &&
+            this.m_state !== FadingState.Undefined &&
+            this.opacity > 0
+        );
     }
 
     /**

--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -162,13 +162,17 @@ export class RenderState {
 
     /**
      * Updates the state to [[FadingState.FadingOut]].
-     * If previous state is [[FadingState.FadingOut]] or [[FadingState.FadedOut]] it remains
-     * unchanged.
+     * If previous state is [[FadingState.FadingOut]], [[FadingState.FadedOut]] or
+     * [[FadingState.Undefined]] it remains unchanged.
      *
      * @param time - Current time.
      */
     startFadeOut(time: number) {
-        if (this.m_state === FadingState.FadingOut || this.m_state === FadingState.FadedOut) {
+        if (
+            this.m_state === FadingState.FadingOut ||
+            this.m_state === FadingState.FadedOut ||
+            this.m_state === FadingState.Undefined
+        ) {
             return;
         }
 

--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -43,7 +43,7 @@ export class RenderState {
     /**
      * Computed opacity depending on value.
      */
-    opacity: number = 1.0;
+    opacity: number = 0.0;
 
     private m_state = FadingState.Undefined;
 
@@ -61,7 +61,7 @@ export class RenderState {
         this.m_state = FadingState.Undefined;
         this.value = 0.0;
         this.startTime = 0.0;
-        this.opacity = 1.0;
+        this.opacity = 0.0;
     }
 
     /**

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -115,7 +115,7 @@ export interface PoiInfo {
 
     /**
      * If isValid is `false`, the icon will no longer be placed or rendered. The reason may be a
-     * missing resource.
+     * missing resource. Defaults to `false`.
      */
     isValid?: boolean;
 
@@ -131,7 +131,7 @@ export interface PoiInfo {
 
     /**
      * @hidden
-     * If false, text will not be rendered during camera movements. Defaults to `true`;
+     * If false, text will not be rendered during camera movements. Defaults to `true`.
      */
     renderTextDuringMovements?: boolean;
 

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1628,6 +1628,9 @@ export class TextElementsRenderer {
             );
             iconInvisible = result === PlacementResult.Invisible;
             iconRejected = result === PlacementResult.Rejected;
+            if (iconInvisible) {
+                iconRenderState.reset();
+            }
         } else if (renderIcon && poiInfo!.isValid !== false) {
             // Ensure that text elements still loading icons get a chance to be rendered if
             // there are no text element updates in the next frames.
@@ -1657,7 +1660,8 @@ export class TextElementsRenderer {
                 tempPosition,
                 iconIndex === undefined
             );
-            if (placeResult === PlacementResult.Invisible) {
+            const textInvisible = placeResult === PlacementResult.Invisible;
+            if (textInvisible) {
                 if (placementStats) {
                     placementStats.numPoiTextsInvisible++;
                 }
@@ -1665,6 +1669,7 @@ export class TextElementsRenderer {
                     labelState.reset();
                     return false;
                 }
+                textRenderState!.reset();
             }
 
             const textRejected = placeResult === PlacementResult.Rejected;
@@ -1679,8 +1684,9 @@ export class TextElementsRenderer {
             }
 
             const textNeedsDraw =
-                (!textRejected && shouldRenderPoiText(labelState, this.m_viewState)) ||
-                textRenderState!.isFading();
+                !textInvisible &&
+                ((!textRejected && shouldRenderPoiText(labelState, this.m_viewState)) ||
+                    textRenderState!.isFading());
 
             if (textNeedsDraw) {
                 if (!textRejected) {
@@ -1705,13 +1711,7 @@ export class TextElementsRenderer {
         // ... and render the icon (if any).
         if (iconReady && !iconInvisible) {
             if (iconRejected) {
-                if (iconRenderState.isVisible()) {
-                    iconRenderState.startFadeOut(renderParams.time);
-                } else if (!iconRenderState.isFadingOut()) {
-                    // Reset the icon and keep it from popping up before fading in.
-                    iconRenderState.reset();
-                    iconRenderState.opacity = 0;
-                }
+                iconRenderState.startFadeOut(renderParams.time);
             } else {
                 iconRenderState!.startFadeIn(renderParams.time, this.m_options.disableFading);
             }

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1678,10 +1678,9 @@ export class TextElementsRenderer {
             }
 
             const iconIsRequired = !(poiInfo?.iconIsOptional === false);
-            const iconIsReady = poiInfo?.isValid === true;
             // Rejected icons are only considered to hide the text if they are valid, so a missing icon image will
             // not keep the text from showing up.
-            const requiredIconRejected: boolean = iconRejected && iconIsReady && iconIsRequired;
+            const requiredIconRejected: boolean = iconRejected && iconReady && iconIsRequired;
 
             const textRejected = requiredIconRejected || placeResult === PlacementResult.Rejected;
             if (!iconRejected && !iconInvisible) {

--- a/@here/harp-mapview/test/PlacementTest.ts
+++ b/@here/harp-mapview/test/PlacementTest.ts
@@ -1003,7 +1003,9 @@ describe("Placement", function() {
                             // Update its fading.
                             state.textRenderState?.startFadeIn(1);
                             // Labels gets persistent state - requires fading to start.
-                            expect(state.visible).to.be.true;
+                            expect(state.visible).to.be.false;
+                            expect(state.textRenderState!.isFadingIn()).to.be.true;
+                            expect(state.textRenderState!.opacity).to.equal(0);
                         }
                         // Cleanup screen for next frame
                         screenCollisions.reset();
@@ -1059,10 +1061,9 @@ describe("Placement", function() {
                     expect(inPositions[i].x).to.equal(outPositions[i].x + marginX);
                     expect(inPositions[i].y).to.equal(outPositions[i].y - marginY);
                 }
-                // First element allocated, second collides, because it's a new label
-                // it retrieves PlacementResult.Invisible status.
+                // First element allocated, second collides.
                 expect(results[0]).to.equal(PlacementResult.Ok);
-                expect(results[1]).to.equal(PlacementResult.Invisible);
+                expect(results[1]).to.equal(PlacementResult.Rejected);
 
                 // Cleanup screen for next frame
                 screenCollisions.reset();
@@ -1146,9 +1147,8 @@ describe("Placement", function() {
                 }
                 // First element allocated, second collides, without alternative placement,
                 // centered labels are not handled with multi-anchor placement.
-                // Because it's a new label it retrieves PlacementResult.Invisible status.
                 expect(results[0]).to.equal(PlacementResult.Ok);
-                expect(results[1]).to.equal(PlacementResult.Invisible);
+                expect(results[1]).to.equal(PlacementResult.Rejected);
             });
 
             it("place two approaching texts", async function() {
@@ -1207,8 +1207,12 @@ describe("Placement", function() {
                 states[0].textRenderState?.startFadeIn(1);
                 states[1].textRenderState?.startFadeIn(1);
                 // Labels gets persistent state.
-                expect(states[0].visible).to.be.true;
-                expect(states[1].visible).to.be.true;
+                expect(states[0].visible).to.be.false;
+                expect(states[1].visible).to.be.false;
+                expect(states[0].textRenderState!.isFadingIn()).to.be.true;
+                expect(states[0].textRenderState!.opacity).to.equal(0);
+                expect(states[1].textRenderState!.isFadingIn()).to.be.true;
+                expect(states[1].textRenderState!.opacity).to.equal(0);
 
                 // Cleanup for the next - approaching frame.
                 screenCollisions.reset();

--- a/@here/harp-mapview/test/PlacementTest.ts
+++ b/@here/harp-mapview/test/PlacementTest.ts
@@ -367,7 +367,6 @@ describe("Placement", function() {
                         textCanvas,
                         new Env(),
                         screenCollisions,
-                        false,
                         outPosition
                     );
 
@@ -404,7 +403,6 @@ describe("Placement", function() {
                     textCanvas,
                     new Env(),
                     screenCollisions,
-                    false,
                     position
                 );
 
@@ -438,7 +436,6 @@ describe("Placement", function() {
                     textCanvas,
                     new Env(),
                     screenCollisions,
-                    false,
                     position
                 );
 
@@ -472,7 +469,6 @@ describe("Placement", function() {
                     textCanvas,
                     new Env(),
                     screenCollisions,
-                    false,
                     position
                 );
 
@@ -509,7 +505,6 @@ describe("Placement", function() {
                     textCanvas,
                     new Env(),
                     screenCollisions,
-                    false,
                     position
                 );
 
@@ -546,7 +541,6 @@ describe("Placement", function() {
                     textCanvas,
                     new Env(),
                     screenCollisions,
-                    false,
                     position
                 );
 
@@ -738,7 +732,6 @@ describe("Placement", function() {
                         textCanvas,
                         new Env(),
                         screenCollisions,
-                        false,
                         outPosition,
                         false
                     );
@@ -763,7 +756,6 @@ describe("Placement", function() {
                         textCanvas,
                         new Env(),
                         screenCollisions,
-                        false,
                         outPosition,
                         true
                     );
@@ -962,7 +954,6 @@ describe("Placement", function() {
                         textCanvas,
                         new Env(),
                         screenCollisions,
-                        false,
                         outPosition,
                         false
                     );
@@ -986,7 +977,6 @@ describe("Placement", function() {
                             textCanvas,
                             new Env(),
                             screenCollisions,
-                            false,
                             outPosition,
                             true
                         );
@@ -1052,7 +1042,6 @@ describe("Placement", function() {
                         textCanvas,
                         env,
                         screenCollisions,
-                        false,
                         outPositions[i]
                     );
                     const textPlacement = states[i].textPlacement;
@@ -1079,7 +1068,6 @@ describe("Placement", function() {
                         textCanvas,
                         env,
                         screenCollisions,
-                        false,
                         outPositions[i],
                         true
                     );
@@ -1136,7 +1124,6 @@ describe("Placement", function() {
                         textCanvas,
                         env,
                         screenCollisions,
-                        false,
                         outPositions[i],
                         true
                     );
@@ -1188,7 +1175,6 @@ describe("Placement", function() {
                         textCanvas,
                         env,
                         screenCollisions,
-                        false,
                         outPositions[i],
                         false
                     );
@@ -1231,7 +1217,6 @@ describe("Placement", function() {
                         textCanvas,
                         env,
                         screenCollisions,
-                        false,
                         outPositions[i],
                         true
                     );
@@ -1274,7 +1259,6 @@ describe("Placement", function() {
                         textCanvas,
                         env,
                         screenCollisions,
-                        false,
                         outPositions[i],
                         true
                     );

--- a/@here/harp-mapview/test/PoiInfoBuilder.ts
+++ b/@here/harp-mapview/test/PoiInfoBuilder.ts
@@ -34,11 +34,11 @@ export class PoiInfoBuilder {
     private readonly m_iconMaxZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MAX_ZL;
     private readonly m_textMinZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MIN_ZL;
     private readonly m_textMaxZl: number = PoiInfoBuilder.DEF_ICON_TEXT_MAX_ZL;
-    private readonly m_textOpt: boolean = PoiInfoBuilder.DEF_TEXT_OPT;
-    private readonly m_iconOpt: boolean = PoiInfoBuilder.DEF_ICON_OPT;
+    private m_textOpt: boolean = PoiInfoBuilder.DEF_TEXT_OPT;
+    private m_iconOpt: boolean = PoiInfoBuilder.DEF_ICON_OPT;
     private m_mayOverlap: boolean = PoiInfoBuilder.DEF_MAY_OVERLAP;
     private readonly m_reserveSpace: boolean = PoiInfoBuilder.DEF_RESERVE_SPACE;
-    private readonly m_valid: boolean = PoiInfoBuilder.DEF_VALID;
+    private m_valid: boolean = PoiInfoBuilder.DEF_VALID;
     private readonly m_renderOnMove: boolean = PoiInfoBuilder.DEF_RENDER_ON_MOVE;
     private readonly m_width: number = PoiInfoBuilder.DEF_WIDTH_HEIGHT;
     private readonly m_height: number = PoiInfoBuilder.DEF_WIDTH_HEIGHT;
@@ -62,6 +62,21 @@ export class PoiInfoBuilder {
 
     withMayOverlap(mayOverlap: boolean): PoiInfoBuilder {
         this.m_mayOverlap = mayOverlap;
+        return this;
+    }
+
+    withIconOptional(iconOptional: boolean): PoiInfoBuilder {
+        this.m_iconOpt = iconOptional;
+        return this;
+    }
+
+    withIconValid(iconValid: boolean): PoiInfoBuilder {
+        this.m_valid = iconValid;
+        return this;
+    }
+
+    withTextOptional(textOptional: boolean): PoiInfoBuilder {
+        this.m_textOpt = textOptional;
         return this;
     }
 

--- a/@here/harp-mapview/test/RenderStateTest.ts
+++ b/@here/harp-mapview/test/RenderStateTest.ts
@@ -35,7 +35,7 @@ describe("RenderState", function() {
             expect(renderState.isUndefined()).to.be.true;
             expect(renderState.value).to.equal(0.0);
             expect(renderState.startTime).to.equal(0.0);
-            expect(renderState.opacity).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
         });
 
         it("resets a fading in render state", function() {
@@ -48,7 +48,7 @@ describe("RenderState", function() {
             expect(renderState.isUndefined()).to.be.true;
             expect(renderState.value).to.equal(0.0);
             expect(renderState.startTime).to.equal(0.0);
-            expect(renderState.opacity).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
         });
     });
 
@@ -143,8 +143,9 @@ describe("RenderState", function() {
     });
 
     describe("isVisible", function() {
-        it("returns true if render states are not undefined or faded out", function() {
+        it("returns true if render states are not undefined or faded out, and opacity > 0", function() {
             const renderState = new RenderState();
+            renderState.opacity = 0.5;
             expect(renderState.isVisible()).to.be.false;
             (renderState as any).m_state = FadingState.FadingIn;
             expect(renderState.isVisible()).to.be.true;
@@ -152,6 +153,19 @@ describe("RenderState", function() {
             expect(renderState.isVisible()).to.be.true;
             (renderState as any).m_state = FadingState.FadingOut;
             expect(renderState.isVisible()).to.be.true;
+            (renderState as any).m_state = FadingState.FadedOut;
+            expect(renderState.isVisible()).to.be.false;
+        });
+
+        it("returns false if render states are not undefined or faded out and opacity is 0", function() {
+            const renderState = new RenderState();
+            expect(renderState.isVisible()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingIn;
+            expect(renderState.isVisible()).to.be.false;
+            (renderState as any).m_state = FadingState.FadedIn;
+            expect(renderState.isVisible()).to.be.false;
+            (renderState as any).m_state = FadingState.FadingOut;
+            expect(renderState.isVisible()).to.be.false;
             (renderState as any).m_state = FadingState.FadedOut;
             expect(renderState.isVisible()).to.be.false;
         });
@@ -241,7 +255,7 @@ describe("RenderState", function() {
             expect(renderState.isFadingOut()).to.be.false;
             expect(renderState.startTime).to.equal(0);
             expect(renderState.value).to.equal(0.0);
-            expect(renderState.opacity).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
         });
 
         it("does not change an already fading out state", function() {
@@ -310,7 +324,7 @@ describe("RenderState", function() {
             expect(renderState.isUndefined()).to.be.true;
             expect(renderState.startTime).to.equal(0);
             expect(renderState.value).to.equal(0.0);
-            expect(renderState.opacity).to.equal(1.0);
+            expect(renderState.opacity).to.equal(0.0);
         });
 
         it("does not update faded in states", function() {

--- a/@here/harp-mapview/test/RenderStateTest.ts
+++ b/@here/harp-mapview/test/RenderStateTest.ts
@@ -238,14 +238,15 @@ describe("RenderState", function() {
             const renderState = new RenderState();
             renderState.startFadeOut(100);
 
-            expect(renderState.isFadingOut()).to.be.true;
-            expect(renderState.startTime).to.equal(100);
+            expect(renderState.isFadingOut()).to.be.false;
+            expect(renderState.startTime).to.equal(0);
             expect(renderState.value).to.equal(0.0);
             expect(renderState.opacity).to.equal(1.0);
         });
 
         it("does not change an already fading out state", function() {
             const renderState = new RenderState();
+            renderState.startFadeIn(100, true);
             renderState.startFadeOut(100);
             renderState.startFadeOut(200);
 
@@ -377,6 +378,7 @@ describe("RenderState", function() {
 
         it("updates fading out states", function() {
             const renderState = new RenderState();
+            renderState.startFadeIn(100, false);
             renderState.startFadeOut(100);
             renderState.updateFading(200, false);
 
@@ -388,6 +390,7 @@ describe("RenderState", function() {
 
         it("switches to faded out after fading time passed", function() {
             const renderState = new RenderState();
+            renderState.startFadeIn(100, false);
             renderState.startFadeOut(100);
             renderState.updateFading(100 + DEFAULT_FADE_TIME, false);
 
@@ -399,6 +402,7 @@ describe("RenderState", function() {
 
         it("skips fading out when fading is disabled", function() {
             const renderState = new RenderState();
+            renderState.startFadeIn(100, false);
             renderState.startFadeOut(100);
             renderState.updateFading(200, true);
 

--- a/@here/harp-mapview/test/ScreenProjectorTest.ts
+++ b/@here/harp-mapview/test/ScreenProjectorTest.ts
@@ -63,7 +63,7 @@ describe("ScreenProjector", () => {
         });
     });
 
-    describe("projectOnScreen", () => {
+    describe("projectToScreen", () => {
         let result: THREE.Vector2;
         const halfScreenSize: number = screenSize / 2;
 
@@ -86,46 +86,49 @@ describe("ScreenProjector", () => {
 
         it("returns projected vector for coordinates within frustum", () => {
             assert.exists(
-                sp.projectOnScreen(new THREE.Vector3(-halfScreenSize + eps, 0, -near - eps), result)
+                sp.projectToScreen(new THREE.Vector3(-halfScreenSize + eps, 0, -near - eps), result)
             );
             expect(result).not.deep.equal(new THREE.Vector2());
             assert.exists(
-                sp.projectOnScreen(new THREE.Vector3(halfScreenSize - eps, 0, -far + eps), result)
+                sp.projectToScreen(new THREE.Vector3(halfScreenSize - eps, 0, -far + eps), result)
             );
         });
 
         it("returns projected vector for coordinates within near/far planes on other frustum\
         planes", () => {
             assert.exists(
-                sp.projectOnScreen(
+                sp.projectToScreen(
                     new THREE.Vector3(-halfScreenSize, halfScreenSize, -near - eps),
                     result
                 )
             );
             expect(result).not.deep.equal(new THREE.Vector2());
             assert.exists(
-                sp.projectOnScreen(
+                sp.projectToScreen(
                     new THREE.Vector3(halfScreenSize, -halfScreenSize, -far + eps),
                     result
                 )
             );
         });
 
-        it("returns undefined for coordinates within near/far planes but outside of\
+        it("returns projected vector for coordinates within near/far planes but outside of\
         frustum", () => {
-            assert.isUndefined(
-                sp.projectOnScreen(new THREE.Vector3(-halfScreenSize - eps, 0, -near - eps), result)
+            assert.exists(
+                sp.projectToScreen(new THREE.Vector3(-halfScreenSize - eps, 0, -near - eps), result)
             );
-            expect(result).deep.equal(new THREE.Vector2());
-            assert.isUndefined(
-                sp.projectOnScreen(new THREE.Vector3(halfScreenSize + eps, 0, -near - eps), result)
+            expect(result).not.deep.equal(new THREE.Vector2());
+            assert.exists(
+                sp.projectToScreen(new THREE.Vector3(halfScreenSize + eps, 0, -near - eps), result)
             );
-            assert.isUndefined(
-                sp.projectOnScreen(new THREE.Vector3(0, -halfScreenSize - eps, -near - eps), result)
+            expect(result).not.deep.equal(new THREE.Vector2());
+            assert.exists(
+                sp.projectToScreen(new THREE.Vector3(0, -halfScreenSize - eps, -near - eps), result)
             );
-            assert.isUndefined(
-                sp.projectOnScreen(new THREE.Vector3(0, halfScreenSize + eps, -near - eps), result)
+            expect(result).not.deep.equal(new THREE.Vector2());
+            assert.exists(
+                sp.projectToScreen(new THREE.Vector3(0, halfScreenSize + eps, -near - eps), result)
             );
+            expect(result).not.deep.equal(new THREE.Vector2());
         });
     });
 });

--- a/@here/harp-mapview/test/TextElementStateCacheTest.ts
+++ b/@here/harp-mapview/test/TextElementStateCacheTest.ts
@@ -154,8 +154,12 @@ describe("TextElementStateCache", function() {
             const textElementStateX2 = new TextElementState(label0Compatible);
             textElementStateX2.update(100);
             textElementStateX2.iconRenderState!.startFadeIn(0);
-            expect(textElementStateX2.visible).to.be.true;
+            expect(textElementStateX2.visible).to.be.false;
+            expect(textElementStateX2.iconRenderState!.isFadingIn()).to.be.true;
+            expect(textElementStateX2.iconRenderState!.isFadedIn()).to.be.false;
 
+            textElementStateX2.updateFading(1, true);
+            expect(textElementStateX2.visible).to.be.true;
             const didReplace = cache.replaceElement(0, textElementStateX2);
             expect(didReplace).to.be.true;
         });
@@ -185,6 +189,8 @@ describe("TextElementStateCache", function() {
             const textElementStateX2 = new TextElementState(label0Compatible);
             textElementStateX2.update(100);
             textElementStateX2.iconRenderState!.startFadeIn(0);
+            expect(textElementStateX2.visible).to.be.false;
+            textElementStateX2.updateFading(1, true);
             expect(textElementStateX2.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, textElementStateX2);
@@ -215,6 +221,8 @@ describe("TextElementStateCache", function() {
             const poiState1 = new TextElementState(poiLabel1);
             poiState1.update(100);
             poiState1.iconRenderState!.startFadeIn(0);
+            expect(poiState1.visible).to.be.false;
+            poiState1.updateFading(1, true);
             expect(poiState1.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, poiState1);
@@ -245,6 +253,8 @@ describe("TextElementStateCache", function() {
             const poiState1 = new TextElementState(poiLabel1);
             poiState1.update(100);
             poiState1.iconRenderState!.startFadeIn(0);
+            expect(poiState1.visible).to.be.false;
+            poiState1.updateFading(1, true);
             expect(poiState1.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, poiState1);
@@ -275,6 +285,8 @@ describe("TextElementStateCache", function() {
             const poiState1 = new TextElementState(poiLabel1);
             poiState1.update(100);
             poiState1.iconRenderState!.startFadeIn(0);
+            expect(poiState1.visible).to.be.false;
+            poiState1.updateFading(1, true);
             expect(poiState1.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, poiState1);
@@ -311,6 +323,8 @@ describe("TextElementStateCache", function() {
             expect(poiState1.iconRenderStates).to.not.be.undefined;
             expect(poiState1.iconRenderStates!.length).to.equal(1);
             poiState1.iconRenderStates![0].startFadeIn(0);
+            expect(poiState1.visible).to.be.false;
+            poiState1.updateFading(1, true);
             expect(poiState1.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, poiState1);
@@ -348,6 +362,8 @@ describe("TextElementStateCache", function() {
             expect(poiState1.iconRenderStates!.length).to.equal(2);
             poiState1.iconRenderStates![0].startFadeIn(0);
             poiState1.iconRenderStates![1].startFadeIn(0);
+            expect(poiState1.visible).to.be.false;
+            poiState1.updateFading(1, true);
             expect(poiState1.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, poiState1);
@@ -383,6 +399,8 @@ describe("TextElementStateCache", function() {
             expect(poiState1.iconRenderStates!.length).to.equal(2);
             poiState1.iconRenderStates![0].startFadeIn(0);
             poiState1.iconRenderStates![1].startFadeIn(0);
+            expect(poiState1.visible).to.be.false;
+            poiState1.updateFading(1, true);
             expect(poiState1.visible).to.be.true;
 
             const didReplace = cache.replaceElement(0, poiState1);

--- a/@here/harp-mapview/test/TextElementStateTest.ts
+++ b/@here/harp-mapview/test/TextElementStateTest.ts
@@ -65,6 +65,8 @@ describe("TextElementState", function() {
             } as any);
             textElementState.update(0);
             textElementState.textRenderState!.startFadeIn(0);
+            expect(textElementState.visible).to.be.false;
+            textElementState.updateFading(1, true);
             expect(textElementState.visible).to.be.true;
         });
 
@@ -77,6 +79,8 @@ describe("TextElementState", function() {
             } as any);
             textElementState.update(0);
             textElementState.iconRenderState!.startFadeIn(0);
+            expect(textElementState.visible).to.be.false;
+            textElementState.updateFading(1, true);
             expect(textElementState.visible).to.be.true;
         });
 
@@ -93,6 +97,8 @@ describe("TextElementState", function() {
             } as any);
             textElementState.update(0);
             textElementState.iconRenderStates![0].startFadeIn(0);
+            expect(textElementState.visible).to.be.false;
+            textElementState.updateFading(1, true);
             expect(textElementState.visible).to.be.true;
         });
     });

--- a/@here/harp-mapview/test/TextElementsRendererTest.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTest.ts
@@ -20,7 +20,8 @@ import {
     pointTextBuilder
 } from "./TextElementBuilder";
 import {
-    DEF_TEXT_WIDTH_HEIGHT,
+    DEF_TEXT_HEIGHT,
+    DEF_TEXT_WIDTH,
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
     TestFixture,
@@ -41,6 +42,7 @@ import {
     firstNFrames,
     framesEnabled,
     frameStates,
+    iconFrameStates,
     INITIAL_TIME,
     InputTextElement,
     InputTile,
@@ -299,6 +301,109 @@ const tests: TestCase[] = [
         frameTimes: FADE_2_CYCLES,
         collisionFrames: not(firstNFrames(FADE_2_CYCLES, 3))
     },
+    {
+        name: "Text is rendered although icon is invisible",
+        tiles: [
+            {
+                labels: [
+                    [
+                        poiBuilder("P0")
+                            .withPriority(0)
+                            .withPosition(
+                                SCREEN_WIDTH / WORLD_SCALE / 2,
+                                SCREEN_HEIGHT / WORLD_SCALE / 2
+                            )
+                            .withPoiInfo(
+                                new PoiInfoBuilder()
+                                    .withPoiTechnique()
+                                    .withIconOffset(SCREEN_WIDTH * 0.5, SCREEN_HEIGHT * 0.5 + 10)
+                                    .withIconOptional(false)
+                            ),
+                        fadeIn(FADE_IN_OUT.length),
+                        [],
+                        fadedOut(FADE_IN_OUT.length)
+                    ]
+                ]
+            }
+        ],
+        frameTimes: FADE_2_CYCLES
+    },
+    {
+        name: "Text is not rendered because the valid icon is rejected",
+        tiles: [
+            {
+                labels: [
+                    [
+                        poiBuilder("P1")
+                            .withPriority(1)
+                            .withPosition(0, 0)
+                            .withPoiInfo(
+                                new PoiInfoBuilder().withPoiTechnique().withIconOptional(false)
+                            )
+                            .withOffset(0, 20),
+                        fadeIn(FADE_IN_OUT.length),
+                        [],
+                        fadeIn(FADE_IN_OUT.length)
+                    ],
+                    [
+                        poiBuilder("P0")
+                            .withPriority(0)
+                            // Manual testing and debugging showed that this position lets the icon
+                            // area be covered by the first poi, while the text area is available.
+                            .withPosition(0, 5)
+                            .withPoiInfo(
+                                new PoiInfoBuilder().withPoiTechnique().withIconOptional(false)
+                            )
+                            .withOffset(0, 20),
+                        fadedOut(FADE_IN_OUT.length),
+                        [],
+                        fadedOut(FADE_IN_OUT.length)
+                    ]
+                ]
+            }
+        ],
+        frameTimes: FADE_2_CYCLES
+    },
+    {
+        name: "Text is rendered because the invalid and optional icon is rejected",
+        tiles: [
+            {
+                labels: [
+                    [
+                        poiBuilder("P1")
+                            .withPriority(1)
+                            .withPosition(0, 0)
+                            .withPoiInfo(
+                                new PoiInfoBuilder().withPoiTechnique().withIconOptional(false)
+                            )
+                            .withOffset(0, 20),
+                        fadeIn(FADE_IN_OUT.length),
+                        [],
+                        fadeIn(FADE_IN_OUT.length)
+                    ],
+                    [
+                        poiBuilder("P0")
+                            .withPriority(0)
+                            // Manual testing and debugging showed that this position lets the icon
+                            // area be covered by the first poi, while the text area is available.
+                            // Same values as in test above.
+                            .withPosition(0, 5)
+                            .withPoiInfo(
+                                new PoiInfoBuilder()
+                                    .withPoiTechnique()
+                                    .withIconOptional(true)
+                                    .withIconValid(false)
+                            )
+                            .withOffset(0, 20),
+                        fadeIn(FADE_IN_OUT.length), // text should fade in
+                        [],
+                        fadedOut(FADE_IN_OUT.length) // icon should stay faded out
+                    ]
+                ]
+            }
+        ],
+        frameTimes: FADE_2_CYCLES
+    },
     // DEDUPLICATION
     {
         name: "Second from two near, non-colliding point labels with same text never fades in",
@@ -307,8 +412,8 @@ const tests: TestCase[] = [
                 labels: [
                     [
                         pointTextBuilder().withPosition(
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_WIDTH,
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_HEIGHT
+                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH)) / SCREEN_WIDTH,
+                            (WORLD_SCALE * (4 * DEF_TEXT_HEIGHT)) / SCREEN_HEIGHT
                         ),
                         fadeIn(FADE_IN_OUT.length)
                     ],
@@ -325,8 +430,8 @@ const tests: TestCase[] = [
                 labels: [
                     [
                         poiBuilder().withPosition(
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_WIDTH,
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_HEIGHT
+                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH)) / SCREEN_WIDTH,
+                            (WORLD_SCALE * (4 * DEF_TEXT_HEIGHT)) / SCREEN_HEIGHT
                         ),
                         fadeIn(FADE_IN_OUT.length)
                     ],
@@ -464,7 +569,7 @@ const tests: TestCase[] = [
     },
     {
         name:
-            "Longest path label with same text within distance tolerace replaces predecessor" +
+            "Longest path label with same text within distance tolerance replaces predecessor" +
             " without fading",
         tiles: [
             {
@@ -585,8 +690,8 @@ const tests: TestCase[] = [
                 labels: [
                     [
                         poiBuilder("outside frustum marker").withPosition(
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_WIDTH,
-                            (WORLD_SCALE * (40 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_HEIGHT,
+                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH)) / SCREEN_WIDTH,
+                            (WORLD_SCALE * (40 * DEF_TEXT_HEIGHT)) / SCREEN_HEIGHT,
                             -WORLD_SCALE * 10
                         ),
                         fadedOut(FADE_2_CYCLES.length)
@@ -604,8 +709,8 @@ const tests: TestCase[] = [
                 labels: [
                     [
                         poiBuilder("behind camera marker").withPosition(
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_WIDTH,
-                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH_HEIGHT)) / SCREEN_HEIGHT,
+                            (WORLD_SCALE * (4 * DEF_TEXT_WIDTH)) / SCREEN_WIDTH,
+                            (WORLD_SCALE * (4 * DEF_TEXT_HEIGHT)) / SCREEN_HEIGHT,
                             -1
                         ),
                         fadedOut(FADE_2_CYCLES.length)
@@ -643,7 +748,7 @@ describe("TextElementsRenderer", function() {
 
     function buildLabels(
         inputElements: InputTextElement[] | undefined,
-        elementFrameStates: Array<[TextElement, FadeState[]]>,
+        elementFrameStates: Array<[TextElement, FadeState[], FadeState[] | undefined]>,
         frameCount: number
     ): TextElement[] {
         if (!inputElements) {
@@ -654,23 +759,30 @@ describe("TextElementsRenderer", function() {
                 frameCount,
                 "frameStates of inputElement equals frameCount"
             );
+            const iconStates = iconFrameStates(inputElement);
+            if (iconStates !== undefined) {
+                expect(iconStates.length).equal(
+                    frameCount,
+                    "iconFrameStates of inputElement equals frameCount"
+                );
+            }
             // Only used to identify some text elements for testing purposes.
             const dummyUserData = {};
             const element = builder(inputElement)
                 .withUserData(dummyUserData)
                 .build();
-            elementFrameStates.push([element, frameStates(inputElement)]);
+            elementFrameStates.push([element, frameStates(inputElement), iconStates]);
             return element;
         });
     }
     async function initTest(
         test: TestCase
     ): Promise<{
-        elementFrameStates: Array<[TextElement, FadeState[]]>;
+        elementFrameStates: Array<[TextElement, FadeState[], FadeState[]]>;
         prevOpacities: number[];
     }> {
         // Array with all text elements and their corresponding expected frame states.
-        const elementFrameStates = new Array<[TextElement, FadeState[]]>();
+        const elementFrameStates = new Array<[TextElement, FadeState[], FadeState[]]>();
 
         let enableElevation = false;
         const allTileIndices: number[] = [];
@@ -748,13 +860,21 @@ describe("TextElementsRenderer", function() {
                 await fixture.renderFrame(frameTime, tileIdcs, terrainTileIdcs, collisionEnabled);
 
                 let elementIdx = 0;
-                for (const [textElement, expectedStates] of elementFrameStates) {
+                for (const [
+                    textElement,
+                    expectedStates,
+                    expectedIconStates
+                ] of elementFrameStates) {
                     const expectedState = expectedStates[frameIdx];
+                    const expectedIconState = expectedIconStates
+                        ? expectedIconStates[frameIdx]
+                        : undefined;
 
                     const prevOpacity = prevOpacities[elementIdx];
                     const newOpacity = fixture.checkTextElementState(
                         textElement,
                         expectedState,
+                        expectedIconState,
                         prevOpacity
                     );
                     prevOpacities[elementIdx++] = newOpacity;

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -64,7 +64,8 @@ type OpacityMatcher = (opacity: number) => boolean;
 
 export const SCREEN_WIDTH = 1920;
 export const SCREEN_HEIGHT = 1080;
-export const DEF_TEXT_WIDTH_HEIGHT = 10;
+export const DEF_TEXT_WIDTH = 30;
+export const DEF_TEXT_HEIGHT = 10;
 export const WORLD_SCALE = 100;
 
 const TILE_LEVEL = 5; // dummy tile level.
@@ -156,7 +157,8 @@ export class TestFixture {
             this.m_addTextSpy,
             this.m_addTextBufferObjSpy,
             fontCatalog,
-            DEF_TEXT_WIDTH_HEIGHT
+            DEF_TEXT_WIDTH,
+            DEF_TEXT_HEIGHT
         );
         const dummyUpdateCall = () => {};
         this.m_textRenderer = new TextElementsRenderer(
@@ -183,30 +185,76 @@ export class TestFixture {
      * Checks that the fading state of a given text element has the specified expected value.
      * @param textElement - The text element to verify.
      * @param expectedState - The expected fading state of the text element.
+     * @param expectedIconState - The expected fading state of the icon.
      * @param prevOpacity - The text element opacity in the previous frame.
      * @returns The text element opacity in the current frame.
      */
     checkTextElementState(
         textElement: TextElement,
         expectedState: FadeState,
+        expectedIconState: FadeState | undefined,
         prevOpacity: number
     ): number {
+        let iconOpacityMatcher: ((arg0: number) => boolean) | undefined;
+        let iconRendered = true;
+
+        if (expectedIconState !== undefined) {
+            switch (expectedIconState) {
+                case FadeState.FadingIn:
+                    iconOpacityMatcher = (opacity: number) => {
+                        return opacity > prevOpacity;
+                    };
+                    break;
+                case FadeState.FadingOut:
+                    iconOpacityMatcher = (opacity: number) => {
+                        return opacity < prevOpacity;
+                    };
+                    break;
+                case FadeState.FadedIn:
+                    iconOpacityMatcher = (opacity: number) => {
+                        return opacity === 1;
+                    };
+                    break;
+                case FadeState.FadedOut:
+                    iconOpacityMatcher = (opacity: number) => {
+                        return opacity === 0;
+                    };
+                    iconRendered = false;
+                    break;
+            }
+        }
+
         let newOpacity = 0;
         switch (expectedState) {
             case FadeState.FadingIn:
-                newOpacity = this.checkTextElementRendered(textElement, (opacity: number) => {
-                    return opacity > prevOpacity;
-                });
+                newOpacity = this.checkTextElementRendered(
+                    textElement,
+                    (opacity: number) => {
+                        return opacity > prevOpacity;
+                    },
+                    iconRendered,
+                    iconOpacityMatcher
+                );
                 break;
             case FadeState.FadingOut:
-                newOpacity = this.checkTextElementRendered(textElement, (opacity: number) => {
-                    return opacity < prevOpacity;
-                });
+                newOpacity = this.checkTextElementRendered(
+                    textElement,
+                    (opacity: number) => {
+                        return opacity < prevOpacity;
+                    },
+                    iconRendered,
+                    iconOpacityMatcher
+                );
                 break;
             case FadeState.FadedIn:
-                newOpacity = this.checkTextElementRendered(textElement, (opacity: number) => {
-                    return opacity === 1;
-                });
+                newOpacity = this.checkTextElementRendered(
+                    textElement,
+                    (opacity: number) => {
+                        return opacity === 1;
+                    },
+                    iconRendered,
+                    iconOpacityMatcher
+                );
                 break;
             case FadeState.FadedOut:
                 this.checkTextElementNotRendered(textElement);
@@ -308,7 +356,9 @@ export class TestFixture {
 
     private checkTextElementRendered(
         textElement: TextElement,
-        opacityMatcher: OpacityMatcher | undefined
+        opacityMatcher: OpacityMatcher | undefined,
+        iconRendered: boolean,
+        iconOpacityMatcher: OpacityMatcher | undefined
     ): number {
         if (this.m_viewState.elevationProvider) {
             assert(textElement.elevated, this.getErrorHeading(textElement) + " was NOT elevated.");
@@ -316,7 +366,12 @@ export class TestFixture {
         switch (textElement.type) {
             case TextElementType.PoiLabel:
                 if (textElement.poiInfo !== undefined) {
-                    return this.checkPoiRendered(textElement, opacityMatcher);
+                    return this.checkPoiRendered(
+                        textElement,
+                        opacityMatcher,
+                        iconRendered,
+                        iconOpacityMatcher
+                    );
                 } else {
                     return this.checkPointTextRendered(textElement, opacityMatcher);
                 }
@@ -480,10 +535,17 @@ export class TestFixture {
 
     private checkPoiRendered(
         textElement: TextElement,
-        opacityMatcher: OpacityMatcher | undefined
+        opacityMatcher: OpacityMatcher | undefined,
+        iconRendered: boolean,
+        iconOpacityMatcher: OpacityMatcher | undefined
     ): number {
-        this.checkPointTextRendered(textElement, opacityMatcher);
-        return this.checkIconRendered(textElement, opacityMatcher);
+        let opacity = this.checkPointTextRendered(textElement, opacityMatcher);
+        if (iconRendered) {
+            opacity = this.checkIconRendered(textElement, iconOpacityMatcher);
+        } else {
+            this.checkIconNotRendered(textElement);
+        }
+        return opacity;
     }
 
     private checkPoiNotRendered(textElement: TextElement) {
@@ -565,7 +627,7 @@ export class TestFixture {
     }
 
     private getErrorHeading(textElement: TextElement): string {
-        // Substract first initialization frame and 1 more because the view state holds the number
+        // Subtract first initialization frame and 1 more because the view state holds the number
         // of the next frame.
         const currentFrame = this.m_viewState.frameNumber - 2;
         return "Frame " + currentFrame + ", label '" + textElement.text + "': ";

--- a/@here/harp-mapview/test/TextElementsRendererTestUtils.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestUtils.ts
@@ -119,7 +119,8 @@ export function allFrames(frames: number[]): boolean[] {
  */
 export type InputTextElement =
     | [TextElementBuilder, FadeState[]]
-    | [TextElementBuilder, FadeState[], boolean[]];
+    | [TextElementBuilder, FadeState[], boolean[]]
+    | [TextElementBuilder, FadeState[], boolean[], FadeState[]];
 
 export function builder(input: InputTextElement) {
     return input[0];
@@ -127,6 +128,10 @@ export function builder(input: InputTextElement) {
 
 export function frameStates(input: InputTextElement) {
     return input[1];
+}
+
+export function iconFrameStates(input: InputTextElement) {
+    return input[3];
 }
 
 export function framesEnabled(input: InputTextElement): boolean[] | undefined {

--- a/@here/harp-mapview/test/stubPoiRenderer.ts
+++ b/@here/harp-mapview/test/stubPoiRenderer.ts
@@ -51,7 +51,11 @@ export function stubPoiRenderer(
                 screenCollisions.allocate(bbox);
             }
             const screenPosCopy = screenPosition.toArray();
-            renderPoiSpy(poiInfo, screenPosCopy, opacity);
+            if (opacity > 0) {
+                renderPoiSpy(poiInfo, screenPosCopy, opacity);
+                return true;
+            }
+            return false;
         }
     );
 

--- a/@here/harp-mapview/test/stubTextCanvas.ts
+++ b/@here/harp-mapview/test/stubTextCanvas.ts
@@ -33,7 +33,8 @@ export function stubTextCanvas(
     addTextSpy: sinon.SinonSpy,
     addTextBufferObjSpy: sinon.SinonSpy,
     fontCatalog: FontCatalog,
-    textWidthHeight: number
+    textWidth: number,
+    textHeight: number
 ): TextCanvas {
     const renderer = ({ capabilities: { isWebGL2: false } } as any) as THREE.WebGLRenderer;
     const textCanvas = new TextCanvas({
@@ -70,8 +71,8 @@ export function stubTextCanvas(
             ) => {
                 // Return a box centered on origin with dimensions DEF_TEXT_WIDTH_HEIGHT
                 outputBounds.set(
-                    new THREE.Vector2(-textWidthHeight / 2, -textWidthHeight / 2),
-                    new THREE.Vector2(textWidthHeight / 2, textWidthHeight / 2)
+                    new THREE.Vector2(-textWidth / 2, -textHeight / 2),
+                    new THREE.Vector2(textWidth / 2, textHeight / 2)
                 );
                 // Same bbox for character bounds, as if text had a single character.
                 if (params !== undefined && params.outputCharacterBounds !== undefined) {

--- a/@here/harp-utils/lib/Math2D.ts
+++ b/@here/harp-utils/lib/Math2D.ts
@@ -42,6 +42,18 @@ export namespace Math2D {
         }
 
         /**
+         * Copy values from another box.
+         *
+         * @param box - Another box.
+         */
+        copy(box: Box) {
+            this.x = box.x;
+            this.y = box.y;
+            this.w = box.w;
+            this.h = box.h;
+        }
+
+        /**
          * Test box for inclusion of point.
          *
          * @param x - X coordinate of point.


### PR DESCRIPTION
* cull using near/far plane
* render partial text and icons near border

Signed-off-by: StefanDachwitz <stefan.dachwitz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
