### PR TITLE
HARP-13345: Fix line marker replacement.

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -48,7 +48,7 @@ export class TextElementState {
      * @hidden
      * Stores index into path for TextElements that are of type LineMarker.
      */
-    private m_lineMarkerIndex?: number;
+    private readonly m_lineMarkerIndex?: number;
 
     /**
      *
@@ -173,7 +173,6 @@ export class TextElementState {
         this.m_textRenderState = predecessor.m_textRenderState;
         this.m_textLayoutState = predecessor.m_textLayoutState;
         this.m_iconRenderState = predecessor.m_iconRenderState;
-        this.m_lineMarkerIndex = predecessor.lineMarkerIndex;
         predecessor.m_textRenderState = undefined;
         predecessor.m_textLayoutState = undefined;
         predecessor.m_iconRenderState = undefined;

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -139,7 +139,7 @@ function findDuplicateByText(
     let duplicate: TextElement | undefined;
     let dupDistSquared: number = Infinity;
     const isBetterDuplicate: DuplicateCmp =
-        element.type === TextElementType.PoiLabel ? isBetterPointDuplicate : isBetterPathDuplicate;
+        element.type === TextElementType.PathLabel ? isBetterPathDuplicate : isBetterPointDuplicate;
 
     for (let i = 0; i < entryCount; ++i) {
         const candidateEntry = candidates[i];

--- a/@here/harp-mapview/test/TextElementBuilder.ts
+++ b/@here/harp-mapview/test/TextElementBuilder.ts
@@ -31,16 +31,18 @@ export function poiBuilder(text: string = DEF_TEXT): TextElementBuilder {
         .withPoiInfo(new PoiInfoBuilder().withPoiTechnique());
 }
 
+export function createPath(coordScale: number, points: THREE.Vector3[]) {
+    return points.map((point: THREE.Vector3) => point.clone().multiplyScalar(coordScale));
+}
+
 export function pathTextBuilder(coordScale: number, text: string = DEF_TEXT): TextElementBuilder {
-    return new TextElementBuilder()
-        .withText(text)
-        .withPath(DEF_PATH.map((point: THREE.Vector3) => point.clone().multiplyScalar(coordScale)));
+    return new TextElementBuilder().withText(text).withPath(createPath(coordScale, DEF_PATH));
 }
 
 export function lineMarkerBuilder(coordScale: number, text: string = DEF_TEXT): TextElementBuilder {
     return new TextElementBuilder()
         .withText(text)
-        .withPath(DEF_PATH.map((point: THREE.Vector3) => point.clone().multiplyScalar(coordScale)))
+        .withPath(createPath(coordScale, DEF_PATH))
         .withPoiInfo(new PoiInfoBuilder().withLineMarkerTechnique());
 }
 

--- a/@here/harp-mapview/test/TextElementsRendererTestUtils.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestUtils.ts
@@ -118,20 +118,22 @@ export function allFrames(frames: number[]): boolean[] {
  * Types to hold input data for TextElementsRenderer tests.
  */
 export type InputTextElement =
-    | [TextElementBuilder, FadeState[]]
-    | [TextElementBuilder, FadeState[], boolean[]]
-    | [TextElementBuilder, FadeState[], boolean[], FadeState[]];
+    | [TextElementBuilder, FadeState[]] // Text-only element.
+    | [TextElementBuilder, FadeState[], boolean[]] // booleans mark frames where element is present.
+    | [TextElementBuilder, FadeState[], boolean[], FadeState[]] // POIs (icon and text)
+    | [TextElementBuilder, FadeState[][], boolean[], FadeState[][]]; // line marker
 
-export function builder(input: InputTextElement) {
+export function builder(input: InputTextElement): TextElementBuilder {
     return input[0];
 }
 
-export function frameStates(input: InputTextElement) {
+export function frameStates(input: InputTextElement): FadeState[] | FadeState[][] {
     return input[1];
 }
 
-export function iconFrameStates(input: InputTextElement) {
-    return input[3];
+// If frame states array is empty, same text frame states are used also for icons.
+export function iconFrameStates(input: InputTextElement): FadeState[] | FadeState[][] | undefined {
+    return input.length > 3 ? (input[3]!.length > 0 ? input[3] : input[1]) : undefined;
 }
 
 export function framesEnabled(input: InputTextElement): boolean[] | undefined {

--- a/@here/harp-mapview/test/stubTextCanvas.ts
+++ b/@here/harp-mapview/test/stubTextCanvas.ts
@@ -91,8 +91,9 @@ export function stubTextCanvas(
         .stub(textCanvas, "addTextBufferObject")
         .callsFake((textBufferObject: TextBufferObject, params?: TextBufferAdditionParameters) => {
             addTextBufferObjSpy(
-                textBufferObject,
-                params === undefined ? undefined : params.opacity
+                params?.pickingData,
+                params?.opacity,
+                params?.position?.toArray().slice(0, 2)
             );
             return true;
         });


### PR DESCRIPTION
TextElementState.lineMarkerIndex must not be copied to the successor.
Predecessor and successor might have different number of markers. The
marker instance used as replacement is chosen by proximity to the
predecessor.

Also findDuplicateByText() was choosing the wrong cmp function for line
markers.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
