### PR TITLE
MINOR: Do not filter styles by minZoomLevel/maxZoomLevel in StyleSetEvaluator if they're dynamic expressions

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -651,9 +651,8 @@ export class StyleSetEvaluator {
         if (style.minZoomLevel !== undefined) {
             let minZoomLevel: Value = style.minZoomLevel;
 
-            if (style._minZoomLevelExpr) {
-                // the constraint is defined as expression, evaluate it and
-                // use its value
+            if (style._minZoomLevelExpr?.isDynamic() === false) {
+                // Only filter by zoom level if the expression is not dynamic.
                 try {
                     minZoomLevel = style._minZoomLevelExpr.evaluate(
                         env,
@@ -677,7 +676,8 @@ export class StyleSetEvaluator {
         if (style.maxZoomLevel !== undefined) {
             let maxZoomLevel: Value = style.maxZoomLevel;
 
-            if (style._maxZoomLevelExpr) {
+            if (style._maxZoomLevelExpr?.isDynamic() === false) {
+                // Only filter by zoom level if the expression is not dynamic.
                 try {
                     maxZoomLevel = style._maxZoomLevelExpr.evaluate(
                         env,

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -664,6 +664,27 @@ describe("StyleSetEvaluator", function () {
                 }
             ])
         );
+
+        // Techniques are not filtered if min/maxZoomLevel are dynamic expressions.
+        assert.isNotEmpty(
+            getMatchingTechniques({ ...defaultProperties, $zoom: 14, minLevel: 15 }, [
+                {
+                    when: ["==", ["geometry-type"], "Polygon"],
+                    technique: "extruded-polygon",
+                    minZoomLevel: ["get", "minLevel", ["dynamic-properties"]]
+                }
+            ])
+        );
+
+        assert.isNotEmpty(
+            getMatchingTechniques({ ...defaultProperties, $zoom: 15, maxLevel: 14 }, [
+                {
+                    when: ["==", ["geometry-type"], "Polygon"],
+                    technique: "extruded-polygon",
+                    maxZoomLevel: ["case", true, ["get", "maxLevel"], ["zoom"]]
+                }
+            ])
+        );
     });
 
     it("serialization of vector properties", () => {


### PR DESCRIPTION
The zoom level passed to StyleSetEvaluator through the environment is not accurate for mixed LOD, the actual zoom level might be higher, and therefore an object will not be rendered even when the current zoom level is within the style zoom range.

However this might be sometimes the desired behaviour, for example when skipping decoding of extruded buildings in far tiles.

To accomodate the two behaviours, StyleSetEvaluator now only filters by min/maxZoomLevel if they are fixed values or static expressions.

Partially fixes MAPSJS-2831.
