### PR TITLE
HARP-13770: Update the copyright header

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ coverage/
 lerna.json
 .github/workflows
 .vscode/
+.history

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ cache:
   directories:
     - "node_modules/.cache"
 
+git:
+  depth: false
+
 addons:
   chrome: stable
   firefox: latest

--- a/@here/generator-harp.gl/generators/app/templates/typescript/View.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/View.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/generator-harp.gl/generators/app/templates/typescript/decoder.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/decoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/generator-harp.gl/generators/app/templates/typescript/index.ts
+++ b/@here/generator-harp.gl/generators/app/templates/typescript/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/AtlasGenerator.ts
+++ b/@here/harp-atlas-tools/src/AtlasGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/BlendOperations.ts
+++ b/@here/harp-atlas-tools/src/BlendOperations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ColorOperations.ts
+++ b/@here/harp-atlas-tools/src/ColorOperations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ColorUtils.ts
+++ b/@here/harp-atlas-tools/src/ColorUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/FileSystem.ts
+++ b/@here/harp-atlas-tools/src/FileSystem.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ImageBitmapCoders.ts
+++ b/@here/harp-atlas-tools/src/ImageBitmapCoders.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ImageFactory.ts
+++ b/@here/harp-atlas-tools/src/ImageFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ImageProcessing.ts
+++ b/@here/harp-atlas-tools/src/ImageProcessing.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ImageUtils.ts
+++ b/@here/harp-atlas-tools/src/ImageUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/ImageVectorCoders.ts
+++ b/@here/harp-atlas-tools/src/ImageVectorCoders.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/Logger.ts
+++ b/@here/harp-atlas-tools/src/Logger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/MaskOperations.ts
+++ b/@here/harp-atlas-tools/src/MaskOperations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/cli-atlas-generator.ts
+++ b/@here/harp-atlas-tools/src/cli-atlas-generator.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/cli-sprites-generator.ts
+++ b/@here/harp-atlas-tools/src/cli-sprites-generator.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-atlas-tools/src/index.ts
+++ b/@here/harp-atlas-tools/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/index-decoder.ts
+++ b/@here/harp-datasource-protocol/index-decoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/index.ts
+++ b/@here/harp-datasource-protocol/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ColorUtils.ts
+++ b/@here/harp-datasource-protocol/lib/ColorUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/Env.ts
+++ b/@here/harp-datasource-protocol/lib/Env.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/Expr.ts
+++ b/@here/harp-datasource-protocol/lib/Expr.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprEvaluator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ExprInstantiator.ts
+++ b/@here/harp-datasource-protocol/lib/ExprInstantiator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ExprParser.ts
+++ b/@here/harp-datasource-protocol/lib/ExprParser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ExprPool.ts
+++ b/@here/harp-datasource-protocol/lib/ExprPool.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/GeoJsonDataType.ts
+++ b/@here/harp-datasource-protocol/lib/GeoJsonDataType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/IMeshBuffers.ts
+++ b/@here/harp-datasource-protocol/lib/IMeshBuffers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ITileDecoder.ts
+++ b/@here/harp-datasource-protocol/lib/ITileDecoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ITiler.ts
+++ b/@here/harp-datasource-protocol/lib/ITiler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
+++ b/@here/harp-datasource-protocol/lib/InterpolatedPropertyDefs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/Outliner.ts
+++ b/@here/harp-datasource-protocol/lib/Outliner.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/Pixels.ts
+++ b/@here/harp-datasource-protocol/lib/Pixels.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/PostEffects.ts
+++ b/@here/harp-datasource-protocol/lib/PostEffects.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/PropertyValue.ts
+++ b/@here/harp-datasource-protocol/lib/PropertyValue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/RGBA.ts
+++ b/@here/harp-datasource-protocol/lib/RGBA.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
+++ b/@here/harp-datasource-protocol/lib/StringEncodedNumeral.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueAttr.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptors.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/Techniques.ts
+++ b/@here/harp-datasource-protocol/lib/Techniques.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/Theme.ts
+++ b/@here/harp-datasource-protocol/lib/Theme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
+++ b/@here/harp-datasource-protocol/lib/ThemeVisitor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ThreeBufferUtils.ts
+++ b/@here/harp-datasource-protocol/lib/ThreeBufferUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/TileInfo.ts
+++ b/@here/harp-datasource-protocol/lib/TileInfo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/ViewRanges.ts
+++ b/@here/harp-datasource-protocol/lib/ViewRanges.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerDecoderProtocol.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/WorkerServiceProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerServiceProtocol.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/WorkerTilerProtocol.ts
+++ b/@here/harp-datasource-protocol/lib/WorkerTilerProtocol.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/ArrayOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ArrayOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/CastOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/CastOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ColorOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/ComparisonOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ComparisonOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FeatureOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/FlowOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/FlowOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/MapOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MapOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MathOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/MiscOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/ObjectOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/ObjectOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/StringOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/StringOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/TypeOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/TypeOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/lib/operators/VectorOperators.ts
+++ b/@here/harp-datasource-protocol/lib/operators/VectorOperators.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/ColorUtilsTest.ts
+++ b/@here/harp-datasource-protocol/test/ColorUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprEvaluatorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/ExprPoolTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprPoolTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/ExprTest.ts
+++ b/@here/harp-datasource-protocol/test/ExprTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/InterpolationTest.ts
+++ b/@here/harp-datasource-protocol/test/InterpolationTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/OutlinesTest.ts
+++ b/@here/harp-datasource-protocol/test/OutlinesTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/StringDecodersTest.ts
+++ b/@here/harp-datasource-protocol/test/StringDecodersTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/ThemeTypingsTest.ts
+++ b/@here/harp-datasource-protocol/test/ThemeTypingsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-datasource-protocol/test/ThreeBufferUtilsTest.ts
+++ b/@here/harp-datasource-protocol/test/ThreeBufferUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-debug-datasource/index.ts
+++ b/@here/harp-debug-datasource/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-debug-datasource/lib/DebugTileDataSource.ts
+++ b/@here/harp-debug-datasource/lib/DebugTileDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-debug-datasource/test/Test.ts
+++ b/@here/harp-debug-datasource/test/Test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/codebrowser.ts
+++ b/@here/harp-examples/codebrowser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/config.ts
+++ b/@here/harp-examples/config.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/decoder/custom_decoder.ts
+++ b/@here/harp-examples/decoder/custom_decoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/decoder/custom_decoder_defs.ts
+++ b/@here/harp-examples/decoder/custom_decoder_defs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/decoder/decoder.ts
+++ b/@here/harp-examples/decoder/decoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/example-browser.ts
+++ b/@here/harp-examples/example-browser.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/lib/PerformanceConfig.ts
+++ b/@here/harp-examples/lib/PerformanceConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/lib/PerformanceUtils.ts
+++ b/@here/harp-examples/lib/PerformanceUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/resources/countries.ts
+++ b/@here/harp-examples/resources/countries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/resources/geology.ts
+++ b/@here/harp-examples/resources/geology.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/bounds-generation.ts
+++ b/@here/harp-examples/src/bounds-generation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/camera-animations_key-track.ts
+++ b/@here/harp-examples/src/camera-animations_key-track.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/camera-animations_quaternion-slerp.ts
+++ b/@here/harp-examples/src/camera-animations_quaternion-slerp.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_custom-texture-tile.ts
+++ b/@here/harp-examples/src/datasource_custom-texture-tile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_custom.ts
+++ b/@here/harp-examples/src/datasource_custom.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_features_lines-and-points.ts
+++ b/@here/harp-examples/src/datasource_features_lines-and-points.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_geojson_choropleth.ts
+++ b/@here/harp-examples/src/datasource_geojson_choropleth.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_geojson_custom-shader.ts
+++ b/@here/harp-examples/src/datasource_geojson_custom-shader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_geojson_elevated-markers.ts
+++ b/@here/harp-examples/src/datasource_geojson_elevated-markers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_geojson_points.ts
+++ b/@here/harp-examples/src/datasource_geojson_points.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_geojson_visibility.ts
+++ b/@here/harp-examples/src/datasource_geojson_visibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_here-webtile.ts
+++ b/@here/harp-examples/src/datasource_here-webtile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_here_vector_tile.ts
+++ b/@here/harp-examples/src/datasource_here_vector_tile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/datasource_satellite-tile.ts
+++ b/@here/harp-examples/src/datasource_satellite-tile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/getting-started_free-camera.ts
+++ b/@here/harp-examples/src/getting-started_free-camera.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/getting-started_globe-projection.ts
+++ b/@here/harp-examples/src/getting-started_globe-projection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/getting-started_hello-world_npm.ts
+++ b/@here/harp-examples/src/getting-started_hello-world_npm.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/getting-started_open-sourced-themes.ts
+++ b/@here/harp-examples/src/getting-started_open-sourced-themes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/getting-started_orbiting-view.ts
+++ b/@here/harp-examples/src/getting-started_orbiting-view.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/markers_dynamic.ts
+++ b/@here/harp-examples/src/markers_dynamic.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/markers_screen-anchor.ts
+++ b/@here/harp-examples/src/markers_screen-anchor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/performance_benchmark.ts
+++ b/@here/harp-examples/src/performance_benchmark.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/real-time-shadows.ts
+++ b/@here/harp-examples/src/real-time-shadows.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/rendering_globe-atmosphere.ts
+++ b/@here/harp-examples/src/rendering_globe-atmosphere.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/rendering_post-effects_all.ts
+++ b/@here/harp-examples/src/rendering_post-effects_all.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/rendering_post-effects_themes.ts
+++ b/@here/harp-examples/src/rendering_post-effects_themes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/rendering_synchronous.ts
+++ b/@here/harp-examples/src/rendering_synchronous.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/styling_square-technique.ts
+++ b/@here/harp-examples/src/styling_square-technique.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/styling_textured-areas.ts
+++ b/@here/harp-examples/src/styling_textured-areas.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/synchronized-views.ts
+++ b/@here/harp-examples/src/synchronized-views.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/textcanvas.ts
+++ b/@here/harp-examples/src/textcanvas.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/threejs_add-object.ts
+++ b/@here/harp-examples/src/threejs_add-object.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/threejs_animation.ts
+++ b/@here/harp-examples/src/threejs_animation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/threejs_raycast.ts
+++ b/@here/harp-examples/src/threejs_raycast.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-examples/src/tile_dependencies.ts
+++ b/@here/harp-examples/src/tile_dependencies.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-features-datasource/index.ts
+++ b/@here/harp-features-datasource/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-features-datasource/lib/Features.ts
+++ b/@here/harp-features-datasource/lib/Features.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-features-datasource/lib/FeaturesDataSource.ts
+++ b/@here/harp-features-datasource/lib/FeaturesDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-fetch/index.ts
+++ b/@here/harp-fetch/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-fetch/index.web.ts
+++ b/@here/harp-fetch/index.web.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-fetch/test/FetchTest.ts
+++ b/@here/harp-fetch/test/FetchTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geojson-datasource/index-worker.ts
+++ b/@here/harp-geojson-datasource/index-worker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geojson-datasource/index.ts
+++ b/@here/harp-geojson-datasource/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geojson-datasource/lib/GeoJsonDataProvider.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonDataProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geojson-datasource/lib/GeoJsonDataSource.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geojson-datasource/lib/GeoJsonTileDecoderService.ts
+++ b/@here/harp-geojson-datasource/lib/GeoJsonTileDecoderService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/index.ts
+++ b/@here/harp-geometry/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/ClipLineString.ts
+++ b/@here/harp-geometry/lib/ClipLineString.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/ClipPolygon.ts
+++ b/@here/harp-geometry/lib/ClipPolygon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/EdgeLengthGeometrySubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/EdgeLengthGeometrySubdivisionModifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/OrientedBox3.ts
+++ b/@here/harp-geometry/lib/OrientedBox3.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/SphericalGeometrySubdivisionModifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/SubdivisionModifier.ts
+++ b/@here/harp-geometry/lib/SubdivisionModifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/WrapLineString.ts
+++ b/@here/harp-geometry/lib/WrapLineString.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/lib/WrapPolygon.ts
+++ b/@here/harp-geometry/lib/WrapPolygon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/test/ClipPolygonTest.ts
+++ b/@here/harp-geometry/test/ClipPolygonTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/test/EdgeLengthGeometrySubdivisionModifierTest.ts
+++ b/@here/harp-geometry/test/EdgeLengthGeometrySubdivisionModifierTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geometry/test/SphericalGeometrySubdivisionModifierTest.ts
+++ b/@here/harp-geometry/test/SphericalGeometrySubdivisionModifierTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/index.ts
+++ b/@here/harp-geoutils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoBox.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoBox.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoCoordLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordLike.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordinates.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoCoordinatesLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoCoordinatesLike.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoPointLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoPointLike.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoPolygon.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoPolygon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/GeoPolygonLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/GeoPolygonLike.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/coordinates/LatLngLike.ts
+++ b/@here/harp-geoutils/lib/coordinates/LatLngLike.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/Box3Like.ts
+++ b/@here/harp-geoutils/lib/math/Box3Like.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/MathUtils.ts
+++ b/@here/harp-geoutils/lib/math/MathUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/OrientedBox3.ts
+++ b/@here/harp-geoutils/lib/math/OrientedBox3.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/OrientedBox3Like.ts
+++ b/@here/harp-geoutils/lib/math/OrientedBox3Like.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/TransformLike.ts
+++ b/@here/harp-geoutils/lib/math/TransformLike.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/Vector2Like.ts
+++ b/@here/harp-geoutils/lib/math/Vector2Like.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/math/Vector3Like.ts
+++ b/@here/harp-geoutils/lib/math/Vector3Like.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/EarthConstants.ts
+++ b/@here/harp-geoutils/lib/projection/EarthConstants.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/EquirectangularProjection.ts
+++ b/@here/harp-geoutils/lib/projection/EquirectangularProjection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/IdentityProjection.ts
+++ b/@here/harp-geoutils/lib/projection/IdentityProjection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/MercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/MercatorProjection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/Projection.ts
+++ b/@here/harp-geoutils/lib/projection/Projection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/SphereProjection.ts
+++ b/@here/harp-geoutils/lib/projection/SphereProjection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
+++ b/@here/harp-geoutils/lib/projection/TransverseMercatorProjection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/FlatTileBoundingBoxGenerator.ts
+++ b/@here/harp-geoutils/lib/tiling/FlatTileBoundingBoxGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/HalfQuadTreeSubdivisionScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/HalfQuadTreeSubdivisionScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/HereTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/HereTilingScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/MercatorTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/MercatorTilingScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/PolarTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/PolarTilingScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/QuadTree.ts
+++ b/@here/harp-geoutils/lib/tiling/QuadTree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/QuadTreeSubdivisionScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/QuadTreeSubdivisionScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/SubTiles.ts
+++ b/@here/harp-geoutils/lib/tiling/SubTiles.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/SubdivisionScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/SubdivisionScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/TileKey.ts
+++ b/@here/harp-geoutils/lib/tiling/TileKey.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
+++ b/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/TileTreeTraverse.ts
+++ b/@here/harp-geoutils/lib/tiling/TileTreeTraverse.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/TilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/TilingScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/lib/tiling/WebMercatorTilingScheme.ts
+++ b/@here/harp-geoutils/lib/tiling/WebMercatorTilingScheme.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/GeoBoxTest.ts
+++ b/@here/harp-geoutils/test/GeoBoxTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/GeoCoordinatesTest.ts
+++ b/@here/harp-geoutils/test/GeoCoordinatesTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/GeoPolygonTest.ts
+++ b/@here/harp-geoutils/test/GeoPolygonTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/MathUtilsTest.ts
+++ b/@here/harp-geoutils/test/MathUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/OrientedBox3Test.ts
+++ b/@here/harp-geoutils/test/OrientedBox3Test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/ProjectionTest.ts
+++ b/@here/harp-geoutils/test/ProjectionTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/SphereProjectionTest.ts
+++ b/@here/harp-geoutils/test/SphereProjectionTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/SubTilesTest.ts
+++ b/@here/harp-geoutils/test/SubTilesTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/TileKeyTest.ts
+++ b/@here/harp-geoutils/test/TileKeyTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/TileTreeTraverseTest.ts
+++ b/@here/harp-geoutils/test/TileTreeTraverseTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-geoutils/test/TransverseMercatorProjectionTest.ts
+++ b/@here/harp-geoutils/test/TransverseMercatorProjectionTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/index.ts
+++ b/@here/harp-lines/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/lib/HighPrecisionLines.ts
+++ b/@here/harp-lines/lib/HighPrecisionLines.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/lib/HighPrecisionPoints.ts
+++ b/@here/harp-lines/lib/HighPrecisionPoints.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/lib/HighPrecisionUtils.ts
+++ b/@here/harp-lines/lib/HighPrecisionUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/lib/Lines.ts
+++ b/@here/harp-lines/lib/Lines.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/lib/TriangulateLines.ts
+++ b/@here/harp-lines/lib/TriangulateLines.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/test/Test.ts
+++ b/@here/harp-lines/test/Test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lines/test/rendering/RenderLines.ts
+++ b/@here/harp-lines/test/rendering/RenderLines.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lrucache/index.ts
+++ b/@here/harp-lrucache/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lrucache/lib/LRUCache.ts
+++ b/@here/harp-lrucache/lib/LRUCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-lrucache/test/LRUCacheTest.ts
+++ b/@here/harp-lrucache/test/LRUCacheTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/index.ts
+++ b/@here/harp-map-controls/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/CameraAnimationBuilder.ts
+++ b/@here/harp-map-controls/lib/CameraAnimationBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/CameraKeyTrackAnimation.ts
+++ b/@here/harp-map-controls/lib/CameraKeyTrackAnimation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/LongPressHandler.ts
+++ b/@here/harp-map-controls/lib/LongPressHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/MapAnimations.ts
+++ b/@here/harp-map-controls/lib/MapAnimations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/MapControls.ts
+++ b/@here/harp-map-controls/lib/MapControls.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/MapControlsUI.ts
+++ b/@here/harp-map-controls/lib/MapControlsUI.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/lib/Utils.ts
+++ b/@here/harp-map-controls/lib/Utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/test/CameraAnimationBuilderTest.ts
+++ b/@here/harp-map-controls/test/CameraAnimationBuilderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/test/MapControlsTest.ts
+++ b/@here/harp-map-controls/test/MapControlsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-controls/test/UtilsTest.ts
+++ b/@here/harp-map-controls/test/UtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-theme/index.ts
+++ b/@here/harp-map-theme/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-theme/scripts/prepack.ts
+++ b/@here/harp-map-theme/scripts/prepack.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-theme/scripts/prepareIcons.ts
+++ b/@here/harp-map-theme/scripts/prepareIcons.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-map-theme/test/DefaultThemeTest.ts
+++ b/@here/harp-map-theme/test/DefaultThemeTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/index-worker.ts
+++ b/@here/harp-mapview-decoder/index-worker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/index.ts
+++ b/@here/harp-mapview-decoder/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/DataProvider.ts
+++ b/@here/harp-mapview-decoder/lib/DataProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
+++ b/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/TestDataProviders.ts
+++ b/@here/harp-mapview-decoder/lib/TestDataProviders.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
+++ b/@here/harp-mapview-decoder/lib/ThemedTileDecoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/TileDataSource.ts
+++ b/@here/harp-mapview-decoder/lib/TileDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/TileDecoderService.ts
+++ b/@here/harp-mapview-decoder/lib/TileDecoderService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/TileLoader.ts
+++ b/@here/harp-mapview-decoder/lib/TileLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/TilerService.ts
+++ b/@here/harp-mapview-decoder/lib/TilerService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/WorkerService.ts
+++ b/@here/harp-mapview-decoder/lib/WorkerService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/lib/WorkerServiceManager.ts
+++ b/@here/harp-mapview-decoder/lib/WorkerServiceManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/test/DataProviderTest.ts
+++ b/@here/harp-mapview-decoder/test/DataProviderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/test/MapViewDecoderTest.ts
+++ b/@here/harp-mapview-decoder/test/MapViewDecoderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/test/TileDataSourceTest.ts
+++ b/@here/harp-mapview-decoder/test/TileDataSourceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileGeometryLoaderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview-decoder/test/TileLoaderTest.ts
+++ b/@here/harp-mapview-decoder/test/TileLoaderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/index.ts
+++ b/@here/harp-mapview/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
+++ b/@here/harp-mapview/lib/AnimatedExtrusionHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/BackgroundDataSource.ts
+++ b/@here/harp-mapview/lib/BackgroundDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/BaseTileLoader.ts
+++ b/@here/harp-mapview/lib/BaseTileLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/BoundsGenerator.ts
+++ b/@here/harp-mapview/lib/BoundsGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/CameraMovementDetector.ts
+++ b/@here/harp-mapview/lib/CameraMovementDetector.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
+++ b/@here/harp-mapview/lib/ClipPlanesEvaluator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ColorCache.ts
+++ b/@here/harp-mapview/lib/ColorCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentDecoderFacade.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
+++ b/@here/harp-mapview/lib/ConcurrentTilerFacade.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
+++ b/@here/harp-mapview/lib/ConcurrentWorkerSet.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/DebugContext.ts
+++ b/@here/harp-mapview/lib/DebugContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/DecodedTileHelpers.ts
+++ b/@here/harp-mapview/lib/DecodedTileHelpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/DepthPrePass.ts
+++ b/@here/harp-mapview/lib/DepthPrePass.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/DisplacementMap.ts
+++ b/@here/harp-mapview/lib/DisplacementMap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ElevationProvider.ts
+++ b/@here/harp-mapview/lib/ElevationProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ElevationRangeSource.ts
+++ b/@here/harp-mapview/lib/ElevationRangeSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/EventDispatcher.ts
+++ b/@here/harp-mapview/lib/EventDispatcher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ITileLoader.ts
+++ b/@here/harp-mapview/lib/ITileLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/IntersectParams.ts
+++ b/@here/harp-mapview/lib/IntersectParams.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapAnchors.ts
+++ b/@here/harp-mapview/lib/MapAnchors.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapMaterialAdapter.ts
+++ b/@here/harp-mapview/lib/MapMaterialAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapObjectAdapter.ts
+++ b/@here/harp-mapview/lib/MapObjectAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapTileCuller.ts
+++ b/@here/harp-mapview/lib/MapTileCuller.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapView.ts
+++ b/@here/harp-mapview/lib/MapView.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapViewAtmosphere.ts
+++ b/@here/harp-mapview/lib/MapViewAtmosphere.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapViewEnvironment.ts
+++ b/@here/harp-mapview/lib/MapViewEnvironment.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapViewFog.ts
+++ b/@here/harp-mapview/lib/MapViewFog.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapViewPoints.ts
+++ b/@here/harp-mapview/lib/MapViewPoints.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapViewTaskScheduler.ts
+++ b/@here/harp-mapview/lib/MapViewTaskScheduler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/MapViewThemeManager.ts
+++ b/@here/harp-mapview/lib/MapViewThemeManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/PathBlockingElement.ts
+++ b/@here/harp-mapview/lib/PathBlockingElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/PickListener.ts
+++ b/@here/harp-mapview/lib/PickListener.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/PickingRaycaster.ts
+++ b/@here/harp-mapview/lib/PickingRaycaster.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/PolarTileDataSource.ts
+++ b/@here/harp-mapview/lib/PolarTileDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ScreenCollisions.ts
+++ b/@here/harp-mapview/lib/ScreenCollisions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ScreenProjector.ts
+++ b/@here/harp-mapview/lib/ScreenProjector.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/SkyBackground.ts
+++ b/@here/harp-mapview/lib/SkyBackground.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/SkyCubemapTexture.ts
+++ b/@here/harp-mapview/lib/SkyCubemapTexture.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/SkyGradientTexture.ts
+++ b/@here/harp-mapview/lib/SkyGradientTexture.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/SphereHorizon.ts
+++ b/@here/harp-mapview/lib/SphereHorizon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/Statistics.ts
+++ b/@here/harp-mapview/lib/Statistics.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ThemeHelpers.ts
+++ b/@here/harp-mapview/lib/ThemeHelpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/TileObjectsRenderer.ts
+++ b/@here/harp-mapview/lib/TileObjectsRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/WorkerBasedDecoder.ts
+++ b/@here/harp-mapview/lib/WorkerBasedDecoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/WorkerBasedTiler.ts
+++ b/@here/harp-mapview/lib/WorkerBasedTiler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/IPassManager.ts
+++ b/@here/harp-mapview/lib/composing/IPassManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/LowResRenderPass.ts
+++ b/@here/harp-mapview/lib/composing/LowResRenderPass.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/MSAARenderPass.ts
+++ b/@here/harp-mapview/lib/composing/MSAARenderPass.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/MapRenderingManager.ts
+++ b/@here/harp-mapview/lib/composing/MapRenderingManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/Outline.ts
+++ b/@here/harp-mapview/lib/composing/Outline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/Pass.ts
+++ b/@here/harp-mapview/lib/composing/Pass.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/UnrealBloomPass.ts
+++ b/@here/harp-mapview/lib/composing/UnrealBloomPass.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/composing/index.ts
+++ b/@here/harp-mapview/lib/composing/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/copyrights/CopyrightCoverageProvider.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightCoverageProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/copyrights/CopyrightElementHandler.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightElementHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/copyrights/CopyrightInfo.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightInfo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/copyrights/CopyrightProvider.ts
+++ b/@here/harp-mapview/lib/copyrights/CopyrightProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/copyrights/UrlCopyrightProvider.ts
+++ b/@here/harp-mapview/lib/copyrights/UrlCopyrightProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/AddGroundPlane.ts
+++ b/@here/harp-mapview/lib/geometry/AddGroundPlane.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/LodMesh.ts
+++ b/@here/harp-mapview/lib/geometry/LodMesh.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/ProjectTilePlaneCorners.ts
+++ b/@here/harp-mapview/lib/geometry/ProjectTilePlaneCorners.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/RegisterTileObject.ts
+++ b/@here/harp-mapview/lib/geometry/RegisterTileObject.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
+++ b/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/TileGeometry.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometry.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
+++ b/@here/harp-mapview/lib/geometry/overlayOnElevation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/image/Image.ts
+++ b/@here/harp-mapview/lib/image/Image.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/image/ImageCache.ts
+++ b/@here/harp-mapview/lib/image/ImageCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/image/MapViewImageCache.ts
+++ b/@here/harp-mapview/lib/image/MapViewImageCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/poi/BoxBuffer.ts
+++ b/@here/harp-mapview/lib/poi/BoxBuffer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/poi/PixelPicker.ts
+++ b/@here/harp-mapview/lib/poi/PixelPicker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/poi/PoiBuilder.ts
+++ b/@here/harp-mapview/lib/poi/PoiBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/poi/PoiTableManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiTableManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/FontCatalogLoader.ts
+++ b/@here/harp-mapview/lib/text/FontCatalogLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/LayoutState.ts
+++ b/@here/harp-mapview/lib/text/LayoutState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/MapViewState.ts
+++ b/@here/harp-mapview/lib/text/MapViewState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/Placement.ts
+++ b/@here/harp-mapview/lib/text/Placement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/PlacementStats.ts
+++ b/@here/harp-mapview/lib/text/PlacementStats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/RenderState.ts
+++ b/@here/harp-mapview/lib/text/RenderState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/SimplePath.ts
+++ b/@here/harp-mapview/lib/text/SimplePath.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextCanvasFactory.ts
+++ b/@here/harp-mapview/lib/text/TextCanvasFactory.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementBuilder.ts
+++ b/@here/harp-mapview/lib/text/TextElementBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementGroup.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementGroupPriorityList.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupPriorityList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementGroupState.ts
+++ b/@here/harp-mapview/lib/text/TextElementGroupState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementState.ts
+++ b/@here/harp-mapview/lib/text/TextElementState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementStateCache.ts
+++ b/@here/harp-mapview/lib/text/TextElementStateCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementType.ts
+++ b/@here/harp-mapview/lib/text/TextElementType.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextElementsRendererOptions.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRendererOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/TextStyleCache.ts
+++ b/@here/harp-mapview/lib/text/TextStyleCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/UpdateStats.ts
+++ b/@here/harp-mapview/lib/text/UpdateStats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/text/ViewState.ts
+++ b/@here/harp-mapview/lib/text/ViewState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/workers/WorkerBootstrapDefs.ts
+++ b/@here/harp-mapview/lib/workers/WorkerBootstrapDefs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/lib/workers/WorkerLoader.ts
+++ b/@here/harp-mapview/lib/workers/WorkerLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/AddGroundPlaneTest.ts
+++ b/@here/harp-mapview/test/AddGroundPlaneTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/AnimatedExtrusionHandlerTest.ts
+++ b/@here/harp-mapview/test/AnimatedExtrusionHandlerTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/BackgroundDataSourceTest.ts
+++ b/@here/harp-mapview/test/BackgroundDataSourceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/BoundsGeneratorTest.ts
+++ b/@here/harp-mapview/test/BoundsGeneratorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ClipPlanesEvaluatorTest.ts
+++ b/@here/harp-mapview/test/ClipPlanesEvaluatorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ColorCacheTest.ts
+++ b/@here/harp-mapview/test/ColorCacheTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ConcurrentWorkerSetTest.ts
+++ b/@here/harp-mapview/test/ConcurrentWorkerSetTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/CopyrightProvidersTest.ts
+++ b/@here/harp-mapview/test/CopyrightProvidersTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/DataSourceTest.ts
+++ b/@here/harp-mapview/test/DataSourceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/DebugContextTest.ts
+++ b/@here/harp-mapview/test/DebugContextTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/DecodedTileHelpersTest.ts
+++ b/@here/harp-mapview/test/DecodedTileHelpersTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/DisplacedBufferAttributeTest.ts
+++ b/@here/harp-mapview/test/DisplacedBufferAttributeTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/DisplacedBufferGeometryTest.ts
+++ b/@here/harp-mapview/test/DisplacedBufferGeometryTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/EventDispatcherTest.ts
+++ b/@here/harp-mapview/test/EventDispatcherTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/FakeOmvDataSource.ts
+++ b/@here/harp-mapview/test/FakeOmvDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/FakeWebWorker.ts
+++ b/@here/harp-mapview/test/FakeWebWorker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ImageCacheTest.ts
+++ b/@here/harp-mapview/test/ImageCacheTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/LodMeshTest.ts
+++ b/@here/harp-mapview/test/LodMeshTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/MapViewFogTest.ts
+++ b/@here/harp-mapview/test/MapViewFogTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/MapViewTest.ts
+++ b/@here/harp-mapview/test/MapViewTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/MipMapGeneratorTest.ts
+++ b/@here/harp-mapview/test/MipMapGeneratorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/OutlineTest.ts
+++ b/@here/harp-mapview/test/OutlineTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PickListenerTest.ts
+++ b/@here/harp-mapview/test/PickListenerTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PickingRaycasterTest.ts
+++ b/@here/harp-mapview/test/PickingRaycasterTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PlacementTest.ts
+++ b/@here/harp-mapview/test/PlacementTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PoiBatchRegistryTest.ts
+++ b/@here/harp-mapview/test/PoiBatchRegistryTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PoiBuilderTest.ts
+++ b/@here/harp-mapview/test/PoiBuilderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PoiInfoBuilder.ts
+++ b/@here/harp-mapview/test/PoiInfoBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PoiRendererTest.ts
+++ b/@here/harp-mapview/test/PoiRendererTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/PolarTileDataSourceTest.ts
+++ b/@here/harp-mapview/test/PolarTileDataSourceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ProjectTilePlaneCornersTest.ts
+++ b/@here/harp-mapview/test/ProjectTilePlaneCornersTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/RenderStateTest.ts
+++ b/@here/harp-mapview/test/RenderStateTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ScreenCollisionsTest.ts
+++ b/@here/harp-mapview/test/ScreenCollisionsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ScreenProjectorTest.ts
+++ b/@here/harp-mapview/test/ScreenProjectorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/SolidLineMeshTest.ts
+++ b/@here/harp-mapview/test/SolidLineMeshTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/SphereHorizonTest.ts
+++ b/@here/harp-mapview/test/SphereHorizonTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/StatisticsTest.ts
+++ b/@here/harp-mapview/test/StatisticsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementBuilder.ts
+++ b/@here/harp-mapview/test/TextElementBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementBuilderTest.ts
+++ b/@here/harp-mapview/test/TextElementBuilderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementStateCacheTest.ts
+++ b/@here/harp-mapview/test/TextElementStateCacheTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementStateTest.ts
+++ b/@here/harp-mapview/test/TextElementStateTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementsRendererTest.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextElementsRendererTestUtils.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TextureLoaderTest.ts
+++ b/@here/harp-mapview/test/TextureLoaderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/ThemeLoaderTest.ts
+++ b/@here/harp-mapview/test/ThemeLoaderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TileCreationTest.ts
+++ b/@here/harp-mapview/test/TileCreationTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TileGeometryCreatorTest.ts
+++ b/@here/harp-mapview/test/TileGeometryCreatorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/TileTest.ts
+++ b/@here/harp-mapview/test/TileTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/VertexCacheTest.ts
+++ b/@here/harp-mapview/test/VertexCacheTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/WorkerBasedDecoderTest.ts
+++ b/@here/harp-mapview/test/WorkerBasedDecoderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/WorkerLoaderTest.ts
+++ b/@here/harp-mapview/test/WorkerLoaderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/stubElevationProvider.ts
+++ b/@here/harp-mapview/test/stubElevationProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/stubFontCatalog.ts
+++ b/@here/harp-mapview/test/stubFontCatalog.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/stubPoiManager.ts
+++ b/@here/harp-mapview/test/stubPoiManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/stubPoiRenderer.ts
+++ b/@here/harp-mapview/test/stubPoiRenderer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-mapview/test/stubTextCanvas.ts
+++ b/@here/harp-mapview/test/stubTextCanvas.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/index.ts
+++ b/@here/harp-materials/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/CirclePointsMaterial.ts
+++ b/@here/harp-materials/lib/CirclePointsMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/CopyMaterial.ts
+++ b/@here/harp-materials/lib/CopyMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/DisplacementFeature.ts
+++ b/@here/harp-materials/lib/DisplacementFeature.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/EdgeMaterial.ts
+++ b/@here/harp-materials/lib/EdgeMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/GroundAtmosphereMaterial.ts
+++ b/@here/harp-materials/lib/GroundAtmosphereMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/HighPrecisionLineMaterial.ts
+++ b/@here/harp-materials/lib/HighPrecisionLineMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/HighPrecisionPointMaterial.ts
+++ b/@here/harp-materials/lib/HighPrecisionPointMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/IconMaterial.ts
+++ b/@here/harp-materials/lib/IconMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/LuminosityHighPassShader.ts
+++ b/@here/harp-materials/lib/LuminosityHighPassShader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/MSAAMaterial.ts
+++ b/@here/harp-materials/lib/MSAAMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/MapMeshMaterials.ts
+++ b/@here/harp-materials/lib/MapMeshMaterials.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/MapMeshMaterialsDefs.ts
+++ b/@here/harp-materials/lib/MapMeshMaterialsDefs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/RawShaderMaterial.ts
+++ b/@here/harp-materials/lib/RawShaderMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/SepiaShader.ts
+++ b/@here/harp-materials/lib/SepiaShader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/ShaderChunks/AtmosphereChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/AtmosphereChunks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ExtrusionChunks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/ShaderChunks/FadingChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/FadingChunks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/ShaderChunks/ShadowChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/ShadowChunks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/SkyAtmosphereMaterial.ts
+++ b/@here/harp-materials/lib/SkyAtmosphereMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/SolidLineMaterial.ts
+++ b/@here/harp-materials/lib/SolidLineMaterial.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/Utils.ts
+++ b/@here/harp-materials/lib/Utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/lib/VignetteShader.ts
+++ b/@here/harp-materials/lib/VignetteShader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-materials/test/CirclePointsMaterialTest.ts
+++ b/@here/harp-materials/test/CirclePointsMaterialTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-olp-utils/index.ts
+++ b/@here/harp-olp-utils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-olp-utils/lib/OlpDataProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpDataProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-olp-utils/test/OlpDataProviderTest.ts
+++ b/@here/harp-olp-utils/test/OlpDataProviderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-omv-datasource/index-worker.ts
+++ b/@here/harp-omv-datasource/index-worker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-omv-datasource/index.ts
+++ b/@here/harp-omv-datasource/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-omv-datasource/lib/OmvDataSource.ts
+++ b/@here/harp-omv-datasource/lib/OmvDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/index.ts
+++ b/@here/harp-test-utils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/index.web.ts
+++ b/@here/harp-test-utils/index.web.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/ProfileHelper.ts
+++ b/@here/harp-test-utils/lib/ProfileHelper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/TestDataUtils.ts
+++ b/@here/harp-test-utils/lib/TestDataUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/TestDataUtils.web.ts
+++ b/@here/harp-test-utils/lib/TestDataUtils.web.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/TestUtils.ts
+++ b/@here/harp-test-utils/lib/TestUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/WebGLStub.ts
+++ b/@here/harp-test-utils/lib/WebGLStub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/DomImageUtils.ts
+++ b/@here/harp-test-utils/lib/rendering/DomImageUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/DomReporter.ts
+++ b/@here/harp-test-utils/lib/rendering/DomReporter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/HtmlReport.ts
+++ b/@here/harp-test-utils/lib/rendering/HtmlReport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/Interface.ts
+++ b/@here/harp-test-utils/lib/rendering/Interface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/Magnifier.ts
+++ b/@here/harp-test-utils/lib/rendering/Magnifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/ReferenceImageLocator.ts
+++ b/@here/harp-test-utils/lib/rendering/ReferenceImageLocator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/RenderingTestHelper.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestHelper.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultCli.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultCli.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultCommon.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultCommon.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultReporter.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultReporter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/lib/rendering/RenderingTestResultServer.ts
+++ b/@here/harp-test-utils/lib/rendering/RenderingTestResultServer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/test/TestDataUtilsTest.ts
+++ b/@here/harp-test-utils/test/TestDataUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-test-utils/test/TestUtilsTest.ts
+++ b/@here/harp-test-utils/test/TestUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/index.ts
+++ b/@here/harp-text-canvas/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/TextCanvas.ts
+++ b/@here/harp-text-canvas/lib/TextCanvas.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/FontCatalog.ts
+++ b/@here/harp-text-canvas/lib/rendering/FontCatalog.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/GlyphData.ts
+++ b/@here/harp-text-canvas/lib/rendering/GlyphData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/GlyphTextureCache.ts
+++ b/@here/harp-text-canvas/lib/rendering/GlyphTextureCache.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/TextBufferObject.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextBufferObject.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/TextGeometry.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextGeometry.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/TextMaterials.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextMaterials.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/rendering/TextStyle.ts
+++ b/@here/harp-text-canvas/lib/rendering/TextStyle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/typesetting/LineTypesetter.ts
+++ b/@here/harp-text-canvas/lib/typesetting/LineTypesetter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/typesetting/PathTypesetter.ts
+++ b/@here/harp-text-canvas/lib/typesetting/PathTypesetter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/typesetting/Typesetter.ts
+++ b/@here/harp-text-canvas/lib/typesetting/Typesetter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/utils/ContextualArabicConverter.ts
+++ b/@here/harp-text-canvas/lib/utils/ContextualArabicConverter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/utils/MaterialUtils.ts
+++ b/@here/harp-text-canvas/lib/utils/MaterialUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/utils/TypesettingUtils.ts
+++ b/@here/harp-text-canvas/lib/utils/TypesettingUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/lib/utils/UnicodeUtils.ts
+++ b/@here/harp-text-canvas/lib/utils/UnicodeUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/test/FontCatalogTest.ts
+++ b/@here/harp-text-canvas/test/FontCatalogTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/test/TextCanvasTest.ts
+++ b/@here/harp-text-canvas/test/TextCanvasTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/test/TextStyleTest.ts
+++ b/@here/harp-text-canvas/test/TextStyleTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-text-canvas/test/rendering/TextCanvasRenderingTest.ts
+++ b/@here/harp-text-canvas/test/rendering/TextCanvasRenderingTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-theme-tools/src/cli-build-theme.ts
+++ b/@here/harp-theme-tools/src/cli-build-theme.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-transfer-manager/index.ts
+++ b/@here/harp-transfer-manager/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-transfer-manager/src/DeferredPromise.ts
+++ b/@here/harp-transfer-manager/src/DeferredPromise.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-transfer-manager/src/TransferManager.ts
+++ b/@here/harp-transfer-manager/src/TransferManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-transfer-manager/test/DeferredPromiseTest.ts
+++ b/@here/harp-transfer-manager/test/DeferredPromiseTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-transfer-manager/test/TransferManagerTest.ts
+++ b/@here/harp-transfer-manager/test/TransferManagerTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/index-common.ts
+++ b/@here/harp-utils/index-common.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/index.ts
+++ b/@here/harp-utils/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/index.web.ts
+++ b/@here/harp-utils/index.web.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/AuthenticationUtils.ts
+++ b/@here/harp-utils/lib/AuthenticationUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/CachedResource.ts
+++ b/@here/harp-utils/lib/CachedResource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/ContextLogger.ts
+++ b/@here/harp-utils/lib/ContextLogger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Functions.ts
+++ b/@here/harp-utils/lib/Functions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/GroupedPriorityList.ts
+++ b/@here/harp-utils/lib/GroupedPriorityList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/ConsoleChannel.ts
+++ b/@here/harp-utils/lib/Logger/ConsoleChannel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/IChannel.ts
+++ b/@here/harp-utils/lib/Logger/IChannel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/ILogger.ts
+++ b/@here/harp-utils/lib/Logger/ILogger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/ILoggerManager.ts
+++ b/@here/harp-utils/lib/Logger/ILoggerManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/Logger.ts
+++ b/@here/harp-utils/lib/Logger/Logger.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/LoggerManager.ts
+++ b/@here/harp-utils/lib/Logger/LoggerManager.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/LoggerManagerImpl.ts
+++ b/@here/harp-utils/lib/Logger/LoggerManagerImpl.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/MultiChannel.ts
+++ b/@here/harp-utils/lib/Logger/MultiChannel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/WorkerChannel.ts
+++ b/@here/harp-utils/lib/Logger/WorkerChannel.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Logger/index.ts
+++ b/@here/harp-utils/lib/Logger/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Math2D.ts
+++ b/@here/harp-utils/lib/Math2D.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/MathUtils.ts
+++ b/@here/harp-utils/lib/MathUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/Mixins.ts
+++ b/@here/harp-utils/lib/Mixins.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/ObjectUtils.ts
+++ b/@here/harp-utils/lib/ObjectUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/OptionsUtils.ts
+++ b/@here/harp-utils/lib/OptionsUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/PerformanceTimer.ts
+++ b/@here/harp-utils/lib/PerformanceTimer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/TaskQueue.ts
+++ b/@here/harp-utils/lib/TaskQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/UriResolver.ts
+++ b/@here/harp-utils/lib/UriResolver.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/UrlPlatformUtils.ts
+++ b/@here/harp-utils/lib/UrlPlatformUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/UrlPlatformUtils.web.ts
+++ b/@here/harp-utils/lib/UrlPlatformUtils.web.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/UrlUtils.ts
+++ b/@here/harp-utils/lib/UrlUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/lib/assert.ts
+++ b/@here/harp-utils/lib/assert.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/GroupedPriorityListTest.ts
+++ b/@here/harp-utils/test/GroupedPriorityListTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/LoggerManagerTest.ts
+++ b/@here/harp-utils/test/LoggerManagerTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/LoggerTest.ts
+++ b/@here/harp-utils/test/LoggerTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/MathUtilsTest.ts
+++ b/@here/harp-utils/test/MathUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/ObjectUtilsTest.ts
+++ b/@here/harp-utils/test/ObjectUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/OptionsUtilsTest.ts
+++ b/@here/harp-utils/test/OptionsUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/PerformanceTimerTest.ts
+++ b/@here/harp-utils/test/PerformanceTimerTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/TaskQueueTest.ts
+++ b/@here/harp-utils/test/TaskQueueTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/UriResolverTest.ts
+++ b/@here/harp-utils/test/UriResolverTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/UrlUtilsTest.ts
+++ b/@here/harp-utils/test/UrlUtilsTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-utils/test/WorkerChannelTest.ts
+++ b/@here/harp-utils/test/WorkerChannelTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/index-worker.ts
+++ b/@here/harp-vectortile-datasource/index-worker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/index.ts
+++ b/@here/harp-vectortile-datasource/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/DataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/DataAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/DecodeInfo.ts
+++ b/@here/harp-vectortile-datasource/lib/DecodeInfo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/GeoJsonDataProvider.ts
+++ b/@here/harp-vectortile-datasource/lib/GeoJsonDataProvider.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/GeoJsonTilerService.ts
+++ b/@here/harp-vectortile-datasource/lib/GeoJsonTilerService.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/IGeometryProcessor.ts
+++ b/@here/harp-vectortile-datasource/lib/IGeometryProcessor.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/OmvDataFilter.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvDataFilter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/OmvDebugLabelsTile.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvDebugLabelsTile.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/OmvDecoderDefs.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvDecoderDefs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/OmvPoliticalViewFeatureModifier.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvPoliticalViewFeatureModifier.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2019 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/OmvUtils.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvUtils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/Ring.ts
+++ b/@here/harp-vectortile-datasource/lib/Ring.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/StyleSetDataFilter.ts
+++ b/@here/harp-vectortile-datasource/lib/StyleSetDataFilter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataSource.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/adapters/omv/OmvData.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/omv/OmvData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/lib/adapters/omv/OmvDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/omv/OmvDataAdapter.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/MapViewPickingTest.ts
+++ b/@here/harp-vectortile-datasource/test/MapViewPickingTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDataSourceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/OmvRestClientTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvRestClientTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/OmvTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/RingTest.ts
+++ b/@here/harp-vectortile-datasource/test/RingTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/VectorTileDecoderTest.ts
+++ b/@here/harp-vectortile-datasource/test/VectorTileDecoderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-vectortile-datasource/test/resources/geoJsonData.ts
+++ b/@here/harp-vectortile-datasource/test/resources/geoJsonData.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webpack-utils/scripts/HarpWebpackConfig.ts
+++ b/@here/harp-webpack-utils/scripts/HarpWebpackConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/index.ts
+++ b/@here/harp-webtile-datasource/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/lib/HereWebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/HereWebTileDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileDataSource.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/lib/WebTileLoader.ts
+++ b/@here/harp-webtile-datasource/lib/WebTileLoader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/test/HereWebTileDataSourceTest.ts
+++ b/@here/harp-webtile-datasource/test/HereWebTileDataSourceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/test/WebTileLoaderTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileLoaderTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp-webtile-datasource/test/WebTileTest.ts
+++ b/@here/harp-webtile-datasource/test/WebTileTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp.gl/lib/BundleMain.ts
+++ b/@here/harp.gl/lib/BundleMain.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp.gl/lib/DecoderBootstrap.ts
+++ b/@here/harp.gl/lib/DecoderBootstrap.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp.gl/lib/DecoderBundleMain.ts
+++ b/@here/harp.gl/lib/DecoderBundleMain.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/@here/harp.gl/lib/index.ts
+++ b/@here/harp.gl/lib/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/docs/@docs/fallback/module.ts
+++ b/docs/@docs/fallback/module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/docs/@docs/label-rendering/module.ts
+++ b/docs/@docs/label-rendering/module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/apidocs.ts
+++ b/scripts/apidocs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/checkLicenses.ts
+++ b/scripts/checkLicenses.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { exec } from "child_process";
+import * as fs from "fs";
+
+/**
+ * To determine the first and last commit year of the file and check against the year(s) in the file's copyright:
+ * @param sourceFile Path of the source file
+ * @param match License match result
+ * @param callback Callback to call once check is completed. Error message should be passed back
+ */
+function checkYear(
+    sourceFile: string,
+    [start, end]: string[],
+    callback: (err?: string) => void
+): void {
+    const currentYear = String(new Date().getFullYear());
+    exec(
+        [
+            // Added
+            `git --no-pager log --follow --diff-filter=A -n 1 --format=%ad --date=format:%Y -- ${sourceFile}`,
+
+            // Last modified
+            `git --no-pager log --follow --diff-filter=MRCA -n 1 --format=%ad --date=format:%Y -- ${sourceFile}`
+        ].join(" && "),
+        (error, stdOut, stdErr) => {
+            const copyrightStart = start;
+            const hasRange = end !== undefined;
+            const copyrightEnd = hasRange ? end : start;
+            const found = `${copyrightStart}${hasRange ? "-" + copyrightEnd : ""}`;
+            if (error) {
+                callback(error.message);
+            } else if (stdErr) {
+                callback(stdErr.toString());
+            } else if (stdOut.toString() === "") {
+                // The file is not in Git repository yet:
+                if (found !== currentYear) {
+                    callback(`${sourceFile} expected: ${currentYear}, found: ${found}`);
+                } else {
+                    callback();
+                }
+            } else if (!/^\d{4}\n\d{4}\n$/.test(stdOut.toString())) {
+                callback(`Can't determine first/last year of Git commit for file ${sourceFile}`);
+            } else {
+                const [firstCommit, lastCommit] = stdOut.toString().split("\n");
+                if (
+                    copyrightStart !== firstCommit ||
+                    copyrightEnd !== lastCommit ||
+                    (hasRange && copyrightStart === copyrightEnd)
+                ) {
+                    // Since a new commit is needed to fix it, the new commit must contain the current year:
+                    callback(
+                        `${sourceFile} expected: ${firstCommit}${
+                            firstCommit !== currentYear ? "-" + currentYear : ""
+                        }, found: ${found}`
+                    );
+                } else {
+                    callback();
+                }
+            }
+        }
+    );
+}
+
+/**
+ * Checks whether specified source files contain license matching the specified RegExp.
+ * @param sourceFiles The source files to check
+ * @param licenseRegEx RegExp to match the license.
+ *                      IMPORTANT, RegExp match should match the whole license and in the match groups returns the
+ *                      following:
+ *                      - match[1] - copyright start year
+ *                      - match[3] - copyright end year (if specified)
+ * @param callback The callback function to execute upon completion. Array of errors strings is passed back,
+ *                 in case not matching file is found.
+ */
+export function checkLicenses(
+    sourceFiles: string[],
+    licenseRegEx: RegExp,
+    callback: (errors: string[]) => void,
+    fix = false
+) {
+    const total = sourceFiles.length;
+    const errors: string[] = [];
+    let current = 0;
+
+    function checkIfDone() {
+        if (++current >= total) {
+            callback(errors);
+        }
+    }
+
+    sourceFiles.forEach(sourceFile => {
+        const content = fs.readFileSync(sourceFile, { encoding: "utf8" });
+        const match = licenseRegEx.exec(content);
+        if (match === null) {
+            errors.push(`${sourceFile} has no valid copyright notice`);
+            checkIfDone();
+        } else {
+            checkYear(sourceFile, [match[1], match[3]], error => {
+                if (error) {
+                    // Let's fix it in case of wrong year(s) found and AUTO_FIX is activated:
+                    const errorMatch = /expected: (.+), found: (.+)/.exec(error);
+                    if (fix && errorMatch !== null) {
+                        fs.writeFileSync(
+                            sourceFile,
+                            content.replace(
+                                licenseRegEx,
+                                match[0].replace(errorMatch[2], errorMatch[1])
+                            ),
+                            { encoding: "utf8" }
+                        );
+                    } else {
+                        errors.push(error);
+                    }
+                }
+                checkIfDone();
+            });
+        }
+    });
+}

