### PR TITLE
MAPSJS-2783: Faster creation of keys for techniques with dynamic array buffer properties.

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -359,6 +359,7 @@ export class StyleSetEvaluator {
     private m_zoomLevel: number | undefined;
     private m_previousResult: IndexedTechnique[] | undefined;
     private m_previousEnv: Env | undefined;
+    private m_nextArrayBufferId = 0;
 
     constructor(private readonly m_options: StyleSetOptions) {
         this.m_definitions = this.m_options.definitions;
@@ -738,9 +739,18 @@ export class StyleSetEvaluator {
                 if (attrValue === undefined) {
                     return "U";
                 } else if (typeof attrValue === "object") {
-                    return JSON.stringify(attrValue, (key, value) => {
-                        // ArrayBuffers cannot be directly stringified, convert them to arrays.
-                        return value instanceof ArrayBuffer ? new Uint8Array(value) : value;
+                    return JSON.stringify(attrValue, (_, value) => {
+                        if (value instanceof ArrayBuffer) {
+                            // ArrayBuffers cannot be directly stringified. They can be converted
+                            // to typed arrays and then stringified, but it's too slow. Instead,
+                            // assign them unique ids.
+                            let arrayBufferId = (value as any).id;
+                            if (arrayBufferId === undefined) {
+                                arrayBufferId = (value as any).id = this.m_nextArrayBufferId++;
+                            }
+                            return arrayBufferId;
+                        }
+                        return value;
                     });
                 } else {
                     return JSON.stringify(attrValue);

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -308,6 +308,29 @@ describe("StyleSetEvaluator", function () {
             assert.deepEqual(techniquesTileA[0], techniquesTileB[1]);
             assert.deepEqual(techniquesTileA[1], techniquesTileB[0]);
         });
+
+        it("returns same technique when same array buffer is used twice", function () {
+            const texturedStyle: StyleSet = [
+                {
+                    technique: "fill",
+                    when: "kind == 'park'",
+                    attr: {
+                        map: ["get", "map"]
+                    }
+                }
+            ];
+
+            const buffer = new Uint8Array([1, 2, 3, 4]).buffer;
+
+            const techniquesTile = (() => {
+                const ev = new StyleSetEvaluator({ styleSet: texturedStyle });
+                ev.getMatchingTechniques(new MapEnv({ kind: "park", map: { buffer } }));
+                ev.getMatchingTechniques(new MapEnv({ kind: "park", map: { buffer } }));
+                return ev.decodedTechniques;
+            })();
+
+            assert.equal(techniquesTile.length, 1);
+        });
     });
     describe('definitions / "ref" operator support', function () {
         const sampleStyleDeclaration: Style = {

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -288,6 +288,25 @@ describe("StyleSetEvaluator", function () {
             })();
 
             assert.equal(techniquesTileA.length, 2);
+
+            const techniquesTileB = (() => {
+                const ev = new StyleSetEvaluator({ styleSet: texturedStyle });
+                ev.getMatchingTechniques(new MapEnv({ kind: "park", map: { buffer: buffer2 } }));
+                ev.getMatchingTechniques(new MapEnv({ kind: "park", map: { buffer: buffer1 } }));
+                return ev.decodedTechniques;
+            })();
+
+            assert.equal(techniquesTileB.length, 2);
+
+            // reset _index from result techniques, because it may differ
+            [...techniquesTileA, ...techniquesTileB].forEach(t => {
+                t._index = 0;
+            });
+
+            // Now, respective techniques should have same cache key irrespectively to from
+            // which tile they come.
+            assert.deepEqual(techniquesTileA[0], techniquesTileB[1]);
+            assert.deepEqual(techniquesTileA[1], techniquesTileB[0]);
         });
     });
     describe('definitions / "ref" operator support', function () {


### PR DESCRIPTION
Instead of stringifying the array buffers, an id is assigned to them
and used as part of the technique key.

Signed-off-by: Andres Mandado <andres.mandado-almajano@here.com>

