### PR TITLE
HARP-12687: User Images are removed from cache when theme is changed

### DIFF
--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -892,7 +892,7 @@ export class MapView extends EventDispatcher {
 
     private readonly m_pickHandler: PickHandler;
 
-    private readonly m_userImageCache: MapViewImageCache = new MapViewImageCache(this);
+    private readonly m_userImageCache: MapViewImageCache = new MapViewImageCache();
     private readonly m_env: MapEnv = new MapEnv({});
 
     private readonly m_poiManager: PoiManager = new PoiManager(this);

--- a/@here/harp-mapview/lib/MapViewThemeManager.ts
+++ b/@here/harp-mapview/lib/MapViewThemeManager.ts
@@ -22,7 +22,7 @@ export class MapViewThemeManager {
     private m_theme: Theme = {};
 
     constructor(private readonly m_mapView: MapView, private readonly m_uriResolver?: UriResolver) {
-        this.m_imageCache = new MapViewImageCache(this.m_mapView);
+        this.m_imageCache = new MapViewImageCache();
     }
 
     async setTheme(theme: Theme | string): Promise<Theme> {

--- a/@here/harp-mapview/lib/image/MapViewImageCache.ts
+++ b/@here/harp-mapview/lib/image/MapViewImageCache.ts
@@ -63,11 +63,9 @@ export class MapViewImageCache {
             this.m_name2Url.set(name, url);
         }
 
-        const imageItem = ImageCache.instance.findImage(url);
-        if (imageItem === undefined) {
-            return ImageCache.instance.registerImage(this.mapView, url, image, htmlElement);
-        }
-        return imageItem;
+        // Register new image or add this mapView to list of MapViews using this image (identified
+        // by URL).)
+        return ImageCache.instance.registerImage(this.mapView, url, image, htmlElement);
     }
 
     /**
@@ -252,7 +250,7 @@ export class MapViewImageCache {
             } else {
                 // URL was used by this image only, remove the image.
                 this.m_url2Name.delete(url);
-                ImageCache.instance.removeImage(url);
+                ImageCache.instance.removeImage(url, this.mapView);
             }
             return true;
         }

--- a/@here/harp-mapview/lib/image/MapViewImageCache.ts
+++ b/@here/harp-mapview/lib/image/MapViewImageCache.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MapView } from "../MapView";
 import { ImageItem } from "./Image";
 import { ImageCache } from "./ImageCache";
 
@@ -26,10 +25,8 @@ export class MapViewImageCache {
 
     /**
      * The constructor for `MapViewImageCache`.
-     *
-     * @param mapView - a {@link MapView} instance.
      */
-    constructor(public mapView: MapView) {}
+    constructor() {}
 
     /**
      * Register an existing image by name.
@@ -65,7 +62,7 @@ export class MapViewImageCache {
 
         // Register new image or add this mapView to list of MapViews using this image (identified
         // by URL).)
-        return ImageCache.instance.registerImage(this.mapView, url, image, htmlElement);
+        return ImageCache.instance.registerImage(this, url, image, htmlElement);
     }
 
     /**
@@ -184,7 +181,7 @@ export class MapViewImageCache {
      */
     clear(): number {
         const oldSize = ImageCache.instance.size;
-        ImageCache.instance.clear(this.mapView);
+        ImageCache.instance.clear(this);
         this.m_name2Url = new Map();
         this.m_url2Name = new Map();
         return oldSize;
@@ -250,7 +247,7 @@ export class MapViewImageCache {
             } else {
                 // URL was used by this image only, remove the image.
                 this.m_url2Name.delete(url);
-                ImageCache.instance.removeImage(url, this.mapView);
+                ImageCache.instance.removeImage(url, this);
             }
             return true;
         }

--- a/@here/harp-mapview/test/ImageCacheTest.ts
+++ b/@here/harp-mapview/test/ImageCacheTest.ts
@@ -21,22 +21,19 @@ class ImageData {
 }
 
 describe("MapViewImageCache", function() {
-    const mapView: MapView = {} as MapView;
-    (mapView as any).imageCache = new MapViewImageCache(mapView);
-
     beforeEach(function() {
         ImageCache.instance.clearAll();
     });
 
     it("#empty", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
         assert.equal(cache.numberOfNames, 0);
         assert.equal(cache.numberOfUrls, 0);
         assert.notExists(cache.findNames("xxx"));
     });
 
     it("#registerImage", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData = new ImageData(16, 16);
 
@@ -56,7 +53,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#addImage", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
         cache.clear();
 
         const imageName = "headshot.png";
@@ -74,7 +71,7 @@ describe("MapViewImageCache", function() {
 
     if (typeof document !== "undefined") {
         it("#addImage with load", async function() {
-            const cache = new MapViewImageCache(mapView);
+            const cache = new MapViewImageCache();
             cache.clear();
 
             const imageName = "headshot.png";
@@ -105,7 +102,7 @@ describe("MapViewImageCache", function() {
         });
 
         it("#addImage (load cancelled)", async function() {
-            const cache = new MapViewImageCache(mapView);
+            const cache = new MapViewImageCache();
             cache.clear();
 
             const imageName = "headshot.png";
@@ -139,7 +136,7 @@ describe("MapViewImageCache", function() {
         });
 
         it("#loadImage", async function() {
-            const cache = new MapViewImageCache(mapView);
+            const cache = new MapViewImageCache();
             cache.clear();
 
             const imageName = "headshot.png";
@@ -172,7 +169,7 @@ describe("MapViewImageCache", function() {
     }
 
     it("#clear", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData = new ImageData(16, 16);
 
@@ -190,7 +187,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#add images", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -220,7 +217,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#add images with same url but differing names", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -245,7 +242,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#add images with same name but differing urls", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
         assert.throws(() => {
             cache.registerImage("testImage", "httpx://naxos.de", undefined);
             cache.registerImage("testImage", "httpx://naxos.de-2", undefined);
@@ -253,7 +250,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
 
@@ -272,7 +269,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image 2", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
 
@@ -295,7 +292,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image by URL", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -317,7 +314,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image by name", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -337,7 +334,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image by filter", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -361,7 +358,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image by filter 2", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -388,7 +385,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove image with name by filter", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -413,7 +410,7 @@ describe("MapViewImageCache", function() {
     });
 
     it("#remove all images by filter", function() {
-        const cache = new MapViewImageCache(mapView);
+        const cache = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -948,8 +945,8 @@ describe("ImageCache", function() {
         const mapView1: MapView = {} as MapView;
         const mapView2: MapView = {} as MapView;
 
-        const cache0 = ((mapView1 as any).imageCache = new MapViewImageCache(mapView1));
-        const cache1 = ((mapView2 as any).imageCache = new MapViewImageCache(mapView2));
+        const cache0 = ((mapView1 as any).imageCache = new MapViewImageCache());
+        const cache1 = ((mapView2 as any).imageCache = new MapViewImageCache());
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -982,11 +979,8 @@ describe("ImageCache", function() {
         const commonCache = ImageCache.instance;
         commonCache.clearAll();
 
-        const mapView1: MapView = {} as MapView;
-        const mapView2: MapView = {} as MapView;
-
-        const cache0 = new MapViewImageCache(mapView1);
-        const cache1 = new MapViewImageCache(mapView2);
+        const cache0 = new MapViewImageCache();
+        const cache1 = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -1008,11 +1002,8 @@ describe("ImageCache", function() {
         const commonCache = ImageCache.instance;
         commonCache.clearAll();
 
-        const mapView1: MapView = {} as MapView;
-        const mapView2: MapView = {} as MapView;
-
-        const cache0 = ((mapView1 as any).imageCache = new MapViewImageCache(mapView1));
-        const cache1 = ((mapView2 as any).imageCache = new MapViewImageCache(mapView2));
+        const cache0 = new MapViewImageCache();
+        const cache1 = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);
@@ -1046,11 +1037,8 @@ describe("ImageCache", function() {
         const commonCache = ImageCache.instance;
         commonCache.clearAll();
 
-        const mapView1: MapView = {} as MapView;
-        const mapView2: MapView = {} as MapView;
-
-        const cache0 = ((mapView1 as any).imageCache = new MapViewImageCache(mapView1));
-        const cache1 = ((mapView2 as any).imageCache = new MapViewImageCache(mapView2));
+        const cache0 = new MapViewImageCache();
+        const cache1 = new MapViewImageCache();
 
         const imageData1 = new ImageData(16, 16);
         const imageData2 = new ImageData(32, 32);


### PR DESCRIPTION
* remove images from cache only if not used in any other MapView

Signed-off-by: stefan.dachwitz <stefan.dachwitz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
