### PR TITLE
Add geo features tests

### DIFF
--- a/test/rendering/GeoJsonFeaturesRendering.ts
+++ b/test/rendering/GeoJsonFeaturesRendering.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
+
+import {
+    FeatureCollection,
+    LineCaps,
+    SolidLineTechniqueParams,
+    Style
+} from "@here/harp-datasource-protocol";
+import { GeoPointLike } from "@here/harp-geoutils";
+import * as turf from "@turf/turf";
+
+import { GeoJsonTest } from "./utils/GeoJsonTest";
+
+const strokePolygonLayer = (params: Partial<SolidLineTechniqueParams> = {}): Style => {
+    return {
+        id: "stroke-polygon",
+        styleSet: "geojson",
+        technique: "solid-line",
+        color: "orange",
+        lineWidth: ["world-ppi-scale", 20],
+        secondaryColor: "magenta",
+        secondaryWidth: ["world-ppi-scale", 35],
+        ...(params as any)
+    };
+};
+
+describe("GeoJson features", function() {
+    const geoJsonTest = new GeoJsonTest();
+
+    const { lights } = geoJsonTest;
+
+    afterEach(() => geoJsonTest.dispose());
+
+    it("Stroke Circle", async function() {
+        const pos = [13.2, 53.2];
+
+        const circle = turf.circle(pos, 600, {
+            units: "meters"
+        });
+
+        const geoJson = turf.featureCollection([circle]);
+
+        await geoJsonTest.run({
+            testImageName: "geojson-stroke-circle",
+            mochaTest: this,
+            geoJson: geoJson as FeatureCollection,
+            lookAt: {
+                target: pos as GeoPointLike,
+                zoomLevel: 14
+            },
+            theme: {
+                lights,
+                styles: [
+                    strokePolygonLayer({
+                        lineWidth: ["world-ppi-scale", 50],
+                        secondaryWidth: ["world-ppi-scale", 80]
+                    })
+                ]
+            }
+        });
+    });
+
+    it("Extrude Circle", async function() {
+        const pos = [13.2, 53.2];
+
+        const circle = turf.circle(pos, 600, {
+            units: "meters"
+        });
+
+        const geoJson = turf.featureCollection([circle]);
+
+        await geoJsonTest.run({
+            testImageName: "geojson-extruded-circle",
+            mochaTest: this,
+            geoJson: geoJson as FeatureCollection,
+            lookAt: {
+                target: pos as GeoPointLike,
+                zoomLevel: 14,
+                tilt: 60
+            },
+            theme: {
+                lights,
+                styles: [
+                    {
+                        styleSet: "geojson",
+                        technique: "extruded-polygon",
+                        color: "red",
+                        constantHeight: true,
+                        height: 700
+                    }
+                ]
+            }
+        });
+    });
+
+    describe("Stroke Arcs", async function() {
+        const lineCaps: LineCaps[] = ["None", "Round", "Square", "TriangleIn", "TriangleOut"];
+
+        lineCaps.forEach(caps => {
+            it(`Stroke Arc using from 0 to 300 using '${caps}' caps`, async function() {
+                const center = [13.2, 53.2];
+
+                const arc = turf.lineArc(center, 5, 0, 300);
+
+                const geoJson = turf.featureCollection([arc]);
+
+                await geoJsonTest.run({
+                    mochaTest: this,
+                    geoJson: geoJson as FeatureCollection,
+                    testImageName: `stroke-arc-with-caps-${caps}`,
+                    lookAt: {
+                        target: center as GeoPointLike,
+                        zoomLevel: 10
+                    },
+                    theme: {
+                        lights,
+                        styles: [strokePolygonLayer({ caps })]
+                    }
+                });
+            });
+        });
+    });
+
+    describe("Stroke Circles created using lineArc", async function() {
+        const lineCaps: LineCaps[] = ["None", "Round", "Square", "TriangleIn", "TriangleOut"];
+
+        lineCaps.forEach(caps => {
+            it(`Stroke Arc from 0 to 360 using '${caps}' caps`, async function() {
+                const center = [13.2, 53.2];
+
+                const arc = turf.lineArc(center, 5, 0, 360);
+
+                const geoJson = turf.featureCollection([arc]);
+
+                await geoJsonTest.run({
+                    mochaTest: this,
+                    geoJson: geoJson as FeatureCollection,
+                    testImageName: `stroke-circles-creates-from-arcs-${caps}`,
+                    lookAt: {
+                        target: center as GeoPointLike,
+                        zoomLevel: 10
+                    },
+                    theme: {
+                        lights,
+                        styles: [strokePolygonLayer({ caps })]
+                    }
+                });
+            });
+        });
+    });
+});

