### PR TITLE
HARP-13812: Tune the default value of extruded-polygon's constantHeight.

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -1216,7 +1216,7 @@ export interface ExtrudedPolygonTechniqueParams extends StandardTechniqueParams 
      * If `true`, the height of the extruded buildings will not be modified by the mercator
      * projection distortion that happens around the poles.
      *
-     * @defaultValue `false`
+     * @defaultValue `true` for geometries stored at level less than `12`.
      */
     constantHeight?: boolean;
 

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
@@ -1304,9 +1304,17 @@ export class VectorTileDataEmitter {
         // computation and extrusion).
         height = Math.max(floorHeight + ExtrusionFeatureDefs.MIN_BUILDING_HEIGHT, height);
 
-        const styleSetConstantHeight = getOptionValue(
+        const tileLevel = this.m_decodeInfo.tileKey.level;
+
+        const SCALED_EXTRUSION_MIN_STORAGE_LEVEL = 12;
+
+        // Unless explicitly defined do not apply the projection
+        // scale factor to convert meters to world space units
+        // if the tile's level is less than `SCALED_EXTRUSION_MIN_STORAGE_LEVEL`.
+        const styleSetConstantHeight = evaluateTechniqueAttr(
+            context,
             extrudedPolygonTechnique.constantHeight,
-            false
+            tileLevel < SCALED_EXTRUSION_MIN_STORAGE_LEVEL
         );
 
         this.m_decodeInfo.tileBounds.getCenter(tempTileOrigin);


### PR DESCRIPTION
This change makes the default value of the `constantHeight`
property of the `extruded-polygon` technique depend on the tile's
storage level. That is, unless explictly set, the projection scaling
factor used to convert meters to world units is applied
only if the tile's level is greater than or equal to 12. This
change of behavior may results to a different height when rendering
extruded polygons coming from tiles at low storage levels but it
will avoid possible artifacts when rendering large polygons.