### PR TITLE
MINOR: Support custom layer name in GeoJSON data adapter

### DIFF
--- a/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
+++ b/@here/harp-vectortile-datasource/lib/adapters/geojson/GeoJsonDataAdapter.ts
@@ -57,11 +57,12 @@ interface GeoJsonMultiPolygonGeometry {
 
 interface GeoJsonFeature {
     id?: string;
+    type: "Feature";
     properties: ValueMap;
     geometry: GeoJsonGeometry;
 }
 
-interface GeoJsonFeatureCollection {
+export interface GeoJsonFeatureCollection {
     type: "FeatureCollection";
     features: GeoJsonFeature[];
 }
@@ -164,12 +165,12 @@ export class GeoJsonDataAdapter implements DataAdapter {
     process(
         featureCollection: GeoJsonFeatureCollection,
         decodeInfo: DecodeInfo,
-        geometryProcessor: IGeometryProcessor
+        geometryProcessor: IGeometryProcessor,
+        layer: string = "geojson"
     ): void {
         if (!Array.isArray(featureCollection.features) || featureCollection.features.length === 0) {
             return;
         }
-        const layer = "geojson";
 
         for (const feature of featureCollection.features) {
             switch (feature.geometry.type) {

--- a/@here/harp-vectortile-datasource/test/GeoJsonDataAdapterTest.ts
+++ b/@here/harp-vectortile-datasource/test/GeoJsonDataAdapterTest.ts
@@ -4,11 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { mercatorProjection } from "@here/harp-geoutils/lib/projection/MercatorProjection";
+import { TileKey } from "@here/harp-geoutils/lib/tiling/TileKey";
 import { expect } from "chai";
+import * as sinon from "sinon";
 
-import { GeoJsonDataAdapter } from "../lib/adapters/geojson/GeoJsonDataAdapter";
+import {
+    GeoJsonDataAdapter,
+    GeoJsonFeatureCollection
+} from "../lib/adapters/geojson/GeoJsonDataAdapter";
+import { DecodeInfo } from "../lib/DecodeInfo";
+import { MockGeometryProcessor } from "./MockGeometryProcessor";
 
-const featureCollection = {
+const featureCollection: GeoJsonFeatureCollection = {
     type: "FeatureCollection",
     features: [
         {
@@ -62,5 +70,45 @@ describe("GeoJsonDataAdapter", function () {
 
     it("canProcess returns true for a FeatureCollection", function () {
         expect(adapter.canProcess(featureCollection as any)).to.be.true;
+    });
+
+    it("sets the specified layer name", () => {
+        const decodeInfo = new DecodeInfo(mercatorProjection, new TileKey(0, 0, 1));
+        const geometryProcessor = new MockGeometryProcessor();
+
+        const pointSpy = sinon.spy(geometryProcessor, "processPointFeature");
+        const lineSpy = sinon.spy(geometryProcessor, "processLineFeature");
+        const polygonSpy = sinon.spy(geometryProcessor, "processPolygonFeature");
+
+        const LAYER_NAME = "foo";
+
+        adapter.process(featureCollection, decodeInfo, geometryProcessor, LAYER_NAME);
+
+        sinon.assert.calledOnce(pointSpy);
+        sinon.assert.calledWith(
+            pointSpy,
+            LAYER_NAME,
+            sinon.match.number,
+            sinon.match.array,
+            sinon.match.object
+        );
+
+        sinon.assert.calledOnce(lineSpy);
+        sinon.assert.calledWith(
+            lineSpy,
+            LAYER_NAME,
+            sinon.match.number,
+            sinon.match.array,
+            sinon.match.object
+        );
+
+        sinon.assert.calledOnce(polygonSpy);
+        sinon.assert.calledWith(
+            polygonSpy,
+            LAYER_NAME,
+            sinon.match.number,
+            sinon.match.array,
+            sinon.match.object
+        );
     });
 });


### PR DESCRIPTION
The change allows inherited adapters to specify a custom GeoJSON layer name instead of standard ``geojson``.