### PR TITLE
MAPSJS-2983 Write to the console if we need too many attempts getting…

### DIFF
--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -393,7 +393,7 @@ function findImageItem(
         }
     }
 
-    // There is a texture messing in the cache, we attempt again, and then error out.
+    // There is a texture missing in the cache, we attempt again, and then error out.
     const missingTextureCount = missingTextureName.get(imageTextureName);
     missingTextureName.set(imageTextureName, missingTextureCount ? missingTextureCount + 1 : 0);
     if (missingTextureName.get(imageTextureName)! >= SEARCH_CACHE_ATTEMPTS) {

--- a/@here/harp-mapview/lib/poi/PoiRenderer.ts
+++ b/@here/harp-mapview/lib/poi/PoiRenderer.ts
@@ -396,11 +396,10 @@ function findImageItem(
     // There is a texture missing in the cache, we attempt again, and then error out.
     const missingTextureCount = missingTextureName.get(imageTextureName);
     missingTextureName.set(imageTextureName, missingTextureCount ? missingTextureCount + 1 : 0);
-    if (missingTextureName.get(imageTextureName)! >= SEARCH_CACHE_ATTEMPTS) {
+    if (missingTextureName.get(imageTextureName)! === SEARCH_CACHE_ATTEMPTS) {
         logger.error(`PoiRenderer::findImageItem: No imageItem found with name:
             '${imageTexture?.image ?? imageTextureName}'
             after ${SEARCH_CACHE_ATTEMPTS} attempts.`);
-        poiInfo.isValid = false;
     }
     return undefined;
 }

--- a/@here/harp-mapview/test/PoiBatchRegistryTest.ts
+++ b/@here/harp-mapview/test/PoiBatchRegistryTest.ts
@@ -30,6 +30,7 @@ describe("PoiBatchRegistry", () => {
             const buffer = registry.registerPoi(poiInfo, defaultPoiLayer);
 
             expect(buffer).to.be.undefined;
+            expect(poiInfo.isValid).true;
         });
 
         it("uses PoiInfo's imageTexture's image by default as batch key", () => {

--- a/@here/harp-mapview/test/PoiBatchRegistryTest.ts
+++ b/@here/harp-mapview/test/PoiBatchRegistryTest.ts
@@ -25,12 +25,11 @@ describe("PoiBatchRegistry", () => {
         registry = new PoiBatchRegistry(renderer.capabilities);
     });
     describe("registerPoi", function () {
-        it("marks PoiInfo as invalid if it has no image item", () => {
+        it("return undefined if poiInfo has no image item", () => {
             const poiInfo = new PoiInfoBuilder().build(textElement);
             const buffer = registry.registerPoi(poiInfo, defaultPoiLayer);
 
             expect(buffer).to.be.undefined;
-            expect((poiInfo as any).isValid).to.be.false;
         });
 
         it("uses PoiInfo's imageTexture's image by default as batch key", () => {

--- a/@here/harp-mapview/test/PoiRendererTest.ts
+++ b/@here/harp-mapview/test/PoiRendererTest.ts
@@ -111,10 +111,7 @@ describe("PoiRenderer", function () {
             }
         } as THREE.WebGLRenderer;
         const mapViewStub = sinon.createStubInstance(MapView);
-        const poiManager = new PoiManager((mapViewStub as any) as MapView);
         const testImageName = "testImage";
-        const mapEnv = new Env();
-
         const createPointLabel = (name: string) => {
             return {
                 poiInfo: {
@@ -127,23 +124,29 @@ describe("PoiRenderer", function () {
             } as TextElement;
         };
 
-        let x = 1;
-        let y = 1;
-
         const addRandomImageToCache = (
             testCache: MapViewImageCache,
             name: string,
             load: boolean
         ) => {
-            // Note, the images must be unique, otherwise the test will fail, because the internal
-            // caching mechanism of the ImageCache will have already loaded the image.
-            return testCache.addImage(name, `https://picsum.photos/${x++}/${y++}`, load);
+            return testCache.addImage(
+                name,
+                `/@here/harp-mapview/test/resources/headshot.jpg`,
+                load
+            );
         };
+        let poiManager: PoiManager;
+        let mapEnv: Env;
+        let testCache: MapViewImageCache;
+        beforeEach(() => {
+            poiManager = new PoiManager((mapViewStub as any) as MapView);
+            mapEnv = new Env();
+            testCache = new MapViewImageCache();
+        });
 
         it("poi is valid when in cache and loading started", async function () {
             this.timeout(5000);
 
-            const testCache = new MapViewImageCache();
             const testImageItem = addRandomImageToCache(testCache, testImageName, true);
             const caches = [testCache];
             const poiRenderer = new PoiRenderer(webGLRenderer, poiManager, caches);
@@ -168,7 +171,6 @@ describe("PoiRenderer", function () {
         it("poi is invalid when not in cache, adding to cache means it will load", async function () {
             this.timeout(5000);
 
-            const testCache = new MapViewImageCache();
             // Empty cache for now
             const caches = [testCache];
             const poiRenderer = new PoiRenderer(webGLRenderer, poiManager, caches);

--- a/@here/harp-mapview/test/PoiRendererTest.ts
+++ b/@here/harp-mapview/test/PoiRendererTest.ts
@@ -13,9 +13,15 @@
 import { Env } from "@here/harp-datasource-protocol";
 import { Math2D } from "@here/harp-utils";
 import { expect } from "chai";
-import * as THREE from "three";
 
+import { MapViewImageCache } from "../lib/image/MapViewImageCache";
+import { MapView } from "../lib/MapView";
+import { PoiManager } from "../lib/poi/PoiManager";
 import { PoiBuffer, PoiRenderer } from "../lib/poi/PoiRenderer";
+import { TextElement } from "../lib/text/TextElement";
+
+import sinon = require("sinon");
+import * as THREE from "three";
 
 describe("PoiRenderer", function () {
     describe("computeIconScreenBox", function () {
@@ -95,6 +101,90 @@ describe("PoiRenderer", function () {
             expect(screenBox.y).to.equal(-16);
             expect(screenBox.w).to.equal(16);
             expect(screenBox.h).to.equal(16);
+        });
+    });
+
+    describe("search for cached images", function () {
+        const webGLRenderer = {
+            capabilities: {
+                isWebGL2: false
+            }
+        } as THREE.WebGLRenderer;
+        const mapViewStub = sinon.createStubInstance(MapView);
+        const poiManager = new PoiManager((mapViewStub as any) as MapView);
+        const testImageName = "testImage";
+        const mapEnv = new Env();
+
+        const createPointLabel = (name: string) => {
+            return {
+                poiInfo: {
+                    imageTextureName: name,
+                    isValid: true,
+                    buffer: undefined,
+                    technique: {}
+                },
+                visible: true
+            } as TextElement;
+        };
+
+        let x = 1;
+        let y = 1;
+
+        const addRandomImageToCache = (
+            testCache: MapViewImageCache,
+            name: string,
+            load: boolean
+        ) => {
+            // Note, the images must be unique, otherwise the test will fail, because the internal
+            // caching mechanism of the ImageCache will have already loaded the image.
+            return testCache.addImage(name, `https://picsum.photos/${x++}/${y++}`, load);
+        };
+
+        it("poi is valid when in cache and loading started", async function () {
+            this.timeout(5000);
+
+            const testCache = new MapViewImageCache();
+            const testImageItem = addRandomImageToCache(testCache, testImageName, true);
+            const caches = [testCache];
+            const poiRenderer = new PoiRenderer(webGLRenderer, poiManager, caches);
+            const pointLabel = createPointLabel(testImageName);
+            const waitingForLoad = poiRenderer.prepareRender(pointLabel, mapEnv);
+            // This is false because the image is still being loaded in the background, notice the
+            // true flag passed to the call to testCache.addImage.
+            expect(waitingForLoad).false;
+
+            // Promise.resolve used to convert the type `ImageItem | Promise<ImageItem>` to
+            // `Promise<ImageItem>`.
+            await Promise.resolve(testImageItem);
+
+            const imageLoaded = poiRenderer.prepareRender(pointLabel, mapEnv);
+            expect(imageLoaded).true;
+
+            // Check that a second attempt to prepareRender succeeds.
+            const imageLoadedAgain = poiRenderer.prepareRender(pointLabel, mapEnv);
+            expect(imageLoadedAgain).true;
+        });
+
+        it("poi is invalid when not in cache, adding to cache means it will load", async function () {
+            this.timeout(5000);
+
+            const testCache = new MapViewImageCache();
+            // Empty cache for now
+            const caches = [testCache];
+            const poiRenderer = new PoiRenderer(webGLRenderer, poiManager, caches);
+            const pointLabel = createPointLabel(testImageName);
+            const waitingForLoad = poiRenderer.prepareRender(pointLabel, mapEnv);
+            expect(waitingForLoad).false;
+
+            const testImageItem = addRandomImageToCache(testCache, testImageName, true);
+
+            // Promise.resolve used to convert the type `ImageItem | Promise<ImageItem>` to
+            // `Promise<ImageItem>`.
+            await Promise.resolve(testImageItem);
+
+            const imageLoaded = poiRenderer.prepareRender(pointLabel, mapEnv);
+            // Check that adding to the cache means it will now load.
+            expect(imageLoaded).true;
         });
     });
 });

--- a/karma.options.js
+++ b/karma.options.js
@@ -170,6 +170,7 @@ const options = function (isCoverage, isMapSdk, prefixDirectory) {
                 allowJs: true
             },
             coverageOptions: {
+                instrumentation: isCoverage ? true : false,
                 // This is needed otherwise the tests are included in the code coverage %.
                 exclude: [
                     /test\/+/,


### PR DESCRIPTION
… the image from the cache

Some failed attempts is ok, because there are cases where the DataSource is attached and ready
and the map has started to render, but the theme isn't fully set.

There are other ways to fix the problem, but they are generally more invasive and could introduce
regressions, some options are:
- In the TileGeometryCreator::createAllGeometries method, await on the getTheme() Promise
- Don't allow new TextElements to be added while the theme is updating
- Investigate and remove all calls to update the mapview while the method `addDataSource` is called
  and see if this can be removed, because no update calls means we don't render and request new tiles
  which may contain references to POI's that don't yet exist on the cache.

But, for the sake of simplicity, this is the preferred method.
