### PR TITLE
MINOR: Schedule view update to render POI icon

### DIFF
--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1741,6 +1741,7 @@ export class TextElementsRenderer {
             // Ensure that text elements still loading icons get a chance to be rendered if
             // there are no text element updates in the next frames.
             this.m_forceNewLabelsPass = true;
+            this.m_viewUpdateCallback();
         }
 
         const distanceFadeFactor = this.getDistanceFadingFactor(


### PR DESCRIPTION
In case POI icon is registered as HTMLCanvasElement in the MapViewImageCache it is not immediately "ready", hence we
need to schedule a second frame to render it correctly.

Signed-off-by: German Zargaryan <2526045+germanz@users.noreply.github.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
