### PR TITLE
MAPSJS-2783: Fix dynamic technique keys for array buffers.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -737,6 +737,11 @@ export class StyleSetEvaluator {
             .map(([_attrName, attrValue]) => {
                 if (attrValue === undefined) {
                     return "U";
+                } else if (typeof attrValue === "object") {
+                    return JSON.stringify(attrValue, (key, value) => {
+                        // ArrayBuffers cannot be directly stringified, convert them to arrays.
+                        return value instanceof ArrayBuffer ? new Uint8Array(value) : value;
+                    });
                 } else {
                     return JSON.stringify(attrValue);
                 }

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -265,6 +265,30 @@ describe("StyleSetEvaluator", function () {
             assert.deepEqual(techniquesTileA[2], techniquesTileB[0]);
             assert.deepEqual(techniquesTileA[0], techniquesTileC[1]);
         });
+
+        it("technique cache key changes for different array buffers", function () {
+            const texturedStyle: StyleSet = [
+                {
+                    technique: "fill",
+                    when: "kind == 'park'",
+                    attr: {
+                        map: ["get", "map"]
+                    }
+                }
+            ];
+
+            const buffer1 = new Uint8Array([1, 2, 3, 4]).buffer;
+            const buffer2 = new Uint8Array([4, 3, 2, 1]).buffer;
+
+            const techniquesTileA = (() => {
+                const ev = new StyleSetEvaluator({ styleSet: texturedStyle });
+                ev.getMatchingTechniques(new MapEnv({ kind: "park", map: { buffer: buffer1 } }));
+                ev.getMatchingTechniques(new MapEnv({ kind: "park", map: { buffer: buffer2 } }));
+                return ev.decodedTechniques;
+            })();
+
+            assert.equal(techniquesTileA.length, 2);
+        });
     });
     describe('definitions / "ref" operator support', function () {
         const sampleStyleDeclaration: Style = {


### PR DESCRIPTION
Dynamic technique keys are generated using JSON.stringify on the
technique property values. However ArrayBuffers (used for texture
properties) return always the same string "{}", causing a collision
in the dynamic technique cache between different techniques.

This is solved by converting array buffers to arrays before stringifying.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

