### PR TITLE
MAPSJS-2927, Fix polygon outline clipped on tile border

### DIFF
--- a/@here/harp-vectortile-datasource/lib/Ring.ts
+++ b/@here/harp-vectortile-datasource/lib/Ring.ts
@@ -120,10 +120,10 @@ export class Ring {
         }
 
         return !(
-            (curr.x <= 0 && next.x <= 0) ||
-            (curr.x >= extents && next.x >= extents) ||
-            (curr.y <= 0 && next.y <= 0) ||
-            (curr.y >= extents && next.y >= extents)
+            (curr.x < 0 && next.x < 0) ||
+            (curr.x > extents && next.x > extents) ||
+            (curr.y < 0 && next.y < 0) ||
+            (curr.y > extents && next.y > extents)
         );
     }
 }


### PR DESCRIPTION
Signed-off-by: Andrii Heonia <andrii.heonia@here.com>

The problem is that one edge (the one which is on the tile border) is skipped because "properEdge" const in VectorTileDataEmitter.ts#processPolygonFeature is "false". I adjusted isProperEdge function to return "true" even if line is on the tile border.
