### PR TITLE
HARP-12334: Support various line joins

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueDescriptors.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueDescriptors.ts
@@ -205,6 +205,7 @@ const solidLineTechniqueDescriptor = mergeTechniqueDescriptor<SolidLineTechnique
             gapSize: AttrScope.TechniqueRendering,
             outlineColor: { scope: AttrScope.TechniqueRendering, automatic: true },
             caps: { scope: AttrScope.TechniqueRendering, automatic: true },
+            joins: { scope: AttrScope.TechniqueRendering, automatic: true },
             drawRangeStart: { scope: AttrScope.TechniqueRendering, automatic: true },
             drawRangeEnd: { scope: AttrScope.TechniqueRendering, automatic: true },
             dashes: { scope: AttrScope.TechniqueRendering, automatic: true },

--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -13,6 +13,19 @@ import { InterpolatedPropertyDefinition } from "./InterpolatedPropertyDefs";
 export type LineCaps = "Square" | "Round" | "None" | "TriangleOut" | "TriangleIn";
 
 /**
+ * The style type of the line caps.
+ * - `Round`
+ *   Rounds off the corners of a shape by filling an additional sector of disc centered at the common endpoint of
+ *   connected segments. The radius for these rounded corners is equal to the line width.
+ * - `Bevel`
+ *   A join with a squared-off end.
+ * - `Miter`
+ *    Connected segments are joined by extending their outside edges to connect at a single point,
+ *    with the effect of filling an additional area.
+ */
+export type LineJoins = "Bevel" | "Round" | "Miter";
+
+/**
  * The style type of the line dashes.
  */
 export type LineDashes = "Square" | "Round" | "Diamond";
@@ -1072,6 +1085,11 @@ export interface SolidLineTechniqueParams extends BaseTechniqueParams, Polygonal
      * @defaultValue `"Round"`.
      */
     caps?: DynamicProperty<LineCaps>;
+    /**
+     * Describes the style of the line joins.
+     * @defaultValue `"Round"`
+     */
+    joins?: DynamicProperty<LineJoins>;
     /**
      * Color of secondary line geometry in hexadecimal or CSS-style notation, for example:
      * `"#e4e9ec"`, `"#fff"`, `"rgb(255, 0, 0)"`, or `"hsl(35, 11%, 88%)"`.

--- a/@here/harp-examples/resources/lines.json
+++ b/@here/harp-examples/resources/lines.json
@@ -1,0 +1,19 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [-40, 0],
+                    [-20, 30],
+                    [0, 0],
+                    [20, 50],
+                    [40, 0]
+                ]
+            }
+        }
+    ]
+}

--- a/@here/harp-examples/src/datasource_features_line_joins.ts
+++ b/@here/harp-examples/src/datasource_features_line_joins.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DebugTileDataSource } from "@here/harp-debug-datasource";
+import { GeoCoordinates, webMercatorTilingScheme } from "@here/harp-geoutils";
+import { MapControls, MapControlsUI } from "@here/harp-map-controls";
+import { CopyrightElementHandler, MapView } from "@here/harp-mapview";
+import {
+    APIFormat,
+    AuthenticationMethod,
+    GeoJsonDataProvider,
+    VectorTileDataSource
+} from "@here/harp-vectortile-datasource";
+
+import { apikey, copyrightInfo } from "../config";
+
+/**
+ * This example demonstrates how to render lines with different line joins.
+ */
+export namespace GeoJsonLineJoinsExample {
+    document.body.innerHTML += `
+        <style>
+            #mapCanvas {
+              top: 0;
+            }
+        </style>
+    `;
+
+    const mapView = initializeMapView("mapCanvas");
+
+    const omvDataSource = new VectorTileDataSource({
+        baseUrl: "https://vector.hereapi.com/v2/vectortiles/base/mc",
+        apiFormat: APIFormat.XYZOMV,
+        styleSetName: "tilezen",
+        maxDataLevel: 17,
+        authenticationCode: apikey,
+        authenticationMethod: {
+            method: AuthenticationMethod.QueryString,
+            name: "apikey"
+        },
+        copyrightInfo
+    });
+
+    mapView.addDataSource(omvDataSource);
+
+    /**
+     * Creates a new MapView for the HTMLCanvasElement of the given id.
+     */
+    // snippet:datasource_features_line_joins.ts
+    function initializeMapView(id: string): MapView {
+        const canvas = document.getElementById(id) as HTMLCanvasElement;
+        const map = new MapView({
+            canvas,
+            theme: {
+                // Create some lights
+                lights: [
+                    {
+                        type: "ambient",
+                        color: "#FFFFFF",
+                        name: "ambientLight",
+                        intensity: 0.9
+                    },
+                    {
+                        type: "directional",
+                        color: "#CCCBBB",
+                        name: "light1",
+                        intensity: 0.8,
+                        direction: {
+                            x: 1,
+                            y: 5,
+                            z: 0.5
+                        }
+                    },
+                    {
+                        type: "directional",
+                        color: "#F4DB9C",
+                        name: "light2",
+                        intensity: 0.8,
+                        direction: {
+                            x: -1,
+                            y: -3,
+                            z: 1
+                        }
+                    }
+                ],
+                styles: {
+                    geojson: [
+                        {
+                            when: ["==", ["geometry-type"], "LineString"],
+                            renderOrder: 1000,
+                            lineColor: "red",
+                            technique: "solid-line",
+                            joins: "Bevel",
+                            lineWidth: "20px"
+                        }
+                    ]
+                }
+            },
+            target: new GeoCoordinates(0, 0),
+            zoomLevel: 3
+        });
+
+        CopyrightElementHandler.install("copyrightNotice").attach(map);
+
+        const controls = new MapControls(map);
+
+        // Add an UI.
+        const ui = new MapControlsUI(controls, { projectionSwitch: true });
+        canvas.parentElement!.appendChild(ui.domElement);
+
+        window.addEventListener("resize", () => {
+            map.resize(window.innerWidth, window.innerHeight);
+        });
+
+        // Create a [[GeoJsonDataProvider]] from a GeoJson URL and plug it into an OmvDataSource.
+        const geoJsonDataProvider = new GeoJsonDataProvider(
+            "lines",
+            new URL("resources/lines.json", window.location.href)
+        );
+        const geoJsonDataSource = new VectorTileDataSource({
+            dataProvider: geoJsonDataProvider,
+            name: "geojson",
+            styleSetName: "geojson"
+        });
+        map.addDataSource(geoJsonDataSource);
+
+        // Also visualize the tile borders:
+        const debugDataSource = new DebugTileDataSource(webMercatorTilingScheme, "debug", 20);
+        map.addDataSource(debugDataSource);
+
+        map.update();
+
+        return map;
+    }
+}

--- a/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
+++ b/@here/harp-materials/lib/ShaderChunks/LinesChunks.ts
@@ -15,6 +15,15 @@ export enum LineCapsModes {
     CAPS_TRIANGLE_OUT
 }
 
+/**
+ * Lists supported line joins.
+ */
+export enum LineJoinModes {
+    JOINS_ROUND = 0,
+    JOINS_BEVEL,
+    JOINS_MITER
+}
+
 export default {
     extrude_line_vert_func: `
 vec3 extrudeLine(


### PR DESCRIPTION
The following PR adds support for **Bevel** and **Miter** line join types along with the existing and default **Round** join.
This feature visually looks similar to the standard 2D Canvas **lineJoin**:

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin