### PR TITLE
HARP-12466: Fix initialization of the webpack's stats.

### DIFF
--- a/@here/harp-examples/webpack.config.js
+++ b/@here/harp-examples/webpack.config.js
@@ -94,7 +94,7 @@ const commonConfig = {
     stats: {
         all: false,
         timings: true,
-        exclude: "/resources/",
+        exclude: "resources/",
         errors: true,
         entrypoints: true,
         warnings: true

--- a/@here/harp-webpack-utils/scripts/HarpWebpackConfig.ts
+++ b/@here/harp-webpack-utils/scripts/HarpWebpackConfig.ts
@@ -59,7 +59,7 @@ export function addHarpWebpackConfig(config?: Configuration, harpConfig?: HarpWe
                 stats: {
                     all: false,
                     timings: true,
-                    exclude: "/resources/",
+                    exclude: "resources/",
                     errors: true,
                     entrypoints: true,
                     warnings: true

--- a/docs/GettingStartedAngular.md
+++ b/docs/GettingStartedAngular.md
@@ -216,7 +216,7 @@ const decoderConfig = {
     stats: {
         all: false,
         timings: true,
-        exclude: "/resources/",
+        exclude: "resources/",
         errors: true,
         entrypoints: true,
         warnings: true

--- a/webpack.tests.config.js
+++ b/webpack.tests.config.js
@@ -142,7 +142,7 @@ const browserTestsConfig = {
     stats: {
         all: false,
         timings: true,
-        exclude: "/resources/",
+        exclude: "resources/",
         errors: true,
         entrypoints: true,
         warnings: true


### PR DESCRIPTION
The `stats` object requires the exclude patterns to be relative
paths.
