### PR TITLE
Increase number of code-fence backticks in CODINGSTYLE.md to increase…

### DIFF
--- a/CODINGSTYLE.md
+++ b/CODINGSTYLE.md
@@ -255,7 +255,7 @@ The purpose of a commit message is to summarize the scope and context of a patch
 
 Example:
 
-```typescript
+````typescript
 /**
  * Instances of `CancellationToken` can be used to cancel an ongoing request.
  *
@@ -299,7 +299,7 @@ Example:
      * @param qnr - The tile key to compare to.
      * @returns `true` if this tile key has identical row, column and level, `false` otherwise.
      */
-```
+````
 
 ## Deprecation
 


### PR DESCRIPTION
… compatability with alternative Markdown renderers

Prevent triple-backtick from closing code fence early in TSDOC.
See: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks

This PR is opened because the markdown document was rendering incorrectly in the PyCharm markdown renderer. When the TSDOC that included triple-backticks was closed, the rest of the code snippet was also closed.

Signed-off-by: Luke Parkinson <luke.parkinson@canterbury.ac.nz>
