### PR TITLE
HARP-14358 Fix incorrect branch and therefore broken documentation / …

### DIFF
--- a/.github/workflows/deploy_to_npm.yaml
+++ b/.github/workflows/deploy_to_npm.yaml
@@ -48,6 +48,8 @@ jobs:
                   # debug: lerna publish expects clean workspace
                   ./scripts/git-check-clean-workspace.sh
               shell: bash
+              env:
+                HEAD_BRANCH: ${{ github.head_ref }}
 
             - name: Setup Node
               if: github.ref == 'refs/heads/release'
@@ -76,4 +78,3 @@ jobs:
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: us-east-1
                   SOURCE_DIR: 'dist/s3_deploy'
-

--- a/scripts/prepare_doc_deploy.ts
+++ b/scripts/prepare_doc_deploy.ts
@@ -17,7 +17,7 @@ const fetch = require("node-fetch");
 // Precondition: documentation ready on /dist folder
 // including docs and examples (e.g. after yarn run build && yarn run typedoc)
 
-const branch = process.env.TRAVIS_BRANCH;
+const branch = process.env.HEAD_BRANCH;
 const commitHash = execSync("git rev-parse --short HEAD").toString().trimRight();
 const refName = branch !== "master" ? commitHash : "master";
 
@@ -55,7 +55,7 @@ interface Release {
     version: string;
 }
 
-if (branch !== "master") {
+if (branch === "release") {
     const now = new Date();
     // WARNING, dates are 0 indexed, hence +1
     const dateString = `${now.getDate()}-${now.getMonth() + 1}-${now.getFullYear()}`;


### PR DESCRIPTION
…releases.json

- The TRAVIS_BRANCH env variable doesn't exist. This meant that the documentation would never push to https://www.harp.gl/docs/master/doc/, (it is out of date). And the releases.json would also be always updated, because the condition to check if it was the release branch would fail.
- Changed the condition to be condition to be clearer to read.