### PR TITLE
HARP-15089 - Remove dynamic job creation script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,14 +4,14 @@ stages:
 
 default:
   interruptible: true
+  image: node
 
 workflow:
   rules:
     - if: $CI_EXTERNAL_PULL_REQUEST_IID
 
-trigger_internal_ci:
+create-branch:
   stage: build
-  image: node
   tags: 
     - docker-prod
   variables:
@@ -20,23 +20,14 @@ trigger_internal_ci:
   script:
     - |
       set -e
-      echo $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
-      export TRIGGER_BRANCH=$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
       #Creating a new branch
         curl --request POST --header \
         "PRIVATE-TOKEN: $SVC_HLS_RENDER_API" \
         "${CI_SERVER_URL}/api/v4/projects/$DOWNSTREAM_PROJECT_ID/repository/branches?branch=$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME&ref=master" || echo "error creating branch $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME"
 
-      scripts/generate-config.sh
-  artifacts:
-     paths:
-      - generated-config.yml
-
-
-bridge_for_bridge:
+downstream_bridge:
   stage: trigger
   trigger:
-    include:
-      - artifact: generated-config.yml
-        job: trigger_internal_ci
+    project: $DOWNSTREAM_PROJECT_NAME
+    branch: $CI_COMMIT_BRANCH
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,6 @@ downstream_bridge:
   variables:
     CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME: $CI_COMMIT_BRANCH
   trigger:
-    project: $CI_PROJECT_NAMESPACE/sdk
+    project: $CI_MERGE_REQUEST_PROJECT_PATH/sdk
     branch: $CI_COMMIT_BRANCH
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ create-branch:
 downstream_bridge:
   stage: trigger
   variables:
-    CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME: $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
+    CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME: $CI_COMMIT_BRANCH
   trigger:
     project: rendering/harp.gl/sdk
     branch: $CI_COMMIT_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,8 @@ create-branch:
 
 downstream_bridge:
   stage: trigger
+  variables:
+    CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME: $CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME
   trigger:
     project: rendering/harp.gl/sdk
     branch: $CI_COMMIT_BRANCH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,6 @@ downstream_bridge:
   variables:
     CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME: $CI_COMMIT_BRANCH
   trigger:
-    project: rendering/harp.gl/sdk
+    project: $CI_PROJECT_NAMESPACE/sdk
     branch: $CI_COMMIT_BRANCH
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,6 @@ create-branch:
 downstream_bridge:
   stage: trigger
   trigger:
-    project: $DOWNSTREAM_PROJECT_NAME
+    project: rendering/harp.gl/sdk
     branch: $CI_COMMIT_BRANCH
     strategy: depend


### PR DESCRIPTION
The dynamic job creation script used generate-config.sh to create the yaml file since
variables could not be directly used with trigger.branch. However with new gitlab agent,
it is possible. Therefore the script is removed to make the CI flow simpler.

Signed-off-by: Aluni <gairik.aluni@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