--- a/test/rendering/utils/GeoJsonTest.ts
+++ b/test/rendering/utils/GeoJsonTest.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FlatTheme, GeoJson, Light, Theme } from "@here/harp-datasource-protocol";
+import { GeoJsonDataProvider } from "@here/harp-geojson-datasource";
+import { LookAtParams, MapView, MapViewEventNames } from "@here/harp-mapview";
+import { DataProvider } from "@here/harp-mapview-decoder";
+import { GeoJsonTiler } from "@here/harp-mapview-decoder/index-worker";
+import { waitForEvent } from "@here/harp-test-utils";
+import { RenderingTestHelper } from "@here/harp-test-utils/index.web";
+import { VectorTileDataSource } from "@here/harp-vectortile-datasource";
+import { VectorTileDecoder } from "@here/harp-vectortile-datasource/index-worker";
+import * as sinon from "sinon";
+
+export interface GeoJsoTestOptions {
+    mochaTest: Mocha.Context;
+    testImageName: string;
+    theme: Theme | FlatTheme;
+    geoJson?: string | GeoJson;
+    lookAt?: Partial<LookAtParams>;
+    tileGeoJson?: boolean;
+    dataProvider?: DataProvider;
+}
+
+export class GeoJsonTest {
+    mapView!: MapView;
+
+    lights: Light[] = [
+        {
+            type: "ambient",
+            color: "#FFFFFF",
+            name: "ambientLight",
+            intensity: 0.9
+        },
+        {
+            type: "directional",
+            color: "#FFFFFF",
+            name: "light1",
+            intensity: 0.8,
+            direction: {
+                x: 1,
+                y: 5,
+                z: 0.5
+            }
+        }
+    ];
+
+    dispose() {
+        this.mapView?.dispose();
+    }
+
+    async run(options: GeoJsoTestOptions) {
+        const ibct = new RenderingTestHelper(options.mochaTest, { module: "mapview" });
+        const canvas = document.createElement("canvas");
+        canvas.width = 400;
+        canvas.height = 300;
+
+        this.mapView = new MapView({
+            canvas,
+            theme: options.theme,
+            preserveDrawingBuffer: true,
+            pixelRatio: 1,
+            disableFading: true
+        });
+        this.mapView.animatedExtrusionHandler.enabled = false;
+
+        const defaultLookAt: Partial<LookAtParams> = {
+            target: { lat: 53.3, lng: 14.6 },
+            distance: 200000,
+            tilt: 0,
+            heading: 0
+        };
+
+        const lookAt: LookAtParams = { ...defaultLookAt, ...options.lookAt } as any;
+
+        this.mapView.lookAt(lookAt);
+        // Shutdown errors cause by firefox bug
+        this.mapView.renderer.getContext().getShaderInfoLog = (x: any) => {
+            return "";
+        };
+
+        const tiler = new GeoJsonTiler();
+        if (options.tileGeoJson === false) {
+            sinon.stub(tiler, "getTile").resolves(options.geoJson);
+        }
+
+        const geoJsonDataSource = new VectorTileDataSource({
+            decoder: new VectorTileDecoder(),
+            dataProvider:
+                options.dataProvider ??
+                new GeoJsonDataProvider(
+                    "geojson",
+                    typeof options.geoJson === "string"
+                        ? new URL(options.geoJson, window.location.href)
+                        : options.geoJson!,
+                    { tiler }
+                ),
+            name: "geojson",
+            styleSetName: "geojson"
+        });
+
+        this.mapView.setDynamicProperty("enabled", true);
+        this.mapView.addDataSource(geoJsonDataSource);
+
+        await waitForEvent(this.mapView, MapViewEventNames.FrameComplete);
+        await ibct.assertCanvasMatchesReference(canvas, options.testImageName);
+    }
+}


### PR DESCRIPTION
Add visual tests for rendering geo features.

This change moves helper code to create GeoJson visual tests
to GeoJsonTest.ts and it adds some initial tests for rendering
circles and stroked arcs.
