### PR TITLE
Fix invalidation of GeoJson inputs

### DIFF
--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -152,7 +152,7 @@ export class TileDataSource<TileType extends Tile = Tile> extends DataSource {
         this.cacheable = true;
 
         this.m_unregisterClearTileCache = this.dataProvider().onDidInvalidate?.(() =>
-            this.mapView.clearTileCache(this.name)
+            this.mapView.markTilesDirty(this)
         );
     }
 

--- a/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
@@ -183,20 +183,20 @@ describe("DataProviders", function() {
             features: []
         });
 
-        assert.isTrue(clearTileCache.called);
+        assert.isTrue(markTilesDirty.called);
 
-        clearTileCache.resetHistory();
+        markTilesDirty.resetHistory();
 
-        assert.isFalse(clearTileCache.called);
+        assert.isFalse(markTilesDirty.called);
 
         dataProvider.updateInput({
             type: "FeatureCollection",
             features: []
         });
 
-        assert.isTrue(clearTileCache.called);
+        assert.isTrue(markTilesDirty.called);
 
-        clearTileCache.resetHistory();
+        markTilesDirty.resetHistory();
 
         omvDataSource.dispose();
 
@@ -205,6 +205,6 @@ describe("DataProviders", function() {
             features: []
         });
 
-        assert.isFalse(clearTileCache.called);
+        assert.isFalse(markTilesDirty.called);
     });
 });


### PR DESCRIPTION
This change replaces the usage of `clearTileCache` with `marksTileDirty`
to ensure smooth updates when the GeoJson document is invalidated.

Also, this change modifies the GeoJson visibility example to
demonstrate how to animate map objects by modifing the GeoJson
features.
