### PR TITLE
HARP-11894 Fixing partially missing tiles

### DIFF
--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -359,7 +359,15 @@ export class FrustumIntersection {
 
         return {
             area: objectSize * objectSize,
-            distance: projectedPoint.z / projectedPoint.w
+            //Dividing by w means we loose information for whether the point is behind the camera
+            //(i.e. it is in front of the near plane) or beyond the far plane, hence we first clamp
+            //to [-1, 1] range, before doing the division.
+            distance:
+                projectedPoint.z <= -projectedPoint.w
+                    ? -1
+                    : projectedPoint.z >= projectedPoint.w
+                    ? 1
+                    : projectedPoint.z / projectedPoint.w
         };
     }
 

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -360,11 +360,11 @@ describe("VisibleTileSet", function() {
         assert.equal(dataSourceTileList[0].visibleTiles.length, 5);
 
         const visibleTiles = dataSourceTileList[0].visibleTiles;
-        assert.equal(visibleTiles[0].tileKey.mortonCode(), 371506849);
-        assert.equal(visibleTiles[1].tileKey.mortonCode(), 371506848);
-        assert.equal(visibleTiles[2].tileKey.mortonCode(), 371506165);
-        assert.equal(visibleTiles[3].tileKey.mortonCode(), 371506827);
-        assert.equal(visibleTiles[4].tileKey.mortonCode(), 371506850);
+        assert.equal(visibleTiles[0].tileKey.mortonCode(), 371506850);
+        assert.equal(visibleTiles[1].tileKey.mortonCode(), 371506849);
+        assert.equal(visibleTiles[2].tileKey.mortonCode(), 371506848);
+        assert.equal(visibleTiles[3].tileKey.mortonCode(), 371506165);
+        assert.equal(visibleTiles[4].tileKey.mortonCode(), 371506827);
 
         const renderedTiles = dataSourceTileList[0].renderedTiles;
         assert.equal(renderedTiles.size, 0);


### PR DESCRIPTION
The problem was that the perspective division looses information about
whether the tile was behind the camera or behind the far plane, which
means we can't sort the tiles correctly. Tiles behind the near plane
are therefore given a distance of -1 and those past the far plane
are given a distance of +1. Note, we know that the tiles are visible
because they intersect the frustum.

Signed-off-by: Jonathan Stichbury <2533428+nzjony@users.noreply.github.com>
