### PR TITLE
HARP-17877: Fixes Style Evaluator expression for cached step expression

### DIFF
--- a/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
+++ b/@here/harp-datasource-protocol/lib/StyleSetEvaluator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -443,15 +443,6 @@ export class StyleSetEvaluator {
             this.getOptimizedStyleSet(this.m_tmpOptimizedSubSetKey.set(layer, geometryType))
                 .length > 0
         );
-    }
-
-    /**
-     * Get the expression evaluation cache, for further feature processing.
-     *
-     * This cache is cleared at the next `getMatchingTechniques` call.
-     */
-    get expressionEvaluatorCache(): Map<Expr, Value> {
-        return this.m_cachedResults;
     }
 
     /**

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -879,8 +879,8 @@ describe("StyleSetEvaluator", function () {
             assert.strictEqual(techniques.length, 0);
         });
     });
-    //not supported at the moment, see HARP-17877
-    it.skip("lookup expressions and lookup table are cached", function () {
+
+    it("lookup expressions and lookup table are cached", function () {
         const lookupTable: JsonArray = [
             "literal",
             [
@@ -990,8 +990,8 @@ describe("StyleSetEvaluator", function () {
                 const technique = techniques[0] as PoiTechnique;
 
                 const context: AttrEvaluationContext = {
-                    env
-                    // cachedExprResults: styleSetEvaluator.expressionEvaluatorCache
+                    env,
+                    cachedExprResults: new Map()
                 };
                 // poiName attribute has FeatureGeometry scope, so it's not resolved on
                 // getMatchingTechniques.
@@ -1000,8 +1000,10 @@ describe("StyleSetEvaluator", function () {
                 expect(poiName).equals(entry.attributes.GENERIC_ICONOGRAPHY_NAME);
             }
         }
-        // Check that each lookup expression is evaluated only once.
-        expect(lookupSpy.callCount).equals(entries.length);
+        // See HARP-17877, the shared caching is not yet implemented, therefore
+        // expressions are evaluated more then once
+        //expect(lookupSpy.callCount).
+        // equals(entries.length, " each look up expression is evaluated once");
         lookupSpy.restore();
     });
 });

--- a/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
+++ b/@here/harp-datasource-protocol/test/StyleSetEvaluatorTest.ts
@@ -879,7 +879,8 @@ describe("StyleSetEvaluator", function () {
             assert.strictEqual(techniques.length, 0);
         });
     });
-    it("lookup expressions and lookup table are cached", function () {
+    //not supported at the moment, see HARP-17877
+    it.skip("lookup expressions and lookup table are cached", function () {
         const lookupTable: JsonArray = [
             "literal",
             [
@@ -989,8 +990,8 @@ describe("StyleSetEvaluator", function () {
                 const technique = techniques[0] as PoiTechnique;
 
                 const context: AttrEvaluationContext = {
-                    env,
-                    cachedExprResults: styleSetEvaluator.expressionEvaluatorCache
+                    env
+                    // cachedExprResults: styleSetEvaluator.expressionEvaluatorCache
                 };
                 // poiName attribute has FeatureGeometry scope, so it's not resolved on
                 // getMatchingTechniques.

--- a/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
+++ b/@here/harp-vectortile-datasource/lib/VectorTileDecoder.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 HERE Europe B.V.
+ * Copyright (C) 2019-2022 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -177,8 +177,7 @@ export class VectorTileDataProcessor implements IGeometryProcessor {
         }
         const context: AttrEvaluationContext = {
             env,
-            // Reuse expressions cached on previous call to getMatchingTechniques.
-            cachedExprResults: this.m_styleSetEvaluator.expressionEvaluatorCache
+            cachedExprResults: new Map()
         };
 
         if (this.m_decodedTileEmitter) {

--- a/@here/harp-vectortile-datasource/test/VectorTileDataProcessorTest.ts
+++ b/@here/harp-vectortile-datasource/test/VectorTileDataProcessorTest.ts
@@ -1,11 +1,10 @@
 /*
- * Copyright (C) 2021 HERE Europe B.V.
+ * Copyright (C) 2021-2022 HERE Europe B.V.
  * Licensed under Apache 2.0, see full license in LICENSE
  * SPDX-License-Identifier: Apache-2.0
  */
 import { GeometryKind, IndexedTechnique } from "@here/harp-datasource-protocol";
 import { StyleSetEvaluator } from "@here/harp-datasource-protocol/index-decoder";
-import { AttrEvaluationContext } from "@here/harp-datasource-protocol/lib/TechniqueAttr";
 import { mercatorProjection, TileKey } from "@here/harp-geoutils";
 import { expect } from "chai";
 import * as sinon from "sinon";
@@ -140,33 +139,6 @@ describe("VectorTileDataProcessor", function () {
                         );
                     });
                 emitterSpy = sinon.spy(VectorTileDataEmitter.prototype, processorMethod as any);
-            });
-
-            it("passes style evaluator cache to emitter", function () {
-                const matchingTechniques: IndexedTechnique[] = [
-                    {
-                        name: "line",
-                        color: "red",
-                        lineWidth: 1,
-                        _index: 0,
-                        _styleSetIndex: 0,
-                        kind: GeometryKind.Road
-                    }
-                ];
-                sinon
-                    .stub(styleSetEvaluator, "getMatchingTechniques")
-                    .callsFake(() => matchingTechniques);
-                sinon.stub(styleSetEvaluator, "techniques").get(() => matchingTechniques);
-                sinon.stub(styleSetEvaluator, "decodedTechniques").get(() => matchingTechniques);
-                sinon.stub(featureFilter, "wantsKind").callsFake((kind: string | string[]) => {
-                    return kind === GeometryKind.Road;
-                });
-                processor.getDecodedTile({});
-                expect(emitterSpy.calledOnce);
-                const context = emitterSpy.firstCall.args[3] as AttrEvaluationContext;
-                expect(context.cachedExprResults).equals(
-                    styleSetEvaluator.expressionEvaluatorCache
-                );
             });
 
             it("sets reserved feature properties", function () {


### PR DESCRIPTION
Signed-off-by: Frauke Fritz <frauke.fritz@here.com>

Thank you for contributing to harp.gl!

Before requesting a pull request, please remember to check the following documents:
* [contribution guidelines](https://github.com/heremaps/harp.gl/blob/master/CONTRIBUTING.md)
* [coding style](https://github.com/heremaps/harp.gl/blob/master/CODINGSTYLE.md)

If you are adding new functionality we would highly appreciate if you can describe what is the capability you are adding and even better if you can add some examples. Please also remember to add tests for it.

# CI Check

Our bots will check whether your PR can be directly integrated into the mainline. We have some internal integration tests running on the background, our bots will inform you of the next steps and someone from our team will take a look and help if needed!

And please do not forget to sign-off your commit! You can read more about DCO [here](https://julien.ponge.org/blog/developer-certificate-of-origin-versus-contributor-license-agreements/). But, in short, you just need to use `git commit -s` or append `--signoff` when you are committing to the repo.

Happy contributing!
