### PR TITLE
HARP-13809: Fix Webpack caching for multiple configurations.

### DIFF
--- a/@here/harp-examples/webpack.config.js
+++ b/@here/harp-examples/webpack.config.js
@@ -31,6 +31,17 @@ const themeList = {
     berlinOutlines: "resources/berlin_tilezen_effects_outlines.json"
 };
 
+function getCacheConfig(name) {
+    // Use a separate cache for each configuration, otherwise cache writing fails.
+    return process.env.HARP_NO_HARD_SOURCE_CACHE ? false :{
+        type: "filesystem",
+        buildDependencies: {
+            config: [ __filename ]
+        },
+        name: "harp-examples_" + name
+    }
+}
+
 function resolveOptional(path, message) {
     try {
         return require.resolve(path);
@@ -106,20 +117,16 @@ const commonConfig = {
         new webpack.DefinePlugin({
             THEMES: JSON.stringify(themeList)
         })
-    ],
-    cache: process.env.HARP_NO_HARD_SOURCE_CACHE ? false :{
-        type: "filesystem",
-        buildDependencies: {
-            config: [ __filename ]
-        }
-    }
+    ]
 };
 
 const decoderConfig = merge(commonConfig, {
     target: "webworker",
     entry: {
         decoder: "./decoder/decoder.ts"
-    }
+    },
+    // @ts-ignore
+    cache: getCacheConfig("decoder")
 });
 
 const webpackEntries = glob
@@ -168,19 +175,25 @@ const browserConfig = merge(commonConfig, {
             minSize: 1000,
             name: "common"
         }
-    }
+    },
+    // @ts-ignore
+    cache: getCacheConfig("browser")
 });
 
 const exampleBrowserConfig = merge(commonConfig, {
     entry: {
         "example-browser": "./example-browser.ts"
-    }
+    },
+    // @ts-ignore
+    cache: getCacheConfig("example_browser")
 });
 
 const codeBrowserConfig = merge(commonConfig, {
     entry: {
         codebrowser: "./codebrowser.ts"
-    }
+    },
+    // @ts-ignore
+    cache: getCacheConfig("code_browser")
 });
 
 browserConfig.plugins.push(

--- a/@here/harp.gl/webpack.config.js
+++ b/@here/harp.gl/webpack.config.js
@@ -15,6 +15,18 @@ const { merge } = require("webpack-merge");
 const isProduction = process.env.NODE_ENV === "production";
 const bundleSuffix = isProduction ? ".min" : "";
 
+
+function getCacheConfig(name) {
+    // Use a separate cache for each configuration, otherwise cache writing fails.
+    return process.env.HARP_NO_HARD_SOURCE_CACHE ? false :{
+        type: "filesystem",
+        buildDependencies: {
+            config: [ __filename ]
+        },
+        name: "harp.gl_" + name
+    }
+}
+
 /** @type{webpack.Configuration} */
 const commonConfig = {
     devtool: "source-map",
@@ -82,7 +94,9 @@ const mapComponentConfig = merge(commonConfig, {
                 ? callback(null, "THREE")
                 : callback(undefined, undefined)
         }
-    ]
+    ],
+    // @ts-ignore
+    cache: getCacheConfig("index")
 });
 
 const mapComponentDecoderConfig = merge(commonConfig, {
@@ -99,7 +113,9 @@ const mapComponentDecoderConfig = merge(commonConfig, {
                 ? callback(null, "THREE")
                 : callback(undefined, undefined)
         }
-    ]
+    ],
+    // @ts-ignore
+    cache: getCacheConfig("decoder")
 });
 
 module.exports = [mapComponentConfig, mapComponentDecoderConfig];


### PR DESCRIPTION
Webpack fails trying to store a cache shared by multiple configurations.
Now each configuration has its own cache.

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
