### PR TITLE
HARP-12470 - Removing set-env from Github CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ env:
   nodeTestTimeout: 4000
   browserTestTimeout: 8000
   DETECT_CHROMEDRIVER_VERSION: true
+  HARP_NO_HARD_SOURCE_CACHE: true
 
 jobs:
   test:
@@ -33,7 +34,6 @@ jobs:
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
-
     - uses: actions/cache@v2
       name: Yarn cache
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -43,15 +43,12 @@ jobs:
         restore-keys: |
           yarn-${{ runner.os }}-${{ matrix.node_version }}-
           yarn-${{ runner.os }}-
-
     - name: Use Node.js ${{ matrix.node_version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node_version }}
     - name: Install dependencies
       run: yarn --frozen-lockfile
-    - name: Disable hard-source-webpack-plugin
-      run: echo "::set-env name=HARP_NO_HARD_SOURCE_CACHE::true"
     - name: Pretest
       run: yarn run pre-test
       shell: bash


### PR DESCRIPTION
Signed-off-by: Aluni <gairik.aluni@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
