### PR TITLE
HARP-12619 Fix slow loading of tiles when zooming out

### DIFF
--- a/@here/harp-transfer-manager/src/TransferManager.ts
+++ b/@here/harp-transfer-manager/src/TransferManager.ts
@@ -96,7 +96,7 @@ export class TransferManager implements ITransferManager {
         } catch (err) {
             if (
                 err.hasOwnProperty("isCancelled") ||
-                (err.hasOwnProperty("name") && err.name === "AbortError") ||
+                err.name === "AbortError" ||
                 retryCount >= maxRetries
             ) {
                 throw err;


### PR DESCRIPTION
- Tiles were slow to load because tiles that were aborted were being
retried up to 5 times, because the hasOwnProperty didn't work on the
DOMException.
