### PR TITLE
Stopping use deprecated code.

### DIFF
--- a/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpCopyrightProvider.ts
@@ -5,13 +5,8 @@
  */
 
 import { AreaCopyrightInfo, CopyrightCoverageProvider } from "@here/harp-mapview";
-import {
-    DataRequest,
-    EnvironmentName,
-    HRN,
-    OlpClientSettings,
-    VersionedLayerClient
-} from "@here/olp-sdk-dataservice-read";
+import { HRN, OlpClientSettings } from "@here/olp-sdk-core";
+import { DataRequest, EnvironmentName, VersionedLayerClient } from "@here/olp-sdk-dataservice-read";
 
 /**
  * [[OlpCopyrightProvider]] initialization parameters.

--- a/@here/harp-olp-utils/lib/OlpDataProvider.ts
+++ b/@here/harp-olp-utils/lib/OlpDataProvider.ts
@@ -7,12 +7,11 @@
 import { TileKey } from "@here/harp-geoutils";
 import { DataProvider } from "@here/harp-mapview-decoder";
 import { LoggerManager } from "@here/harp-utils";
+import { HRN, OlpClientSettings } from "@here/olp-sdk-core";
 import {
     CatalogClient,
     CatalogVersionRequest,
     DataRequest,
-    HRN,
-    OlpClientSettings,
     VersionedLayerClient
 } from "@here/olp-sdk-dataservice-read";
 

--- a/@here/harp-olp-utils/package.json
+++ b/@here/harp-olp-utils/package.json
@@ -23,7 +23,8 @@
         "@here/harp-mapview": "^0.22.0",
         "@here/harp-mapview-decoder": "^0.22.0",
         "@here/harp-utils": "^0.22.0",
-        "@here/olp-sdk-dataservice-read": "^1.8.0"
+        "@here/olp-sdk-dataservice-read": "^1.8.0",
+        "@here/olp-sdk-core": "1.3.0"
     },
     "devDependencies": {
         "@here/harp-fetch": "^0.22.0",


### PR DESCRIPTION
The classes `OlpClientSettings` and `HRN` in
`@here/olp-sdk-dataservice-read` will be removed
in the next release.

Those classes copied to the `@here/olp-sdk-core`.

This CR adapts the code according to future changes.