### PR TITLE
HARP-12759 Split dependent tiles from visible tiles

### DIFF
--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -14,7 +14,7 @@ import { assert } from "@here/harp-utils";
 import * as THREE from "three";
 
 import { DataSource } from "./DataSource";
-import { CalculationStatus, ElevationRangeSource } from "./ElevationRangeSource";
+import { CalculationStatus, ElevationRange, ElevationRangeSource } from "./ElevationRangeSource";
 import { MapTileCuller } from "./MapTileCuller";
 import { MapView } from "./MapView";
 import { MapViewUtils, TileOffsetUtils } from "./Utils";
@@ -34,8 +34,7 @@ export class TileKeyEntry {
         public tileKey: TileKey,
         public area: number,
         public offset: number = 0,
-        public minElevation: number = 0,
-        public maxElevation: number = 0,
+        public elevationRange?: ElevationRange,
         public distance: number = 0
     ) {}
 }
@@ -310,8 +309,10 @@ export class FrustumIntersection {
                 tileKey,
                 area,
                 offset,
-                geoBox.southWest.altitude, // minElevation
-                geoBox.northEast.altitude, // maxElevation
+                {
+                    minElevation: geoBox.southWest.altitude,
+                    maxElevation: geoBox.northEast.altitude
+                },
                 distance
             );
         }
@@ -379,7 +380,7 @@ export class FrustumIntersection {
         const tileWrappingEnabled = this.mapView.projection.type === ProjectionType.Planar;
 
         if (!tileWrappingEnabled || !this.m_tileWrappingEnabled) {
-            this.m_rootTileKeys.push(new TileKeyEntry(rootTileKey, Infinity, 0, 0));
+            this.m_rootTileKeys.push(new TileKeyEntry(rootTileKey, Infinity, 0));
             return;
         }
 
@@ -453,7 +454,7 @@ export class FrustumIntersection {
             offset <= offsetRange + startOffset;
             offset++
         ) {
-            this.m_rootTileKeys.push(new TileKeyEntry(rootTileKey, Infinity, offset, 0, 0));
+            this.m_rootTileKeys.push(new TileKeyEntry(rootTileKey, Infinity, offset));
         }
     }
 }

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -291,12 +291,22 @@ describe("VisibleTileSet", function() {
         const zoomLevel = 15;
         const storageLevel = 14;
 
-        const dataSourceTileList = updateRenderList(zoomLevel, storageLevel).tileList;
+        const dataSourceTileList_1 = updateRenderList(zoomLevel, storageLevel).tileList;
 
-        assert.equal(dataSourceTileList.length, 1);
-        assert.equal(dataSourceTileList[0].visibleTiles.length, 3);
+        assert.equal(dataSourceTileList_1.length, 1);
+        assert.equal(dataSourceTileList_1[0].visibleTiles.length, 3);
 
-        const visibleTiles = dataSourceTileList[0].visibleTiles;
+        const tile3 = fixture.vts.getCachedTile(dataSource, tileKey3, 0, 0);
+        assert.notEqual(tile3, undefined);
+        const tileKey4 = TileKey.fromMortonCode(371506853);
+        tile3!.dependencies.push(tileKey4);
+
+        const dataSourceTileList_2 = updateRenderList(zoomLevel, storageLevel).tileList;
+        assert.equal(dataSourceTileList_2.length, 1);
+        // Ensure that the fourth tile isn't `visible`.
+        assert.equal(dataSourceTileList_2[0].visibleTiles.length, 3);
+
+        const visibleTiles = dataSourceTileList_2[0].visibleTiles;
         assert.equal(visibleTiles[0].tileKey.mortonCode(), tileKey1.mortonCode());
         assert.equal(visibleTiles[1].tileKey.mortonCode(), tileKey2.mortonCode());
         assert.equal(visibleTiles[2].tileKey.mortonCode(), tileKey3.mortonCode());
@@ -304,7 +314,7 @@ describe("VisibleTileSet", function() {
         // Check that the dependent tile exists in the cache.
         assert.notEqual(fixture.vts.getCachedTile(dataSource, tileKey3, 0, 0), undefined);
 
-        const renderedTiles = dataSourceTileList[0].renderedTiles;
+        const renderedTiles = dataSourceTileList_2[0].renderedTiles;
         assert.equal(renderedTiles.size, 0);
     });
 


### PR DESCRIPTION
This is required because otherwise dependent tiles's dependencies are loaded, which continues infinitely.

This PR is split into two commits, the first is just a pure refactor, i.e. there is no functional change.
The second commit shows how the first refactor makes it easy to split the groups and fix the issue.