### PR TITLE
MAPSJS-2660: Clean MapViewUtils namespace

### DIFF
--- a/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
+++ b/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
@@ -11,62 +11,10 @@ import { Vector3Like } from "../math/Vector3Like";
 import { TileKey } from "./TileKey";
 import { TilingScheme } from "./TilingScheme";
 
-/** @hidden */
-export const powerOfTwo = [
-    0x1,
-    0x2,
-    0x4,
-    0x8,
-    0x10,
-    0x20,
-    0x40,
-    0x80,
-    0x100,
-    0x200,
-    0x400,
-    0x800,
-    0x1000,
-    0x2000,
-    0x4000,
-    0x8000,
-    0x10000,
-    0x20000,
-    0x40000,
-    0x80000,
-    0x100000,
-    0x200000,
-    0x400000,
-    0x800000,
-    0x1000000,
-    0x2000000,
-    0x4000000,
-    0x8000000,
-    0x10000000,
-    0x20000000,
-    0x40000000,
-    0x80000000,
-    0x100000000,
-    0x200000000,
-    0x400000000,
-    0x800000000,
-    0x1000000000,
-    0x2000000000,
-    0x4000000000,
-    0x8000000000,
-    0x10000000000,
-    0x20000000000,
-    0x40000000000,
-    0x80000000000,
-    0x100000000000,
-    0x200000000000,
-    0x400000000000,
-    0x800000000000,
-    0x1000000000000,
-    0x2000000000000,
-    0x4000000000000,
-    0x8000000000000,
-    0x10000000000000
-];
+export const powerOfTwo = (() => {
+    let val = 0.5;
+    return new Array(53).fill(0).map(() => (val *= 2));
+})();
 
 export namespace TileKeyUtils {
     export function geoCoordinatesToTileKey(

--- a/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
+++ b/@here/harp-geoutils/lib/tiling/TileKeyUtils.ts
@@ -11,8 +11,65 @@ import { Vector3Like } from "../math/Vector3Like";
 import { TileKey } from "./TileKey";
 import { TilingScheme } from "./TilingScheme";
 
-export class TileKeyUtils {
-    static geoCoordinatesToTileKey(
+/** @hidden */
+export const powerOfTwo = [
+    0x1,
+    0x2,
+    0x4,
+    0x8,
+    0x10,
+    0x20,
+    0x40,
+    0x80,
+    0x100,
+    0x200,
+    0x400,
+    0x800,
+    0x1000,
+    0x2000,
+    0x4000,
+    0x8000,
+    0x10000,
+    0x20000,
+    0x40000,
+    0x80000,
+    0x100000,
+    0x200000,
+    0x400000,
+    0x800000,
+    0x1000000,
+    0x2000000,
+    0x4000000,
+    0x8000000,
+    0x10000000,
+    0x20000000,
+    0x40000000,
+    0x80000000,
+    0x100000000,
+    0x200000000,
+    0x400000000,
+    0x800000000,
+    0x1000000000,
+    0x2000000000,
+    0x4000000000,
+    0x8000000000,
+    0x10000000000,
+    0x20000000000,
+    0x40000000000,
+    0x80000000000,
+    0x100000000000,
+    0x200000000000,
+    0x400000000000,
+    0x800000000000,
+    0x1000000000000,
+    0x2000000000000,
+    0x4000000000000,
+    0x8000000000000,
+    0x10000000000000
+];
+
+export namespace TileKeyUtils {
+    export function geoCoordinatesToTileKey(
         tilingScheme: TilingScheme,
         geoPoint: GeoCoordinatesLike,
         level: number
@@ -20,10 +77,10 @@ export class TileKeyUtils {
         const projection = tilingScheme.projection;
         const worldPoint = projection.projectPoint(geoPoint);
 
-        return this.worldCoordinatesToTileKey(tilingScheme, worldPoint, level);
+        return worldCoordinatesToTileKey(tilingScheme, worldPoint, level);
     }
 
-    static worldCoordinatesToTileKey(
+    export function worldCoordinatesToTileKey(
         tilingScheme: TilingScheme,
         worldPoint: Vector3Like,
         level: number
@@ -52,7 +109,7 @@ export class TileKeyUtils {
         return TileKey.fromRowColumnLevel(row, column, level);
     }
 
-    static geoRectangleToTileKeys(
+    export function geoRectangleToTileKeys(
         tilingScheme: TilingScheme,
         geoBox: GeoBox,
         level: number
@@ -123,5 +180,111 @@ export class TileKeyUtils {
         }
 
         return keys;
+    }
+
+    /**
+     * Creates a unique key based on the supplied parameters. Note, the uniqueness is bounded by the
+     * bitshift. The [[TileKey.mortonCode()]] supports currently up to 26 levels (this is because
+     * 26*2 equals 52, and 2^52 is the highest bit that can be set in an integer in Javascript), the
+     * bitshift reduces this accordingly, so given the default bitshift of four, we support up to 24
+     * levels. Given the current support up to level 19 this should be fine.
+     *
+     * @param tileKey - The unique {@link @here/harp-geoutils#TileKey}
+     *                  from which to compute the unique key.
+     * @param offset - How much the given {@link @here/harp-geoutils#TileKey} is offset
+     * @param bitshift - How much space we have to store the offset. The default of 4 means we have
+     *      enough space to store 16 unique tiles in a single view.
+     */
+    export function getKeyForTileKeyAndOffset(
+        tileKey: TileKey,
+        offset: number,
+        bitshift: number = 4
+    ) {
+        const shiftedOffset = getShiftedOffset(offset, bitshift);
+        return tileKey.mortonCode() + shiftedOffset;
+    }
+
+    /**
+     * Extracts the offset and morton key from the given key (must be created by:
+     * [[getKeyForTileKeyAndOffset]])
+     *
+     * Note, we can't use bitshift operators in Javascript because they work on 32-bit integers, and
+     * would truncate the numbers, hence using powers of two.
+     *
+     * @param key - Key to extract offset and morton key.
+     * @param bitshift - How many bits to shift by, must be the same as was used when creating the
+     * key.
+     */
+    export function extractOffsetAndMortonKeyFromKey(key: number, bitshift: number = 4) {
+        let offset = 0;
+        let mortonCode = key;
+        let i = 0;
+        // Compute the offset
+        for (; i < bitshift; i++) {
+            // Note, we use 52, because 2^53-1 is the biggest value, the highest value
+            // that can be set is the bit in the 52th position.
+            const num = powerOfTwo[52 - i];
+            if (mortonCode >= num) {
+                mortonCode -= num;
+                offset += powerOfTwo[bitshift - 1 - i];
+            }
+        }
+        // We subtract half of the total amount, this undoes what is computed in getShiftedOffset
+        offset -= powerOfTwo[bitshift - 1];
+        return { offset, mortonCode };
+    }
+
+    /**
+     * Returns the key of the parent. Key must have been computed using the function
+     * [[getKeyForTileKeyAndOffset]].
+     *
+     * @param calculatedKey - Key to decompose
+     * @param bitshift - Bit shift used to create the key
+     */
+    export function getParentKeyFromKey(calculatedKey: number, bitshift: number = 4) {
+        const { offset, mortonCode } = extractOffsetAndMortonKeyFromKey(calculatedKey, bitshift);
+        const parentTileKey = TileKey.fromMortonCode(TileKey.parentMortonCode(mortonCode));
+        return getKeyForTileKeyAndOffset(parentTileKey, offset, bitshift);
+    }
+
+    /**
+     * Packs the supplied offset into the high bits, where the highbits are between 2^52 and
+     * 2^(52-bitshift).
+     *
+     * Offsets are wrapped around, to fit in the offsetBits. In practice, this doesn't really
+     * matter, this is primarily used to find a unique id, if there is an offset 10, which is
+     * wrapped to 2, it doesn't matter, because the offset of 10 is still stored in the tile.
+     * What can be a problem though is that the cache gets filled up and isn't emptied.
+     *
+     * Note, because bit shifting in JavaScript works on 32 bit integers, we use powers of 2 to set
+     * the high bits instead.
+     *
+     * @param offset - Offset to pack into the high bits.
+     * @param offsetBits - How many bits to use to pack the offset.
+     */
+    function getShiftedOffset(offset: number, offsetBits: number = 4) {
+        let result = 0;
+        const totalOffsetsToStore = powerOfTwo[offsetBits];
+        //Offsets are stored by adding half 2 ^ (bitshift - 1), i.e.half of the max amount stored,
+        //and then wrapped based on this value.For example, given a bitshift of 3, and an offset -
+        //3, it would have 4 added(half of 2 ^ 3), and be stored as 1, 3 would have 4 added and be
+        //stored as 7, 4 would be added with 4 and be stored as 0 (it wraps around).
+        offset += totalOffsetsToStore / 2;
+        while (offset < 0) {
+            offset += totalOffsetsToStore;
+        }
+        while (offset >= totalOffsetsToStore) {
+            offset -= totalOffsetsToStore;
+        }
+        // Offset is now a number between >= 0 and < totalOffsetsToStore
+        for (let i = 0; i < offsetBits && offset > 0; i++) {
+            // 53 is used because 2^53-1 is the biggest number that Javascript can represent as an
+            // integer safely.
+            if (offset & 0x1) {
+                result += powerOfTwo[53 - offsetBits + i];
+            }
+            offset >>>= 1;
+        }
+        return result;
     }
 }

--- a/@here/harp-geoutils/test/TileKeyTest.ts
+++ b/@here/harp-geoutils/test/TileKeyTest.ts
@@ -128,19 +128,3 @@ describe("Equirectangular", function () {
         assert.strictEqual(tileKey.level, 13);
     });
 });
-
-describe("TileKeyUtils", function () {
-    it("geoRectangleToTileKeys", function () {
-        const geoBox = new GeoBox(
-            new GeoCoordinates(52.5163, 13.3777), // Brandenburg gate
-            new GeoCoordinates(52.5309, 13.385) // HERE office
-        );
-        const expectedResult = [371506848, 371506849, 371506850, 371506851];
-
-        const result = TileKeyUtils.geoRectangleToTileKeys(webMercatorTilingScheme, geoBox, 14);
-        assert.sameMembers(
-            result.map(tk => tk.mortonCode()),
-            expectedResult
-        );
-    });
-});

--- a/@here/harp-geoutils/test/TileKeyUtilsTest.ts
+++ b/@here/harp-geoutils/test/TileKeyUtilsTest.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
+import { assert, expect } from "chai";
 
+import { GeoBox } from "../lib/coordinates/GeoBox";
+import { GeoCoordinates } from "../lib/coordinates/GeoCoordinates";
 import { TileKey } from "../lib/tiling/TileKey";
 import { TileKeyUtils } from "../lib/tiling/TileKeyUtils";
+import { webMercatorTilingScheme } from "../lib/tiling/WebMercatorTilingScheme";
 
 describe("TileKeyUtils", function () {
     it("test getKeyForTileKeyAndOffset and extractOffsetAndMortonKeyFromKey", async function () {
@@ -47,5 +50,19 @@ describe("TileKeyUtils", function () {
             expect(offset).to.be.equal(offsetResults[i]);
             expect(mortonCode).to.be.equal(tileKey.mortonCode());
         }
+    });
+
+    it("geoRectangleToTileKeys", function () {
+        const geoBox = new GeoBox(
+            new GeoCoordinates(52.5163, 13.3777), // Brandenburg gate
+            new GeoCoordinates(52.5309, 13.385) // HERE office
+        );
+        const expectedResult = [371506848, 371506849, 371506850, 371506851];
+
+        const result = TileKeyUtils.geoRectangleToTileKeys(webMercatorTilingScheme, geoBox, 14);
+        assert.sameMembers(
+            result.map(tk => tk.mortonCode()),
+            expectedResult
+        );
     });
 });

--- a/@here/harp-geoutils/test/TileKeyUtilsTest.ts
+++ b/@here/harp-geoutils/test/TileKeyUtilsTest.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "chai";
+
+import { TileKey } from "../lib/tiling/TileKey";
+import { TileKeyUtils } from "../lib/tiling/TileKeyUtils";
+
+describe("TileKeyUtils", function () {
+    it("test getKeyForTileKeyAndOffset and extractOffsetAndMortonKeyFromKey", async function () {
+        // This allows 8 offsets to be stored, -4 -> 3, we test also outside this range
+        const bitshift = 3;
+        const offsets = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5];
+        // Binary is the easist to read, here you can see the -4 -> 3 is mapped to 0 -> 7
+        // in the 3 highest bits.
+        const results = [
+            0b11100000000000000000000000000000000000000000000000111,
+            0b00000000000000000000000000000000000000000000000000111,
+            0b00100000000000000000000000000000000000000000000000111,
+            0b01000000000000000000000000000000000000000000000000111,
+            0b01100000000000000000000000000000000000000000000000111,
+            0b10000000000000000000000000000000000000000000000000111,
+            0b10100000000000000000000000000000000000000000000000111,
+            0b11000000000000000000000000000000000000000000000000111,
+            0b11100000000000000000000000000000000000000000000000111,
+            // Check that we wrap back around to 0
+            0b00000000000000000000000000000000000000000000000000111,
+            0b00100000000000000000000000000000000000000000000000111
+        ];
+        const offsetResults = [3, -4, -3, -2, -1, 0, 1, 2, 3, -4, -3];
+        const tileKey = TileKey.fromRowColumnLevel(1, 1, 1);
+        for (let i = 0; i < offsets.length; i++) {
+            const keyByTileKeyAndOffset = TileKeyUtils.getKeyForTileKeyAndOffset(
+                tileKey,
+                offsets[i],
+                bitshift
+            );
+            expect(keyByTileKeyAndOffset).to.be.equal(results[i]);
+
+            const { offset, mortonCode } = TileKeyUtils.extractOffsetAndMortonKeyFromKey(
+                keyByTileKeyAndOffset,
+                bitshift
+            );
+            expect(offset).to.be.equal(offsetResults[i]);
+            expect(mortonCode).to.be.equal(tileKey.mortonCode());
+        }
+    });
+});

--- a/@here/harp-mapview/lib/FrustumIntersection.ts
+++ b/@here/harp-mapview/lib/FrustumIntersection.ts
@@ -8,6 +8,7 @@ import {
     Projection,
     ProjectionType,
     TileKey,
+    TileKeyUtils,
     TilingScheme
 } from "@here/harp-geoutils";
 import { assert } from "@here/harp-utils";
@@ -17,7 +18,7 @@ import { DataSource } from "./DataSource";
 import { CalculationStatus, ElevationRange, ElevationRangeSource } from "./ElevationRangeSource";
 import { MapTileCuller } from "./MapTileCuller";
 import { MapView } from "./MapView";
-import { MapViewUtils, TileOffsetUtils } from "./Utils";
+import { MapViewUtils } from "./Utils";
 
 const tmpVectors3 = [new THREE.Vector3(), new THREE.Vector3()];
 const tmpVector4 = new THREE.Vector4();
@@ -197,7 +198,7 @@ export class FrustumIntersection {
                 for (const zoomLevel of uniqueZoomLevels) {
                     const tileKeyEntries = this.m_tileKeyEntries.get(zoomLevel)!;
                     tileKeyEntries.set(
-                        TileOffsetUtils.getKeyForTileKeyAndOffset(tileKey, offset),
+                        TileKeyUtils.getKeyForTileKeyAndOffset(tileKey, offset),
                         tileKeyEntry
                     );
                 }
@@ -227,7 +228,7 @@ export class FrustumIntersection {
                 continue;
             }
 
-            const tileKeyAndOffset = TileOffsetUtils.getKeyForTileKeyAndOffset(tileKey, offset);
+            const tileKeyAndOffset = TileKeyUtils.getKeyForTileKeyAndOffset(tileKey, offset);
 
             // delete parent tile key from applicable zoom levels
             for (const zoomLevel of uniqueZoomLevels) {
@@ -257,7 +258,7 @@ export class FrustumIntersection {
                             continue;
                         }
 
-                        const subTileKeyAndOffset = TileOffsetUtils.getKeyForTileKeyAndOffset(
+                        const subTileKeyAndOffset = TileKeyUtils.getKeyForTileKeyAndOffset(
                             subTileKey,
                             offset
                         );

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -17,6 +17,7 @@ import { CopyrightInfo } from "./copyrights/CopyrightInfo";
 import { DataSource } from "./DataSource";
 import { ElevationRange } from "./ElevationRangeSource";
 import { LodMesh } from "./geometry/LodMesh";
+import { Object3DUtils } from "./geometry/Object3DUtils";
 import { TileGeometryLoader } from "./geometry/TileGeometryLoader";
 import { ITileLoader, TileLoaderState } from "./ITileLoader";
 import { MapView } from "./MapView";
@@ -26,7 +27,6 @@ import { TextElement } from "./text/TextElement";
 import { TextElementGroup } from "./text/TextElementGroup";
 import { TextElementGroupPriorityList } from "./text/TextElementGroupPriorityList";
 import { TileTextStyleCache } from "./text/TileTextStyleCache";
-import { MapViewUtils } from "./Utils";
 
 const logger = LoggerManager.instance.create("Tile");
 
@@ -1167,7 +1167,7 @@ export class Tile implements CachedResource {
             if (object.visible) {
                 num3dObjects++;
             }
-            MapViewUtils.estimateObject3dSize(object, aggregatedObjSize, visitedObjects);
+            Object3DUtils.estimateSize(object, aggregatedObjSize, visitedObjects);
         }
 
         for (const group of this.textElementGroups.groups) {

--- a/@here/harp-mapview/lib/Tile.ts
+++ b/@here/harp-mapview/lib/Tile.ts
@@ -9,7 +9,7 @@ import {
     GeometryType,
     TextPathGeometry
 } from "@here/harp-datasource-protocol";
-import { GeoBox, OrientedBox3, Projection, TileKey } from "@here/harp-geoutils";
+import { GeoBox, OrientedBox3, Projection, TileKey, TileKeyUtils } from "@here/harp-geoutils";
 import { assert, CachedResource, chainCallbacks, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
 
@@ -26,7 +26,7 @@ import { TextElement } from "./text/TextElement";
 import { TextElementGroup } from "./text/TextElementGroup";
 import { TextElementGroupPriorityList } from "./text/TextElementGroupPriorityList";
 import { TileTextStyleCache } from "./text/TileTextStyleCache";
-import { MapViewUtils, TileOffsetUtils } from "./Utils";
+import { MapViewUtils } from "./Utils";
 
 const logger = LoggerManager.instance.create("Tile");
 
@@ -324,7 +324,7 @@ export class Tile implements CachedResource {
         this.m_localTangentSpace = localTangentSpace ?? false;
         this.m_textStyleCache = new TileTextStyleCache(this);
         this.m_offset = offset;
-        this.m_uniqueKey = TileOffsetUtils.getKeyForTileKeyAndOffset(this.tileKey, this.offset);
+        this.m_uniqueKey = TileKeyUtils.getKeyForTileKeyAndOffset(this.tileKey, this.offset);
         if (dataSource.useGeometryLoader) {
             this.m_tileGeometryLoader = new TileGeometryLoader(this, this.mapView.taskQueue);
             this.attachGeometryLoadedCallback();
@@ -434,7 +434,7 @@ export class Tile implements CachedResource {
      */
     set offset(offset: number) {
         if (this.m_offset !== offset) {
-            this.m_uniqueKey = TileOffsetUtils.getKeyForTileKeyAndOffset(this.tileKey, offset);
+            this.m_uniqueKey = TileKeyUtils.getKeyForTileKeyAndOffset(this.tileKey, offset);
         }
         this.m_offset = offset;
     }

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -12,7 +12,7 @@ import {
     Projection,
     ProjectionType,
     sphereProjection,
-    TileKey,
+    TileKeyUtils,
     Vector2Like,
     Vector3Like
 } from "@here/harp-geoutils";
@@ -2059,168 +2059,19 @@ export namespace MapViewUtils {
     }
 }
 
-/** @hidden */
-const powerOfTwo = [
-    0x1,
-    0x2,
-    0x4,
-    0x8,
-    0x10,
-    0x20,
-    0x40,
-    0x80,
-    0x100,
-    0x200,
-    0x400,
-    0x800,
-    0x1000,
-    0x2000,
-    0x4000,
-    0x8000,
-    0x10000,
-    0x20000,
-    0x40000,
-    0x80000,
-    0x100000,
-    0x200000,
-    0x400000,
-    0x800000,
-    0x1000000,
-    0x2000000,
-    0x4000000,
-    0x8000000,
-    0x10000000,
-    0x20000000,
-    0x40000000,
-    0x80000000,
-    0x100000000,
-    0x200000000,
-    0x400000000,
-    0x800000000,
-    0x1000000000,
-    0x2000000000,
-    0x4000000000,
-    0x8000000000,
-    0x10000000000,
-    0x20000000000,
-    0x40000000000,
-    0x80000000000,
-    0x100000000000,
-    0x200000000000,
-    0x400000000000,
-    0x800000000000,
-    0x1000000000000,
-    0x2000000000000,
-    0x4000000000000,
-    0x8000000000000,
-    0x10000000000000
-];
-
 export namespace TileOffsetUtils {
     /**
-     * Creates a unique key based on the supplied parameters. Note, the uniqueness is bounded by the
-     * bitshift. The [[TileKey.mortonCode()]] supports currently up to 26 levels (this is because
-     * 26*2 equals 52, and 2^52 is the highest bit that can be set in an integer in Javascript), the
-     * bitshift reduces this accordingly, so given the default bitshift of four, we support up to 24
-     * levels. Given the current support up to level 19 this should be fine.
-     *
-     * @param tileKey - The unique {@link @here/harp-geoutils#TileKey}
-     *                  from which to compute the unique key.
-     * @param offset - How much the given {@link @here/harp-geoutils#TileKey} is offset
-     * @param bitshift - How much space we have to store the offset. The default of 4 means we have
-     *      enough space to store 16 unique tiles in a single view.
+     * @deprecated Use {@link @here/harp-geoutils#TileKeyUtils.getKeyForTileKeyAndOffset}.
      */
-    export function getKeyForTileKeyAndOffset(
-        tileKey: TileKey,
-        offset: number,
-        bitshift: number = 4
-    ) {
-        const shiftedOffset = getShiftedOffset(offset, bitshift);
-        return tileKey.mortonCode() + shiftedOffset;
-    }
+    export const getKeyForTileKeyAndOffset = TileKeyUtils.getKeyForTileKeyAndOffset;
 
     /**
-     * Extracts the offset and morton key from the given key (must be created by:
-     * [[getKeyForTileKeyAndOffset]])
-     *
-     * Note, we can't use bitshift operators in Javascript because they work on 32-bit integers, and
-     * would truncate the numbers, hence using powers of two.
-     *
-     * @param key - Key to extract offset and morton key.
-     * @param bitshift - How many bits to shift by, must be the same as was used when creating the
-     * key.
+     * @deprecated Use {@link @here/harp-geoutils#TileKeyUtils.getKeyForTileKeyAndOffset}.
      */
-    export function extractOffsetAndMortonKeyFromKey(key: number, bitshift: number = 4) {
-        let offset = 0;
-        let mortonCode = key;
-        let i = 0;
-        // Compute the offset
-        for (; i < bitshift; i++) {
-            // Note, we use 52, because 2^53-1 is the biggest value, the highest value
-            // that can be set is the bit in the 52th position.
-            const num = powerOfTwo[52 - i];
-            if (mortonCode >= num) {
-                mortonCode -= num;
-                offset += powerOfTwo[bitshift - 1 - i];
-            }
-        }
-        // We subtract half of the total amount, this undoes what is computed in getShiftedOffset
-        offset -= powerOfTwo[bitshift - 1];
-        return { offset, mortonCode };
-    }
+    export const extractOffsetAndMortonKeyFromKey = TileKeyUtils.extractOffsetAndMortonKeyFromKey;
 
     /**
-     * Returns the key of the parent. Key must have been computed using the function
-     * [[getKeyForTileKeyAndOffset]].
-     *
-     * @param calculatedKey - Key to decompose
-     * @param bitshift - Bit shift used to create the key
+     * @deprecated Use {@link @here/harp-geoutils#TileKeyUtils.getParentKeyFromKey}.
      */
-    export function getParentKeyFromKey(calculatedKey: number, bitshift: number = 4) {
-        const { offset, mortonCode } = extractOffsetAndMortonKeyFromKey(calculatedKey, bitshift);
-        const parentTileKey = TileKey.fromMortonCode(TileKey.parentMortonCode(mortonCode));
-        return getKeyForTileKeyAndOffset(parentTileKey, offset, bitshift);
-    }
-
-    /**
-     * Packs the supplied offset into the high bits, where the highbits are between 2^52 and
-     * 2^(52-bitshift).
-     *
-     * Offsets are wrapped around, to fit in the offsetBits. In practice, this doesn't really
-     * matter, this is primarily used to find a unique id, if there is an offset 10, which is
-     * wrapped to 2, it doesn't matter, because the offset of 10 is still stored in the tile.
-     * What can be a problem though is that the cache gets filled up and isn't emptied.
-     *
-     * Note, because bit shifting in JavaScript works on 32 bit integers, we use powers of 2 to set
-     * the high bits instead.
-     *
-     * @param offset - Offset to pack into the high bits.
-     * @param offsetBits - How many bits to use to pack the offset.
-     */
-    function getShiftedOffset(offset: number, offsetBits: number = 4) {
-        let result = 0;
-        const totalOffsetsToStore = powerOfTwo[offsetBits];
-        //Offsets are stored by adding half 2 ^ (bitshift - 1), i.e.half of the max amount stored,
-        //and then wrapped based on this value.For example, given a bitshift of 3, and an offset -
-        //3, it would have 4 added(half of 2 ^ 3), and be stored as 1, 3 would have 4 added and be
-        //stored as 7, 4 would be added with 4 and be stored as 0 (it wraps around).
-        offset += totalOffsetsToStore / 2;
-        while (offset < 0) {
-            offset += totalOffsetsToStore;
-        }
-        while (offset >= totalOffsetsToStore) {
-            offset -= totalOffsetsToStore;
-        }
-        // Offset is now a number between >= 0 and < totalOffsetsToStore
-        for (let i = 0; i < offsetBits && offset > 0; i++) {
-            // 53 is used because 2^53-1 is the biggest number that Javascript can represent as an
-            // integer safely.
-            if (offset & 0x1) {
-                result += powerOfTwo[53 - offsetBits + i];
-            }
-            offset >>>= 1;
-        }
-        assert(offset === 0);
-        return result;
-    }
+    export const getParentKeyFromKey = TileKeyUtils.getParentKeyFromKey;
 }

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -18,7 +18,7 @@ import {
 } from "@here/harp-geoutils";
 import { GeoCoordLike } from "@here/harp-geoutils/lib/coordinates/GeoCoordLike";
 import { EarthConstants } from "@here/harp-geoutils/lib/projection/EarthConstants";
-import { assert, LoggerManager } from "@here/harp-utils";
+import { assert, DOMUtils, LoggerManager } from "@here/harp-utils";
 import * as THREE from "three";
 
 import { CameraUtils } from "./CameraUtils";
@@ -1774,30 +1774,9 @@ export namespace MapViewUtils {
     }
 
     /**
-     * Gets language list used by the browser
-     *
-     * @returns Array of iso language codes
+     * @deprecated Use {@link @here/harp-utils#DOMUtils.getBrowserLanguages}
      */
-    export function getBrowserLanguages(): string[] | undefined {
-        if (navigator.languages !== undefined && navigator.languages.length > 0) {
-            const languageList = [];
-            for (const lang of navigator.languages) {
-                languageList.push(getIsoLanguageCode(lang));
-            }
-            return languageList;
-        }
-        if (navigator.language !== undefined) {
-            return [getIsoLanguageCode(navigator.language)];
-        }
-        return undefined;
-    }
-
-    /**
-     * Gets ISO-639-1 language code from browser's code (ex. en for en-US)
-     */
-    function getIsoLanguageCode(language: string) {
-        return language.substring(0, 2);
-    }
+    export const getBrowserLanguages = DOMUtils.getBrowserLanguages;
 }
 
 export namespace TileOffsetUtils {

--- a/@here/harp-mapview/lib/Utils.ts
+++ b/@here/harp-mapview/lib/Utils.ts
@@ -96,6 +96,9 @@ function snapToCeilingZoomLevel(zoomLevel: number) {
     return ceiling - zoomLevel < eps ? ceiling : zoomLevel;
 }
 
+/**
+ * MapView utilities: View transformations, camera setup, view bounds computation...
+ */
 export namespace MapViewUtils {
     export const MAX_TILT_DEG = 89;
     export const MAX_TILT_RAD = MAX_TILT_DEG * THREE.MathUtils.DEG2RAD;

--- a/@here/harp-mapview/lib/VisibleTileSet.ts
+++ b/@here/harp-mapview/lib/VisibleTileSet.ts
@@ -24,7 +24,6 @@ import { FrustumIntersection, TileKeyEntry } from "./FrustumIntersection";
 import { TileGeometryManager } from "./geometry/TileGeometryManager";
 import { TileTaskGroups } from "./MapView";
 import { Tile } from "./Tile";
-import { TileOffsetUtils } from "./Utils";
 
 /**
  * Way the memory consumption of a tile is computed. Either in number of tiles, or in MegaBytes. If
@@ -722,7 +721,7 @@ export class VisibleTileSet {
         }
 
         return dataSourceVisibleTileList.renderedTiles.get(
-            TileOffsetUtils.getKeyForTileKeyAndOffset(tileKey, offset)
+            TileKeyUtils.getKeyForTileKeyAndOffset(tileKey, offset)
         );
     }
 
@@ -755,7 +754,7 @@ export class VisibleTileSet {
         }
 
         let tile = dataSourceVisibleTileList.renderedTiles.get(
-            TileOffsetUtils.getKeyForTileKeyAndOffset(visibleTileKey, offset)
+            TileKeyUtils.getKeyForTileKeyAndOffset(visibleTileKey, offset)
         );
 
         if (tile !== undefined) {
@@ -772,7 +771,7 @@ export class VisibleTileSet {
             parentTileKey = parentTileKey.parent();
 
             tile = dataSourceVisibleTileList.renderedTiles.get(
-                TileOffsetUtils.getKeyForTileKeyAndOffset(parentTileKey, offset)
+                TileKeyUtils.getKeyForTileKeyAndOffset(parentTileKey, offset)
             );
             if (tile !== undefined) {
                 return tile;
@@ -790,7 +789,7 @@ export class VisibleTileSet {
             );
             if (childTileKey) {
                 tile = dataSourceVisibleTileList.renderedTiles.get(
-                    TileOffsetUtils.getKeyForTileKeyAndOffset(childTileKey, offset)
+                    TileKeyUtils.getKeyForTileKeyAndOffset(childTileKey, offset)
                 );
 
                 if (tile !== undefined) {
@@ -1154,14 +1153,12 @@ export class VisibleTileSet {
         renderedTiles: Map<number, Tile>,
         dataSource: DataSource
     ) {
-        const { offset, mortonCode } = TileOffsetUtils.extractOffsetAndMortonKeyFromKey(
-            tileKeyCode
-        );
+        const { offset, mortonCode } = TileKeyUtils.extractOffsetAndMortonKeyFromKey(tileKeyCode);
         const tileKey = TileKey.fromMortonCode(mortonCode);
 
         const tilingScheme = dataSource.getTilingScheme();
         for (const childTileKey of tilingScheme.getSubTileKeys(tileKey)) {
-            const childTileCode = TileOffsetUtils.getKeyForTileKeyAndOffset(childTileKey, offset);
+            const childTileCode = TileKeyUtils.getKeyForTileKeyAndOffset(childTileKey, offset);
             const childTile = this.m_dataSourceCache.get(
                 childTileKey.mortonCode(),
                 offset,
@@ -1201,7 +1198,7 @@ export class VisibleTileSet {
         checkedTiles: Map<number, boolean>,
         dataSource: DataSource
     ): boolean {
-        const parentCode = TileOffsetUtils.getParentKeyFromKey(tileKeyCode);
+        const parentCode = TileKeyUtils.getParentKeyFromKey(tileKeyCode);
         // Check if another sibling has already added the parent.
         if (renderedTiles.get(parentCode) !== undefined) {
             return true;
@@ -1211,7 +1208,7 @@ export class VisibleTileSet {
             return exists;
         }
 
-        const { offset, mortonCode } = TileOffsetUtils.extractOffsetAndMortonKeyFromKey(parentCode);
+        const { offset, mortonCode } = TileKeyUtils.extractOffsetAndMortonKeyFromKey(parentCode);
         const parentTile = this.m_dataSourceCache.get(mortonCode, offset, dataSource);
         const parentTileKey = parentTile ? parentTile.tileKey : TileKey.fromMortonCode(mortonCode);
         const nextLevelDiff = Math.abs(dataZoomLevel - parentTileKey.level);

--- a/@here/harp-mapview/lib/geometry/Object3DUtils.ts
+++ b/@here/harp-mapview/lib/geometry/Object3DUtils.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { MapMeshBasicMaterial, MapMeshStandardMaterial } from "@here/harp-materials";
+import { LoggerManager } from "@here/harp-utils";
+import * as THREE from "three";
+
+import { getFeatureDataSize, TileFeatureData } from "../Tile";
+import { LodMesh } from "./LodMesh";
+
+// Estimation of the size of an Object3D with all the simple properties, like matrices and flags.
+// There may be cases where it is possible to construct Object3Ds with considerable less memory
+// consumption, but this value is used to simplify the estimation.
+const MINIMUM_OBJECT3D_SIZE_ESTIMATION = 1000;
+
+const MINIMUM_ATTRIBUTE_SIZE_ESTIMATION = 56;
+
+const logger = LoggerManager.instance.create("Object3DUtils");
+
+/**
+ * @internal
+ */
+export namespace Object3DUtils {
+    /**
+     * Describes estimated usage of memory on heap and GPU.
+     */
+    export interface MemoryUsage {
+        heapSize: number;
+        gpuSize: number;
+    }
+
+    function estimateTextureSize(
+        texture: THREE.Texture | null,
+        objectSize: MemoryUsage,
+        visitedObjects: Map<string, boolean>
+    ): void {
+        if (
+            texture === null ||
+            texture === undefined ||
+            texture.image === undefined ||
+            texture.image === null
+        ) {
+            return;
+        }
+
+        if (texture.uuid !== undefined && visitedObjects.get(texture.uuid) === true) {
+            return;
+        }
+        visitedObjects.set(texture.uuid, true);
+
+        // May be HTMLImage or ImageData
+        const image = texture.image;
+        // Assuming RGBA
+        const imageBytes = 4 * image.width * image.height;
+        objectSize.heapSize += imageBytes;
+        objectSize.gpuSize += imageBytes;
+    }
+
+    function estimateMaterialSize(
+        material: THREE.Material,
+        objectSize: MemoryUsage,
+        visitedObjects: Map<string, boolean>
+    ): void {
+        if (material.uuid !== undefined && visitedObjects.get(material.uuid) === true) {
+            return;
+        }
+        visitedObjects.set(material.uuid, true);
+
+        if (
+            material instanceof THREE.RawShaderMaterial ||
+            material instanceof THREE.ShaderMaterial
+        ) {
+            const rawMaterial = material;
+            for (const name in rawMaterial.uniforms) {
+                if (rawMaterial.uniforms[name] !== undefined) {
+                    const uniform = rawMaterial.uniforms[name];
+                    if (uniform instanceof THREE.Texture) {
+                        estimateTextureSize(uniform, objectSize, visitedObjects);
+                    }
+                }
+            }
+        } else if (
+            material instanceof THREE.MeshBasicMaterial ||
+            material instanceof MapMeshBasicMaterial
+        ) {
+            const meshMaterial = material;
+            estimateTextureSize(meshMaterial.map, objectSize, visitedObjects);
+            estimateTextureSize(meshMaterial.aoMap, objectSize, visitedObjects);
+            estimateTextureSize(meshMaterial.specularMap, objectSize, visitedObjects);
+            estimateTextureSize(meshMaterial.alphaMap, objectSize, visitedObjects);
+            estimateTextureSize(meshMaterial.envMap, objectSize, visitedObjects);
+        } else if (material instanceof MapMeshStandardMaterial) {
+            const standardMaterial = material;
+
+            estimateTextureSize(standardMaterial.map, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.lightMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.aoMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.emissiveMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.bumpMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.normalMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.displacementMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.roughnessMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.metalnessMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.alphaMap, objectSize, visitedObjects);
+            estimateTextureSize(standardMaterial.envMap, objectSize, visitedObjects);
+        } else if (
+            material instanceof THREE.LineBasicMaterial ||
+            material instanceof THREE.LineDashedMaterial ||
+            material instanceof THREE.PointsMaterial
+        ) {
+            // Nothing to be done here
+        } else {
+            logger.warn("estimateMeshSize: unidentified material: ", material);
+        }
+    }
+
+    function estimateAttributeSize(
+        attribute: any,
+        attrName: string,
+        objectSize: MemoryUsage,
+        visitedObjects: Map<string, boolean>
+    ): void {
+        // Attributes (apparently) do not have their uuid set up.
+        if (attribute.uuid === undefined) {
+            attribute.uuid = THREE.MathUtils.generateUUID();
+        }
+
+        if (visitedObjects.get(attribute.uuid) === true) {
+            return;
+        }
+        visitedObjects.set(attribute.uuid, true);
+
+        let attrBytes = 0;
+        let bytesPerElement = 4;
+        if (attribute.array.BYTES_PER_ELEMENT !== undefined) {
+            bytesPerElement = attribute.array.BYTES_PER_ELEMENT;
+        }
+        if (
+            attribute instanceof THREE.InterleavedBufferAttribute ||
+            attribute instanceof THREE.BufferAttribute
+        ) {
+            attrBytes = bytesPerElement * attribute.count * attribute.itemSize;
+        } else {
+            logger.warn("estimateMeshSize: unidentified attribute: ", attrName);
+        }
+
+        objectSize.heapSize += attrBytes + MINIMUM_ATTRIBUTE_SIZE_ESTIMATION;
+        objectSize.gpuSize += attrBytes;
+    }
+
+    function estimateGeometrySize(
+        geometry: THREE.BufferGeometry,
+        objectSize: MemoryUsage,
+        visitedObjects: Map<string, boolean>
+    ): void {
+        const isNewObject =
+            geometry.uuid === undefined || visitedObjects.get(geometry.uuid) !== true;
+
+        if (!isNewObject) {
+            return;
+        }
+        visitedObjects.set(geometry.uuid, true);
+
+        if (geometry === undefined) {
+            // Nothing more to calculate.
+            return;
+        }
+
+        const attributes = geometry.attributes;
+        if (attributes === undefined) {
+            logger.warn("estimateGeometrySize: unidentified geometry: ", geometry);
+            return;
+        }
+
+        for (const property in attributes) {
+            if (attributes[property] !== undefined) {
+                estimateAttributeSize(attributes[property], property, objectSize, visitedObjects);
+            }
+        }
+        if (geometry.index !== null) {
+            estimateAttributeSize(geometry.index, "index", objectSize, visitedObjects);
+        }
+    }
+
+    function estimateMeshSize(
+        object: THREE.Object3D,
+        objectSize: MemoryUsage,
+        visitedObjects: Map<string, boolean>
+    ): void {
+        if (!object.isObject3D || object instanceof THREE.Scene) {
+            return;
+        }
+
+        if (object.uuid !== undefined && visitedObjects.get(object.uuid) === true) {
+            return;
+        }
+        visitedObjects.set(object.uuid, true);
+
+        if ((object as any).isMesh || (object as any).isLine || (object as any).isPoints) {
+            // Estimated minimum impact on heap.
+            let heapSize = MINIMUM_OBJECT3D_SIZE_ESTIMATION;
+            const gpuSize = 0;
+
+            // Cast to LodMesh class which contains the minimal required properties sub-set.
+            const mesh = object as LodMesh;
+
+            // Calculate material(s) impact.
+            if (mesh.material !== undefined) {
+                if (Array.isArray(mesh.material)) {
+                    const materials = mesh.material as THREE.Material[];
+                    for (const material of materials) {
+                        estimateMaterialSize(material, objectSize, visitedObjects);
+                    }
+                } else {
+                    const material = mesh.material as THREE.Material;
+                    estimateMaterialSize(material, objectSize, visitedObjects);
+                }
+            }
+
+            // Calculate cost of geometry.
+            if (mesh.geometries !== undefined) {
+                for (const geometry of mesh.geometries) {
+                    estimateGeometrySize(geometry, objectSize, visitedObjects);
+                }
+            } else if (mesh.geometry !== undefined) {
+                estimateGeometrySize(mesh.geometry, objectSize, visitedObjects);
+            }
+
+            // Add info that is required for picking (parts of) objects and match them to
+            // the featureID in the map data.
+            const featureData: TileFeatureData | undefined =
+                object.userData !== undefined
+                    ? (object.userData.feature as TileFeatureData)
+                    : undefined;
+
+            if (featureData !== undefined) {
+                heapSize += getFeatureDataSize(featureData);
+            }
+
+            objectSize.heapSize += heapSize;
+            objectSize.gpuSize += gpuSize;
+        } else {
+            logger.warn("estimateMeshSize: unidentified object", object);
+        }
+    }
+
+    /**
+     * Computes estimate for size of a THREE.Object3D object and its children. Shared materials
+     * and/or attributes will be counted multiple times.
+     *
+     * @param object - The mesh object to evaluate
+     * @param size - The {@link MemoryUsage} to update.
+     * @param visitedObjects - Optional map to store large objects that could be shared.
+     *
+     * @returns Estimate of object size in bytes for heap and GPU.
+     */
+    export function estimateSize(
+        object: THREE.Object3D,
+        parentSize?: MemoryUsage,
+        visitedObjects?: Map<string, boolean>
+    ): MemoryUsage {
+        const size =
+            parentSize !== undefined
+                ? parentSize
+                : {
+                      heapSize: 0,
+                      gpuSize: 0
+                  };
+
+        if (visitedObjects === undefined) {
+            visitedObjects = new Map();
+        }
+
+        estimateMeshSize(object, size, visitedObjects);
+
+        if (object.children.length > 0) {
+            for (const child of object.children) {
+                estimateSize(child, size, visitedObjects);
+            }
+        }
+        return size;
+    }
+}

--- a/@here/harp-mapview/test/Object3DUtilsTest.ts
+++ b/@here/harp-mapview/test/Object3DUtilsTest.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "chai";
+import * as THREE from "three";
+
+import { Object3DUtils } from "../lib/geometry/Object3DUtils";
+
+describe("Object3DUtils", function () {
+    it("estimate size of world with one cube", async function () {
+        const scene: THREE.Scene = new THREE.Scene();
+        const geometry = new THREE.BoxGeometry(1, 1, 1);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const cube = new THREE.Mesh(geometry, material);
+        scene.add(cube);
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(2064);
+        expect(objSize.gpuSize).to.be.equal(840);
+    });
+
+    it("estimate size of world with two cubes that share the geometry", async function () {
+        const scene: THREE.Scene = new THREE.Scene();
+        const geometry = new THREE.BoxGeometry(1, 1, 1);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const cube0 = new THREE.Mesh(geometry, material);
+        scene.add(cube0);
+        const cube1 = new THREE.Mesh(geometry, material);
+        scene.add(cube1);
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(3064); // see previous test: 2064 + 1000 = 3808
+        expect(objSize.gpuSize).to.be.equal(840); // see previous test
+    });
+
+    it("estimate size of world with 1000 cubes", async function (this: Mocha.Context) {
+        this.timeout(4000);
+        const scene: THREE.Scene = new THREE.Scene();
+        for (let i = 0; i < 1000; i++) {
+            const geometry = new THREE.BoxGeometry(1, 1, 1);
+            const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+            const cube = new THREE.Mesh(geometry, material);
+            scene.add(cube);
+        }
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(2064000); // see previous test: 2064 * 1000
+        expect(objSize.gpuSize).to.be.equal(840000); // see previous test: 1584 * 1000
+    });
+
+    it("estimate size of world with single point", async function () {
+        const scene: THREE.Scene = new THREE.Scene();
+        const vertexArray: THREE.Vector3[] = [new THREE.Vector3(0, 1, 0)];
+        const geometry = new THREE.BufferGeometry().setFromPoints(vertexArray);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const points = new THREE.Points(geometry, material);
+        scene.add(points);
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(1068); // 1*vector3 + object3d overhead
+        expect(objSize.gpuSize).to.be.equal(12);
+    });
+
+    it("estimate size of world with 6 points", async function () {
+        const scene: THREE.Scene = new THREE.Scene();
+        const vertexArray = new Array<THREE.Vector3>(6).fill(new THREE.Vector3());
+        const bufferGeometry = new THREE.BufferGeometry().setFromPoints(vertexArray);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const points = new THREE.Points(bufferGeometry, material);
+        scene.add(points);
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(1128); // see previous test
+        expect(objSize.gpuSize).to.be.equal(72); // 6*3*4 bytes - buffered data
+    });
+
+    it("estimate size of world with 6 points making circle", async function () {
+        const scene: THREE.Scene = new THREE.Scene();
+        const geometry = new THREE.CircleGeometry(1, 6);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const points = new THREE.Points(geometry, material);
+        scene.add(points);
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(1516); // 7*vector3 + 6*face + object3d overhead
+        expect(objSize.gpuSize).to.be.equal(292);
+    });
+
+    it("estimate size of world with line between 2 points", async function () {
+        const scene: THREE.Scene = new THREE.Scene();
+        const vertexArray: THREE.Vector3[] = [
+            new THREE.Vector3(0, 0, 0),
+            new THREE.Vector3(0, 5, 0)
+        ];
+        const geometry = new THREE.BufferGeometry().setFromPoints(vertexArray);
+        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+        const line = new THREE.Line(geometry, material);
+        scene.add(line);
+
+        const objSize = Object3DUtils.estimateSize(scene);
+        expect(objSize.heapSize).to.be.equal(1080);
+        expect(objSize.gpuSize).to.be.equal(24);
+    });
+});

--- a/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
+++ b/@here/harp-mapview/test/TextElementsRendererTestFixture.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { MapEnv, Theme } from "@here/harp-datasource-protocol";
-import { identityProjection, TileKey } from "@here/harp-geoutils";
+import { identityProjection, TileKey, TileKeyUtils } from "@here/harp-geoutils";
 import { silenceLoggingAroundFunction } from "@here/harp-test-utils";
 import { FontCatalog, TextCanvas } from "@here/harp-text-canvas";
 import { assert, expect } from "chai";
@@ -22,7 +22,6 @@ import { TextElementsRendererOptions } from "../lib/text/TextElementsRendererOpt
 import { TextElementType } from "../lib/text/TextElementType";
 import { ViewState } from "../lib/text/ViewState";
 import { Tile } from "../lib/Tile";
-import { TileOffsetUtils } from "../lib/Utils";
 import { DataSourceTileList } from "../lib/VisibleTileSet";
 import { FakeOmvDataSource } from "./FakeOmvDataSource";
 import {
@@ -472,7 +471,7 @@ export class TestFixture {
         this.tileLists[0].renderedTiles.clear();
         for (const tile of tiles) {
             this.tileLists[0].renderedTiles.set(
-                TileOffsetUtils.getKeyForTileKeyAndOffset(tile.tileKey, 0),
+                TileKeyUtils.getKeyForTileKeyAndOffset(tile.tileKey, 0),
                 tile
             );
         }

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -12,7 +12,8 @@ import {
     OrientedBox3,
     Projection,
     ProjectionType,
-    sphereProjection} from "@here/harp-geoutils";
+    sphereProjection
+} from "@here/harp-geoutils";
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
@@ -474,101 +475,6 @@ describe("MapViewUtils", function () {
         });
     });
 
-    it("estimate size of world with one cube", async function () {
-        const scene: THREE.Scene = new THREE.Scene();
-        const geometry = new THREE.BoxGeometry(1, 1, 1);
-        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-        const cube = new THREE.Mesh(geometry, material);
-        scene.add(cube);
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(2064);
-        expect(objSize.gpuSize).to.be.equal(840);
-    });
-
-    it("estimate size of world with two cubes that share the geometry", async function () {
-        const scene: THREE.Scene = new THREE.Scene();
-        const geometry = new THREE.BoxGeometry(1, 1, 1);
-        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-        const cube0 = new THREE.Mesh(geometry, material);
-        scene.add(cube0);
-        const cube1 = new THREE.Mesh(geometry, material);
-        scene.add(cube1);
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(3064); // see previous test: 2064 + 1000 = 3808
-        expect(objSize.gpuSize).to.be.equal(840); // see previous test
-    });
-
-    it("estimate size of world with 1000 cubes", async function (this: Mocha.Context) {
-        this.timeout(4000);
-        const scene: THREE.Scene = new THREE.Scene();
-        for (let i = 0; i < 1000; i++) {
-            const geometry = new THREE.BoxGeometry(1, 1, 1);
-            const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-            const cube = new THREE.Mesh(geometry, material);
-            scene.add(cube);
-        }
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(2064000); // see previous test: 2064 * 1000
-        expect(objSize.gpuSize).to.be.equal(840000); // see previous test: 1584 * 1000
-    });
-
-    it("estimate size of world with single point", async function () {
-        const scene: THREE.Scene = new THREE.Scene();
-        const vertexArray: THREE.Vector3[] = [new THREE.Vector3(0, 1, 0)];
-        const geometry = new THREE.BufferGeometry().setFromPoints(vertexArray);
-        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-        const points = new THREE.Points(geometry, material);
-        scene.add(points);
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(1068); // 1*vector3 + object3d overhead
-        expect(objSize.gpuSize).to.be.equal(12);
-    });
-
-    it("estimate size of world with 6 points", async function () {
-        const scene: THREE.Scene = new THREE.Scene();
-        const vertexArray = new Array<THREE.Vector3>(6).fill(new THREE.Vector3());
-        const bufferGeometry = new THREE.BufferGeometry().setFromPoints(vertexArray);
-        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-        const points = new THREE.Points(bufferGeometry, material);
-        scene.add(points);
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(1128); // see previous test
-        expect(objSize.gpuSize).to.be.equal(72); // 6*3*4 bytes - buffered data
-    });
-
-    it("estimate size of world with 6 points making circle", async function () {
-        const scene: THREE.Scene = new THREE.Scene();
-        const geometry = new THREE.CircleGeometry(1, 6);
-        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-        const points = new THREE.Points(geometry, material);
-        scene.add(points);
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(1516); // 7*vector3 + 6*face + object3d overhead
-        expect(objSize.gpuSize).to.be.equal(292);
-    });
-
-    it("estimate size of world with line between 2 points", async function () {
-        const scene: THREE.Scene = new THREE.Scene();
-        const vertexArray: THREE.Vector3[] = [
-            new THREE.Vector3(0, 0, 0),
-            new THREE.Vector3(0, 5, 0)
-        ];
-        const geometry = new THREE.BufferGeometry().setFromPoints(vertexArray);
-        const material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-        const line = new THREE.Line(geometry, material);
-        scene.add(line);
-
-        const objSize = MapViewUtils.estimateObject3dSize(scene);
-        expect(objSize.heapSize).to.be.equal(1080);
-        expect(objSize.gpuSize).to.be.equal(24);
-    });
-
     for (const { projName, projection } of [
         { projName: "mercator", projection: mercatorProjection },
         { projName: "sphere", projection: sphereProjection }
@@ -805,4 +711,3 @@ describe("MapViewUtils", function () {
         });
     }
 });
-

--- a/@here/harp-mapview/test/UtilsTest.ts
+++ b/@here/harp-mapview/test/UtilsTest.ts
@@ -12,9 +12,7 @@ import {
     OrientedBox3,
     Projection,
     ProjectionType,
-    sphereProjection,
-    TileKey
-} from "@here/harp-geoutils";
+    sphereProjection} from "@here/harp-geoutils";
 import { assert, expect } from "chai";
 import * as sinon from "sinon";
 import * as THREE from "three";
@@ -22,7 +20,7 @@ import * as THREE from "three";
 import { CameraUtils } from "../lib/CameraUtils";
 import { ElevationProvider } from "../lib/ElevationProvider";
 import { MapView } from "../lib/MapView";
-import { MapViewUtils, TileOffsetUtils } from "../lib/Utils";
+import { MapViewUtils } from "../lib/Utils";
 
 //    Mocha discourages using arrow functions, see https://mochajs.org/#arrow-functions
 
@@ -808,43 +806,3 @@ describe("MapViewUtils", function () {
     }
 });
 
-describe("tile-offset#Utils", function () {
-    it("test getKeyForTileKeyAndOffset and extractOffsetAndMortonKeyFromKey", async function () {
-        // This allows 8 offsets to be stored, -4 -> 3, we test also outside this range
-        const bitshift = 3;
-        const offsets = [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5];
-        // Binary is the easist to read, here you can see the -4 -> 3 is mapped to 0 -> 7
-        // in the 3 highest bits.
-        const results = [
-            0b11100000000000000000000000000000000000000000000000111,
-            0b00000000000000000000000000000000000000000000000000111,
-            0b00100000000000000000000000000000000000000000000000111,
-            0b01000000000000000000000000000000000000000000000000111,
-            0b01100000000000000000000000000000000000000000000000111,
-            0b10000000000000000000000000000000000000000000000000111,
-            0b10100000000000000000000000000000000000000000000000111,
-            0b11000000000000000000000000000000000000000000000000111,
-            0b11100000000000000000000000000000000000000000000000111,
-            // Check that we wrap back around to 0
-            0b00000000000000000000000000000000000000000000000000111,
-            0b00100000000000000000000000000000000000000000000000111
-        ];
-        const offsetResults = [3, -4, -3, -2, -1, 0, 1, 2, 3, -4, -3];
-        const tileKey = TileKey.fromRowColumnLevel(1, 1, 1);
-        for (let i = 0; i < offsets.length; i++) {
-            const keyByTileKeyAndOffset = TileOffsetUtils.getKeyForTileKeyAndOffset(
-                tileKey,
-                offsets[i],
-                bitshift
-            );
-            expect(keyByTileKeyAndOffset).to.be.equal(results[i]);
-
-            const { offset, mortonCode } = TileOffsetUtils.extractOffsetAndMortonKeyFromKey(
-                keyByTileKeyAndOffset,
-                bitshift
-            );
-            expect(offset).to.be.equal(offsetResults[i]);
-            expect(mortonCode).to.be.equal(tileKey.mortonCode());
-        }
-    });
-});

--- a/@here/harp-mapview/test/VisibleTileSetTest.ts
+++ b/@here/harp-mapview/test/VisibleTileSetTest.ts
@@ -11,6 +11,7 @@ import {
     Projection,
     sphereProjection,
     TileKey,
+    TileKeyUtils,
     TilingScheme,
     webMercatorTilingScheme
 } from "@here/harp-geoutils";
@@ -28,7 +29,6 @@ import { TileGeometryManager } from "../lib/geometry/TileGeometryManager";
 import { TileLoaderState } from "../lib/ITileLoader";
 import { MapView, TileTaskGroups } from "../lib/MapView";
 import { Tile } from "../lib/Tile";
-import { TileOffsetUtils } from "../lib/Utils";
 import {
     DataSourceTileList,
     ResourceComputationType,
@@ -382,7 +382,7 @@ describe("VisibleTileSet", function () {
         // same as first found code few lines below
         const parentCode = TileKey.parentMortonCode(371506851);
         const parentTileKey = TileKey.fromMortonCode(parentCode);
-        const parentKey = TileOffsetUtils.getKeyForTileKeyAndOffset(parentTileKey, 0);
+        const parentKey = TileKeyUtils.getKeyForTileKeyAndOffset(parentTileKey, 0);
 
         // fake MapView to think that it has already loaded
         // parent of both found tiles

--- a/@here/harp-utils/index-common.ts
+++ b/@here/harp-utils/index-common.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from "./lib/DOMUtils";
 export * from "./lib/GroupedPriorityList";
 export * from "./lib/Logger";
 export * from "./lib/Math2D";

--- a/@here/harp-utils/lib/DOMUtils.ts
+++ b/@here/harp-utils/lib/DOMUtils.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 HERE Europe B.V.
+ * Licensed under Apache 2.0, see full license in LICENSE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export namespace DOMUtils {
+    /**
+     * Gets language list used by the browser
+     *
+     * @returns Array of iso language codes
+     */
+    export function getBrowserLanguages(): string[] | undefined {
+        if (navigator.languages !== undefined && navigator.languages.length > 0) {
+            const languageList = [];
+            for (const lang of navigator.languages) {
+                languageList.push(getIsoLanguageCode(lang));
+            }
+            return languageList;
+        }
+        if (navigator.language !== undefined) {
+            return [getIsoLanguageCode(navigator.language)];
+        }
+        return undefined;
+    }
+
+    /**
+     * Gets ISO-639-1 language code from browser's code (ex. en for en-US)
+     */
+    function getIsoLanguageCode(language: string) {
+        return language.substring(0, 2);
+    }
+}


### PR DESCRIPTION
Remove from MapViewUtils functions that are unrelated to MapView.
MapViewUtils namespace has now only functions related to view transformations, camera setup, and view bounds computation.