### PR TITLE
HARP-13852 Increase precision, otherwise tilt is too inaccurate

### DIFF
--- a/@here/harp-map-controls/lib/MapControls.ts
+++ b/@here/harp-map-controls/lib/MapControls.ts
@@ -618,6 +618,9 @@ export class MapControls extends EventDispatcher {
             this.m_tiltRequested = undefined;
         }
 
+        // Whether the tilt animation has reached full duration & a final frame is rendered. We need
+        // this to know when to stop the tilt (and hence deregister the methon )
+        let tiltAnimationFinished = false;
         if (this.inertiaEnabled) {
             if (!this.m_tiltIsAnimated) {
                 this.m_tiltIsAnimated = true;
@@ -625,12 +628,12 @@ export class MapControls extends EventDispatcher {
             }
             const currentTime = performance.now();
             this.m_tiltAnimationTime = (currentTime - this.m_tiltAnimationStartTime) / 1000;
-            const tiltFinished = this.m_tiltAnimationTime > this.tiltToggleDuration;
+            const tiltFinished = this.m_tiltAnimationTime >= this.tiltToggleDuration;
             if (tiltFinished) {
                 if (this.m_needsRenderLastFrame) {
                     this.m_needsRenderLastFrame = false;
                     this.m_tiltAnimationTime = this.tiltToggleDuration;
-                    this.stopTilt();
+                    tiltAnimationFinished = true;
                 }
             } else {
                 this.m_needsRenderLastFrame = true;
@@ -650,6 +653,10 @@ export class MapControls extends EventDispatcher {
 
         MapViewUtils.orbitAroundScreenPoint(this.mapView, 0, 0, 0, deltaAngle, this.m_maxTiltAngle);
         this.updateMapView();
+
+        if (tiltAnimationFinished) {
+            this.stopTilt();
+        }
     }
 
     private stopTilt() {

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -1329,8 +1329,8 @@ export namespace MapViewUtils {
 
         // Decompose rotation matrix into Z0 X Z1 Euler angles.
         const d = space.z.dot(cache.vector3[1].set(0, 0, 1));
-        if (d < 1.0 - epsilon) {
-            if (d > -1.0 + epsilon) {
+        if (d < 1.0 - Number.EPSILON) {
+            if (d > -1.0 + Number.EPSILON) {
                 yaw = Math.atan2(space.z.x, -space.z.y);
                 pitch = Math.acos(space.z.z);
                 roll = Math.atan2(space.x.z, space.y.z);
@@ -1387,7 +1387,7 @@ export namespace MapViewUtils {
         // Get point to object vector in `cache.vector3[1]` and deduce `tilt` from the angle with
         // tangent Z.
         cache.vector3[1].copy(object.position).sub(cache.vector3[0]).normalize();
-        if (cache.vector3[1].dot(tangentSpace.z) > 1 - epsilon) {
+        if (cache.vector3[1].dot(tangentSpace.z) > 1 - Number.EPSILON) {
             // Top down view: the azimuth of the object would be opposite the yaw, and clockwise.
             azimuth = Math.PI - extractAttitude(mapView, object).yaw;
             // Wrap between -PI and PI.
@@ -1450,7 +1450,7 @@ export namespace MapViewUtils {
         dirVec.divideScalar(dirLen);
 
         const cosTheta = dirVec.dot(tangentSpace.z);
-        if (cosTheta > 1 - epsilon) {
+        if (cosTheta >= 1 - Number.EPSILON) {
             // Top down view.
             return 0;
         }


### PR DESCRIPTION
- Improve the epsilon used when comparing the dot product.
- When the tilt animation has finished, a final check is done to see if the targeted tilt is reached, and if not, we apply the delta needed to reach the desired tilt.