### PR TITLE
Allow dynamic properties for size

### DIFF
--- a/@here/harp-datasource-protocol/lib/TechniqueParams.ts
+++ b/@here/harp-datasource-protocol/lib/TechniqueParams.ts
@@ -480,7 +480,7 @@ export interface PointTechniqueParams extends BaseTechniqueParams {
     /**
      * Size of point in pixels.
      */
-    size?: number;
+    size?: DynamicProperty<number>;
     /**
      * Whether to enable picking on these points.
      */

--- a/test/rendering/GeoJsonDataRendering.ts
+++ b/test/rendering/GeoJsonDataRendering.ts
@@ -100,7 +100,7 @@ describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", functio
                 color: "#BC002D",
                 // This causes the bug HARP-12247
                 enabled: ["get", "enabled", ["dynamic-properties"]],
-                size: 150
+                size: ["get", "size", ["dynamic-properties"]]
             }
         ];
 
@@ -108,7 +108,8 @@ describe("MapView + OmvDataSource + GeoJsonDataProvider rendering test", functio
             mochaTest: this,
             testImageName: "geojson-point-enabled-as-dynamic-expression",
             theme: { lights, styles: { geojson: greenStyle } },
-            geoJson: "../dist/resources/basic_polygon.json"
+            geoJson: "../dist/resources/basic_polygon.json",
+            size: 150
         });
     });
     it("renders extruded polygons with height", async function () {

--- a/test/rendering/utils/GeoJsonTest.ts
+++ b/test/rendering/utils/GeoJsonTest.ts
@@ -29,6 +29,7 @@ export interface GeoJsonTestOptions extends GeoJsonDataSourceTestOptions {
     dataProvider?: DataProvider;
     extraDataSource?: GeoJsonDataSourceTestOptions;
     beforeFinishCallback?: (mapView: MapView) => void;
+    size?: number;
 }
 
 function createDataSource(
@@ -102,6 +103,9 @@ export class GeoJsonTest {
         const dataSource = createDataSource("geojson", options);
 
         this.mapView.setDynamicProperty("enabled", true);
+        if (options.size) {
+            this.mapView.setDynamicProperty("size", options.size);
+        }
         await this.mapView.addDataSource(dataSource);
 
         if (options.extraDataSource) {


### PR DESCRIPTION
All except Point allowed dynamic size properties, so adjust
PointTechniqueParams to also allow dynamic properties for size.

Tested and worked, seems only the typing needed a small update.
