### PR TITLE
HARP-14633: island geometry disappears on certain zoom level

### DIFF
--- a/@here/harp-geometry/lib/ClipPolygon.ts
+++ b/@here/harp-geometry/lib/ClipPolygon.ts
@@ -51,6 +51,8 @@ export abstract class ClippingEdge {
      *
      * @param polygon Clip the polygon against this edge.
      * @param extent The extent of the bounding box.
+     *
+     * @return The clipped polygon.
      */
     clipPolygon(polygon: Vector2[], extent: number): Vector2[] {
         const inputList = polygon;
@@ -200,7 +202,7 @@ const clipEdges = [
 ];
 
 /**
- * Clip the given polygon using the Sutherland-Hodgman algorithm.
+ * Clip the given polygon against a rectangle using the Sutherland-Hodgman algorithm.
  *
  * @remarks
  * The coordinates of the polygon must be integer numbers.

--- a/@here/harp-vectortile-datasource/lib/Ring.ts
+++ b/@here/harp-vectortile-datasource/lib/Ring.ts
@@ -17,6 +17,7 @@ export class Ring {
      * @remarks
      * The sign of the area depends on the projection and the axis orientation
      * of the ring coordinates.
+     * For example, given a ring with `CW winding`: `area > 0` with Y-axis that grows downwards and `area < 0` otherwise.
      */
     readonly area: number;
 

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson-vt/GeoJsonVtDataAdapter.ts
@@ -7,7 +7,7 @@
 import { MapEnv, ValueMap } from "@here/harp-datasource-protocol/index-decoder";
 import { webMercatorProjection } from "@here/harp-geoutils";
 import { ILogger } from "@here/harp-utils";
-import { Vector2, Vector3 } from "three";
+import { ShapeUtils, Vector2, Vector3 } from "three";
 
 import { DataAdapter } from "../../DataAdapter";
 import { DecodeInfo } from "../../DecodeInfo";
@@ -181,20 +181,29 @@ export class GeoJsonVtDataAdapter implements DataAdapter {
                     break;
                 }
                 case VTJsonGeometryType.Polygon: {
-                    const polygon: IPolygonGeometry = { rings: [] };
+                    const polygons: IPolygonGeometry[] = [];
+                    let polygon: IPolygonGeometry | undefined;
                     for (const outline of feature.geometry as VTJsonPosition[][]) {
                         const ring: Vector2[] = [];
                         for (const [currX, currY] of outline) {
                             const position = new Vector2(currX, currY);
                             ring.push(position);
                         }
-                        polygon.rings.push(ring);
+                        // MVT spec defines that each exterior ring signals the beginning of a new polygon.
+                        // See https://github.com/mapbox/vector-tile-spec/tree/master/2.1
+                        if (ShapeUtils.area(ring) > 0) {
+                            // Create a new polygon and push it into the collection of polygons
+                            polygon = { rings: [] };
+                            polygons.push(polygon);
+                        }
+                        // Push the ring into the current polygon
+                        polygon?.rings.push(ring);
                     }
 
                     this.m_processor.processPolygonFeature(
                         tile.layer,
                         VT_JSON_EXTENTS,
-                        [polygon],
+                        polygons,
                         env,
                         tileKey.level
                     );

--- a/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
@@ -9,7 +9,7 @@ import { clipLineString } from "@here/harp-geometry/lib/ClipLineString";
 import { GeoCoordinates, GeoPointLike, webMercatorProjection } from "@here/harp-geoutils";
 import { Vector2Like } from "@here/harp-geoutils/lib/math/Vector2Like";
 import { ILogger } from "@here/harp-utils";
-import { Vector2, Vector3 } from "three";
+import { ShapeUtils, Vector2, Vector3 } from "three";
 
 import { DataAdapter } from "../../DataAdapter";
 import { DecodeInfo } from "../../DecodeInfo";
@@ -134,21 +134,11 @@ function convertLineGeometry(
         convertLineStringGeometry(lineString, decodeInfo)
     );
 }
-
-function signedPolygonArea(contour: GeoPointLike[]): number {
-    const n = contour.length;
-    let area = 0.0;
-    for (let p = n - 1, q = 0; q < n; p = q++) {
-        area += contour[p][0] * contour[q][1] - contour[q][0] * contour[p][1];
-    }
-    return area * 0.5;
-}
-
 function convertRings(coordinates: GeoPointLike[][], decodeInfo: DecodeInfo): IPolygonGeometry {
     const rings = coordinates.map((ring, i) => {
         const isOuterRing = i === 0;
-        const isClockWise = signedPolygonArea(ring) < 0;
         const { positions } = convertLineStringGeometry(ring, decodeInfo);
+        const isClockWise = ShapeUtils.area(positions) > 0;
         if ((isOuterRing && !isClockWise) || (!isOuterRing && isClockWise)) {
             positions.reverse();
         }

--- a/@here/harp-vectortile-datasource/test/OmvDataAdapterTest.ts
+++ b/@here/harp-vectortile-datasource/test/OmvDataAdapterTest.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mercatorProjection, TileKey } from "@here/harp-geoutils";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { OmvDataAdapter } from "../lib/adapters/omv/OmvDataAdapter";
+import { com } from "../lib/adapters/omv/proto/vector_tile";
+import { DecodeInfo } from "../lib/DecodeInfo";
+import { FakeOmvFeatureFilter } from "./FakeOmvFeatureFilter";
+import { MockGeometryProcessor } from "./MockGeometryProcessor";
+
+enum VTJsonGeometryType {
+    Unknown,
+    Point,
+    LineString,
+    Polygon
+}
+
+// Encoded geometries - https://docs.mapbox.com/vector-tiles/specification/#encoding-geometry
+// See https://github.com/mapbox/vector-tile-spec/blob/master/2.1/README.md#4356-example-multi-polygon
+// Polygon 1:
+// Exterior Ring: CW
+// (0,0)
+// (10,0)
+// (10,10)
+// (0,10)
+// (0,0)
+// Polygon 2:
+// Exterior Ring: CW
+// (11,11)
+// (20,11)
+// (20,20)
+// (11,20)
+// Interior Ring: CCW
+// (13,13)
+// (13,17)
+// (17,17)
+// (17,13)
+
+const MultiPolygon = [
+    9,
+    0,
+    0,
+    26,
+    20,
+    0,
+    0,
+    20,
+    19,
+    0,
+    15, // end Polygon1
+    9,
+    22,
+    2,
+    26,
+    18,
+    0,
+    0,
+    18,
+    17,
+    0,
+    15, // end Polygon2#exterior
+    9,
+    4,
+    13,
+    26,
+    0,
+    8,
+    8,
+    0,
+    0,
+    7,
+    15 // end Polygon2#interior
+];
+// MultiPolygon with rings having opposite winding
+// Polygon#1 - [ext:CCW]
+// Polygon#2 - [ext:CCW, int:CW]
+const WrongWindingMultiPolygon = [
+    9,
+    0,
+    0,
+    26,
+    0,
+    20,
+    20,
+    0,
+    0,
+    19,
+    15, // end Polygon1
+    9,
+    2,
+    22,
+    26,
+    0,
+    18,
+    18,
+    0,
+    0,
+    17,
+    15, // end Polygon2#exterior
+    9,
+    13,
+    4,
+    26,
+    0,
+    0,
+    8,
+    7,
+    0,
+    15 // end Polygon2#interior
+];
+
+const MVTLayer = {
+    name: "layer",
+    features: [
+        {
+            type: VTJsonGeometryType.Polygon,
+            id: 1,
+            tags: {},
+            geometry: MultiPolygon
+        }
+    ]
+};
+const MVTTile = {
+    layers: [MVTLayer]
+};
+
+describe("OmvDataAdapter", function () {
+    let decodeInfo: DecodeInfo;
+    let geometryProcessor: MockGeometryProcessor;
+    let adapter: OmvDataAdapter;
+    let TileDecodeStub: any;
+
+    beforeEach(function () {
+        decodeInfo = new DecodeInfo("", mercatorProjection, new TileKey(0, 0, 1));
+        geometryProcessor = new MockGeometryProcessor();
+        adapter = new OmvDataAdapter(geometryProcessor, new FakeOmvFeatureFilter());
+        TileDecodeStub = sinon.stub(com.mapbox.pb.Tile, "decode");
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it("process polygon geometries with correct winding", function () {
+        const polygonSpy = sinon.spy(geometryProcessor, "processPolygonFeature");
+        TileDecodeStub.returns(MVTTile);
+        adapter.process(1 as any, decodeInfo);
+        const polygons = polygonSpy.getCalls()[0].args[2];
+        expect(polygons.length).equals(2);
+    });
+
+    it("process polygon geometries with opposite winding", function () {
+        const polygonSpy = sinon.spy(geometryProcessor, "processPolygonFeature");
+        const tile = { ...MVTTile };
+        const layer = { ...MVTLayer };
+        const fakeData = 1;
+
+        layer.features[0].geometry = WrongWindingMultiPolygon;
+        tile.layers = [layer];
+        TileDecodeStub.returns(tile);
+
+        adapter.process(fakeData as any, decodeInfo);
+        const polygons = polygonSpy.getCalls()[0].args[2];
+        expect(polygons.length).equals(2);
+    });
+});


### PR DESCRIPTION
Currently, in master, all the ring geometries forming multi-polygons are processed and put into a single polygon composed of an interleaved list of exterior/interior rings. The winding (determined in function of the sign of the area) of these rings is used to differentiate exteriors from interiors.

This layout besides being not fully compliant to the MVT spec, see [Polygon Geometry Type](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4344-polygon-geometry-type), creates confusion in case clipped rings result in a `0` area.


This PR proposes to process and create polygon objects in accordance with the MVT spec while stopping relying on the winding.

