### PR TITLE
HARP-16327, Switch to the flat list index page for the examples

### DIFF
--- a/@here/harp-examples/src/camera-animations_quaternion-slerp.ts
+++ b/@here/harp-examples/src/camera-animations_quaternion-slerp.ts
@@ -64,10 +64,9 @@ Tap or use left/right keys to change location`;
 
     message.style.cssText = `
     color: #000;
-    width: 80%;
-    left: 50%;
-    position: relative;
-    margin-left: -40%;
+    width: 100%;
+    text-align: center;
+    position: absolute;
     font-size: 15px;
     `;
     document.body.appendChild(message);

--- a/@here/harp-examples/src/datasource_features_lines-and-points.ts
+++ b/@here/harp-examples/src/datasource_features_lines-and-points.ts
@@ -205,7 +205,11 @@ export namespace LinesPointsFeaturesExample {
     }
 
     function createBaseMap(theme: Theme): MapView {
-        document.body.innerHTML += getExampleHTML();
+        const template = document.createElement("template");
+        template.innerHTML = getExampleHTML();
+        template.content.childNodes.forEach(node => {
+            document.body.appendChild(node);
+        });
 
         const canvas = document.getElementById("mapCanvas") as HTMLCanvasElement;
         const mapView = new MapView({
@@ -236,8 +240,7 @@ export namespace LinesPointsFeaturesExample {
 
     function getExampleHTML() {
         return (
-            `
-            <style>
+            `<style>
                 #mapCanvas {
                     top: 0;
                 }
@@ -247,7 +250,7 @@ export namespace LinesPointsFeaturesExample {
                     text-align: center;
                     font-family: monospace;
                     left: 50%;
-                    position: relative;
+                    position: absolute;
                     margin: 10px 0 0 -40%;
                     font-size: 15px;
                 }
@@ -289,8 +292,7 @@ export namespace LinesPointsFeaturesExample {
                     <div id=caption-bg>
                         <h1>Hotspots on Earth's mantle, with main ridges and trenches.</h1>
                     </div>
-                </div>
-        `
+                </div>`
         );
     }
 }

--- a/@here/harp-examples/src/datasource_features_polygons.ts
+++ b/@here/harp-examples/src/datasource_features_polygons.ts
@@ -275,7 +275,11 @@ export namespace PolygonsFeaturesExample {
     }
 
     function createBaseMap(): MapView {
-        document.body.innerHTML += getExampleHTML();
+        const template = document.createElement("template");
+        template.innerHTML = getExampleHTML();
+        template.content.childNodes.forEach(node => {
+            document.body.appendChild(node);
+        });
 
         const canvas = document.getElementById("mapCanvas") as HTMLCanvasElement;
         const mapView = new MapView({
@@ -405,8 +409,7 @@ export namespace PolygonsFeaturesExample {
 
     function getExampleHTML() {
         return (
-            `
-            <style>
+            `<style>
                 #mapCanvas {
                     top: 0;
                 }
@@ -482,8 +485,7 @@ export namespace PolygonsFeaturesExample {
                     <h1>Member states of the European Union</h1>
                     <div id=dates-container></div>
                 </div>
-            </div>
-        `
+            </div>`
         );
     }
 }

--- a/@here/harp-examples/src/datasource_geojson_choropleth.ts
+++ b/@here/harp-examples/src/datasource_geojson_choropleth.ts
@@ -37,27 +37,26 @@ import { apikey } from "../config";
  * ```
  */
 export namespace GeoJsonHeatmapExample {
-    document.body.innerHTML += `
-        <style>
-            #mapCanvas {
-              top: 0;
-            }
+    const template = document.createElement("template");
+    template.innerHTML = `<style>
+        #info{
+            color: #fff;
+            width: 80%;
+            left: 50%;
+            position: absolute;
+            margin: 10px 0 0 -40%;
+            font-size: 15px;
+        }
+        @media screen and (max-width: 700px) {
             #info{
-                color: #fff;
-                width: 80%;
-                left: 50%;
-                position: relative;
-                margin: 10px 0 0 -40%;
-                font-size: 15px;
+                font-size:11px;
             }
