### PR TITLE
HARP-14531: sort picking results by 'dataSourceOrder'

### DIFF
--- a/@here/harp-mapview/lib/PickHandler.ts
+++ b/@here/harp-mapview/lib/PickHandler.ts
@@ -83,6 +83,14 @@ export interface PickResult {
     dataSourceName: string | undefined;
 
     /**
+     * Data source order, useful for sorting a collection of picking results.
+     * A number for objects/features coming from tiles (as those have data sources attached),
+     * an undefined when objects are added via "mapView.mapAnchors.add(object)" - those are treated as
+     * base layer objects during picking (same as "dataSourceOrder: 0").
+     */
+    dataSourceOrder: number | undefined;
+
+    /**
      * Render order of the intersected object.
      */
     renderOrder?: number;
@@ -90,7 +98,7 @@ export interface PickResult {
     /**
      * An optional feature ID of the picked object.
      * @remarks The ID may be assigned by the object's {@link DataSource}, for example in case of
-     * Optimized Map Vector (OMV) and GeoJSON datata sources.
+     * Optimized Map Vector (OMV) and GeoJSON data sources.
      */
     featureId?: number | string;
 
@@ -259,6 +267,7 @@ export class PickHandler {
             point: intersection.point,
             distance: intersection.distance,
             dataSourceName: intersection.object.userData?.dataSource,
+            dataSourceOrder: tile?.dataSource?.dataSourceOrder,
             intersection,
             tileKey: tile?.tileKey
         };

--- a/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
+++ b/@here/harp-mapview/lib/geometry/TileGeometryCreator.ts
@@ -489,6 +489,7 @@ export class TileGeometryCreator {
                         path,
                         tile.offset,
                         tile.dataSource.name,
+                        tile.dataSource.dataSourceOrder,
                         textPath.objInfos,
                         textPath.pathLengthSqr
                     );
@@ -542,6 +543,7 @@ export class TileGeometryCreator {
                         point,
                         tile.offset,
                         tile.dataSource.name,
+                        tile.dataSource.dataSourceOrder,
                         attributes
                     );
                     tile.addTextElement(textElement);

--- a/@here/harp-mapview/lib/poi/PoiManager.ts
+++ b/@here/harp-mapview/lib/poi/PoiManager.ts
@@ -382,6 +382,7 @@ export class PoiManager {
                 positionArray,
                 tile.offset,
                 tile.dataSource.name,
+                tile.dataSource.dataSourceOrder,
                 getAttributes(poiGeometry)
             );
 
@@ -408,6 +409,7 @@ export class PoiManager {
                     getPosition(positions, worldOffsetX, i),
                     tile.offset,
                     tile.dataSource.name,
+                    tile.dataSource.dataSourceOrder,
                     getAttributes(poiGeometry, i),
                     undefined,
                     offsetDirection

--- a/@here/harp-mapview/lib/text/TextElement.ts
+++ b/@here/harp-mapview/lib/text/TextElement.ts
@@ -395,7 +395,8 @@ export class TextElement {
         public fadeFar?: number,
         readonly tileOffset?: number,
         readonly offsetDirection?: number,
-        readonly dataSourceName?: string
+        readonly dataSourceName?: string,
+        readonly dataSourceOrder?: number
     ) {
         if (renderParams instanceof TextRenderStyle) {
             this.renderStyle = renderParams;

--- a/@here/harp-mapview/lib/text/TextElementBuilder.ts
+++ b/@here/harp-mapview/lib/text/TextElementBuilder.ts
@@ -205,6 +205,7 @@ export class TextElementBuilder {
         points: THREE.Vector3 | THREE.Vector3[],
         tileOffset: number,
         dataSourceName: string,
+        dataSourceOrder: number,
         attributes?: AttributeMap,
         pathLengthSqr?: number,
         offsetDirection?: number
@@ -232,7 +233,8 @@ export class TextElementBuilder {
             this.m_fadeFar,
             tileOffset,
             offsetDirection,
-            dataSourceName
+            dataSourceName,
+            dataSourceOrder
         );
         textElement.minZoomLevel = this.m_minZoomLevel;
         textElement.maxZoomLevel = this.m_maxZoomLevel;

--- a/@here/harp-mapview/lib/text/TextElementsRenderer.ts
+++ b/@here/harp-mapview/lib/text/TextElementsRenderer.ts
@@ -703,6 +703,7 @@ export class TextElementsRenderer {
                 featureId: textElement.featureId,
                 userData: textElement.userData,
                 dataSourceName: textElement.dataSourceName,
+                dataSourceOrder: textElement.dataSourceOrder,
                 text: textElement.text
             };
 

--- a/@here/harp-mapview/test/TextElementBuilderTest.ts
+++ b/@here/harp-mapview/test/TextElementBuilderTest.ts
@@ -29,6 +29,7 @@ describe("TextElementBuilder", function () {
         getLayoutStyle: () => layoutStyle
     } as any) as TileTextStyleCache;
     const dataSourceName = "anonymous";
+    const dataSourceOrder = 0;
 
     function buildPoiTechnique(properties: {}): PoiTechnique & IndexedTechniqueParams {
         return { name: "labeled-icon", _index: 0, _styleSetIndex: 0, ...properties };
@@ -48,8 +49,8 @@ describe("TextElementBuilder", function () {
         const builder = new TextElementBuilder(env, styleCache, 0);
         const label1 = builder
             .withTechnique(textTechnique)
-            .build("one", new Vector3(), 0, dataSourceName);
-        const label2 = builder.build("two", new Vector3(), 0, dataSourceName);
+            .build("one", new Vector3(), 0, dataSourceName, dataSourceOrder);
+        const label2 = builder.build("two", new Vector3(), 0, dataSourceName, dataSourceOrder);
 
         expect(label1?.priority).equals(label2?.priority).and.equals(textTechnique.priority);
     });
@@ -62,8 +63,8 @@ describe("TextElementBuilder", function () {
         const label1 = builder
             .withTechnique(poiTechnique)
             .withIcon(iconName, shieldGroupIndex)
-            .build("one", new Vector3(), 0, dataSourceName);
-        const label2 = builder.build("two", new Vector3(), 0, dataSourceName);
+            .build("one", new Vector3(), 0, dataSourceName, dataSourceOrder);
+        const label2 = builder.build("two", new Vector3(), 0, dataSourceName, dataSourceOrder);
 
         expect(label1.poiInfo?.imageTextureName)
             .equals(label2.poiInfo?.imageTextureName)
@@ -83,10 +84,12 @@ describe("TextElementBuilder", function () {
             textReserveSpace: true
         });
         const builder = new TextElementBuilder(env, styleCache, 0);
-        const poi = builder.withTechnique(poiTechnique).build("", new Vector3(), 0, dataSourceName);
+        const poi = builder
+            .withTechnique(poiTechnique)
+            .build("", new Vector3(), 0, dataSourceName, dataSourceOrder);
         const lineMarker = builder
             .withTechnique(lineMarkerTechnique)
-            .build("", new Vector3(), 0, dataSourceName);
+            .build("", new Vector3(), 0, dataSourceName, dataSourceOrder);
 
         expect(poi.mayOverlap).equals(poiTechnique.textMayOverlap);
         expect(poi.reserveSpace).equals(poiTechnique.textReserveSpace);
@@ -99,7 +102,7 @@ describe("TextElementBuilder", function () {
         const poi = new TextElementBuilder(env, styleCache, 0)
             .withTechnique(poiTechnique)
             .withIcon(undefined)
-            .build("", new Vector3(), 0, dataSourceName);
+            .build("", new Vector3(), 0, dataSourceName, dataSourceOrder);
         expect(poi.poiInfo).undefined;
     });
 
@@ -117,7 +120,7 @@ describe("TextElementBuilder", function () {
         const poi = new TextElementBuilder(env, styleCache, 0)
             .withTechnique(poiTechnique)
             .withIcon("")
-            .build("", new Vector3(), 0, dataSourceName);
+            .build("", new Vector3(), 0, dataSourceName, dataSourceOrder);
         expect(poi.minZoomLevel).equals(Math.min(iconMinZoomLevel, textMinZoomLevel));
         expect(poi.maxZoomLevel).equals(Math.max(iconMaxZoomLevel, textMaxZoomLevel));
     });
@@ -127,7 +130,7 @@ describe("TextElementBuilder", function () {
         const poi = new TextElementBuilder(env, styleCache, 0)
             .withTechnique(poiTechnique)
             .withIcon("dummy")
-            .build("", new Vector3(), 0, dataSourceName);
+            .build("", new Vector3(), 0, dataSourceName, dataSourceOrder);
         expect(poi.renderOrder)
             .equals(poi.poiInfo?.renderOrder)
             .and.equals(poiTechnique.renderOrder);
@@ -139,7 +142,7 @@ describe("TextElementBuilder", function () {
         const poi = new TextElementBuilder(env, styleCache, baseRenderOrder)
             .withTechnique(poiTechnique)
             .withIcon("dummy")
-            .build("", new Vector3(), 0, dataSourceName);
+            .build("", new Vector3(), 0, dataSourceName, dataSourceOrder);
         expect(poi.renderOrder)
             .equals(poi.poiInfo?.renderOrder)
             .and.equals(


### PR DESCRIPTION
Signed-off-by: Oleksii Markhovskyi <oleksii.markhovskyi@here.com>

This PR introduces a higher tie-breaker (comparator criterion) for sorting picking results - by `.dataSourceOrder`. It defaults those values to zeros to ensure consistent sorting.

It also orders zero-distance results (screen-space objects, e.g. labels) higher, because those are currently rendered on top.

Sorting by `.distance` and `.renderOrder` remains in place for results with same `.dataSourceOrder`.