--- a/scripts/checkLicenses.ts
+++ b/scripts/checkLicenses.ts
@@ -37,12 +37,9 @@ function checkYear(
             } else if (stdErr) {
                 callback(stdErr.toString());
             } else if (stdOut.toString() === "") {
-                // The file is not in Git repository yet:
-                if (found !== currentYear) {
-                    callback(`${sourceFile} expected: ${currentYear}, found: ${found}`);
-                } else {
-                    callback();
-                }
+                // The file is not in Git repository yet, we can't detect the years.
+                // Please commit first and re-run.
+                callback();
             } else if (!/^\d{4}\n\d{4}\n$/.test(stdOut.toString())) {
                 callback(`Can't determine first/last year of Git commit for file ${sourceFile}`);
             } else {

--- a/scripts/checkLicenses.ts
+++ b/scripts/checkLicenses.ts
@@ -73,9 +73,10 @@ function checkYear(
  *                      IMPORTANT, RegExp match should match the whole license and in the match groups returns the
  *                      following:
  *                      - match[1] - copyright start year
- *                      - match[3] - copyright end year (if specified)
+ *                      - match[2] - copyright end year (if specified)
  * @param callback The callback function to execute upon completion. Array of errors strings is passed back,
  *                 in case not matching file is found.
+ * @param [fix=false] Flag indicating whether correct licenses should be automatically fixed. Default is false.
  */
 export function checkLicenses(
     sourceFiles: string[],
@@ -100,7 +101,7 @@ export function checkLicenses(
             errors.push(`${sourceFile} has no valid copyright notice`);
             checkIfDone();
         } else {
-            checkYear(sourceFile, [match[1], match[3]], error => {
+            checkYear(sourceFile, [match[1], match[2]], error => {
                 if (error) {
                     // Let's fix it in case of wrong year(s) found and AUTO_FIX is activated:
                     const errorMatch = /expected: (.+), found: (.+)/.exec(error);

--- a/scripts/checkLicenses.ts
+++ b/scripts/checkLicenses.ts
@@ -53,11 +53,14 @@ function checkYear(
                     (hasRange && copyrightStart === copyrightEnd)
                 ) {
                     // Since a new commit is needed to fix it, the new commit must contain the current year:
-                    callback(
-                        `${sourceFile} expected: ${firstCommit}${
-                            firstCommit !== currentYear ? "-" + currentYear : ""
-                        }, found: ${found}`
-                    );
+                    const expected = `${firstCommit}${
+                        firstCommit !== currentYear ? "-" + currentYear : ""
+                    }`;
+                    if (found !== expected) {
+                        callback(`${sourceFile} expected: ${expected}, found: ${found}`);
+                    } else {
+                        callback();
+                    }
                 } else {
                     callback();
                 }

--- a/scripts/credentials.ts
+++ b/scripts/credentials.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/prepare_doc_deploy.ts
+++ b/scripts/prepare_doc_deploy.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/reset-dependency-version.ts
+++ b/scripts/reset-dependency-version.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/setup-docs.ts
+++ b/scripts/setup-docs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/scripts/with-http-server.ts
+++ b/scripts/with-http-server.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ts-node
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/ImportTest.ts
+++ b/test/ImportTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/LicenseHeaderTest.ts
+++ b/test/LicenseHeaderTest.ts
@@ -1,63 +1,36 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { assert } from "chai";
-import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
 
-const licenseRegEx = /\/\*\n \* Copyright \(C\) (\d\d\d\d)-?(\d\d\d\d)? HERE Europe.B\.V\.\n \* Licensed under Apache 2\.0\, see full license in LICENSE\n \* SPDX\-License\-Identifier\: Apache\-2\.0\n \*\//;
+import { checkLicenses } from "../scripts/checkLicenses";
+
+const APACHE_LICENSE = /\/\*\n \* Copyright \(C\) (\d{4})(-(\d{4}))? HERE Europe B\.V\.\n \* Licensed under Apache 2\.0\, see full license in LICENSE\n \* SPDX\-License\-Identifier\: Apache\-2\.0\n \*\//;
+// To fix wrong year(s) of the copyright notice on a local machine automatically:
+const AUTO_FIX = process.argv.slice(2).includes("--fix");
 
 describe("LicenseHeaderCheck", function () {
-    let sourceFiles: string[];
-
-    before(function () {
-        sourceFiles = glob
+    it("Contains correct license header", function (done) {
+        const sourceFiles = glob
             .sync(path.join(__dirname, "..", "**/*.ts"))
             .filter(file => !file.includes("/node_modules/"))
             .filter(file => !file.includes("/dist/"))
-            .filter(file => !file.endsWith(".d.ts"));
-    });
+            .filter(file => !file.endsWith(".d.ts"))
+            .sort();
 
-    it("Contains license header", function () {
-        const failedFiles = new Array<string>();
-        for (const sourceFile of sourceFiles) {
-            let contents = fs.readFileSync(sourceFile, { encoding: "utf8" });
-
-            // support for shebang scripts
-            if (contents.startsWith("#!/")) {
-                const firstNewLineIndex = contents.indexOf("\n");
-                if (firstNewLineIndex !== -1) {
-                    contents = contents.substr(firstNewLineIndex + 1);
-                }
-            }
-
-            const match = licenseRegEx.exec(contents);
-            let validLicenseRange = false;
-            if (match !== null && match.length === 3) {
-                const currentYear = new Date().getFullYear();
-                const start = parseInt(match[1], 10);
-                if (match[2] !== undefined) {
-                    // Year is a range
-                    const end = parseInt(match[2], 10);
-                    validLicenseRange =
-                        !isNaN(start) &&
-                        !isNaN(end) &&
-                        start >= 2017 &&
-                        start < end &&
-                        end <= currentYear;
-                } else {
-                    // Year is just one value
-                    validLicenseRange = !isNaN(start) && start >= 2017 && start <= currentYear;
-                }
-            }
-            if (!validLicenseRange) {
-                failedFiles.push(sourceFile);
-            }
-        }
-        assert.deepEqual(failedFiles, [], "Some files did not contain correct license header");
+        checkLicenses(
+            sourceFiles,
+            APACHE_LICENSE,
+            errors => {
+                assert.deepEqual(errors, []);
+                done();
+            },
+            AUTO_FIX
+        );
     });
 });

--- a/test/LicenseHeaderTest.ts
+++ b/test/LicenseHeaderTest.ts
@@ -16,6 +16,9 @@ const AUTO_FIX = process.argv.slice(2).includes("--fix");
 
 describe("LicenseHeaderCheck", function () {
     it("Contains correct license header", function (done) {
+        // In some cases (coverage run on CI) --no-timeouts flag is not passed,
+        // so we have to set it here specifically.
+        this.timeout(180000); // 3 mins
         const sourceFiles = glob
             .sync(path.join(__dirname, "..", "**/*.ts"))
             .filter(file => !file.includes("/node_modules/"))

--- a/test/LicenseHeaderTest.ts
+++ b/test/LicenseHeaderTest.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 
 import { checkLicenses } from "../scripts/checkLicenses";
 
-const APACHE_LICENSE = /\/\*\n \* Copyright \(C\) (\d{4})(-(\d{4}))? HERE Europe B\.V\.\n \* Licensed under Apache 2\.0\, see full license in LICENSE\n \* SPDX\-License\-Identifier\: Apache\-2\.0\n \*\//;
+const APACHE_LICENSE = /\/\*\n \* Copyright \(C\) (\d{4})(?:-(\d{4}))? HERE Europe B\.V\.\n \* Licensed under Apache 2\.0\, see full license in LICENSE\n \* SPDX\-License\-Identifier\: Apache\-2\.0\n \*\//;
 // To fix wrong year(s) of the copyright notice on a local machine automatically:
 const AUTO_FIX = process.argv.slice(2).includes("--fix");
 

--- a/test/YarnLockTest.ts
+++ b/test/YarnLockTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2018-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/performance/LinesPerformanceTest.ts
+++ b/test/performance/LinesPerformanceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/performance/OmvDecoderPerformanceTest.ts
+++ b/test/performance/OmvDecoderPerformanceTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/GeoJsonDataRendering.ts
+++ b/test/rendering/GeoJsonDataRendering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/GeoJsonFeaturesRendering.ts
+++ b/test/rendering/GeoJsonFeaturesRendering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/ScreenSpaceRenderingTests.ts
+++ b/test/rendering/ScreenSpaceRenderingTests.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/StylingTest.ts
+++ b/test/rendering/StylingTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/WebTileDataRendering.ts
+++ b/test/rendering/WebTileDataRendering.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/utils/GeoJsonTest.ts
+++ b/test/rendering/utils/GeoJsonTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/test/rendering/utils/ThemeBuilder.ts
+++ b/test/rendering/utils/ThemeBuilder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/www/src/decoder.ts
+++ b/www/src/decoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2019-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/www/src/index.ts
+++ b/www/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 HERE Europe B.V.
+ * Copyright (C) 2020-2021 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */


### PR DESCRIPTION
Now `test/LicenseHeaderTest.ts` checks all files to have correct license header by taking the last and first Git commit of this file into account to check the year statements. It also provides an option to adjust wrong year statements when ran locally (see `AUTO_FIX`)