### PR TITLE
HARP-13229: Fix possible precision issues when converting coords from world to local space

### DIFF
--- a/@here/harp-vectortile-datasource/lib/OmvUtils.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvUtils.ts
@@ -117,8 +117,8 @@ export function world2tile<VectorType extends Vector2Like>(
     const { top, left, scale } = decodeInfo.worldTileProjectionCookie;
     const R = EarthConstants.EQUATORIAL_CIRCUMFERENCE;
 
-    target.x = (position.x / R) * scale - left;
-    target.y = (flipY ? -1 : 1) * ((position.y / R) * scale - top);
+    target.x = Math.round((position.x / R) * scale - left);
+    target.y = Math.round((flipY ? -1 : 1) * ((position.y / R) * scale - top));
     if (isVector3Like(target)) {
         target.z = position.z;
     }

--- a/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -26,7 +26,7 @@ import { Vector2, Vector3 } from "three";
 
 import { DecodeInfo } from "../lib/DecodeInfo";
 import { IPolygonGeometry } from "../lib/IGeometryProcessor";
-import { world2tile } from "../lib/OmvUtils";
+import { tile2world, world2tile } from "../lib/OmvUtils";
 import { VectorTileDataEmitter } from "../lib/VectorTileDataEmitter";
 
 class OmvDecodedTileEmitterTest extends VectorTileDataEmitter {
@@ -140,7 +140,9 @@ describe("OmvDecodedTileEmitter", function () {
                 false,
                 new Vector3()
             );
-            const worldCoords = decodeInfo.targetProjection.projectPoint(geoCoords);
+
+            const worldCoords = new Vector3();
+            tile2world(extents, decodeInfo, tileLocalCoords, false, worldCoords);
 
             const { tileEmitter, styleSetEvaluator } = createTileEmitter(decodeInfo, [
                 {
@@ -172,7 +174,11 @@ describe("OmvDecodedTileEmitter", function () {
             assert.equal(buffer.length, 3, "one position (3 coordinates)");
 
             const actualHeight = buffer[2];
-            assert.equal(actualHeight, getExpectedHeight(geoCoords.altitude, worldCoords));
+            assert.approximately(
+                actualHeight,
+                getExpectedHeight(geoCoords.altitude, worldCoords),
+                1e-6
+            );
         });
 
         it(`Extruded polygon height at level ${level} with constantHeight ${constantHeight} is ${result}`, function () {
@@ -278,7 +284,7 @@ describe("OmvDecodedTileEmitter", function () {
         );
 
         const firstGeometry = geometries[0];
-        const vertexCount = 5;
+        const vertexCount = 4;
         checkVertexAttribute(firstGeometry, 0, "position", vertexCount);
         const texCoords = checkVertexAttribute(firstGeometry, 1, "uv", vertexCount);
 

--- a/test/rendering/GeoJsonDataRendering.ts
+++ b/test/rendering/GeoJsonDataRendering.ts
@@ -3,7 +3,7 @@
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Feature, FeatureCollection, StyleSet } from "@here/harp-datasource-protocol";
+import { Feature, FeatureCollection, FlatTheme, StyleSet } from "@here/harp-datasource-protocol";
 import { clipLineString } from "@here/harp-geometry/lib/ClipLineString";
 import { wrapLineString } from "@here/harp-geometry/lib/WrapLineString";
 import { wrapPolygon } from "@here/harp-geometry/lib/WrapPolygon";
@@ -22,6 +22,7 @@ import * as turf from "@turf/turf";
 import { Vector2, Vector3 } from "three";
 
 import * as polygon_crossing_antimeridian from "../resources/polygon_crossing_antimeridian.json";
+import { GeoJsonStore } from "./utils/GeoJsonStore";
 import { GeoJsonTest } from "./utils/GeoJsonTest";
 import { ThemeBuilder } from "./utils/ThemeBuilder";
 
@@ -1165,6 +1166,55 @@ describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", functio
                             13
                         )!
                     ).center
+                }
+            });
+        });
+    });
+
+    describe("Polygons", async function () {
+        it("Triangle with a hole rendered at zoom level 2", async function () {
+            const theme: FlatTheme = {
+                lights,
+                styles: [
+                    {
+                        styleSet: "geojson",
+                        when: ["==", ["geometry-type"], "Polygon"],
+                        technique: "fill",
+                        color: "rgba(100,100,100,0.5)",
+                        lineWidth: 2
+                    }
+                ]
+            };
+
+            const polygon = turf.polygon([
+                [
+                    [0, 0, 0],
+                    [170, 35, 0],
+                    [170, -35, 0],
+                    [0, 0, 0]
+                ],
+                [
+                    [0, 0, 0],
+                    [170, 15, 0],
+                    [170, -15, 0],
+                    [0, 0, 0]
+                ]
+            ]);
+
+            const [lng, lat] = turf.center(polygon).geometry!.coordinates;
+
+            const geoJsonStore = new GeoJsonStore();
+
+            geoJsonStore.features.insert(polygon);
+
+            await geoJsonTest.run({
+                mochaTest: this,
+                testImageName: "geojson-triangle-with-hole-at-zoom-level-2",
+                dataProvider: geoJsonStore,
+                theme,
+                lookAt: {
+                    zoomLevel: 2,
+                    target: [lng, lat]
                 }
             });
         });


### PR DESCRIPTION
There is a precision issue and the clipping fails to correctly
classify the inner rings of clipped polygons at level 2.
