### PR TITLE
Add catch block to cli-build-theme 

### DIFF
--- a/@here/harp-theme-tools/src/cli-build-theme.ts
+++ b/@here/harp-theme-tools/src/cli-build-theme.ts
@@ -61,7 +61,7 @@ inputFiles.forEach(file => {
             : JSON.stringify(theme, undefined, 4);
         fs.writeFileSync(filename, json);
     }).catch(error => {
-        console.error(`Error building theme ${filename}`, error);
+        console.error("Error building theme", error);
         process.exit(1);
     });;
 });

--- a/@here/harp-theme-tools/src/cli-build-theme.ts
+++ b/@here/harp-theme-tools/src/cli-build-theme.ts
@@ -60,5 +60,8 @@ inputFiles.forEach(file => {
             ? JSON.stringify(theme)
             : JSON.stringify(theme, undefined, 4);
         fs.writeFileSync(filename, json);
-    });
+    }).catch(error => {
+        console.error(`Error building theme ${filename}`, error);
+        process.exit(1);
+    });;
 });

--- a/@here/harp-theme-tools/src/cli-build-theme.ts
+++ b/@here/harp-theme-tools/src/cli-build-theme.ts
@@ -63,5 +63,5 @@ inputFiles.forEach(file => {
     }).catch(error => {
         console.error("Error building theme", error);
         process.exit(1);
-    });;
+    });
 });

--- a/@here/harp-theme-tools/src/cli-build-theme.ts
+++ b/@here/harp-theme-tools/src/cli-build-theme.ts
@@ -52,16 +52,18 @@ inputFiles.forEach(file => {
     ThemeLoader.load(file, {
         resolveResourceUris: false,
         resolveIncludeUris: true
-    }).then(theme => {
-        theme.url = undefined;
-        const filename = `${cliOptions.out}/${path.basename(file)}`;
-        console.log(`Writing ${filename}`);
-        const json = cliOptions.minify
-            ? JSON.stringify(theme)
-            : JSON.stringify(theme, undefined, 4);
-        fs.writeFileSync(filename, json);
-    }).catch(error => {
-        console.error("Error building theme", error);
-        process.exit(1);
-    });
+    })
+        .then(theme => {
+            theme.url = undefined;
+            const filename = `${cliOptions.out}/${path.basename(file)}`;
+            console.log(`Writing ${filename}`);
+            const json = cliOptions.minify
+                ? JSON.stringify(theme)
+                : JSON.stringify(theme, undefined, 4);
+            fs.writeFileSync(filename, json);
+        })
+        .catch(error => {
+            console.error("Error building theme", error);
+            process.exit(1);
+        });
 });


### PR DESCRIPTION
Add catch block to cli-build-theme to fail the script in CI
Signed-off-by: Aluni <gairik.aluni@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
