### PR TITLE
HARP-14417: fix picking of polygon outlines

### DIFF
--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -356,7 +356,7 @@ export class PickHandler {
         if (
             featureData.starts === undefined ||
             featureData.starts.length === 0 ||
-            (intersect.faceIndex === undefined && intersect.index === undefined)
+            (typeof intersect.faceIndex !== "number" && intersect.index === undefined)
         ) {
             if (featureData.objInfos.length === 1) {
                 pickResult.userData = featureData.objInfos[0];
@@ -370,7 +370,7 @@ export class PickHandler {
         }
 
         const intersectIndex =
-            intersect.faceIndex !== undefined ? intersect.faceIndex * 3 : intersect.index!;
+            typeof intersect.faceIndex === "number" ? intersect.faceIndex * 3 : intersect.index!;
 
         // TODO: Implement binary search.
         let objInfosIndex = 0;

--- a/@here/harp-mapview/test/PickHandlerTest.ts
+++ b/@here/harp-mapview/test/PickHandlerTest.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as THREE from "three";
+
+import { MapView } from "../lib/MapView";
+import { PickHandler } from "../lib/PickHandler";
+import { Tile } from "../lib/Tile";
+
+describe("PickHandler", function () {
+    let pickHandler: PickHandler;
+    let mapViewMock: MapView;
+
+    beforeEach(function () {
+        const size = new THREE.Vector2(800, 600);
+        const camera = new THREE.PerspectiveCamera();
+        const tile = ({
+            boundingBox: {
+                extents: new THREE.Vector3(1252344.2714, 1252344.2714, 11064),
+                position: new THREE.Vector3(21289852.6142, 26299229.6999, 11064),
+                xAxis: new THREE.Vector3(1, 0, 0),
+                yAxis: new THREE.Vector3(0, 1, 0),
+                zAxis: new THREE.Vector3(0, 0, 1)
+            },
+            computeWorldOffsetX: () => 0,
+            dependencies: []
+        } as unknown) as Tile;
+
+        mapViewMock = ({
+            camera,
+            worldCenter: new THREE.Vector3(21429001.9777, 25228494.0575, 2160787.9966),
+            renderer: {
+                getSize: () => size
+            },
+            mapAnchors: {
+                children: []
+            },
+            getNormalizedScreenCoordinates: (x: number, y: number) =>
+                new THREE.Vector3(x / size.x - 1, -y / size.y + 1, 0),
+            visibleTileSet: {
+                dataSourceTileList: [
+                    {
+                        dataSource: {
+                            enablePicking: true
+                        },
+                        renderedTiles: new Map().set(1, tile)
+                    }
+                ]
+            },
+            getWorldPositionAt: () => {} // to be overridden (by stubs) for given coords
+        } as unknown) as MapView;
+
+        pickHandler = new PickHandler(mapViewMock, camera, true);
+    });
+
+    describe("#intersectMapObjects", function () {
+        let raycasterFromScreenPointStub: sinon.SinonStub<[x: number, y: number], THREE.Raycaster>;
+
+        beforeEach(function () {
+            raycasterFromScreenPointStub = sinon.stub(pickHandler, "raycasterFromScreenPoint");
+        });
+
+        it("collects results for objects based on '.faceIndex' of intersection", function () {
+            sinon
+                .stub(mapViewMock, "getWorldPositionAt")
+                .callsFake(() => new THREE.Vector3(21604645.272347387, 25283546.433446992, 0));
+
+            raycasterFromScreenPointStub.callsFake((x: number, y: number) => {
+                const raycaster = raycasterFromScreenPointStub.wrappedMethod.call(
+                    pickHandler,
+                    x,
+                    y
+                );
+
+                sinon
+                    .stub(raycaster, "intersectObjects")
+                    .callsFake((objects, recursive, target: THREE.Intersection[] = []) => {
+                        // contains ".face" and ".faceIndex", but doesn't contain ".index"
+                        target.push({
+                            distance: 2168613.8654252696,
+                            point: new THREE.Vector3(175643.2946, 55052.3759, -2160787.9966),
+                            face: {
+                                a: 1661,
+                                b: 1737,
+                                c: 1736,
+                                materialIndex: 0,
+                                normal: new THREE.Vector3(0, 0, 1)
+                            },
+                            faceIndex: 1653,
+                            object: ({
+                                renderOrder: 1000,
+                                userData: {
+                                    dataSource: "geojson",
+                                    feature: {
+                                        geometryType: 7,
+                                        starts: [
+                                            0,
+                                            558,
+                                            690,
+                                            1329,
+                                            1704,
+                                            2169,
+                                            2448,
+                                            2778,
+                                            3282,
+                                            3726,
+                                            3789,
+                                            3795,
+                                            3804,
+                                            3810,
+                                            3816,
+                                            3822,
+                                            3825,
+                                            4128,
+                                            4131,
+                                            4383,
+                                            4797,
+                                            5031,
+                                            5223,
+                                            5370,
+                                            5523,
+                                            5550,
+                                            5658,
+                                            5688,
+                                            5694
+                                        ],
+                                        objInfos: [
+                                            // duplicate entries are taken from original multi-polygons
+                                            // and correspond to the index defined in ".starts"
+                                            { $id: "KLRKDk6pCr", name: "piemonte" },
+                                            { $id: "XBfAalZEh7", name: "valle d'aosta" },
+                                            { $id: "Xgfuk2roHZ", name: "lombardia" },
+                                            { $id: "pJMwZ8oREr", name: "trentino-alto adige" },
+                                            { $id: "ZKFRobO3Pm", name: "veneto" },
+                                            { $id: "QogIXpZ2Z6", name: "friuli venezia giulia" },
+                                            { $id: "Qu7fcJcV84", name: "liguria" },
+                                            { $id: "7FkQc7sUxe", name: "emilia-romagna" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "vaPSWJfKuh", name: "umbria" },
+                                            { $id: "vaPSWJfKuh", name: "umbria" },
+                                            { $id: "ZOU85Bs5O0", name: "marche" },
+                                            { $id: "jmfNYjkZJr", name: "lazio" },
+                                            { $id: "yVgD20bhJO", name: "abruzzo" },
+                                            { $id: "GwuetqFMcf", name: "molise" },
+                                            { $id: "2J3GTgA5fc", name: "campania" },
+                                            { $id: "tZ9VB13xm1", name: "puglia" },
+                                            { $id: "GT1soJEJke", name: "basilicata" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" }
+                                        ]
+                                    }
+                                }
+                            } as unknown) as THREE.Object3D
+                        });
+
+                        return target;
+                    });
+
+                return raycaster;
+            });
+
+            const results = pickHandler.intersectMapObjects(467, 279);
+
+            expect(results).not.to.be.empty;
+            expect(results[0].featureId).to.equal("yVgD20bhJO");
+            expect(results[0].userData).to.deep.equal({
+                $id: "yVgD20bhJO",
+                name: "abruzzo"
+            });
+        });
+
+        it("collects results for objects based on '.index' of intersection", function () {
+            sinon
+                .stub(mapViewMock, "getWorldPositionAt")
+                .callsFake(() => new THREE.Vector3(21604645.272347387, 25315004.93397993, 0));
+
+            raycasterFromScreenPointStub.callsFake((x: number, y: number) => {
+                const raycaster = raycasterFromScreenPointStub.wrappedMethod.call(
+                    pickHandler,
+                    x,
+                    y
+                );
+
+                sinon
+                    .stub(raycaster, "intersectObjects")
+                    .callsFake((objects, recursive, target: THREE.Intersection[] = []) => {
+                        // contains ".index", but doesn't contain ".face" and ".faceIndex"
+                        target.push({
+                            distance: 2168743.4081880464,
+                            point: new THREE.Vector3(174781.2243, 62415.6655, -2160787.9966),
+                            index: 3318,
+                            object: ({
+                                renderOrder: 1000,
+                                userData: {
+                                    dataSource: "geojson",
+                                    feature: {
+                                        geometryType: 7,
+                                        starts: [
+                                            0,
+                                            378,
+                                            472,
+                                            904,
+                                            1160,
+                                            1476,
+                                            1668,
+                                            1894,
+                                            2234,
+                                            2536,
+                                            2584,
+                                            2594,
+                                            2606,
+                                            2616,
+                                            2626,
+                                            2636,
+                                            2644,
+                                            2852,
+                                            2860,
+                                            3034,
+                                            3316,
+                                            3478,
+                                            3612,
+                                            3712,
+                                            3828,
+                                            3848,
+                                            3922,
+                                            3948,
+                                            3958
+                                        ],
+                                        objInfos: [
+                                            { $id: "KLRKDk6pCr", name: "piemonte" },
+                                            { $id: "XBfAalZEh7", name: "valle d'aosta" },
+                                            { $id: "Xgfuk2roHZ", name: "lombardia" },
+                                            { $id: "pJMwZ8oREr", name: "trentino-alto adige" },
+                                            { $id: "ZKFRobO3Pm", name: "veneto" },
+                                            { $id: "QogIXpZ2Z6", name: "friuli venezia giulia" },
+                                            { $id: "Qu7fcJcV84", name: "liguria" },
+                                            { $id: "7FkQc7sUxe", name: "emilia-romagna" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "cWl3QbtsTR", name: "toscana" },
+                                            { $id: "vaPSWJfKuh", name: "umbria" },
+                                            { $id: "vaPSWJfKuh", name: "umbria" },
+                                            { $id: "ZOU85Bs5O0", name: "marche" },
+                                            { $id: "jmfNYjkZJr", name: "lazio" },
+                                            { $id: "yVgD20bhJO", name: "abruzzo" },
+                                            { $id: "GwuetqFMcf", name: "molise" },
+                                            { $id: "2J3GTgA5fc", name: "campania" },
+                                            { $id: "tZ9VB13xm1", name: "puglia" },
+                                            { $id: "GT1soJEJke", name: "basilicata" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" },
+                                            { $id: "z3HpNZ0YaQ", name: "sardegna" }
+                                        ]
+                                    }
+                                }
+                            } as unknown) as THREE.Object3D
+                        });
+
+                        return target;
+                    });
+
+                return raycaster;
+            });
+
+            const results = pickHandler.intersectMapObjects(467, 276);
+
+            expect(results).not.to.be.empty;
+            expect(results[0].featureId).to.equal("yVgD20bhJO");
+            expect(results[0].userData).to.deep.equal({
+                $id: "yVgD20bhJO",
+                name: "abruzzo"
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR fixes picking at polygonal outlines for the `fill` technique.

Before the fix:

<img width="400" alt="picking example" src="https://user-images.githubusercontent.com/2470363/114062030-b8a56080-989f-11eb-8dd0-78d643934e23.png">

* Expected result: when an outline is picked, all resulting objects (belonging to a given datasource) contain `.featureId` and `.userData` derived from original GeoJSON features that were used to render both `Mesh` and `LineSegments` objects.
* Actual result: while for `Mesh` objects results are correct (underlying polygons), for `LineSegments` it's always the first polygon of a given tile that's being returned instead. E.g. on the screenshot above, "Piemonte" is returned instead of "Abruzzo".

Reason:

<img width="251" alt="faceIndex value" src="https://user-images.githubusercontent.com/2470363/114064014-e2f81d80-98a1-11eb-97fb-762b55b1a87b.png">

`PickHandler` was comparing `.faceIndex` with `undefined` when deciding whether to take `.faceIndex * 3` or `.index` in order to recognise the proper feature. In case of `LineSegments` it's `null`, as that's the default value coming from THREE's [`.intersectObject()`](https://threejs.org/docs/#api/en/core/Raycaster.intersectObject).