-            @media screen and (max-width: 700px) {
-                #info{
-                    font-size:11px;
-                }
-            }
-        </style>
-        <p id=info></p>
-    `;
+        }
+    </style>
+    <p id=info></p>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
 
     /**
      * Creates a new MapView for the HTMLCanvasElement of the given id.

--- a/@here/harp-examples/src/datasource_geojson_elevated-markers.ts
+++ b/@here/harp-examples/src/datasource_geojson_elevated-markers.ts
@@ -116,14 +116,6 @@ export namespace ElevatedGeoJsonMarkersExample {
         return map;
     }
 
-    document.body.innerHTML += `
-    <style>
-        #mapCanvas {
-          top: 0;
-        }
-    </style>
-`;
-
     const mapView = initializeMapView("mapCanvas");
 
     const omvDataSource = new VectorTileDataSource({

--- a/@here/harp-examples/src/datasource_geojson_points.ts
+++ b/@here/harp-examples/src/datasource_geojson_points.ts
@@ -21,14 +21,6 @@ import { apikey, copyrightInfo } from "../config";
  * [[TextElement]]s read from GeoJson on top of [[MapView]].
  */
 export namespace TiledGeoJsonPointExample {
-    document.body.innerHTML += `
-        <style>
-            #mapCanvas {
-              top: 0;
-            }
-        </style>
-    `;
-
     const imageString =
         // tslint:disable-next-line:max-line-length
         "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHdpZHRoPSI0OHB4IiBoZWlnaHQ9IjQ4cHgiIHZlcnNpb249IjEuMSIgaWQ9Imx1aS1pY29uLWRlc3RpbmF0aW9ucGluLW9uZGFyay1zb2xpZC1sYXJnZSIKCSB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIgdmlld0JveD0iMCAwIDQ4IDQ4IgoJIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDQ4IDQ4IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPGc+Cgk8ZyBpZD0ibHVpLWljb24tZGVzdGluYXRpb25waW4tb25kYXJrLXNvbGlkLWxhcmdlLWJvdW5kaW5nLWJveCIgb3BhY2l0eT0iMCI+CgkJPHBhdGggZmlsbD0iI2ZmZmZmZiIgZD0iTTQ3LDF2NDZIMVYxSDQ3IE00OCwwSDB2NDhoNDhWMEw0OCwweiIvPgoJPC9nPgoJPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGZpbGw9IiNmZmZmZmYiIGQ9Ik0yNCwyQzEzLjg3MDgsMiw1LjY2NjcsMTAuMTU4NCw1LjY2NjcsMjAuMjIzMwoJCWMwLDUuMDMyNSwyLjA1MzMsOS41ODg0LDUuMzcxNywxMi44ODgzTDI0LDQ2bDEyLjk2MTctMTIuODg4M2MzLjMxODMtMy4zLDUuMzcxNy03Ljg1NTgsNS4zNzE3LTEyLjg4ODMKCQlDNDIuMzMzMywxMC4xNTg0LDM0LjEyOTIsMiwyNCwyeiBNMjQsMjVjLTIuNzY1LDAtNS0yLjIzNS01LTVzMi4yMzUtNSw1LTVzNSwyLjIzNSw1LDVTMjYuNzY1LDI1LDI0LDI1eiIvPgo8L2c+Cjwvc3ZnPgo=";

--- a/@here/harp-examples/src/datasource_geojson_styling_game.ts
+++ b/@here/harp-examples/src/datasource_geojson_styling_game.ts
@@ -49,12 +49,9 @@ import * as geojson from "../resources/italy.json";
 
 export namespace GeoJsonStylingGame {
     async function main() {
-        document.body.innerHTML += `
-        <style>
-            #mapCanvas {
-              top: 0;
-            }
-            #prompter{
+        const template = document.createElement("template");
+        template.innerHTML = `<style>
+            #prompter {
                 margin: 10px;
                 padding: 10px;
                 display: inline-block;
@@ -63,12 +60,14 @@ export namespace GeoJsonStylingGame {
                 position: absolute;
                 right: 0;
             }
-            #asked-name{
+            #asked-name {
                 text-transform: uppercase
             }
         </style>
-        <p id="prompter">Find the following region: <strong id="asked-name"></strong></p>
-    `;
+        <p id="prompter">Find the following region: <strong id="asked-name"></strong></p>`;
+        template.content.childNodes.forEach(node => {
+            document.body.appendChild(node);
+        });
 
         const REGION_LIST = (geojson.features as Feature[])
             .filter(feature => {

--- a/@here/harp-examples/src/geojson-viewer.ts
+++ b/@here/harp-examples/src/geojson-viewer.ts
@@ -142,7 +142,11 @@ export namespace GeoJsonExample {
     }
 
     function createBaseMap(theme: Theme): MapView {
-        document.body.innerHTML += getExampleHTML();
+        const template = document.createElement("template");
+        template.innerHTML = getExampleHTML();
+        template.content.childNodes.forEach(node => {
+            document.body.appendChild(node);
+        });
 
         const canvas = document.getElementById("mapCanvas") as HTMLCanvasElement;
         const mapView = new MapView({
@@ -180,8 +184,7 @@ export namespace GeoJsonExample {
     }
 
     function getExampleHTML(): string {
-        return `
-            <link href="https://fonts.googleapis.com/css?family=Fira+Sans&amp;display=swap" rel="stylesheet">
+        return `<link href="https://fonts.googleapis.com/css?family=Fira+Sans&amp;display=swap" rel="stylesheet">
             <style>
                 :root{
                     --editor-width:${editorWidth};
@@ -287,7 +290,6 @@ export namespace GeoJsonExample {
             <div id="drag-overlay">
                 <div id="drag-dashes"></div>
             </div>
-            <p id=info>Drag and drop a GeoJSON or browse a local one.</p>
-        `;
+            <p id=info>Drag and drop a GeoJSON or browse a local one.</p>`;
     }
 }

--- a/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
+++ b/@here/harp-examples/src/getting-started_hello-world_js-bundle.html
@@ -39,12 +39,72 @@
                 font-weight: normal;
             }
         </style>
+        <link href="menu.css" rel="stylesheet"/>
+        <link href="view-source-btn.css" rel="stylesheet"/>
     </head>
     <body>
+        <button id="hamburgerMenu" href="#">
+            <span></span>
+            <span></span>
+            <span></span>
+        </button>
+        <div id="navPanel" class="collapsed">
+            <div id="titleBar">
+                <a href="http://harp.gl">
+                    <h1 id="title">harp.gl</h1>
+                </a>
+                <a id=documentation title="Documentation" target="_blank"
+                    href=https://www.harp.gl/docs/master/doc/> <svg viewBox="0 0 23 60"
+                    height="25" width="23">
+                    <path
+                        d="M -1.6965819,8.2701467 V 35.224035 c 0.0283,0.847295 0.648697,1.588424 1.318981,1.5861 0.64875499,0.0046 1.15590999,-0.400431 1.463019,-0.762541 l 4.217,-7.516842 4.217,7.517911 c 0.327,0.582909 0.9389999,0.856715 1.5499999,0.734786 0.045,-0.0086 0.089,-0.0021 0.134,-0.01497 0.657,-0.195729 1.099,-0.816072 1.099,-1.54444 V 8.2701467 Z" />
+                    <path
+                        style="fill:none;stroke-width:4px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+                        d="M 31.544194,1.8446699 31.499,58.375 H -4.4999998 v -47 H 31.499" />
+                    <path
+                        style="fill:none;stroke-width:4px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+                        d="m -4.5,58.375 c -2.8186816,0.0081 -5.078877,-1.790886 -5.125,-4.3545 V 6.6875 C -9.580216,4.4229047 -7.1760603,2.001032 -4.6438447,1.9924176 L 31.544194,1.8446699" />
+                    <path
+                        style="fill:none;stroke-width:4px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+                        d="m -9.625,6.6875 c 0.02296,2.96301 1.8301551,4.714336 5.1250002,4.6875" />
+                    </svg>
+                </a>
+                <a id=github title="Visit Harp.gl repository on GitHub"
+                    href=https://github.com/heremaps/harp.gl target="_blank"> <svg
+                    class="octicon octicon-mark-github v-align-middle" height="25"
+                    viewBox="0 0 16 16" version="1.1" aria-hidden="true">
+                    <path
+                        d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z">
+                    </path></svg>
+                </a>
+
+                <button id="closeButton" href="#">
+                    <span></span>
+                    <span></span>
+                </button>
+                <div style="clear:both"></div>
+            </div>
+
+            <div class="filterBlock">
+                <input type="text" id="filterInput">
+                <svg id=magnifier-placeholder viewBox="30 30 110 110" width=20 height=20>
+                    <circle style="stroke-width:15;fill:none;stroke:#252c36;" cx="75" cy="75"
+                        r="35" />
+                    <path style="fill:none;stroke:#252c36;stroke-width:15;" d="m 100,100 35,35" />
+                </svg>
+                </input>
+                <button href="#" id="clearFilterButton" style="display:none;">&#215;</button>
+            </div>
+            <div id="exampleList"></div>
+        </div>
+
         <canvas id="mapCanvas"></canvas>
         <div id="app"></div>
         <div id="copyrightNotice"></div>
 
+        <button id="viewSource" title="View the source code" href=# style="display:block;">
+            <p>&#60;/&#62;</p>
+        </button>
         <!--
             These paths are to be used by clients, when using map bundle from CDN.
         -->
@@ -58,6 +118,8 @@
         <script src="credentials.js"></script>
         <script src="three.min.js"></script>
         <script src="harp.js"></script>
+        <script src="example-definitions.js"></script>
+        <script src="example-browser.bundle.js"></script>
 
         <script>
             const canvas = document.getElementById("mapCanvas");

--- a/@here/harp-examples/src/getting-started_orbiting-view.ts
+++ b/@here/harp-examples/src/getting-started_orbiting-view.ts
@@ -68,7 +68,29 @@ export namespace CameraOrbitExample {
     });
 
     function createBaseMap(): MapView {
-        document.body.innerHTML += getExampleHTML();
+        const template = document.createElement("template");
+        template.innerHTML = `<style>
+            #mapCanvas {
+                top:0
+            }
+            #info {
+                color: #fff;
+                width: 80%;
+                left: 50%;
+                position: absolute;
+                margin: 10px 0 0 -40%;
+                font-size: 15px;
+            }
+            @media screen and (max-width: 700px) {
+                #info{
+                    font-size:11px;
+                }
+            }
+            </style>
+            <p id=info></p>`;
+        template.content.childNodes.forEach(node => {
+            document.body.appendChild(node);
+        });
 
         const canvas = document.getElementById("mapCanvas") as HTMLCanvasElement;
         const mapView = new MapView({
@@ -102,29 +124,5 @@ export namespace CameraOrbitExample {
             `zoomLevel: ${options.zoomLevel.toFixed(1)}, ` +
             `tilt: ${options.tilt.toFixed(1)}, ` +
             `heading: ${options.heading.toFixed(1)}})`;
-    }
-
-    function getExampleHTML() {
-        return `
-            <style>
-                #mapCanvas{
-                    top:0
-                }
-                #info{
-                    color: #fff;
-                    width: 80%;
-                    left: 50%;
-                    position: relative;
-                    margin: 10px 0 0 -40%;
-                    font-size: 15px;
-                }
-                @media screen and (max-width: 700px) {
-                    #info{
-                        font-size:11px;
-                    }
-                }
-                </style>
-                <p id=info></p>
-        `;
     }
 }

--- a/@here/harp-examples/src/markers_dynamic.ts
+++ b/@here/harp-examples/src/markers_dynamic.ts
@@ -189,8 +189,10 @@ export namespace DynamicMarkersExample {
     function addInstructions() {
         const message = document.createElement("div");
         message.innerHTML = `Tap map to add a marker, long press on a marker to remove it`;
-        message.style.position = "relative";
+        message.style.position = "absolute";
+        message.style.width = "100%";
         message.style.top = "60px";
+        message.style.textAlign = "center";
         document.body.appendChild(message);
     }
 

--- a/@here/harp-examples/src/markers_screen-anchor.ts
+++ b/@here/harp-examples/src/markers_screen-anchor.ts
@@ -13,8 +13,8 @@ import THREE = require("three");
 import { apikey } from "../config";
 
 export namespace GeoToScreenExample {
-    document.body.innerHTML += `
-        <style>
+    const template = document.createElement("template");
+    template.innerHTML = `<style>
         .message {
             position: absolute;
             top: 10px;
@@ -28,8 +28,11 @@ export namespace GeoToScreenExample {
                 display: none;
             }
         }
-        </style>
-    `;
+        </style>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
+
     const BERLIN = new GeoCoordinates(52.5186234, 13.373993);
     const geoPosition = {
         latitude: BERLIN.lat,

--- a/@here/harp-examples/src/object-picking.ts
+++ b/@here/harp-examples/src/object-picking.ts
@@ -33,8 +33,8 @@ import { apikey } from "../config";
  */
 
 export namespace PickingExample {
-    document.body.innerHTML += `
-        <style>
+    const template = document.createElement("template");
+    template.innerHTML = `<style>
             #mouse-picked-result{
                 position:absolute;
                 bottom:5px;
@@ -47,16 +47,15 @@ export namespace PickingExample {
                 text-align: left;
                 right:50px;
             }
-            #mapCanvas {
-              top: 0;
-            }
             #info{
-                color: #fff;
+                position: absolute;
+                left: 0;
+                right: 0;
+                margin: 0 auto;
                 width: 80%;
-                left: 50%;
-                position: relative;
-                margin: 10px 0 0 -40%;
+                color: #fff;
                 font-size: 15px;
+                text-align: center;
             }
             @media screen and (max-width: 700px) {
                 #info{
@@ -66,8 +65,10 @@ export namespace PickingExample {
         </style>
         <p id=info>Click/touch a feature on the map to read its data (Land masses are not features).
         </p>
-        <pre id="mouse-picked-result"></pre>
-    `;
+        <pre id="mouse-picked-result"></pre>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
 
     initializeMapView("mapCanvas").catch(err => {
         throw err;

--- a/@here/harp-examples/src/performance_benchmark.ts
+++ b/@here/harp-examples/src/performance_benchmark.ts
@@ -109,9 +109,8 @@ powerPreferenceMap.set("LowPower", MapViewPowerPreference.LowPower);
 powerPreferenceMap.set("HighPerformance", MapViewPowerPreference.HighPerformance);
 
 // Append the HTML code for the table styles.
-document.head.innerHTML += `
-<style>
-
+const template1 = document.createElement("template");
+template1.innerHTML = `<style>
 #canvasDiv {
     pointer-events: none;
 }
@@ -187,13 +186,16 @@ th:hover {
     font-size: 0.8em;
     font-weight: normal;
 }
-</style>
-`;
+</style>`;
+template1.content.childNodes.forEach(node => {
+    document.body.appendChild(node);
+});
 
 // Add the HTML code for the table.
 const canvasParent = document.getElementById("mapCanvas")!.parentNode! as HTMLElement;
-canvasParent.innerHTML += `
-<div id="tableDiv">
+
+const template2 = document.createElement("template");
+template2.innerHTML = `<div id="tableDiv">
 <p class="labelLine">
     <span class="label">Benchmark:</span>
     <span id="testTitle" class="value"></span>
@@ -254,9 +256,10 @@ canvasParent.innerHTML += `
     <span id="testDuration" class="value"></span>
 </p>
 <table id="resultTable"> </table>
-</div>
-`;
-
+</div>`;
+template2.content.childNodes.forEach(node => {
+    canvasParent.appendChild(node);
+});
 export namespace PerformanceBenchmark {
     let mapViewApp: PerformanceUtils.MapViewApp;
 

--- a/@here/harp-examples/src/rendering_synchronous.ts
+++ b/@here/harp-examples/src/rendering_synchronous.ts
@@ -102,8 +102,8 @@ export namespace SynchronousRendering {
         }
 
         addHTMLElements(text: string) {
-            document.body.innerHTML += `
-                <style>
+            const template = document.createElement("template");
+            template.innerHTML = `<style>
                     #popupLine {
                         position: absolute;
                         border: 0;
@@ -112,7 +112,7 @@ export namespace SynchronousRendering {
                         height: 100%;
                         top: 0;
                         overflow: hidden;
-                        z-index: 1;
+                        z-index: 0;
                     }
                     .popup {
                         background: #000;
@@ -125,8 +125,10 @@ export namespace SynchronousRendering {
                     }
                 </style>
                 <canvas id="popupLine"></canvas>
-                <div class="popup">${text}</div>
-            `;
+                <div class="popup">${text}</div>`;
+            template.content.childNodes.forEach(node => {
+                document.body.appendChild(node);
+            });
         }
 
         drawConnectionLine() {

--- a/@here/harp-examples/src/styling_data-driven.ts
+++ b/@here/harp-examples/src/styling_data-driven.ts
@@ -16,18 +16,14 @@ import {
 import { apikey, copyrightInfo } from "../config";
 
 export namespace DataDrivenThemeExample {
-    document.body.innerHTML +=
-        `
-    <style>
-        #mapCanvas {
-          top: 0;
-        }
-        #info{
+    const template = document.createElement("template");
+    template.innerHTML =
+        `<style>
+        #info {
+            position: absolute;
             color: #fff;
-            width: 80%;
-            left: 50%;
-            position: relative;
-            margin: 10px 0 0 -40%;
+            width: 100%;
+            text-align: center;
             font-size: 15px;
         }
         @media screen and (max-width: 700px) {
@@ -38,6 +34,9 @@ export namespace DataDrivenThemeExample {
     </style>
     <p id=info>This example shows how to utilize the data from the styles.<br/>` +
         `Here the population of a city is displayed below its name.</p>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
     function initializeMapView(id: string): MapView {
         const canvas = document.getElementById(id) as HTMLCanvasElement;
 

--- a/@here/harp-examples/src/styling_extend-a-theme.ts
+++ b/@here/harp-examples/src/styling_extend-a-theme.ts
@@ -54,19 +54,18 @@ import { apikey, copyrightInfo } from "../config";
  */
 
 export namespace HelloCustomThemeExample {
-    document.body.innerHTML +=
-        `
-    <style>
-        #mapCanvas {
-          top: 0;
-        }
+    const template = document.createElement("template");
+    template.innerHTML =
+        `<style>
         #info{
-            color: #fff;
+            position: absolute;
+            left: 0;
+            right: 0;
+            margin: 0 auto;
             width: 80%;
-            left: 50%;
-            position: relative;
-            margin: 10px 0 0 -40%;
+            color: #fff;
             font-size: 15px;
+            text-align: center;
         }
         @media screen and (max-width: 700px) {
             #info{
@@ -74,10 +73,12 @@ export namespace HelloCustomThemeExample {
             }
         }
     </style>
-    <p id=info>This example shows the theme extension mechanism: the styles for the parks ` +
+    <p id="info">This example shows the theme extension mechanism: the styles for the parks ` +
         `and the buildings are overwritten from an original theme to make them respectively green` +
-        ` and brown.</p>
-`;
+        ` and brown.</p>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
     // Create a new MapView for the HTMLCanvasElement of the given id.
     function initializeMapView(id: string): MapView {
         const canvas = document.getElementById(id) as HTMLCanvasElement;

--- a/@here/harp-examples/src/styling_interpolation.ts
+++ b/@here/harp-examples/src/styling_interpolation.ts
@@ -21,27 +21,28 @@ import { apikey, copyrightInfo } from "../config";
  * This example showcases interpolated [[MapView]] techniques.
  */
 export namespace TiledGeoJsonTechniquesExample {
-    document.body.innerHTML += `
-        <style>
-            #mapCanvas {
-              top: 0;
-            }
-            #info{
-                color: #fff;
+    const template = document.createElement("template");
+    template.innerHTML = `<style>
+            #info {
+                position: absolute;
+                left: 0;
+                right: 0;
+                margin: 0 auto;
                 width: 80%;
-                left: 50%;
-                position: relative;
-                margin: 10px 0 0 -40%;
+                color: #fff;
                 font-size: 15px;
+                text-align: center;
             }
             @media screen and (max-width: 700px) {
-                #info{
+                #info {
                     font-size:11px;
                 }
             }
         </style>
-        <p id=info>Zoom in and out to smoothly transition between styles.</p>
-    `;
+        <p id=info>Zoom in and out to smoothly transition between styles.</p>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
 
     const theme: Theme = {
         clearColor: "#234152",

--- a/@here/harp-examples/src/styling_textured-areas.ts
+++ b/@here/harp-examples/src/styling_textured-areas.ts
@@ -39,20 +39,21 @@ export namespace HelloWorldTexturedExample {
     }
 
     function addTextureCopyright() {
-        document.body.innerHTML += `
-<style>
-    #mapCanvas {
-        top: 0;
-    }
-    #texture-license{
-        margin: 10px;
-        padding: 10px;
-        color: #cccccc;
-    }
-</style>
-<p id="texture-license">Textures by
-<a href="https://opengameart.org/content/wall-grass-rock-stone-wood-and-dirt-480" target="_blank">
-West</a>.</p>`;
+        const template = document.createElement("template");
+        template.innerHTML = `<style>
+            #texture-license {
+                position: absolute;
+                width: 100%;
+                text-align: center;
+                color: #cccccc;
+            }
+        </style>
+        <p id="texture-license">Textures by
+        <a href="https://opengameart.org/content/wall-grass-rock-stone-wood-and-dirt-480" target="_blank">
+        West</a>.</p>`;
+        template.content.childNodes.forEach(node => {
+            document.body.appendChild(node);
+        });
     }
 
     /**

--- a/@here/harp-examples/src/synchronized-views.ts
+++ b/@here/harp-examples/src/synchronized-views.ts
@@ -37,7 +37,11 @@ import { apikey, copyrightInfo } from "../config";
 
 export namespace TripleViewExample {
     // inject HTML code to page to show additional map canvases and position them side-by-side
-    document.body.innerHTML += getExampleHTML();
+    const template = document.createElement("template");
+    template.innerHTML = getExampleHTML();
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
 
     const numberOfSyncXViews = 3;
     // Adjust CSS to see more then 1 row in Y axis
@@ -178,8 +182,7 @@ export namespace TripleViewExample {
     // end:harp_gl_multiview_tripleView_3.ts
 
     function getExampleHTML() {
-        return `
-            <style>
+        return `<style>
                 .themeName {
                     font-weight: bold;
                     padding: 1em;
@@ -252,7 +255,6 @@ export namespace TripleViewExample {
                 <div class="themeName" id="mapTheme3">
                     Day reduced theme
                 </div>
-            </div>
-        `;
+            </div>`;
     }
 }

--- a/@here/harp-examples/src/textcanvas.ts
+++ b/@here/harp-examples/src/textcanvas.ts
@@ -23,6 +23,8 @@ import * as THREE from "three";
  */
 export namespace TextCanvasDynamicExample {
     const stats = new Stats();
+    stats.dom.style.bottom = "0px";
+    stats.dom.style.top = "auto";
     const gui = new GUI({ hideable: false });
     const guiOptions = {
         input: "Type to start...",

--- a/@here/harp-examples/src/threejs_add-object.ts
+++ b/@here/harp-examples/src/threejs_add-object.ts
@@ -104,10 +104,9 @@ export namespace ThreejsAddSimpleObject {
     message.innerHTML = `Long click to add a ${scale}m wide cube to the scene.`;
     message.style.cssText = `
         color: #000;
-        width: 80%;
-        left: 50%;
-        position: relative;
-        margin-left: -40%;
+        width: 100%;
+        position: absolute;
+        text-align: center;
         font-size: 15px;
     `;
 

--- a/@here/harp-examples/src/threejs_raycast.ts
+++ b/@here/harp-examples/src/threejs_raycast.ts
@@ -112,18 +112,18 @@ export namespace ThreejsRaycast {
         return map;
     }
 
-    document.body.innerHTML +=
+    const template = document.createElement("template");
+    template.innerHTML =
         `<style>
-            #mapCanvas{
-                top:0;
-            }
             #info{
-                color: #000;
+                position: absolute;
+                left: 0;
+                right: 0;
+                margin: 0 auto;
                 width: 80%;
-                left: 50%;
-                position: relative;
-                margin: 10px 0 0 -40%;
+                color: #fff;
                 font-size: 15px;
+                text-align: center;
             }
             @media screen and (max-width: 700px) {
                 #info{
@@ -132,8 +132,10 @@ export namespace ThreejsRaycast {
             }
         </style>
         <p id=info>Long click to add a pink box under the mouse cursor, with respect of ` +
-        `buildings' height.</p>
-    `;
+        `buildings' height.</p>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
 
     const mapView = initializeMapView("mapCanvas");
 

--- a/@here/harp-examples/src/tile_dependencies.ts
+++ b/@here/harp-examples/src/tile_dependencies.ts
@@ -38,8 +38,8 @@ import { CUSTOM_DECODER_SERVICE_TYPE } from "../decoder/custom_decoder_defs";
 
 export namespace TileDependenciesExample {
     const guiOptions = { tileDependencies: false };
-    document.body.innerHTML += `
-        <style>
+    const template = document.createElement("template");
+    template.innerHTML = `<style>
             #mouse-picked-result{
                 position:absolute;
                 bottom:5px;
@@ -56,8 +56,10 @@ export namespace TileDependenciesExample {
               top: 0;
             }
         </style>
-        <pre id="mouse-picked-result"></pre>
-    `;
+        <pre id="mouse-picked-result"></pre>`;
+    template.content.childNodes.forEach(node => {
+        document.body.appendChild(node);
+    });
     class CustomDataProvider extends DataProvider {
         enableTileDependencies: boolean = false;
 


### PR DESCRIPTION
Adjust examples to avoid writing into document.body.innerHTML. This fix prevents destruction of event listeners attached by the main (template) page.
