### PR TITLE
HARP-13952: Handle error states, like 404 in OmvRestClient

### DIFF
--- a/@here/harp-transfer-manager/src/TransferManager.ts
+++ b/@here/harp-transfer-manager/src/TransferManager.ts
@@ -87,8 +87,14 @@ export class TransferManager implements ITransferManager {
         try {
             if (retryCount < maxRetries) {
                 const response = await fetchFunction(url, init);
-                if (response.status !== 503) {
+                // Return response when successful or empty
+                if (response.status === 200 || response.status === 204) {
                     return response;
+                } else if (response.status >= 400 && response.status < 500) {
+                    // Prevent further retries in case of a client error code
+                    retryCount = maxRetries;
+                    const responseText = await response.text();
+                    throw new Error(responseText);
                 }
             } else {
                 throw new Error("Max number of retries reached");

--- a/@here/harp-transfer-manager/test/TransferManagerTest.ts
+++ b/@here/harp-transfer-manager/test/TransferManagerTest.ts
@@ -51,26 +51,20 @@ describe("TransferManager", function () {
         const mock = createMockDownloadResponse();
         mock.status = 404;
         mock.ok = false;
-        mock.json.resolves({ version: "4" });
+        mock.text.resolves("Dummy error");
         const fetchStub = sinon.stub().resolves(mock);
         const downloadMgr = new TransferManager(fetchStub, 5);
 
         // Act
-        const downloadResponse = downloadMgr.download(fakeDataUrl);
-
-        const resp = await downloadResponse.then(response => {
-            return response;
-        });
-
-        const data = await resp.json();
-
-        // Assert
-        assert(fetchStub.called);
-        assert(fetchStub.callCount === 1);
-        assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
-        assert.isFalse(resp.ok);
-        assert.equal(resp.status, 404);
-        assert.deepEqual(data, { version: "4" });
+        try {
+            await downloadMgr.download(fakeDataUrl);
+        } catch (err) {
+            // Assert
+            assert(fetchStub.called);
+            assert(fetchStub.callCount === 1);
+            assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
+            assert.equal(err.message, "Dummy error");
+        }
     });
 
     it("#downloadJson handles HTTP 503 status response with max retries", async function () {
@@ -100,6 +94,28 @@ describe("TransferManager", function () {
         assert(fetchStub.called);
         assert(fetchStub.callCount === maxRetries);
         assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
+    });
+
+    it("#downloadJson handles HTTP client codes like 400, 401 without retry", async function () {
+        // Arrange
+        const mock = createMockDownloadResponse();
+        mock.status = 401;
+        mock.ok = false;
+        mock.text.resolves("Dummy error");
+        const fetchStub = sinon.stub().resolves(mock);
+        const downloadMgr = new TransferManager(fetchStub, 5);
+
+        // Act
+        try {
+            await downloadMgr.download(fakeDataUrl);
+        } catch (err) {
+            // Assert
+            assert(fetchStub.called);
+            assert(fetchStub.callCount === 1);
+            assert(fetchStub.getCall(0).args[0] === fakeDataUrl);
+            assert.isDefined(err);
+            assert.equal(err.message, "Dummy error");
+        }
     });
 
     it("#instance handles returning same single static instance correctly", async function () {

--- a/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
+++ b/@here/harp-vectortile-datasource/lib/OmvRestClient.ts
@@ -310,8 +310,8 @@ export class OmvRestClient extends DataProvider {
      * Asynchronously fetches a tile from this restful server.
      *
      * @remarks
-     * **Note:** If the tile doesn't exist, a successful response with a `404` status code is
-     * returned.
+     * **Note:** In case of an HTTP Error, rejected promise is returned
+     * with an error.
      *
      * @example
      * ```typescript
@@ -319,10 +319,6 @@ export class OmvRestClient extends DataProvider {
      * if (!response.ok) {
      *     // a network error happened
      *     console.error("Unable to download tile", response.statusText);
-     *     return;
-     * }
-     * if (response.status === 404) {
-     *     // 404 -, no data exists at the given tile. Do nothing.
      *     return;
      * }
      *


### PR DESCRIPTION
Thie change handles HTTP error messages which in the case of the OMV client can be due to various reasons:

- **401** Invalid credentials
- **404** No data, when for example the supported ``maxDataLevel`` is exceeded

Error messages obtained from the server are logged for easy troubleshooting. Furthermore, in the case of HTTP client error codes, we do not attempt to fetch the data again.
