### PR TITLE
HARP-12352: subsequent DataProvider.register() return early

### DIFF
--- a/@here/harp-mapview-decoder/lib/DataProvider.ts
+++ b/@here/harp-mapview-decoder/lib/DataProvider.ts
@@ -19,6 +19,7 @@ import { EventDispatcher } from "three";
  */
 export abstract class DataProvider extends EventDispatcher {
     private readonly m_clients: Set<Object> = new Set();
+    private m_connectPromise: Promise<void> | undefined;
 
     /**
      * Registers a client to the data provider.
@@ -27,9 +28,11 @@ export abstract class DataProvider extends EventDispatcher {
      * @returns Promise to wait for successful (or failed) connection to the data source.
      */
     register(client: Object): Promise<void> {
-        const result = this.m_clients.size === 0 ? this.connect() : Promise.resolve();
+        if (this.m_clients.size === 0) {
+            this.m_connectPromise = this.connect();
+        }
         this.m_clients.add(client);
-        return result;
+        return this.m_connectPromise!;
     }
 
     /**

--- a/@here/harp-mapview-decoder/test/DataProviderTest.ts
+++ b/@here/harp-mapview-decoder/test/DataProviderTest.ts
@@ -29,6 +29,17 @@ class FakeDataProvider extends DataProvider {
     }
 }
 
+class TimedFakeDataProvider extends FakeDataProvider {
+    /** @override */ async connect(): Promise<void> {
+        const promise = new Promise<void>(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, 100);
+        });
+        return promise;
+    }
+}
+
 describe("DataProvider", function() {
     const clients = [{}, {}];
 
@@ -59,5 +70,77 @@ describe("DataProvider", function() {
         expect(disposeSpy.calledOnce).is.true;
         dataProvider.unregister(clients[1]);
         expect(disposeSpy.calledOnce).is.true;
+    });
+
+    it("calls connect only on first registered client", async function() {
+        const dataProvider = new TimedFakeDataProvider();
+        const connectSpy = sinon.spy(dataProvider, "connect");
+
+        await dataProvider.register(clients[0]);
+        expect(connectSpy.calledOnce).is.true;
+
+        await dataProvider.register(clients[0]);
+        await dataProvider.register(clients[1]);
+        expect(connectSpy.calledOnce).is.true;
+    });
+
+    it("calls connect again after unregister", async function() {
+        const dataProvider = new TimedFakeDataProvider();
+        const connectSpy = sinon.spy(dataProvider, "connect");
+
+        dataProvider.register(clients[0]);
+        expect(connectSpy.calledOnce).is.true;
+
+        dataProvider.unregister(clients[0]);
+        expect(connectSpy.calledOnce).is.true;
+
+        dataProvider.register(clients[0]);
+        expect(connectSpy.calledTwice).is.true;
+    });
+
+    it("calls connect after one provider call unregister", async function() {
+        const dataProvider = new TimedFakeDataProvider();
+
+        const promise0 = dataProvider.register(clients[0]);
+        const promise1 = dataProvider.register(clients[1]);
+        dataProvider.unregister(clients[0]);
+
+        let promise0Resolved = false;
+        await promise0.then(() => {
+            promise0Resolved = true;
+        });
+
+        let promise1Resolved = false;
+        await promise1.then(() => {
+            promise1Resolved = true;
+        });
+
+        expect(promise0Resolved, "unregistered provider resolve not called").to.be.true;
+        expect(promise1Resolved, "registered provider resolve not called after an unregister").to.be
+            .true;
+    });
+
+    it("subsequent register operations wait for connect", async function() {
+        const dataProvider = new TimedFakeDataProvider();
+        const connectSpy = sinon.spy(dataProvider, "connect");
+
+        const promise0 = dataProvider.register(clients[0]);
+        const promise1 = dataProvider.register(clients[1]);
+
+        let promise0Resolved = false;
+
+        const _promise2 = promise0.then(() => {
+            promise0Resolved = true;
+        });
+
+        expect(promise0Resolved, "promise resolved immediately").to.be.false;
+
+        // Assert that when promise1 is resolved, promise0 is also resolved.
+        await promise1;
+
+        // Assert that at this stage, promise0Resolved is true. State of promise2 can be ignored
+        // here.
+        expect(promise0Resolved, "subsequent promises resolve before the first").to.be.true;
+        expect(connectSpy.calledOnce).is.true;
     });
 });


### PR DESCRIPTION
* subsequent register operations should resolve after first connect

Signed-off-by: stefan.dachwitz <stefan.dachwitz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
