### PR TITLE
Stopping use deprecates.

### DIFF
--- a/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
@@ -81,15 +81,14 @@ export class OlpCopyrightProvider extends CopyrightCoverageProvider {
                 getToken: this.m_params.getToken,
                 environment: this.m_params.environment ?? hrn.data.partition
             });
-            const client = new VersionedLayerClient(
-                hrn,
-                this.m_params.layer ?? DEFAULT_LAYER,
+            const client = new VersionedLayerClient({
+                catalogHrn: hrn,
+                layerId: this.m_params.layer ?? DEFAULT_LAYER,
+                version: this.m_params.version,
                 settings
-            );
+            });
             const partition = await client.getData(
-                new DataRequest()
-                    .withPartitionId(this.m_params.partition ?? DEFAULT_PARTITION)
-                    .withVersion(this.m_params.version),
+                new DataRequest().withPartitionId(this.m_params.partition ?? DEFAULT_PARTITION),
                 abortSignal
             );
             const json = await partition.json();

--- a/@here/harp-olp-utils/lib/OlpDataProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpDataProvider.ts
@@ -75,11 +75,12 @@ export class OlpDataProvider extends DataProvider {
 
             this.m_catalogVersion = latestVersion;
         }
-        this.m_versionLayerClient = new VersionedLayerClient(
-            HRN.fromString(this.params.hrn),
-            this.params.layerId,
+        this.m_versionLayerClient = new VersionedLayerClient({
+            catalogHrn: HRN.fromString(this.params.hrn),
+            layerId: this.params.layerId,
+            version: this.m_catalogVersion,
             settings
-        );
+        });
     }
 
     /**
@@ -103,7 +104,7 @@ export class OlpDataProvider extends DataProvider {
 
         try {
             const response = await this.m_versionLayerClient.getData(
-                new DataRequest().withQuadKey(tileKey).withVersion(this.m_catalogVersion),
+                new DataRequest().withQuadKey(tileKey),
                 abortSignal
             );
             if (abortSignal && abortSignal.aborted) {


### PR DESCRIPTION
The Data SDK for Typescript will have removed in the next release the
deprecated constructor for the `VersionedLayerClient` and also
methods `getVersion()` and `withVersion()` for the `DataRequest`.

This CR adapts the code according to future changes.

Signed-off-by: Oleksii Zubko <ext-oleksii.zubko@here.com>