### PR TITLE
Change URL caching inside ThemeLoader.

### DIFF
--- a/@here/harp-mapview/lib/ThemeLoader.ts
+++ b/@here/harp-mapview/lib/ThemeLoader.ts
@@ -24,7 +24,6 @@ import {
     IContextLogger,
     ISimpleChannel,
     RelativeUriResolver,
-    resolveReferenceUri,
     UriResolver
 } from "@here/harp-utils";
 
@@ -135,7 +134,7 @@ export class ThemeLoader {
                 throw new Error(`ThemeLoader#load: cannot load theme: ${response.statusText}`);
             }
             theme = (await response.json()) as Theme;
-            theme.url = resolveReferenceUri(getAppBaseUrl(), themeUrl);
+            theme.url = themeUrl;
             theme = this.resolveUrls(theme, options);
         } else if (theme.url === undefined) {
             // assume that theme url is same as baseUrl

--- a/@here/harp-mapview/test/ThemeLoaderTest.ts
+++ b/@here/harp-mapview/test/ThemeLoaderTest.ts
@@ -50,12 +50,7 @@ describe("ThemeLoader", function () {
 
         it("resolves absolute theme url of theme loaded from relative url", async function () {
             const result = await ThemeLoader.load(sampleThemeUrl);
-            assert.equal(result.url, resolveReferenceUri(appBaseUrl, sampleThemeUrl));
-        });
-
-        it("resolves absolute url of theme loaded from relative url", async function () {
-            const result = await ThemeLoader.load(sampleThemeUrl);
-            assert.equal(result.url, resolveReferenceUri(appBaseUrl, sampleThemeUrl));
+            assert.equal(result.url, sampleThemeUrl);
         });
 
         it("resolves urls of resources embedded in theme", async function () {


### PR DESCRIPTION
This is another way of patching the issue we're facing with Figma application's plugin sandbox.
