### PR TITLE
MAPSJS-2783: Disable flaky test until fixed.

### DIFF
--- a/test/rendering/StylingTest.ts
+++ b/test/rendering/StylingTest.ts
@@ -875,7 +875,8 @@ describe("MapView Styling Test", function () {
                     // }
                 });
             });
-            describe("textured", function () {
+            xdescribe("textured", function () {
+                // Flaky, frame complete needs to be fixed.
                 makePolygonTestCases(
                     "fill",
                     {


### PR DESCRIPTION
Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>
