### PR TITLE
HARP-13251: Add support for wrapping linestrings crossing the antimeridian.

### DIFF
--- a/@here/harp-geometry/lib/WrapLineString.ts
+++ b/@here/harp-geometry/lib/WrapLineString.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { wrapLineString } from "./ClipLineString";


### PR DESCRIPTION
This change adds the function `wrapLineString` that can be used
to wrap line features crossing the antimeridian.
