### PR TITLE
HARP-11013: Support GeoJson feature ids

### DIFF
--- a/@here/harp-datasource-protocol/lib/DecodedTile.ts
+++ b/@here/harp-datasource-protocol/lib/DecodedTile.ts
@@ -87,9 +87,10 @@ export interface PathGeometry {
 
 /**
  * Attributes corresponding to some decoded geometry. It may be either a map
- * of multiple attributes or just a number with the geometry's feature id.
+ * of multiple attributes or just a string with the geometry's feature id (id numbers are
+ * deprecated).
  */
-export type AttributeMap = {} | number;
+export type AttributeMap = {} | string | number;
 
 /**
  * This object keeps textual data together with metadata to place it on the map.
@@ -339,18 +340,21 @@ export function getProjectionName(projection: Projection): string | never {
 
 /**
  * @returns Feature id from the provided attribute map.
+ * @internal
  */
-export function getFeatureId(attributeMap: AttributeMap | undefined): number {
+export function getFeatureId(attributeMap: AttributeMap | undefined): string | number {
     if (attributeMap === undefined) {
         return 0;
     }
 
-    if (typeof attributeMap === "number") {
+    if (typeof attributeMap === "string" || typeof attributeMap === "number") {
         return attributeMap;
-    }
+    } else if (attributeMap.hasOwnProperty("$id")) {
+        const id = (attributeMap as any).$id;
 
-    if (attributeMap.hasOwnProperty("$id")) {
-        return (attributeMap as any).$id as number;
+        if (typeof id === "string" || typeof id === "number") {
+            return id;
+        }
     }
 
     return 0;

--- a/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
+++ b/@here/harp-mapview-decoder/lib/GeoJsonTiler.ts
@@ -69,7 +69,7 @@ export class GeoJsonTiler implements ITiler {
             buffer: BUFFER, // tile buffer on each side
             lineMetrics: false, // whether to calculate line metrics
             promoteId: null, // name of a feature property to be promoted to feature.id
-            generateId: true, // whether to generate feature ids. Cannot be used with promoteId
+            generateId: false, // whether to generate feature ids. Cannot be used with promoteId
             debug: 0 // logging level (0, 1 or 2)
         });
         index.geojson = input;
@@ -85,27 +85,7 @@ export class GeoJsonTiler implements ITiler {
         const tile = index.getTile(tileKey.level, tileKey.column, tileKey.row);
         if (tile !== null) {
             tile.layer = indexId;
-            for (const feature of tile.features) {
-                feature.originalGeometry = this.getOriginalGeometry(feature, index.geojson);
-            }
         }
         return tile || {};
-    }
-
-    private getOriginalGeometry(feature: any, geojson: GeoJson): any {
-        switch (geojson.type) {
-            case "Point":
-            case "MultiPoint":
-            case "LineString":
-            case "MultiLineString":
-            case "Polygon":
-            case "MultiPolygon":
-            case "GeometryCollection":
-                return geojson;
-            case "Feature":
-                return geojson.geometry;
-            case "FeatureCollection":
-                return geojson.features[feature.id].geometry;
-        }
     }
 }

--- a/@here/harp-mapview-decoder/test/GeoJsonTilerTest.ts
+++ b/@here/harp-mapview-decoder/test/GeoJsonTilerTest.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FeatureCollection } from "@here/harp-datasource-protocol";
+import { TileKey } from "@here/harp-geoutils";
+import { expect } from "chai";
+
+import { GeoJsonTiler } from "../lib/GeoJsonTiler";
+
+const featureCollection: FeatureCollection = {
+    type: "FeatureCollection",
+    features: [
+        {
+            type: "Feature",
+            id: "point id",
+            properties: {},
+
+            geometry: {
+                type: "Point",
+                coordinates: [1, 2]
+            }
+        },
+        {
+            type: "Feature",
+            id: "line id",
+            properties: {},
+
+            geometry: {
+                type: "LineString",
+                coordinates: [
+                    [1, 2],
+                    [3, 4]
+                ]
+            }
+        },
+        {
+            type: "Feature",
+            id: "polygon id",
+            properties: {},
+
+            geometry: {
+                type: "Polygon",
+                coordinates: [
+                    [
+                        [1, 2],
+                        [3, 4],
+                        [5, 6]
+                    ]
+                ]
+            }
+        }
+    ]
+};
+
+describe("GeoJsonTiler", function () {
+    let tiler: GeoJsonTiler;
+
+    beforeEach(function () {
+        tiler = new GeoJsonTiler();
+    });
+
+    it("returns features with their original geojson ids", async function () {
+        const indexId = "dummy";
+        await tiler.registerIndex(indexId, featureCollection);
+
+        const tile = (await tiler.getTile(indexId, new TileKey(0, 0, 1))) as any;
+
+        expect(tile.features).has.lengthOf(3);
+        const expectedFeatureIds = featureCollection.features.map(feature => feature.id);
+        const actualFeatureIds: string[] = tile.features.map(
+            (feature: { id: string }) => feature.id
+        );
+        expect(actualFeatureIds).has.members(expectedFeatureIds);
+    });
+});

--- a/@here/harp-mapview/lib/DataSource.ts
+++ b/@here/harp-mapview/lib/DataSource.ts
@@ -225,7 +225,7 @@ export abstract class DataSource extends THREE.EventDispatcher {
      */
     private m_storageLevelOffset: number = 0;
 
-    private readonly m_featureStateMap = new Map<number, ValueMap>();
+    private readonly m_featureStateMap = new Map<number | string, ValueMap>();
 
     /**
      *  An array of ISO 639-1 language codes.
@@ -310,9 +310,9 @@ export abstract class DataSource extends THREE.EventDispatcher {
     /**
      * Gets the state of the given feature id.
      *
-     * @param featureId - The id of the feature.
+     * @param featureId - The id of the feature. Id numbers are deprecated in favor of strings.
      */
-    getFeatureState(featureId: number): ValueMap | undefined {
+    getFeatureState(featureId: number | string): ValueMap | undefined {
         return this.m_featureStateMap.get(featureId);
     }
 
@@ -330,19 +330,19 @@ export abstract class DataSource extends THREE.EventDispatcher {
      * dataSource.setFeatureState(featureId, { enabled: true });
      * ```
      *
-     * @param featureId - The id of the feature.
+     * @param featureId - The id of the feature. Id numbers are deprecated in favor of strings.
      * @param state - The new state of the feature.
      */
-    setFeatureState(featureId: number, state: ValueMap) {
+    setFeatureState(featureId: number | string, state: ValueMap) {
         this.m_featureStateMap.set(featureId, state);
     }
 
     /**
      * Removes the state associated to the given feature.
      *
-     * @param featureId - The id of the feature.
+     * @param featureId - The id of the feature. Id numbers are deprecated in favor of strings.
      */
-    removeFeatureState(featureId: number) {
+    removeFeatureState(featureId: number | string) {
         this.m_featureStateMap.delete(featureId);
     }
 

--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -83,10 +83,11 @@ export interface PickResult {
     renderOrder?: number;
 
     /**
-     * An optional feature ID of the picked object; typically applies to the Optimized Map
-     * Vector (OMV) format.
+     * An optional feature ID of the picked object.
+     * @remarks The ID may be assigned by the object's {@link DataSource}, for example in case of
+     * Optimized Map Vector (OMV) and GeoJSON datata sources.
      */
-    featureId?: number;
+    featureId?: number | string;
 
     /**
      * Defined for geometry only.

--- a/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
+++ b/@here/harp-mapview/lib/geometry/TileDataAccessor.ts
@@ -31,56 +31,68 @@ export interface ITileDataVisitor {
     /**
      * Should return `true` if the visitor wants to visit the object with the specified
      * `featureId`. This function is called before the type of the object is even known.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    wantsFeature(featureId: number | undefined): boolean;
+    wantsFeature(featureId: number | string | undefined): boolean;
 
     /**
      * Should return `true` if the visitor wants to visit the point with the specified
      * `featureId`.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    wantsPoint(featureId: number | undefined): boolean;
+    wantsPoint(featureId: number | string | undefined): boolean;
 
     /**
      * Should return `true` if the visitor wants to visit the line with the specified
      * `featureId`.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    wantsLine(featureId: number | undefined): boolean;
+    wantsLine(featureId: number | string | undefined): boolean;
 
     /**
      * Should return `true` if the visitor wants to visit the area object with the specified
      * `featureId`.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    wantsArea(featureId: number | undefined): boolean;
+    wantsArea(featureId: number | string | undefined): boolean;
 
     /**
      * Should return `true` if the visitor wants to visit the object with the specified
      * `featureId`.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    wantsObject3D(featureId: number | undefined): boolean;
+    wantsObject3D(featureId: number | string | undefined): boolean;
 
     /**
      * Visits a point object with the specified `featureId`; use `pointAccessor` to get the
      * object's properties.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    visitPoint(featureId: number | undefined): void;
+    visitPoint(featureId: number | string | undefined): void;
 
     /**
      * Visits a line object with the specified `featureId`; use `pointAccessor` to get the
      * object's properties.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    visitLine(featureId: number | undefined, lineAccessor: ILineAccessor): void;
+    visitLine(featureId: number | string | undefined, lineAccessor: ILineAccessor): void;
 
     /**
      * Visit an area object with the specified `featureId`; use `pointAccessor` to get the
      * object's properties.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    visitArea(featureId: number | undefined): void;
+    visitArea(featureId: number | string | undefined): void;
 
     /**
      * Visits a 3D object with the specified `featureId`; use `pointAccessor` to get the
      * object's properties.
+     * @remarks Number ids are deprecated in favor of strings.
      */
-    visitObject3D(featureId: number | undefined, object3dAccessor: IObject3dAccessor): void;
+    visitObject3D(
+        featureId: number | string | undefined,
+        object3dAccessor: IObject3dAccessor
+    ): void;
 }
 
 /**

--- a/@here/harp-mapview/lib/poi/PoiBuilder.ts
+++ b/@here/harp-mapview/lib/poi/PoiBuilder.ts
@@ -146,7 +146,6 @@ export class PoiBuilder {
             renderTextDuringMovements,
             mayOverlap: iconMayOverlap,
             reserveSpace: iconReserveSpace,
-            featureId: textElement.featureId,
             iconBrightness: technique.iconBrightness,
             iconColor,
             iconMinZoomLevel: this.m_iconMinZoomLevel,

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -30,6 +30,7 @@ import { TextElementType } from "./TextElementType";
 
 /**
  * Additional information for an icon that is to be rendered along with a {@link TextElement}.
+ * @internal
  */
 export interface PoiInfo {
     /**
@@ -122,11 +123,6 @@ export interface PoiInfo {
     isValid?: boolean;
 
     /**
-     * ID to identify the (POI) icon.
-     */
-    featureId?: number;
-
-    /**
      * Reference back to owning {@link TextElement}.
      */
     textElement: TextElement;
@@ -216,6 +212,7 @@ export enum LoadingState {
 
 /**
  * `TextElement` is used to create 2D text elements (for example, labels).
+ * @internal
  */
 export class TextElement {
     /**
@@ -375,7 +372,8 @@ export class TextElement {
      *              negative value are always rendered, ignoring priorities and allowing overrides.
      * @param xOffset - Optional X offset of this `TextElement` in screen coordinates.
      * @param yOffset - Optional Y offset of this `TextElement` in screen coordinates.
-     * @param featureId - Optional number to identify feature (originated from `OmvDataSource`).
+     * @param featureId - Optional string to identify feature (originated from {@link DataSource}).
+     *                  Number ids are deprecated in favor of strings.
      * @param fadeNear - Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the
      *              label starts fading out (opacity decreases).
      * @param fadeFar - Distance to the camera (0.0 = camera position, 1.0 = farPlane) at which the
@@ -391,7 +389,7 @@ export class TextElement {
         public priority = 0,
         public xOffset: number = 0,
         public yOffset: number = 0,
-        public featureId?: number,
+        public featureId?: string | number,
         public style?: string,
         public fadeNear?: number,
         public fadeFar?: number,
@@ -506,8 +504,19 @@ export class TextElement {
         this.m_layoutStyle = style;
     }
 
+    /**
+     * @returns Whether this text element has a valid feature id.
+     */
     hasFeatureId(): boolean {
-        return this.featureId !== undefined && this.featureId !== 0;
+        if (this.featureId === undefined) {
+            return false;
+        }
+
+        if (typeof this.featureId === "number") {
+            return this.featureId !== 0;
+        }
+
+        return this.featureId.length > 0;
     }
 
     /**

--- a/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDataEmitter.ts
@@ -388,15 +388,13 @@ export class VectorTileDataEmitter {
      * @param geometry - The current feature containing the main geometry.
      * @param env - The [[MapEnv]] containing the environment information for the map.
      * @param techniques - The array of [[Technique]] that will be applied to the geometry.
-     * @param featureId - The id of the feature.
      */
     processLineFeature(
         layer: string,
         extents: number,
         geometry: ILineGeometry[],
         context: AttrEvaluationContext,
-        techniques: IndexedTechnique[],
-        featureId: number | undefined
+        techniques: IndexedTechnique[]
     ): void {
         const env = context.env;
         this.processFeatureCommon(env);
@@ -789,15 +787,13 @@ export class VectorTileDataEmitter {
      * @param geometry - The current feature containing the main geometry.
      * @param feature - The [[MapEnv]] containing the environment information for the map.
      * @param techniques - The array of [[Technique]] that will be applied to the geometry.
-     * @param featureId - The id of the feature.
      */
     processPolygonFeature(
         layer: string,
         extents: number,
         geometry: IPolygonGeometry[],
         context: AttrEvaluationContext,
-        techniques: IndexedTechnique[],
-        featureId: number | undefined
+        techniques: IndexedTechnique[]
     ): void {
         const env = context.env;
         this.processFeatureCommon(env);

--- a/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
@@ -217,16 +217,13 @@ export class VectorTileDataProcessor implements IGeometryProcessor {
             cachedExprResults: new Map()
         };
 
-        const featureId = env.lookup("$id") as number | undefined;
-
         if (this.m_decodedTileEmitter) {
             this.m_decodedTileEmitter.processLineFeature(
                 layer,
                 extents,
                 geometry,
                 context,
-                techniques,
-                featureId
+                techniques
             );
         }
     }
@@ -269,16 +266,13 @@ export class VectorTileDataProcessor implements IGeometryProcessor {
             cachedExprResults: new Map()
         };
 
-        const featureId = env.lookup("$id") as number | undefined;
-
         if (this.m_decodedTileEmitter) {
             this.m_decodedTileEmitter.processPolygonFeature(
                 layer,
                 extents,
                 geometry,
                 context,
-                techniques,
-                featureId
+                techniques
             );
         }
     }

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
@@ -4,12 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    FeatureGeometry,
-    GeometryCollection,
-    MapEnv,
-    ValueMap
-} from "@here/harp-datasource-protocol/index-decoder";
+import { MapEnv, ValueMap } from "@here/harp-datasource-protocol/index-decoder";
 import { webMercatorProjection } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
 import { Vector2, Vector3 } from "three";
@@ -33,7 +28,6 @@ enum VTJsonGeometryType {
 
 interface VTJsonFeatureInterface {
     geometry: VTJsonPosition[] | VTJsonPosition[][];
-    originalGeometry: FeatureGeometry | GeometryCollection;
     id: string;
     tags: ValueMap;
     type: VTJsonGeometryType;

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
@@ -209,9 +209,9 @@ export class GeoJsonDataAdapter implements DataAdapter {
 
         for (const feature of featureCollection.features) {
             const $geometryType = convertGeometryType(feature.geometry.type);
-
             const env = new MapEnv({
                 ...feature.properties,
+                $id: feature.id ?? null,
                 $layer,
                 $level,
                 $zoom,

--- a/@here/harp-vectortile-datasource/test/FakeOmvFeatureFilter.ts
+++ b/@here/harp-vectortile-datasource/test/FakeOmvFeatureFilter.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OmvFeatureFilter } from "../lib/OmvDataFilter";
+import { OmvGeometryType } from "../lib/OmvDecoderDefs";
+
+export class FakeOmvFeatureFilter implements OmvFeatureFilter {
+    hasKindFilter: boolean = false;
+    wantsLayer(layer: string, level: number): boolean {
+        return true;
+    }
+
+    wantsPointFeature(layer: string, geometryType: OmvGeometryType, level: number): boolean {
+        return true;
+    }
+
+    wantsLineFeature(layer: string, geometryType: OmvGeometryType, level: number): boolean {
+        return true;
+    }
+
+    wantsPolygonFeature(layer: string, geometryType: OmvGeometryType, level: number): boolean {
+        return true;
+    }
+
+    wantsKind(kind: string | string[]): boolean {
+        return true;
+    }
+}

--- a/@here/harp-vectortile-datasource/test/GeoJsonDataAdapterTest.ts
+++ b/@here/harp-vectortile-datasource/test/GeoJsonDataAdapterTest.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mercatorProjection, TileKey } from "@here/harp-geoutils";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { GeoJsonDataAdapter } from "../lib/adapters/geojson/GeoJsonDataAdapter";
+import { DecodeInfo } from "../lib/DecodeInfo";
+import { FakeOmvFeatureFilter } from "./FakeOmvFeatureFilter";
+import { MockGeometryProcessor } from "./MockGeometryProcessor";
+
+const featureCollection = {
+    type: "FeatureCollection",
+    features: [
+        {
+            type: "Feature",
+            id: "point id",
+            properties: {},
+
+            geometry: {
+                type: "Point",
+                coordinates: [1, 2]
+            }
+        },
+        {
+            type: "Feature",
+            id: "line id",
+            properties: {},
+
+            geometry: {
+                type: "LineString",
+                coordinates: [
+                    [1, 2],
+                    [3, 4]
+                ]
+            }
+        },
+        {
+            type: "Feature",
+            id: "polygon id",
+            properties: {},
+
+            geometry: {
+                type: "Polygon",
+                coordinates: [
+                    [
+                        [1, 2],
+                        [3, 4],
+                        [5, 6]
+                    ]
+                ]
+            }
+        }
+    ]
+};
+
+describe("GeoJsonDataAdapter", function () {
+    let decodeInfo: DecodeInfo;
+    let geometryProcessor: MockGeometryProcessor;
+    let adapter: GeoJsonDataAdapter;
+
+    beforeEach(function () {
+        decodeInfo = new DecodeInfo("", mercatorProjection, new TileKey(0, 0, 1));
+        geometryProcessor = new MockGeometryProcessor();
+        adapter = new GeoJsonDataAdapter(geometryProcessor, new FakeOmvFeatureFilter());
+    });
+
+    it("canProcess returns true for a FeatureCollection", function () {
+        expect(adapter.canProcess(featureCollection as any)).to.be.true;
+    });
+
+    it("process copies geojson feature's id to env's $id", function () {
+        const pointSpy = sinon.spy(geometryProcessor, "processPointFeature");
+        const lineSpy = sinon.spy(geometryProcessor, "processLineFeature");
+        const polygonSpy = sinon.spy(geometryProcessor, "processPolygonFeature");
+        adapter.process(featureCollection as any, decodeInfo);
+
+        expect(pointSpy.calledOnce);
+        const pointEnv = pointSpy.getCalls()[0].args[3];
+        expect(pointEnv.lookup("$id")).equals(featureCollection.features[0].id);
+
+        expect(lineSpy.calledOnce);
+        const lineEnv = lineSpy.getCalls()[0].args[3];
+        expect(lineEnv.lookup("$id")).equals(featureCollection.features[1].id);
+
+        expect(polygonSpy.calledOnce);
+        const polygonEnv = polygonSpy.getCalls()[0].args[3];
+        expect(polygonEnv.lookup("$id")).equals(featureCollection.features[2].id);
+    });
+});

--- a/@here/harp-vectortile-datasource/test/GeoJsonVtDataAdapterTest.ts
+++ b/@here/harp-vectortile-datasource/test/GeoJsonVtDataAdapterTest.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mercatorProjection, TileKey } from "@here/harp-geoutils";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { GeoJsonVtDataAdapter } from "../lib/adapters/geojson-vt/GeoJsonVtDataAdapter";
+import { DecodeInfo } from "../lib/DecodeInfo";
+import { FakeOmvFeatureFilter } from "./FakeOmvFeatureFilter";
+import { MockGeometryProcessor } from "./MockGeometryProcessor";
+
+enum VTJsonGeometryType {
+    Unknown,
+    Point,
+    LineString,
+    Polygon
+}
+
+const geojsonVtTile = {
+    features: [
+        {
+            type: VTJsonGeometryType.Point,
+            id: "point id",
+            tags: {},
+
+            geometry: [[1, 2]]
+        },
+        {
+            type: VTJsonGeometryType.LineString,
+            id: "line id",
+            tags: {},
+
+            geometry: [
+                [
+                    [1, 2],
+                    [3, 4]
+                ]
+            ]
+        },
+        {
+            type: VTJsonGeometryType.Polygon,
+            id: "polygon id",
+            tags: {},
+            geometry: [
+                [
+                    [1, 2],
+                    [3, 4],
+                    [5, 6]
+                ]
+            ]
+        }
+    ],
+    maxX: 0,
+    maxY: 0,
+    minX: 0,
+    minY: 0,
+    numFeatures: 3,
+    numPoints: 1,
+    numSimplified: 0,
+    source: [],
+    transformed: false,
+    x: 0,
+    y: 0,
+    z: 0,
+    layer: ""
+};
+
+describe("GeoJsonVtDataAdapter", function () {
+    let decodeInfo: DecodeInfo;
+    let geometryProcessor: MockGeometryProcessor;
+    let adapter: GeoJsonVtDataAdapter;
+
+    beforeEach(function () {
+        decodeInfo = new DecodeInfo("", mercatorProjection, new TileKey(0, 0, 1));
+        geometryProcessor = new MockGeometryProcessor();
+        adapter = new GeoJsonVtDataAdapter(geometryProcessor, new FakeOmvFeatureFilter());
+    });
+
+    it("canProcess returns true for a geojson-vt Tile", function () {
+        expect(adapter.canProcess(geojsonVtTile as any)).to.be.true;
+    });
+
+    it("process copies geojson-vt feature's id to env's $id", function () {
+        const pointSpy = sinon.spy(geometryProcessor, "processPointFeature");
+        const lineSpy = sinon.spy(geometryProcessor, "processLineFeature");
+        const polygonSpy = sinon.spy(geometryProcessor, "processPolygonFeature");
+        adapter.process(geojsonVtTile as any, decodeInfo);
+
+        expect(pointSpy.calledOnce);
+        const pointEnv = pointSpy.getCalls()[0].args[3];
+        expect(pointEnv.lookup("$id")).equals(geojsonVtTile.features[0].id);
+
+        expect(lineSpy.calledOnce);
+        const lineEnv = lineSpy.getCalls()[0].args[3];
+        expect(lineEnv.lookup("$id")).equals(geojsonVtTile.features[1].id);
+
+        expect(polygonSpy.calledOnce);
+        const polygonEnv = polygonSpy.getCalls()[0].args[3];
+        expect(polygonEnv.lookup("$id")).equals(geojsonVtTile.features[2].id);
+    });
+});

--- a/@here/harp-vectortile-datasource/test/MockGeometryProcessor.ts
+++ b/@here/harp-vectortile-datasource/test/MockGeometryProcessor.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MapEnv } from "@here/harp-datasource-protocol";
+import { Vector3 } from "three";
+
+import { IGeometryProcessor, ILineGeometry, IPolygonGeometry } from "../lib/IGeometryProcessor";
+
+export class MockGeometryProcessor implements IGeometryProcessor {
+    storageLevelOffset?: number | undefined;
+    processPointFeature(
+        layerName: string,
+        layerExtents: number,
+        geometry: Vector3[],
+        env: MapEnv,
+        storageLevel: number
+    ): void {}
+
+    processLineFeature(
+        layerName: string,
+        layerExtents: number,
+        geometry: ILineGeometry[],
+        env: MapEnv,
+        storageLevel: number
+    ): void {}
+
+    processPolygonFeature(
+        layerName: string,
+        layerExtents: number,
+        geometry: IPolygonGeometry[],
+        env: MapEnv,
+        storageLevel: number
+    ): void {}
+}

--- a/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDecodedTileEmitterTest.ts
@@ -201,8 +201,7 @@ describe("OmvDecodedTileEmitter", function () {
                 extents,
                 polygons,
                 mockContext,
-                styleSetEvaluator.getMatchingTechniques(mockContext.env),
-                undefined
+                styleSetEvaluator.getMatchingTechniques(mockContext.env)
             );
 
             const decodedTile = tileEmitter.getDecodedTile();
@@ -255,8 +254,7 @@ describe("OmvDecodedTileEmitter", function () {
             4096,
             polygons,
             mockContext,
-            matchedTechniques,
-            undefined
+            matchedTechniques
         );
 
         const decodedTile = tileEmitter.getDecodedTile();


### PR DESCRIPTION
So far feature ids were expected to be numbers, therefore original feature ids coming from geojson data were ignored.